### PR TITLE
Make TLS 1.3 tickets time-agnostic

### DIFF
--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -3254,9 +3254,14 @@ int mbedtls_ssl_conf_ke(mbedtls_ssl_config* conf,
 *
 */
 
+#if defined(MBEDTLS_HAVE_TIME)
 int mbedtls_ssl_conf_ticket_meta(mbedtls_ssl_config* conf,
     const uint32_t ticket_age_add,
     const time_t ticket_received);
+#else
+int mbedtls_ssl_conf_ticket_meta(mbedtls_ssl_config* conf,
+    const uint32_t ticket_age_add);
+#endif /* MBEDTLS_HAVE_TIME */
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3 */
 
 #if defined(MBEDTLS_KEY_EXCHANGE__SOME__PSK_ENABLED)

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -4162,9 +4162,14 @@ int ssl_parse_new_session_ticket(mbedtls_ssl_context *ssl)
  * received will be set.
  */
 
+#if defined(MBEDTLS_HAVE_TIME)
 int mbedtls_ssl_conf_ticket_meta(mbedtls_ssl_config *conf,
-	const uint32_t ticket_age_add, 
+	const uint32_t ticket_age_add,
 	const time_t ticket_received)
+#else
+int mbedtls_ssl_conf_ticket_meta(mbedtls_ssl_config *conf,
+	const uint32_t ticket_age_add)
+#endif /* MBEDTLS_HAVE_TIME */
 {
 	conf->ticket_age_add = ticket_age_add; 
 #if defined(MBEDTLS_HAVE_TIME)
@@ -4244,7 +4249,11 @@ int mbedtls_ssl_conf_client_ticket(const mbedtls_ssl_context *ssl, mbedtls_ssl_t
 	if (ret != 0) return -1;
 
 	/* We set the ticket_age_add and the time we received the ticket */
-	ret = mbedtls_ssl_conf_ticket_meta(conf, ticket->ticket_age_add, ticket->start); 
+#if defined(MBEDTLS_HAVE_TIME)
+	ret = mbedtls_ssl_conf_ticket_meta(conf, ticket->ticket_age_add, ticket->start);
+#else
+	ret = mbedtls_ssl_conf_ticket_meta(conf, ticket->ticket_age_add);
+#endif /* MBEDTLS_HAVE_TIME */
 
 	if (ret != 0) return -1;
 
@@ -4293,8 +4302,10 @@ int mbedtls_ssl_get_client_ticket(const mbedtls_ssl_context *ssl, mbedtls_ssl_ti
 		// store ticket_age_add
 		ticket->ticket_age_add = ssl->session->ticket_age_add;
 
+#if defined(MBEDTLS_HAVE_TIME)
 		// store time we received the ticket
 		ticket->start = ssl->session->ticket_received; 
+#endif /* MBEDTLS_HAVE_TIME */
 
 		return 0;
 	}


### PR DESCRIPTION
The current implementation of TLS 1.3 tickets relies on time, however the platform doesn't necessarily have access to time functions (cf. `MBEDTLS_HAVE_TIME`).
The idea is to not record the time the ticket was obtained in case the platform doesn't support it.
It may make tickets useless though.