### PR TITLE
Select handshake PSK over externally configured PSK (server-side)

### DIFF
--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -1233,30 +1233,41 @@ void mbedtls_ssl_optimize_checksum( mbedtls_ssl_context *ssl,
 int mbedtls_ssl_psk_derive_premaster( mbedtls_ssl_context *ssl, mbedtls_key_exchange_type_t key_ex );
 
 /**
- * Get the first defined PSK by order of precedence:
+ * Get the first properly defined PSK by order of precedence:
  * 1. handshake PSK set by \c mbedtls_ssl_set_hs_psk() in the PSK callback
  * 2. static PSK configured by \c mbedtls_ssl_conf_psk()
- * Return a code and update the pair (PSK, PSK length) passed to this function
+ * Update the pair (PSK, PSK length) passed to the function if they're not null.
+ * Return whether any PSK was found
  */
 static inline int mbedtls_ssl_get_psk( const mbedtls_ssl_context *ssl,
     const unsigned char **psk, size_t *psk_len )
 {
     if( ssl->handshake->psk != NULL && ssl->handshake->psk_len > 0 )
     {
-        *psk = ssl->handshake->psk;
-        *psk_len = ssl->handshake->psk_len;
+        if( psk != NULL && psk_len != NULL )
+        {
+            *psk = ssl->handshake->psk;
+            *psk_len = ssl->handshake->psk_len;
+        }
     }
 
-    else if( ssl->conf->psk != NULL && ssl->conf->psk_len > 0 )
+    else if( ssl->conf->psk != NULL && ssl->conf->psk_len > 0 &&
+             ssl->conf->psk_identity != NULL && ssl->conf->psk_identity_len > 0)
     {
-        *psk = ssl->conf->psk;
-        *psk_len = ssl->conf->psk_len;
+        if( psk != NULL && psk_len != NULL )
+        {
+            *psk = ssl->conf->psk;
+            *psk_len = ssl->conf->psk_len;
+        }
     }
 
     else
     {
-        *psk = NULL;
-        *psk_len = 0;
+        if( psk != NULL && psk_len != NULL )
+        {
+            *psk = NULL;
+            *psk_len = 0;
+        }
         return( MBEDTLS_ERR_SSL_PRIVATE_KEY_REQUIRED );
     }
 

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -941,8 +941,7 @@ int ssl_write_pre_shared_key_ext( mbedtls_ssl_context *ssl,
     }
 
     /* Check whether we have any PSK credentials configured. */
-    if( ssl->conf->psk == NULL || ssl->conf->psk_identity == NULL ||
-        ssl->conf->psk_identity_len == 0 || ssl->conf->psk_len == 0 )
+    if( mbedtls_ssl_get_psk( ssl, NULL, NULL ) != 0 )
     {
         MBEDTLS_SSL_DEBUG_MSG( 3, ( "No externally configured PSK available." ) );
 
@@ -2046,9 +2045,7 @@ static int ssl_parse_server_psk_identity_ext( mbedtls_ssl_context *ssl,
     int ret = 0;
     size_t selected_identity;
 
-    if( ssl->conf->f_psk == NULL &&
-        ( ssl->conf->psk == NULL || ssl->conf->psk_identity == NULL ||
-          ssl->conf->psk_identity_len == 0 || ssl->conf->psk_len == 0 ) )
+    if( mbedtls_ssl_get_psk( ssl, NULL, NULL ) != 0 )
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "got no pre-shared key" ) );
         return( MBEDTLS_ERR_SSL_PRIVATE_KEY_REQUIRED );

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -1044,7 +1044,7 @@ psk_parsing_successful:
                                   truncated_clienthello_start, truncated_clienthello_end - truncated_clienthello_start, server_computed_binder );
         }
         else {
-            /* Case 2: We are using an externally configured PSK, or a dynamically configured PSK if one is defined */
+            /* Case 2: We are using a static PSK, or a dynamic PSK if one is defined */
             if( mbedtls_ssl_get_psk( ssl, &psk, &psk_len ) == MBEDTLS_ERR_SSL_PRIVATE_KEY_REQUIRED )
             {
                 return( MBEDTLS_ERR_SSL_PRIVATE_KEY_REQUIRED );

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -1050,7 +1050,7 @@ psk_parsing_successful:
                 MBEDTLS_SSL_DEBUG_MSG( 1, ( "should never happen" ) );
                 return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
             }
-            ret = ssl_calc_binder( ssl, psk, psk_len,
+            ret = ssl_calc_binder( ssl, (unsigned char *) psk, psk_len,
                                   mbedtls_md_info_from_type( ssl->transform_negotiate->ciphersuite_info->mac ), ssl->transform_negotiate->ciphersuite_info,
                                   truncated_clienthello_start, truncated_clienthello_end - truncated_clienthello_start, server_computed_binder );
         }

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -1111,9 +1111,10 @@ static int ssl_write_server_pre_shared_key_ext( mbedtls_ssl_context *ssl,
 
     *olen = 0;
 
-    /* Are we using an external PSK? */
-    if( ssl->conf->psk == NULL || ssl->conf->psk_identity == NULL ||
-        ssl->conf->psk_identity_len == 0 || ssl->conf->psk_len == 0 )
+    /* Are we using any PSK at all? */
+    if( ( ssl->conf->psk == NULL || ssl->conf->psk_identity == NULL ||
+          ssl->conf->psk_identity_len == 0 || ssl->conf->psk_len == 0 ) &&
+        ( ssl->handshake->psk == NULL || ssl->handshake->psk_len == 0 ) )
         ret = MBEDTLS_ERR_SSL_PRIVATE_KEY_REQUIRED;
 
     /* Are we using resumption? */

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -1045,8 +1045,8 @@ psk_parsing_successful:
         }
         else {
             /* Case 2: We are using a static PSK, or a dynamic PSK if one is defined */
-            if( mbedtls_ssl_get_psk( ssl, &psk, &psk_len ) == MBEDTLS_ERR_SSL_PRIVATE_KEY_REQUIRED )
-                return( MBEDTLS_ERR_SSL_PRIVATE_KEY_REQUIRED );
+            if( ( ret = mbedtls_ssl_get_psk( ssl, &psk, &psk_len ) ) != 0 )
+                return( ret );
 
             ret = ssl_calc_binder( ssl, (unsigned char *) psk, psk_len,
                                   mbedtls_md_info_from_type( ssl->transform_negotiate->ciphersuite_info->mac ), ssl->transform_negotiate->ciphersuite_info,

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -1047,8 +1047,7 @@ psk_parsing_successful:
             /* Case 2: We are using an externally configured PSK, or a dynamically configured PSK if one is defined */
             if( mbedtls_ssl_get_psk( ssl, &psk, &psk_len ) == MBEDTLS_ERR_SSL_PRIVATE_KEY_REQUIRED )
             {
-                MBEDTLS_SSL_DEBUG_MSG( 1, ( "should never happen" ) );
-                return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
+                return( MBEDTLS_ERR_SSL_PRIVATE_KEY_REQUIRED );
             }
             ret = ssl_calc_binder( ssl, (unsigned char *) psk, psk_len,
                                   mbedtls_md_info_from_type( ssl->transform_negotiate->ciphersuite_info->mac ), ssl->transform_negotiate->ciphersuite_info,

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -1046,9 +1046,8 @@ psk_parsing_successful:
         else {
             /* Case 2: We are using a static PSK, or a dynamic PSK if one is defined */
             if( mbedtls_ssl_get_psk( ssl, &psk, &psk_len ) == MBEDTLS_ERR_SSL_PRIVATE_KEY_REQUIRED )
-            {
                 return( MBEDTLS_ERR_SSL_PRIVATE_KEY_REQUIRED );
-            }
+
             ret = ssl_calc_binder( ssl, (unsigned char *) psk, psk_len,
                                   mbedtls_md_info_from_type( ssl->transform_negotiate->ciphersuite_info->mac ), ssl->transform_negotiate->ciphersuite_info,
                                   truncated_clienthello_start, truncated_clienthello_end - truncated_clienthello_start, server_computed_binder );

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -777,6 +777,8 @@ int ssl_parse_client_psk_identity_ext( mbedtls_ssl_context *ssl,
     unsigned char server_computed_binder[MBEDTLS_MD_MAX_SIZE];
     uint32_t obfuscated_ticket_age;
     mbedtls_ssl_ticket ticket;
+    const unsigned char *psk = NULL;
+    size_t psk_len = 0;
 #if defined(MBEDTLS_HAVE_TIME)
     time_t now;
     int64_t diff;
@@ -1042,8 +1044,13 @@ psk_parsing_successful:
                                   truncated_clienthello_start, truncated_clienthello_end - truncated_clienthello_start, server_computed_binder );
         }
         else {
-            /* Case 2: We are using an externally configured PSK */
-            ret = ssl_calc_binder( ssl, ssl->conf->psk, ssl->conf->psk_len,
+            /* Case 2: We are using an externally configured PSK, or a dynamically configured PSK if one is defined */
+            if( mbedtls_ssl_get_psk( ssl, &psk, &psk_len ) == MBEDTLS_ERR_SSL_PRIVATE_KEY_REQUIRED )
+            {
+                MBEDTLS_SSL_DEBUG_MSG( 1, ( "should never happen" ) );
+                return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
+            }
+            ret = ssl_calc_binder( ssl, psk, psk_len,
                                   mbedtls_md_info_from_type( ssl->transform_negotiate->ciphersuite_info->mac ), ssl->transform_negotiate->ciphersuite_info,
                                   truncated_clienthello_start, truncated_clienthello_end - truncated_clienthello_start, server_computed_binder );
         }

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -1110,9 +1110,7 @@ static int ssl_write_server_pre_shared_key_ext( mbedtls_ssl_context *ssl,
     *olen = 0;
 
     /* Are we using any PSK at all? */
-    if( ( ssl->conf->psk == NULL || ssl->conf->psk_identity == NULL ||
-          ssl->conf->psk_identity_len == 0 || ssl->conf->psk_len == 0 ) &&
-        ( ssl->handshake->psk == NULL || ssl->handshake->psk_len == 0 ) )
+    if( mbedtls_ssl_get_psk( ssl, NULL, NULL ) != 0 )
         ret = MBEDTLS_ERR_SSL_PRIVATE_KEY_REQUIRED;
 
     /* Are we using resumption? */


### PR DESCRIPTION
In Mbed TLS there are two kinds of PSK:

- Externally configured PSK (`ssl->conf->psk...`): Essentially used client-side although nothing prevents the server from using it. It is set by `mbedtls_ssl_conf_psk()`

- Handshake PSK, aka dynamically configured PSK (`ssl->handshake->psk...`): Server-side only. That PSK is bound to the handshake hence doesn't survive renegotiation or session reset.
It is set by `mbedtls_ssl_set_hs_psk()`, which `should only be called inside the PSK callback` according to the documentation.
The handshake PSK is supposed to precede the externally configured one as showed in  `mbedtls_ssl_psk_derive_premaster()`.

In this implementation, the server skips the handshake PSK, resulting in the externally configured PSK being chosen.
On another note `mbedtls_ssl_set_hs_psk()` is called in `ssl_parse_client_psk_identity_ext()` to save the ticket's key, which contradicts the documentation.

This PR aims at reestablishing the precedence of the handshake PSK over the externally configured PSK.