### PR TITLE
Fix compiler warnings in out-of-box compilation

### DIFF
--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -156,14 +156,14 @@
  /* List of extensions used in ssl_internal.h / extensions_present in mbedtls_ssl_handshake_params */
 #define NO_EXTENSION 0
 #define PRE_SHARED_KEY_EXTENSION 1
-#define KEY_SHARE_EXTENSION 2 
+#define KEY_SHARE_EXTENSION 2
 #define SIGNATURE_ALGORITHM_EXTENSION 4
 #define SUPPORTED_GROUPS_EXTENSION 8
-#define MAX_FRAGMENT_LENGTH_EXTENSION 16 
+#define MAX_FRAGMENT_LENGTH_EXTENSION 16
 #define ALPN_EXTENSION 32
-#define SUPPORTED_VERSION_EXTENSION 64 
+#define SUPPORTED_VERSION_EXTENSION 64
 #define PSK_KEY_EXCHANGE_MODES_EXTENSION 128
-#define EARLY_DATA_EXTENSION 256 
+#define EARLY_DATA_EXTENSION 256
 #define SERVERNAME_EXTENSION 512
 #define COOKIE_EXTENSION 1024
 #define CID_EXTENSION 2048
@@ -428,7 +428,7 @@
 #define MBEDTLS_SSL_MSG_APPLICATION_DATA       23
 #define MBEDTLS_SSL_MSG_CID                    25
 #define MBEDTLS_SSL_MSG_ACK                    26
-#define MBEDTLS_SSL_MSG_TLS_CID                25 // OLD CID Implementation 
+#define MBEDTLS_SSL_MSG_TLS_CID                25 // OLD CID Implementation
 
 #define MBEDTLS_SSL_ALERT_LEVEL_WARNING         1
 #define MBEDTLS_SSL_ALERT_LEVEL_FATAL           2
@@ -498,7 +498,7 @@
 #define MBEDTLS_TLS_EXT_TRUNCATED_HMAC               4
 
 #define MBEDTLS_TLS_EXT_SUPPORTED_ELLIPTIC_CURVES   10
-#define MBEDTLS_TLS_EXT_SUPPORTED_GROUPS   10 // Renamed in TLS 1.3 
+#define MBEDTLS_TLS_EXT_SUPPORTED_GROUPS   10 // Renamed in TLS 1.3
 
 #define MBEDTLS_TLS_EXT_SUPPORTED_POINT_FORMATS     11
 
@@ -512,7 +512,7 @@
 #define MBEDTLS_TLS_EXT_SESSION_TICKET              35
 
  /* TLS 1.3 */
-#define MBEDTLS_TLS_EXT_KEY_SHARES                 51 
+#define MBEDTLS_TLS_EXT_KEY_SHARES                 51
 #define MBEDTLS_TLS_EXT_PRE_SHARED_KEY             41
 #define MBEDTLS_TLS_EXT_EARLY_DATA                 42
 #define MBEDTLS_TLS_EXT_SUPPORTED_VERSIONS         43
@@ -609,7 +609,7 @@ extern "C" {
         MBEDTLS_SSL_EARLY_APP_DATA
     }
     mbedtls_ssl_states;
-#else 
+#else
 /*
  * SSL state machine
  */
@@ -763,7 +763,7 @@ typedef int mbedtls_ssl_get_timer_t( void * ctx );
 typedef struct mbedtls_ssl_session mbedtls_ssl_session;
 typedef struct mbedtls_ssl_context mbedtls_ssl_context;
 typedef struct mbedtls_ssl_config  mbedtls_ssl_config;
-#if defined(MBEDTLS_SSL_PROTO_TLS1_3) 
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3)
 typedef struct mbedtls_ssl_ticket  mbedtls_ssl_ticket;
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3 */
 
@@ -1062,12 +1062,12 @@ typedef struct KeySet {
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
 	unsigned char iv[12];
 
-	/* The [sender]_sn_key is indirectly used to 
-	 * encrypt the sequence number in the record layer. 
+	/* The [sender]_sn_key is indirectly used to
+	 * encrypt the sequence number in the record layer.
 	 *
-	 * The client_sn_key is used to encrypt the 
-	 * sequence number for outgoing transmission. 
-	 * server_sn_key is used for incoming payloads. 
+	 * The client_sn_key is used to encrypt the
+	 * sequence number for outgoing transmission.
+	 * server_sn_key is used for incoming payloads.
 	 */
 	unsigned char *server_sn_key;
 	unsigned char *client_sn_key;
@@ -1131,7 +1131,7 @@ struct mbedtls_ssl_session
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3)
 #if defined(MBEDTLS_SSL_NEW_SESSION_TICKET) && defined(MBEDTLS_SSL_CLI_C)
-// TBD: Replace fields by ticket structure 
+// TBD: Replace fields by ticket structure
 // We currently only store a single ticket on the client size
     unsigned char* ticket;      /*!< TLS 1.3 session ticket acting as psk identity */
     size_t ticket_len;          /*!< ticket length   */
@@ -1171,7 +1171,7 @@ struct mbedtls_ssl_session
  *    1  -- MBEDTLS_SSL_EARLY_DATA_ENABLED (for use early data)
  */
     int process_early_data; /*!< Indication about using early data or not on the server side */
-#endif 
+#endif
 
 #if defined(MBEDTLS_CID)
     unsigned int cid;           /*!< flag about CID usage           */
@@ -1249,12 +1249,12 @@ struct mbedtls_ssl_config
     void *p_cookie;                 /*!< context for the cookie callbacks   */
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3)
-    unsigned int rr_config; 
+    unsigned int rr_config;
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3 */
 
 #endif
 
-#if ((defined(MBEDTLS_SSL_SESSION_TICKETS) || (defined(MBEDTLS_SSL_NEW_SESSION_TICKET) && defined(MBEDTLS_SSL_PROTO_TLS1_3)) ) && defined(MBEDTLS_SSL_SRV_C)) 
+#if ((defined(MBEDTLS_SSL_SESSION_TICKETS) || (defined(MBEDTLS_SSL_NEW_SESSION_TICKET) && defined(MBEDTLS_SSL_PROTO_TLS1_3)) ) && defined(MBEDTLS_SSL_SRV_C))
     /** Callback to create & write a session ticket                         */
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3)
     int(*f_ticket_write)(void*, const mbedtls_ssl_ticket*,
@@ -1262,7 +1262,7 @@ struct mbedtls_ssl_config
     /** Callback to parse a session ticket into a session structure         */
     int(*f_ticket_parse)(void*, mbedtls_ssl_ticket*, unsigned char*, size_t);
     void* p_ticket;                 /*!< context for the ticket callbacks   */
-#else 
+#else
     int (*f_ticket_write)( void *, const mbedtls_ssl_session *,
             unsigned char *, const unsigned char *, size_t *, uint32_t * );
     /** Callback to parse a session ticket into a session structure         */
@@ -1381,7 +1381,7 @@ struct mbedtls_ssl_config
       *   1  -- MBEDTLS_SSL_EARLY_DATA_ENABLED (for use early data)
       */
     int early_data;
-    // Pointer to early data buffer 
+    // Pointer to early data buffer
     char* early_data_buf;
     // Length of early data
     unsigned int early_data_len;
@@ -2327,7 +2327,7 @@ typedef int mbedtls_ssl_ticket_write_t(void* p_ticket,
     size_t* tlen,
     uint32_t* lifetime, TicketFlags* flags);
 
-#else 
+#else
 
 /**
  * \brief           Callback type: generate and write session ticket
@@ -2448,7 +2448,7 @@ typedef int mbedtls_ssl_ticket_parse_t(void* p_ticket,
     mbedtls_ssl_ticket* session,
     unsigned char* buf,
     size_t len);
-#else 
+#else
 /**
  * \brief           Callback type: parse and load session ticket
  *
@@ -2695,7 +2695,7 @@ void mbedtls_ssl_conf_cookies(mbedtls_ssl_config* conf,
     mbedtls_ssl_cookie_check_t* f_cookie_check,
     void* p_cookie,
     unsigned int rr_conf);
-#else 
+#else
 /**
  * \brief           Register callbacks for DTLS cookies
  *                  (Server only. DTLS only.)
@@ -4170,7 +4170,7 @@ const char *mbedtls_ssl_get_version( const mbedtls_ssl_context *ssl );
  *                 enabled, which makes expansion much less predictable
  */
 int mbedtls_ssl_get_record_expansion(const mbedtls_ssl_context* ssl, int direction);
-#else 
+#else
 /**
  * \brief          Return the (maximum) number of bytes added by the record
  *                 layer: header + encryption/MAC overhead (inc. padding)

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -2688,7 +2688,7 @@ typedef int mbedtls_ssl_cookie_check_t( void *ctx,
  * \param f_cookie_write    Cookie write callback
  * \param f_cookie_check    Cookie check callback
  * \param p_cookie          Context for both callbacks
- * \param rr_config         Determines whether a return-routability check is enforced
+ * \param rr_conf           Determines whether a return-routability check is enforced
  */
 void mbedtls_ssl_conf_cookies(mbedtls_ssl_config* conf,
     mbedtls_ssl_cookie_write_t* f_cookie_write,
@@ -3241,16 +3241,16 @@ int mbedtls_ssl_conf_ke(mbedtls_ssl_config* conf,
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3)
 
 /**
-* \brief Set meta-data for server-provided tickets
+* \brief Set meta-data for server-provided tickets.
 *
 * \note This function is used in context of tickets since the
-*       ticket_age_add value is provided by the server-side.
+*       \p ticket_age_add value is provided by the server-side.
 *       Furthermore, we also need to record the time the ticket
 *       was obtained.
 *
-* \param conf     SSL configuration
-* \param ticket_age_add    ticket age add value
-* \param start    time when the ticket was received
+* \param conf             The SSL configuration to use.
+* \param ticket_age_add   The ticket age add value.
+* \param ticket_received  The time when the ticket was received.
 *
 */
 

--- a/include/mbedtls/ssl_ciphersuites.h
+++ b/include/mbedtls/ssl_ciphersuites.h
@@ -441,7 +441,7 @@ const mbedtls_ssl_ciphersuite_t *mbedtls_ssl_ciphersuite_from_id( int ciphersuit
 *
 * \return          Size of output in bytes, -1 in case of error
 */
-int mbedtls_hash_size_for_ciphersuite(const mbedtls_ssl_ciphersuite_t* ciphersuite);
+unsigned int mbedtls_hash_size_for_ciphersuite(const mbedtls_ssl_ciphersuite_t* ciphersuite);
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3 */
 
 #if defined(MBEDTLS_PK_C)

--- a/include/mbedtls/ssl_ciphersuites.h
+++ b/include/mbedtls/ssl_ciphersuites.h
@@ -39,7 +39,7 @@ extern "C" {
 #endif
 
 /*
- * Supported ciphersuites (Official IANA names) 
+ * Supported ciphersuites (Official IANA names)
  */
 #define MBEDTLS_TLS_RSA_WITH_NULL_MD5                    0x01   /**< Weak! */
 #define MBEDTLS_TLS_RSA_WITH_NULL_SHA                    0x02   /**< Weak! */
@@ -287,11 +287,11 @@ extern "C" {
 #define MBEDTLS_TLS_RSA_PSK_WITH_CHACHA20_POLY1305_SHA256     0xCCAE /**< TLS 1.2 */
 
 /*
- * Supported ciphersuites (Official IANA names) for TLS / DTLS 1.3 
+ * Supported ciphersuites (Official IANA names) for TLS / DTLS 1.3
  */
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3)
-#define TLS_AES_128_GCM_SHA256                                0x1301 
-#define TLS_AES_256_GCM_SHA384                                0x1302 
+#define TLS_AES_128_GCM_SHA256                                0x1301
+#define TLS_AES_256_GCM_SHA384                                0x1302
 #define TLS_CHACHA20_POLY1305_SHA256                          0x1303
 #define TLS_AES_128_CCM_SHA256                                0x1304
 #define TLS_AES_128_CCM_8_SHA256                              0x1305
@@ -412,10 +412,10 @@ struct mbedtls_ssl_ciphersuite_t
     const char * name;
 
     mbedtls_cipher_type_t cipher;
-    /* For TLS 1.3 we use this field to populate it with the hash function 
+    /* For TLS 1.3 we use this field to populate it with the hash function
      * (instead of a MAC).
      */
-    mbedtls_md_type_t mac; 
+    mbedtls_md_type_t mac;
     /* In TLS 1.3 we do not make use of this key_exchange field. */
     mbedtls_key_exchange_type_t key_exchange;
 

--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -1280,6 +1280,10 @@ void mbedtls_ssl_read_version( int *major, int *minor, int transport,
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3)
 static inline size_t mbedtls_ssl_hdr_len(const mbedtls_ssl_context* ssl, const int direction, mbedtls_ssl_transform* transform)
 {
+#if !defined(MBEDTLS_CID)
+    ((void) direction);
+#endif /* MBEDTLS_CID */
+
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
     if (ssl->conf->transport == MBEDTLS_SSL_TRANSPORT_DATAGRAM) {
 

--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -106,7 +106,7 @@
 #else
 #if defined(MBEDTLS_SSL_PROTO_TLS1_2)
 #define MBEDTLS_SSL_MAX_MINOR_VERSION           MBEDTLS_SSL_MINOR_VERSION_3
-#else 
+#else
 #if defined(MBEDTLS_SSL_PROTO_TLS1_1)
 #define MBEDTLS_SSL_MAX_MINOR_VERSION           MBEDTLS_SSL_MINOR_VERSION_2
 #else
@@ -359,7 +359,7 @@ struct mbedtls_ssl_handshake_params
     mbedtls_ecdh_context ecdh_ctx[MBEDTLS_SSL_MAX_KEY_SHARES]; /*!<  ECDH key exchange       */
     int ecdh_ctx_selected; /*!< Selected ECDHE context */
     int ecdh_ctx_max; /* !< Maximum number of used structures */
-#else 
+#else
     mbedtls_ecdh_context ecdh_ctx;              /*!<  ECDH key exchange       */
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3 */
 
@@ -417,16 +417,16 @@ struct mbedtls_ssl_handshake_params
     mbedtls_pk_context peer_pubkey;     /*!< The public key from the peer.  */
 #endif /* MBEDTLS_X509_CRT_PARSE_C && !MBEDTLS_SSL_KEEP_PEER_CERTIFICATE */
 
-#if (defined(MBEDTLS_SSL_PROTO_DTLS) || defined(MBEDTLS_SSL_PROTO_TLS1_3)) 
-   /* Prior to TLS 1.3 cookies were only used with DTLS. In TLS 1.3 a cookie 
-    * mechanism has been introduced. 
+#if (defined(MBEDTLS_SSL_PROTO_DTLS) || defined(MBEDTLS_SSL_PROTO_TLS1_3))
+   /* Prior to TLS 1.3 cookies were only used with DTLS. In TLS 1.3 a cookie
+    * mechanism has been introduced.
     */
 
     unsigned char* verify_cookie;       /*!<  Cli: HelloVerifyRequest cookie
                                           Srv: unused                    */
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3)
     size_t verify_cookie_len;
-#else 
+#else
     unsigned char verify_cookie_len;    /*!<  Cli: cookie length
                                               Srv: flag for sending a cookie */
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3*/
@@ -516,7 +516,7 @@ struct mbedtls_ssl_handshake_params
     void (*update_checksum)(mbedtls_ssl_context*, const unsigned char*, size_t);
     int (*calc_verify)(mbedtls_ssl_context*, unsigned char*, int);
     int(*calc_finished)(mbedtls_ssl_context*, unsigned char*, int);
-#else 
+#else
     void (*update_checksum)(mbedtls_ssl_context *, const unsigned char *, size_t);
     void (*calc_verify)(const mbedtls_ssl_context *, unsigned char *, size_t *);
     void (*calc_finished)(mbedtls_ssl_context *, unsigned char *, int);
@@ -613,7 +613,7 @@ struct mbedtls_ssl_handshake_params
 #if defined(MBEDTLS_ECDSA_C)
     unsigned char certificate_request_context_len;
     unsigned char* certificate_request_context;
-#endif 
+#endif
 
 #if defined(MBEDTLS_ECDH_C) && defined(MBEDTLS_SSL_CLI_C)
     /* This is the actual key share list we sent.
@@ -651,14 +651,14 @@ struct mbedtls_ssl_handshake_params
     int early_data;
 #endif /* MBEDTLS_ZERO_RTT */
 
-#else 
+#else
     size_t pmslen;                      /*!<  premaster length        */
 
     unsigned char premaster[MBEDTLS_PREMASTER_SIZE];
     /*!<  premaster secret        */
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3 */
 
-    
+
     int resume;                         /*!<  session resume indicator*/
     int max_major_ver;                  /*!< max. major version client*/
     int max_minor_ver;                  /*!< max. minor version client*/
@@ -1098,7 +1098,7 @@ void mbedtls_ssl_handshake_wrapup(mbedtls_ssl_context* ssl);
 
 int mbedtls_ssl_send_fatal_handshake_failure(mbedtls_ssl_context* ssl);
 
-#else 
+#else
 int mbedtls_ssl_read_record( mbedtls_ssl_context *ssl,
                              unsigned update_hs_digest );
 int mbedtls_ssl_fetch_input( mbedtls_ssl_context *ssl, size_t nb_want );
@@ -1112,7 +1112,7 @@ int mbedtls_ssl_flush_output( mbedtls_ssl_context *ssl );
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3)
 int ssl_read_certificate_process(mbedtls_ssl_context* ssl);
 int ssl_write_certificate_process(mbedtls_ssl_context* ssl);
-#else 
+#else
 int mbedtls_ssl_parse_certificate( mbedtls_ssl_context *ssl );
 int mbedtls_ssl_write_certificate( mbedtls_ssl_context *ssl );
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3 */
@@ -1123,7 +1123,7 @@ int mbedtls_ssl_write_change_cipher_spec( mbedtls_ssl_context *ssl );
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3)
 int ssl_finished_in_process(mbedtls_ssl_context* ssl);
 int ssl_finished_out_process(mbedtls_ssl_context* ssl);
-#else 
+#else
 int mbedtls_ssl_parse_finished( mbedtls_ssl_context *ssl );
 int mbedtls_ssl_write_finished( mbedtls_ssl_context *ssl );
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3 */
@@ -1185,7 +1185,7 @@ int ssl_parse_client_psk_identity_ext(mbedtls_ssl_context* ssl, const unsigned c
 #endif /* MBEDTLS_KEY_EXCHANGE__SOME__PSK_ENABLED */
 
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
-#define MBEDTLS_SSL_ACK_RECORDS_SENT 0 
+#define MBEDTLS_SSL_ACK_RECORDS_SENT 0
 #define MBEDTLS_SSL_ACK_RECORDS_RECEIVED 1
 int mbedtls_ssl_parse_ack(mbedtls_ssl_context* ssl);
 int mbedtls_ssl_write_ack(mbedtls_ssl_context* ssl);
@@ -1277,7 +1277,7 @@ void mbedtls_ssl_read_version( int *major, int *minor, int transport,
                        const unsigned char ver[2] );
 
 
-#if defined(MBEDTLS_SSL_PROTO_TLS1_3) 
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3)
 static inline size_t mbedtls_ssl_hdr_len(const mbedtls_ssl_context* ssl, const int direction, mbedtls_ssl_transform* transform)
 {
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
@@ -1300,7 +1300,7 @@ static inline size_t mbedtls_ssl_hdr_len(const mbedtls_ssl_context* ssl, const i
             len += ssl->out_cid_len;
         else
             len += ssl->in_cid_len;
-#endif /* MBEDTLS_CID */			
+#endif /* MBEDTLS_CID */
         return (len);
     }
     else
@@ -1312,7 +1312,7 @@ static inline size_t mbedtls_ssl_hdr_len(const mbedtls_ssl_context* ssl, const i
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
     return(5); /* TLS 1.3 header */
 }
-#else 
+#else
 static inline size_t mbedtls_ssl_hdr_len(const mbedtls_ssl_context* ssl)
 {
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
@@ -1497,4 +1497,3 @@ void mbedtls_ssl_flight_free( mbedtls_ssl_flight_item *flight );
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
 
 #endif /* ssl_internal.h */
- 

--- a/library/ssl_ciphersuites.c
+++ b/library/ssl_ciphersuites.c
@@ -333,7 +333,7 @@ static const mbedtls_ssl_ciphersuite_t ciphersuite_definitions[] =
     MBEDTLS_CIPHER_AES_256_GCM, MBEDTLS_MD_SHA384,
     MBEDTLS_KEY_EXCHANGE_NONE, // field not used in TLS 1.3 implementation
     MBEDTLS_SSL_MAJOR_VERSION_3, MBEDTLS_SSL_MINOR_VERSION_4,
-    MBEDTLS_SSL_MAJOR_VERSION_3, MBEDTLS_SSL_MINOR_VERSION_4, 
+    MBEDTLS_SSL_MAJOR_VERSION_3, MBEDTLS_SSL_MINOR_VERSION_4,
     0 // field not used in TLS 1.3 implementation
     },
 #endif /* MBEDTLS_SHA512_C */
@@ -342,7 +342,7 @@ static const mbedtls_ssl_ciphersuite_t ciphersuite_definitions[] =
     MBEDTLS_CIPHER_AES_128_GCM, MBEDTLS_MD_SHA256,
     MBEDTLS_KEY_EXCHANGE_NONE, // field not used in TLS 1.3 implementation
     MBEDTLS_SSL_MAJOR_VERSION_3, MBEDTLS_SSL_MINOR_VERSION_4,
-    MBEDTLS_SSL_MAJOR_VERSION_3, MBEDTLS_SSL_MINOR_VERSION_4, 
+    MBEDTLS_SSL_MAJOR_VERSION_3, MBEDTLS_SSL_MINOR_VERSION_4,
     0 // field not used in TLS 1.3 implementation
     },
 #endif /* MBEDTLS_SHA256_C */
@@ -354,7 +354,7 @@ static const mbedtls_ssl_ciphersuite_t ciphersuite_definitions[] =
     MBEDTLS_CIPHER_AES_128_CCM, MBEDTLS_MD_SHA256,
     MBEDTLS_KEY_EXCHANGE_NONE, // field not used in TLS 1.3 implementation
     MBEDTLS_SSL_MAJOR_VERSION_3, MBEDTLS_SSL_MINOR_VERSION_4,
-    MBEDTLS_SSL_MAJOR_VERSION_3, MBEDTLS_SSL_MINOR_VERSION_4, 
+    MBEDTLS_SSL_MAJOR_VERSION_3, MBEDTLS_SSL_MINOR_VERSION_4,
     0 // field not used in TLS 1.3 implementation
     },
 
@@ -362,7 +362,7 @@ static const mbedtls_ssl_ciphersuite_t ciphersuite_definitions[] =
     MBEDTLS_CIPHER_AES_128_CCM_8, MBEDTLS_MD_SHA256,
     MBEDTLS_KEY_EXCHANGE_NONE, // field not used in TLS 1.3 implementation
     MBEDTLS_SSL_MAJOR_VERSION_3, MBEDTLS_SSL_MINOR_VERSION_4,
-    MBEDTLS_SSL_MAJOR_VERSION_3, MBEDTLS_SSL_MINOR_VERSION_4, 
+    MBEDTLS_SSL_MAJOR_VERSION_3, MBEDTLS_SSL_MINOR_VERSION_4,
     0 // field not used in TLS 1.3 implementation
     },
 #endif /* MBEDTLS_SHA256_C */

--- a/library/ssl_ciphersuites.c
+++ b/library/ssl_ciphersuites.c
@@ -2348,7 +2348,7 @@ int mbedtls_ssl_get_ciphersuite_id( const char *ciphersuite_name )
 }
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3)
-int mbedtls_hash_size_for_ciphersuite(const mbedtls_ssl_ciphersuite_t* ciphersuite)
+unsigned int mbedtls_hash_size_for_ciphersuite(const mbedtls_ssl_ciphersuite_t* ciphersuite)
 {
     // We assume that the input parameter, ciphersuite, is not NULL
     switch (ciphersuite->mac)
@@ -2357,7 +2357,7 @@ int mbedtls_hash_size_for_ciphersuite(const mbedtls_ssl_ciphersuite_t* ciphersui
     case MBEDTLS_MD_SHA384: return 48;
     case MBEDTLS_MD_SHA512: return 64;
     default:
-        return -1;
+        return( 0 );
     }
 }
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3 */

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -1996,7 +1996,7 @@ int mbedtls_ssl_psk_derive_premaster(mbedtls_ssl_context* ssl, mbedtls_key_excha
 }
 #endif /* MBEDTLS_KEY_EXCHANGE__SOME__PSK_ENABLED */
 
-#else 
+#else
 
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3 */
 
@@ -2952,7 +2952,7 @@ static void ssl_update_checksum_start(mbedtls_ssl_context* ssl,
 #if defined(MBEDTLS_SSL_DEBUG_HANDSHAKE_HASHES)
     mbedtls_sha256_context sha256_debug;
 #endif // MBEDTLS_SSL_DEBUG_HANDSHAKE_HASHES
-#endif // MBEDTLS_SHA256_C 
+#endif // MBEDTLS_SHA256_C
 
 #if defined(MBEDTLS_SHA512_C)
 #if defined(MBEDTLS_SSL_DEBUG_HANDSHAKE_HASHES)
@@ -2980,14 +2980,14 @@ static void ssl_update_checksum_start(mbedtls_ssl_context* ssl,
             MBEDTLS_SSL_DEBUG_BUF(4, "Input to handshake hash", buf, len);
             MBEDTLS_SSL_DEBUG_BUF(4, "Transcript state (after)", (unsigned char*)
                 ssl->handshake->fin_sha256.state, 32);
-#if defined(MBEDTLS_SSL_DEBUG_HANDSHAKE_HASHES) 
+#if defined(MBEDTLS_SSL_DEBUG_HANDSHAKE_HASHES)
             mbedtls_sha256_init(&sha256_debug);
             mbedtls_sha256_clone(&sha256_debug, &ssl->handshake->fin_sha256);
             mbedtls_sha256_finish(&sha256_debug, padbuf);
             MBEDTLS_SSL_DEBUG_BUF(4, "Handshake hash", (unsigned char*)
                 padbuf, 32);
 #endif // MBEDTLS_SSL_DEBUG_HANDSHAKE_HASHES
-#else 
+#else
             MBEDTLS_SSL_DEBUG_MSG(1, ("ssl_update_checksum_start: Unknow hash function."));
             return;
 #endif /* MBEDTLS_SHA256_C */
@@ -3001,7 +3001,7 @@ static void ssl_update_checksum_start(mbedtls_ssl_context* ssl,
             MBEDTLS_SSL_DEBUG_BUF(4, "Transcript state (after)", (unsigned char*)
                 ssl->handshake->fin_sha512.state, 48);
 
-#if defined(MBEDTLS_SSL_DEBUG_HANDSHAKE_HASHES) 
+#if defined(MBEDTLS_SSL_DEBUG_HANDSHAKE_HASHES)
             mbedtls_sha512_init(&sha512_debug);
             mbedtls_sha512_starts(&sha512_debug, 1 /* = use SHA384 */);
             mbedtls_sha512_clone(&sha512_debug, &ssl->handshake->fin_sha512);
@@ -3009,7 +3009,7 @@ static void ssl_update_checksum_start(mbedtls_ssl_context* ssl,
             MBEDTLS_SSL_DEBUG_BUF(4, "Handshake hash", (unsigned char*)
                 padbuf, 48);
 #endif // MBEDTLS_SSL_DEBUG_HANDSHAKE_HASHES
-#else 
+#else
             MBEDTLS_SSL_DEBUG_MSG(1, ("ssl_update_checksum_start: Unknow hash function."));
             return;
 #endif /* MBEDTLS_SHA512_C */
@@ -3029,7 +3029,7 @@ static void ssl_update_checksum_start(mbedtls_ssl_context* ssl,
         MBEDTLS_SSL_DEBUG_BUF(4, "Transcript state (after)", (unsigned char*)
             ssl->handshake->fin_sha256.state, 32);
 
-#if defined(MBEDTLS_SSL_DEBUG_HANDSHAKE_HASHES) 
+#if defined(MBEDTLS_SSL_DEBUG_HANDSHAKE_HASHES)
         mbedtls_sha256_init(&sha256_debug);
         mbedtls_sha256_clone(&sha256_debug, &ssl->handshake->fin_sha256);
         mbedtls_sha256_finish(&sha256_debug, padbuf);
@@ -3046,7 +3046,7 @@ static void ssl_update_checksum_start(mbedtls_ssl_context* ssl,
         MBEDTLS_SSL_DEBUG_BUF(4, "Transcript state (after)", (unsigned char*)
             ssl->handshake->fin_sha512.state, 48);
 
-#if defined(MBEDTLS_SSL_DEBUG_HANDSHAKE_HASHES) 
+#if defined(MBEDTLS_SSL_DEBUG_HANDSHAKE_HASHES)
         mbedtls_sha512_init(&sha512_debug);
         mbedtls_sha512_starts(&sha512_debug, 1 /* = use SHA384 */);
         mbedtls_sha512_clone(&sha512_debug, &ssl->handshake->fin_sha512);
@@ -3143,7 +3143,7 @@ static void ssl_update_checksum_sha384(mbedtls_ssl_context* ssl,
 }
 #endif
 #endif /* MBEDTLS_SSL_PROTO_TLS1_2 */
-#endif 
+#endif
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3)
 
@@ -3843,7 +3843,7 @@ static void ssl_handshake_params_init(mbedtls_ssl_handshake_params* handshake)
 
 #if !defined(MBEDTLS_SSL_PROTO_TLS1_3)
     mbedtls_ecdh_init(&handshake->ecdh_ctx);
-#else 
+#else
     for (int i = 0; i < MBEDTLS_SSL_MAX_KEY_SHARES; i++)
         mbedtls_ecdh_init(&handshake->ecdh_ctx[i]);
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3 */
@@ -4075,7 +4075,7 @@ int mbedtls_ssl_setup(mbedtls_ssl_context* ssl,
 
 #if !defined(MBEDTLS_SSL_PROTO_TLS1_3)
     mbedtls_ssl_reset_in_out_pointers(ssl);
-#else 
+#else
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
     if (conf->transport == MBEDTLS_SSL_TRANSPORT_DATAGRAM)
     {
@@ -4191,7 +4191,7 @@ int mbedtls_ssl_session_reset_int(mbedtls_ssl_context* ssl, int partial)
 
 #if !defined(MBEDTLS_SSL_PROTO_TLS1_3)
     mbedtls_ssl_reset_in_out_pointers(ssl);
-#else 
+#else
     ssl->out_msg = ssl->out_buf + 13;
     ssl->in_msg = ssl->in_buf + 13;
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3 */
@@ -4863,8 +4863,8 @@ void mbedtls_ssl_conf_sig_hashes(mbedtls_ssl_config* conf,
 {
 #if !defined(MBEDTLS_SSL_PROTO_TLS1_3)
     conf->sig_hashes = hashes;
-#else 
-    conf->signature_schemes = hashes; 
+#else
+    conf->signature_schemes = hashes;
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3 */
 
 }
@@ -5105,7 +5105,7 @@ void mbedtls_ssl_conf_session_tickets_cb(mbedtls_ssl_config* conf,
     conf->f_ticket_parse = f_ticket_parse;
     conf->p_ticket = p_ticket;
 }
-#else 
+#else
 void mbedtls_ssl_conf_session_tickets_cb(mbedtls_ssl_config* conf,
     mbedtls_ssl_ticket_write_t* f_ticket_write,
     mbedtls_ssl_ticket_parse_t* f_ticket_parse,
@@ -6202,7 +6202,7 @@ void mbedtls_ssl_handshake_free(mbedtls_ssl_context* ssl)
 
 #if !defined(MBEDTLS_SSL_PROTO_TLS1_3)
     mbedtls_ecdh_free(&handshake->ecdh_ctx);
-#else 
+#else
     for (int i = 0; i < MBEDTLS_SSL_MAX_KEY_SHARES; i++)
         mbedtls_ecdh_free(&handshake->ecdh_ctx[i]);
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3 */
@@ -7118,7 +7118,7 @@ static int ssl_preset_suiteb_ciphersuites[] = {
     MBEDTLS_TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
     0
 };
-#else 
+#else
 static int ssl_preset_suiteb_ciphersuites[] = {
     TLS_AES_128_GCM_SHA256,
     TLS_AES_256_GCM_SHA384,
@@ -7136,7 +7136,7 @@ static int ssl_preset_suiteb_hashes[] = {
 #endif
 
 
-#if defined(MBEDTLS_KEY_EXCHANGE__WITH_CERT__ENABLED) && defined(MBEDTLS_SSL_PROTO_TLS1_3) 
+#if defined(MBEDTLS_KEY_EXCHANGE__WITH_CERT__ENABLED) && defined(MBEDTLS_SSL_PROTO_TLS1_3)
 static int ssl_preset_signature_schemes[] = {
 #if defined(MBEDTLS_ECDSA_SECP256r1_SHA256)
     SIGNATURE_ECDSA_SECP256r1_SHA256,
@@ -7279,7 +7279,7 @@ int mbedtls_ssl_config_defaults(mbedtls_ssl_config* conf,
 #if defined(MBEDTLS_KEY_EXCHANGE__WITH_CERT__ENABLED)
 #if !defined(MBEDTLS_SSL_PROTO_TLS1_3)
         conf->sig_hashes = ssl_preset_suiteb_hashes;
-#else 
+#else
         conf->signature_schemes = ssl_preset_suiteb_hashes;
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3 */
 #endif
@@ -7315,7 +7315,7 @@ int mbedtls_ssl_config_defaults(mbedtls_ssl_config* conf,
 #if !defined(MBEDTLS_SSL_PROTO_TLS1_3)
         if (transport == MBEDTLS_SSL_TRANSPORT_DATAGRAM)
             conf->min_minor_ver = MBEDTLS_SSL_MINOR_VERSION_2;
-#else 
+#else
         conf->min_minor_ver = MBEDTLS_SSL_MINOR_VERSION_3;
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3 */
 #endif
@@ -7336,7 +7336,7 @@ int mbedtls_ssl_config_defaults(mbedtls_ssl_config* conf,
 #if defined(MBEDTLS_KEY_EXCHANGE__WITH_CERT__ENABLED)
 #if !defined(MBEDTLS_SSL_PROTO_TLS1_3)
         conf->sig_hashes = ssl_preset_default_hashes;
-#else 
+#else
         conf->signature_schemes = ssl_preset_default_hashes;
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3 */
 
@@ -7590,7 +7590,7 @@ int mbedtls_ssl_check_sig_hash(const mbedtls_ssl_context* ssl,
     for (cur = ssl->conf->sig_hashes; *cur != MBEDTLS_MD_NONE; cur++)
         if (*cur == (int)md)
             return(0);
-#else 
+#else
     if (ssl->conf->signature_schemes == NULL)
         return(-1);
 
@@ -7677,7 +7677,7 @@ int mbedtls_ssl_check_cert_usage(const mbedtls_x509_crt* cert,
         /* Server part of the key exchange */
 #if !defined(MBEDTLS_SSL_PROTO_TLS1_3)
         switch (ciphersuite->key_exchange)
-#else 
+#else
         switch (key_exchange)
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3 */
         {

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -722,14 +722,10 @@ static void ssl_calc_finished_tls_sha384(mbedtls_ssl_context*, unsigned char*, i
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3)
 #if defined(MBEDTLS_SHA256_C)
 static void ssl_update_checksum_sha256(mbedtls_ssl_context*, const unsigned char*, size_t);
-static void ssl_calc_verify_tls_sha256(const mbedtls_ssl_context*, unsigned char*, size_t*);
-static void ssl_calc_finished_tls_sha256(mbedtls_ssl_context*, unsigned char*, int);
 #endif
 
 #if defined(MBEDTLS_SHA512_C)
 static void ssl_update_checksum_sha384(mbedtls_ssl_context*, const unsigned char*, size_t);
-static void ssl_calc_verify_tls_sha384(const mbedtls_ssl_context*, unsigned char*, size_t*);
-static void ssl_calc_finished_tls_sha384(mbedtls_ssl_context*, unsigned char*, int);
 #endif
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3 */
 
@@ -7629,6 +7625,8 @@ int mbedtls_ssl_check_signature_scheme(const mbedtls_ssl_context* ssl,
 void mbedtls_ssl_write_version(int major, int minor, int transport,
     unsigned char ver[2])
 {
+    ((void) transport);
+
     ver[0] = (unsigned char)major;
     ver[1] = (unsigned char)minor;
 
@@ -7637,6 +7635,8 @@ void mbedtls_ssl_write_version(int major, int minor, int transport,
 void mbedtls_ssl_read_version(int* major, int* minor, int transport,
     const unsigned char ver[2])
 {
+    ((void) transport);
+
     *major = ver[0];
     *minor = ver[1];
 }

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -3990,7 +3990,7 @@ static int ssl_handshake_init(mbedtls_ssl_context* ssl)
     return(0);
 }
 
-#if (defined(MBEDTLS_SSL_DTLS_HELLO_VERIFY) || defined(MBEDTLS_SSL_COOKIE_C)) && defined(MBEDTLS_SSL_SRV_C)
+#if defined(MBEDTLS_SSL_DTLS_HELLO_VERIFY) && defined(MBEDTLS_SSL_SRV_C)
 /* Dummy cookie callbacks for defaults */
 static int ssl_cookie_write_dummy(void* ctx,
     unsigned char** p, unsigned char* end,

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -2044,8 +2044,6 @@ cleanup:
 static int ssl_certificate_request_coordinate(mbedtls_ssl_context* ssl)
 {
 	int ret;
-	const mbedtls_ssl_ciphersuite_t* info =
-		ssl->transform_negotiate->ciphersuite_info;
 
 	if (ssl->session_negotiate->key_exchange == MBEDTLS_KEY_EXCHANGE_PSK ||
 		ssl->session_negotiate->key_exchange == MBEDTLS_KEY_EXCHANGE_ECDHE_PSK)

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -1865,9 +1865,11 @@ static int ssl_parse_key_shares_ext(mbedtls_ssl_context *ssl,
 	 * those sent out.
 	 */
 
-	for (i = 0; gid = ssl->handshake->key_shares_curve_list[i]; i++) {
+	for( i=0;
+             ssl->handshake->key_shares_curve_list[i] != MBEDTLS_ECP_DP_NONE;
+             i++ ) {
 
-		if (gid == MBEDTLS_ECP_DP_NONE) break;
+                gid = ssl->handshake->key_shares_curve_list[i];
 
 		curve_info = mbedtls_ecp_curve_info_from_grp_id(gid);
 

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -184,9 +184,9 @@ static void ssl_write_hostname_ext(mbedtls_ssl_context *ssl,
 #endif /* MBEDTLS_SSL_SERVER_NAME_INDICATION */
 
 
-/* 
- * ssl_write_supported_versions_ext(): 
- * 
+/*
+ * ssl_write_supported_versions_ext():
+ *
  * struct {
  *      ProtocolVersion versions<2..254>;
  * } SupportedVersions;
@@ -212,15 +212,15 @@ static void ssl_write_supported_versions_ext(mbedtls_ssl_context *ssl,
 	*p++ = (unsigned char)((MBEDTLS_TLS_EXT_SUPPORTED_VERSIONS >> 8) & 0xFF);
 	*p++ = (unsigned char)((MBEDTLS_TLS_EXT_SUPPORTED_VERSIONS) & 0xFF);
 
-	// total length 
-	*p++ = 0x00; 
-	*p++ = 3; 
+	// total length
+	*p++ = 0x00;
+	*p++ = 3;
 
 	// length of next field
 	*p++ = 0x2;
 
-	/* This implementation only supports a single TLS version, and only 
-	 * advertises a single value. 
+	/* This implementation only supports a single TLS version, and only
+	 * advertises a single value.
 	 */
 	mbedtls_ssl_write_version(ssl->conf->max_major_ver, ssl->conf->max_minor_ver,
 		ssl->conf->transport, p);
@@ -232,8 +232,8 @@ static void ssl_write_supported_versions_ext(mbedtls_ssl_context *ssl,
 
 #if defined(MBEDTLS_SSL_MAX_FRAGMENT_LENGTH)
 
-/* 
- * ssl_write_max_fragment_length_ext(): 
+/*
+ * ssl_write_max_fragment_length_ext():
  *
  * enum{
  *    2^9(1), 2^10(2), 2^11(3), 2^12(4), (255)
@@ -278,9 +278,9 @@ static int ssl_write_max_fragment_length_ext(mbedtls_ssl_context *ssl,
 
 
 #if defined(MBEDTLS_SSL_ALPN)
-/* 
- * ssl_write_alpn_ext() structure: 
- * 
+/*
+ * ssl_write_alpn_ext() structure:
+ *
  * opaque ProtocolName<1..2^8-1>;
  *
  * struct {
@@ -289,8 +289,8 @@ static int ssl_write_max_fragment_length_ext(mbedtls_ssl_context *ssl,
  *
  */
 static int ssl_write_alpn_ext(mbedtls_ssl_context *ssl,
-	unsigned char *buf, 
-	size_t buflen, 
+	unsigned char *buf,
+	size_t buflen,
 	size_t *olen)
 {
 	unsigned char *p = buf;
@@ -351,17 +351,17 @@ static int ssl_write_alpn_ext(mbedtls_ssl_context *ssl,
 }
 #endif /* MBEDTLS_SSL_ALPN */
 
-#if defined(MBEDTLS_KEY_EXCHANGE__SOME__PSK_ENABLED) 
+#if defined(MBEDTLS_KEY_EXCHANGE__SOME__PSK_ENABLED)
 
-/* 
- * ssl_write_psk_key_exchange_modes_ext() structure: 
- * 
+/*
+ * ssl_write_psk_key_exchange_modes_ext() structure:
+ *
  * enum { psk_ke(0), psk_dhe_ke(1), (255) } PskKeyExchangeMode;
  *
  * struct {
  *     PskKeyExchangeMode ke_modes<1..255>;
  * } PskKeyExchangeModes;
- */ 
+ */
 
 static int ssl_write_psk_key_exchange_modes_ext(mbedtls_ssl_context *ssl,
 	unsigned char* buf,
@@ -371,7 +371,7 @@ static int ssl_write_psk_key_exchange_modes_ext(mbedtls_ssl_context *ssl,
 	unsigned char *p = (unsigned char *) buf;
 	*olen = 0;
 
-	// Check whether we have any PSK credentials configured. 
+	// Check whether we have any PSK credentials configured.
 	//if (ssl->conf->psk == NULL || ssl->conf->psk_identity == NULL ||
 	//	ssl->conf->psk_identity_len == 0 || ssl->conf->psk_len == 0)
 	//{
@@ -379,7 +379,7 @@ static int ssl_write_psk_key_exchange_modes_ext(mbedtls_ssl_context *ssl,
 	//	return(MBEDTLS_ERR_SSL_PRIVATE_KEY_REQUIRED);
 	//}
 
-	// max length of this extension is 7 bytes 
+	// max length of this extension is 7 bytes
 	if ((size_t)(end - p) < (7))
 	{
 		MBEDTLS_SSL_DEBUG_MSG(1, ("Not enough buffer"));
@@ -392,18 +392,18 @@ static int ssl_write_psk_key_exchange_modes_ext(mbedtls_ssl_context *ssl,
 	*p++ = (unsigned char)((MBEDTLS_TLS_EXT_PSK_KEY_EXCHANGE_MODES >> 8) & 0xFF);
 	*p++ = (unsigned char)((MBEDTLS_TLS_EXT_PSK_KEY_EXCHANGE_MODES) & 0xFF);
 
-	if (ssl->conf->key_exchange_modes == KEY_EXCHANGE_MODE_PSK_ALL || 
+	if (ssl->conf->key_exchange_modes == KEY_EXCHANGE_MODE_PSK_ALL ||
 		ssl->conf->key_exchange_modes == KEY_EXCHANGE_MODE_ALL ) {
-	
+
 		// Extension Length
 		*p++ = 0;
-		*p++ = 3; 
+		*p++ = 3;
 
 		// 1 byte length field for array of PskKeyExchangeMode
 		*p++ = 2;
 		*p++ = KEY_EXCHANGE_MODE_PSK_KE;
 		*p++ = KEY_EXCHANGE_MODE_PSK_DHE_KE;
-		*olen = 7; 
+		*olen = 7;
 
 		MBEDTLS_SSL_DEBUG_MSG(5, ("Adding %d and %d psk_key_exchange_modes", KEY_EXCHANGE_MODE_PSK_KE, KEY_EXCHANGE_MODE_PSK_DHE_KE));
 	}
@@ -419,7 +419,7 @@ static int ssl_write_psk_key_exchange_modes_ext(mbedtls_ssl_context *ssl,
 
 		MBEDTLS_SSL_DEBUG_MSG(5, ("Adding %d psk_key_exchange_mode", ssl->conf->key_exchange_modes));
 	}
-	
+
 	return (0);
 }
 #endif /* MBEDTLS_KEY_EXCHANGE__SOME__PSK_ENABLED */
@@ -536,20 +536,20 @@ int ssl_create_binder(mbedtls_ssl_context *ssl, unsigned char *psk, size_t psk_l
 	*/
 
 	if (suite_info->mac == MBEDTLS_MD_SHA256) {
-#if defined(MBEDTLS_SHA256_C) 
+#if defined(MBEDTLS_SHA256_C)
 		mbedtls_sha256((const unsigned char *)"", 0, hash, 0);
-#else 
+#else
 		MBEDTLS_SSL_DEBUG_MSG(1, ("mbedtls_ssl_derive_master_secret: Unknow hash function."));
 		return(MBEDTLS_ERR_SSL_INTERNAL_ERROR);
-#endif 
+#endif
 	}
 	else if (suite_info->mac == MBEDTLS_MD_SHA384) {
 #if defined(MBEDTLS_SHA512_C)
 		mbedtls_sha512( (const unsigned char *)"", 0, hash, 1 /* for SHA384 */);
-#else 
+#else
 		MBEDTLS_SSL_DEBUG_MSG(1, ("mbedtls_ssl_derive_master_secret: Unknow hash function."));
 		return(MBEDTLS_ERR_SSL_INTERNAL_ERROR);
-#endif 
+#endif
 	}
 
 	if (ssl->conf->resumption_mode == 1) {
@@ -574,7 +574,7 @@ int ssl_create_binder(mbedtls_ssl_context *ssl, unsigned char *psk, size_t psk_l
 	}
 
 	if (suite_info->mac == MBEDTLS_MD_SHA256) {
-#if defined(MBEDTLS_SHA256_C) 
+#if defined(MBEDTLS_SHA256_C)
 
 		mbedtls_sha256_init(&sha256);
 		mbedtls_sha256_starts(&sha256, 0 /* = use SHA256 */);
@@ -585,10 +585,10 @@ int ssl_create_binder(mbedtls_ssl_context *ssl, unsigned char *psk, size_t psk_l
 		MBEDTLS_SSL_DEBUG_BUF(5, "input buffer for psk binder", buffer, blen);
 		mbedtls_sha256_finish(&sha256, padbuf);
 		MBEDTLS_SSL_DEBUG_BUF(5, "handshake hash for psk binder", padbuf, 32);
-#else 
+#else
 		MBEDTLS_SSL_DEBUG_MSG(1, ("mbedtls_ssl_derive_master_secret: Unknow hash function."));
 		return(MBEDTLS_ERR_SSL_INTERNAL_ERROR);
-#endif 
+#endif
 	}
 	else if (suite_info->mac == MBEDTLS_MD_SHA384) {
 #if defined(MBEDTLS_SHA512_C)
@@ -610,10 +610,10 @@ int ssl_create_binder(mbedtls_ssl_context *ssl, unsigned char *psk, size_t psk_l
 		MBEDTLS_SSL_DEBUG_BUF(5, "handshake hash for psk binder", padbuf, 64);
 	}
 	else {
-#else 
+#else
 		MBEDTLS_SSL_DEBUG_MSG(1, ("mbedtls_ssl_derive_master_secret: Unknow hash function."));
 		return(MBEDTLS_ERR_SSL_INTERNAL_ERROR);
-#endif 
+#endif
 	}
 
 	/*
@@ -657,7 +657,7 @@ int ssl_create_binder(mbedtls_ssl_context *ssl, unsigned char *psk, size_t psk_l
 			mbedtls_sha512_free(&sha512);
 		}
 		else
-#endif 
+#endif
 		{
 			MBEDTLS_SSL_DEBUG_MSG(1, ("mbedtls_ssl_derive_master_secret: Unknow hash function."));
 			return(MBEDTLS_ERR_SSL_INTERNAL_ERROR);
@@ -689,12 +689,12 @@ int ssl_write_pre_shared_key_ext(mbedtls_ssl_context *ssl,
 		return(MBEDTLS_ERR_SSL_BAD_HS_CLIENT_HELLO);
 	}
 
-	// Check whether we have any PSK credentials configured.                          
+	// Check whether we have any PSK credentials configured.
 	if (ssl->conf->psk == NULL || ssl->conf->psk_identity == NULL ||
 		ssl->conf->psk_identity_len == 0 || ssl->conf->psk_len == 0)
 	{
 		MBEDTLS_SSL_DEBUG_MSG(3, ("No externally configured PSK available."));
-		
+
 		return(0);
 	}
 
@@ -730,7 +730,7 @@ int ssl_write_pre_shared_key_ext(mbedtls_ssl_context *ssl,
 		if (ssl->handshake->early_data == MBEDTLS_SSL_EARLY_DATA_ON) {
 			ssl->session_negotiate->key_exchange = KEY_EXCHANGE_MODE_PSK_KE;
 		}
-#endif 
+#endif
 		break;
 	}
 	if (hash_len == -1)
@@ -739,7 +739,7 @@ int ssl_write_pre_shared_key_ext(mbedtls_ssl_context *ssl,
 		return(MBEDTLS_ERR_SSL_BAD_HS_CLIENT_HELLO);
 	}
 
-	/* 
+	/*
 	* The length (excluding the extension header) includes:
 	*
 	*  - 2 bytes for total length of identities
@@ -756,7 +756,7 @@ int ssl_write_pre_shared_key_ext(mbedtls_ssl_context *ssl,
 	*/
 	ext_length = 2 + 2 + ssl->conf->psk_identity_len + 4 + 2 + 1 + hash_len;
 
-	// ext_length + Extension Type (2 bytes) + Extension Length (2 bytes) 
+	// ext_length + Extension Type (2 bytes) + Extension Length (2 bytes)
 	if (end < p || (size_t)(end - p) < (ext_length + 4))
 	{
 		MBEDTLS_SSL_DEBUG_MSG(1, ("buffer too short"));
@@ -775,7 +775,7 @@ int ssl_write_pre_shared_key_ext(mbedtls_ssl_context *ssl,
 		*p++ = (unsigned char)((ext_length >> 8) & 0xFF);
 		*p++ = (unsigned char)(ext_length & 0xFF);
 
-		// 2 bytes length field for array of PskIdentity 
+		// 2 bytes length field for array of PskIdentity
 		*p++ = (unsigned char)(((ssl->conf->psk_identity_len + 4 + 2) >> 8) & 0xFF);
 		*p++ = (unsigned char)((ssl->conf->psk_identity_len + 4 + 2) & 0xFF);
 
@@ -796,7 +796,7 @@ int ssl_write_pre_shared_key_ext(mbedtls_ssl_context *ssl,
 
 			if (!(ssl->conf->ticket_received <= now && now - ssl->conf->ticket_received < 7 * 86400 * 1000)) {
 				MBEDTLS_SSL_DEBUG_MSG(3, ("ticket expired"));
-				// TBD: We would have to fall back to another PSK 
+				// TBD: We would have to fall back to another PSK
 				return(MBEDTLS_ERR_SSL_BAD_HS_CLIENT_HELLO);
 			}
 
@@ -855,14 +855,15 @@ static int ssl_write_cookie_ext(mbedtls_ssl_context *ssl,
 
 	if (ssl->handshake->verify_cookie == NULL) {
 		MBEDTLS_SSL_DEBUG_MSG(3, ("no cookie to send; skip extension"));
-		return 0; 
+		return 0;
 	}
 
 	MBEDTLS_SSL_DEBUG_BUF(3, "client hello, cookie",
 		ssl->handshake->verify_cookie,
 		ssl->handshake->verify_cookie_len);
 
-	if (end < p || (end - p) < (ssl->handshake->verify_cookie_len + 4))
+	if( end < p ||
+            (size_t)( end - p ) < ( ssl->handshake->verify_cookie_len + 4 ) )
 	{
 		MBEDTLS_SSL_DEBUG_MSG(1, ("buffer too small"));
 		return MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL;
@@ -880,7 +881,7 @@ static int ssl_write_cookie_ext(mbedtls_ssl_context *ssl,
 
 	// Copy Cookie
 	memcpy(p, ssl->handshake->verify_cookie, ssl->handshake->verify_cookie_len);
-	
+
 	*olen = ssl->handshake->verify_cookie_len + 4;
 
 	return 0;
@@ -1014,13 +1015,13 @@ struct {
 static int ssl_write_key_shares_ext(mbedtls_ssl_context *ssl,
 	unsigned char* buf,
 	unsigned char* end,
-	size_t* olen) 
+	size_t* olen)
 {
 	unsigned char* p;
 	unsigned char *header = buf; // Pointer where the header has to go.
 	size_t len;
 	int ret;
-	int nr; 
+	int nr;
 	//const int *ciphersuites;
 
 #if defined(MBEDTLS_CTLS)
@@ -1036,7 +1037,7 @@ static int ssl_write_key_shares_ext(mbedtls_ssl_context *ssl,
 
 	const mbedtls_ecp_curve_info *info = NULL;
 	const mbedtls_ecp_group_id *grp_id;
-	// int max_size = 0; 
+	// int max_size = 0;
 	//const mbedtls_ssl_ciphersuite_t *suite_info;
 
 	*olen = 0;
@@ -1074,16 +1075,16 @@ static int ssl_write_key_shares_ext(mbedtls_ssl_context *ssl,
 	MBEDTLS_SSL_DEBUG_MSG(3, ("Ciphersuites require a key length of max %d bits", max_size));
 	*/
 
-	/* The key_shares_curve_list provides us information about what we are expected to 
-	 * send, either based on the info provided by the app or by info offered by the server 
-	 * using the HRR. 
+	/* The key_shares_curve_list provides us information about what we are expected to
+	 * send, either based on the info provided by the app or by info offered by the server
+	 * using the HRR.
 	 */
-	nr = 0; 
+	nr = 0;
 
 	for (grp_id = ssl->handshake->key_shares_curve_list; *grp_id != MBEDTLS_ECP_DP_NONE; grp_id++) {
 
 		info = mbedtls_ecp_curve_info_from_grp_id(*grp_id);
-		
+
 		/* Check whether the key share matches the selected ciphersuite
 		* in terms of key length.
         *
@@ -1091,7 +1092,7 @@ static int ssl_write_key_shares_ext(mbedtls_ssl_context *ssl,
 		*
 		* TBD: Do we need this check?
 
-		switch (max_size) { 
+		switch (max_size) {
 			case 128: if (info->bit_size != 256 && info->bit_size!=192 && info->bit_size!= 224) continue;
 				break;
 			case 384: if (info->bit_size != 384) continue;
@@ -1104,7 +1105,7 @@ static int ssl_write_key_shares_ext(mbedtls_ssl_context *ssl,
 		if ((ret = mbedtls_ecp_group_load(&ssl->handshake->ecdh_ctx[nr].grp, info->grp_id)) != 0) {
 			MBEDTLS_SSL_DEBUG_RET(1, "mbedtls_ecp_group_load", ret);
 			return(ret);
-		} 
+		}
 
 		if ((ret = mbedtls_ecdh_make_params(&ssl->handshake->ecdh_ctx[nr], &len,
 			p+2, MBEDTLS_SSL_MAX_CONTENT_LEN - *olen,
@@ -1119,9 +1120,9 @@ static int ssl_write_key_shares_ext(mbedtls_ssl_context *ssl,
 		*p++ = (unsigned char)(((len)) & 0xFF);
 
 		p += len;
-		*olen += len + 2; 
+		*olen += len + 2;
 		MBEDTLS_SSL_DEBUG_ECP(3, "ECDHE: Q ", &ssl->handshake->ecdh_ctx[nr].Q);
-		
+
 		nr++;
 		if (nr == MBEDTLS_SSL_MAX_KEY_SHARES) {
 			MBEDTLS_SSL_DEBUG_MSG(4, ("Reached maximum number of KeyShareEntries: %d", nr));
@@ -1129,7 +1130,7 @@ static int ssl_write_key_shares_ext(mbedtls_ssl_context *ssl,
 		}
 	}
 
-	// Write extension header 
+	// Write extension header
 	*header++ = (unsigned char)((MBEDTLS_TLS_EXT_KEY_SHARES >> 8) & 0xFF);
 	*header++ = (unsigned char)((MBEDTLS_TLS_EXT_KEY_SHARES) & 0xFF);
 
@@ -1161,7 +1162,6 @@ static int ssl_client_hello_write(mbedtls_ssl_context* ssl,
 	unsigned char* buf,
 	size_t buflen,
 	size_t* olen);
-static int ssl_client_hello_postprocess(mbedtls_ssl_context* ssl);
 
 static int ssl_client_hello_process(mbedtls_ssl_context* ssl)
 {
@@ -1206,7 +1206,7 @@ static int ssl_client_hello_process(mbedtls_ssl_context* ssl)
 	 *       this function again on retry.
 	 *
 	 *       Further, once the two calls can be re-ordered, the two
-	 *       calls can be consolidated. 
+	 *       calls can be consolidated.
 	 */
 
 cleanup:
@@ -1218,7 +1218,7 @@ cleanup:
 static int ssl_client_hello_prepare(mbedtls_ssl_context* ssl)
 {
 	int ret;
-	size_t rand_bytes_len; 
+	size_t rand_bytes_len;
 
 	if (ssl->conf->f_rng == NULL)
 	{
@@ -1255,7 +1255,7 @@ static int ssl_client_hello_prepare(mbedtls_ssl_context* ssl)
 
 	ssl->session_negotiate->id_len = 32;
 #endif /* MBEDTLS_COMPATIBILITY_MODE */
-	
+
 	return(0);
 }
 
@@ -1283,7 +1283,7 @@ static int ssl_client_hello_write(mbedtls_ssl_context* ssl,
 	size_t rand_bytes_len;
 	size_t version_len;
 
-	// Buffer management 
+	// Buffer management
 	unsigned char* start = buf;
 	unsigned char* end = buf + buflen;
 
@@ -1317,7 +1317,7 @@ static int ssl_client_hello_write(mbedtls_ssl_context* ssl,
 	 * are elided. The random bytes are shorter.
 	 */
 #if defined(MBEDTLS_CTLS)
-	 // With cTLS the version field is elided. 
+	 // With cTLS the version field is elided.
 	if (ssl->handshake->ctls == MBEDTLS_CTLS_USE)
 	{
 		version_len = 0;
@@ -1366,7 +1366,7 @@ static int ssl_client_hello_write(mbedtls_ssl_context* ssl,
 			*buf++ = 0xfd; // 253
 		}
 		else
-#else 
+#else
 		{
 			*buf++ = 0x03;
 			*buf++ = 0x03;
@@ -1375,7 +1375,7 @@ static int ssl_client_hello_write(mbedtls_ssl_context* ssl,
 		buflen -= version_len;
 	}
 
-	// Write random bytes 
+	// Write random bytes
 	memcpy(buf, ssl->handshake->randbytes, rand_bytes_len);
 	MBEDTLS_SSL_DEBUG_BUF(3, "client hello, random bytes", buf, rand_bytes_len);
 
@@ -1410,8 +1410,8 @@ static int ssl_client_hello_write(mbedtls_ssl_context* ssl,
 
 	MBEDTLS_SSL_DEBUG_MSG(3, ("session id len.: %d", ssl->session_negotiate->id_len));
 	MBEDTLS_SSL_DEBUG_BUF(3, "session id", ssl->session_negotiate->id, ssl->session_negotiate->id_len);
-#else 
-#if defined(MBEDTLS_CTLS) 
+#else
+#if defined(MBEDTLS_CTLS)
 	 // For cTLS we are not using a session id
 	if (ssl->handshake->ctls == MBEDTLS_CTLS_DO_NOT_USE)
 #endif /* MBEDTLS_CTLS */
@@ -1452,10 +1452,10 @@ static int ssl_client_hello_write(mbedtls_ssl_context* ssl,
 
 	/*
 	* Ciphersuite list
-	* 
-	* This is a list of the symmetric cipher options supported by 
-	* the client, specifically the record protection algorithm 
-	* (including secret key length) and a hash to be used with 
+	*
+	* This is a list of the symmetric cipher options supported by
+	* the client, specifically the record protection algorithm
+	* (including secret key length) and a hash to be used with
 	* HKDF, in descending order of client preference.
 	*/
 	ciphersuites = ssl->conf->ciphersuite_list[ssl->minor_ver];
@@ -1500,8 +1500,8 @@ static int ssl_client_hello_write(mbedtls_ssl_context* ssl,
 		buflen -= 2;
 
 #if defined(MBEDTLS_ZERO_RTT)
-		// For ZeroRTT we only add a single ciphersuite. 
-		break; 
+		// For ZeroRTT we only add a single ciphersuite.
+		break;
 #endif /* MBEDTLS_ZERO_RTT */
 	}
 
@@ -1511,13 +1511,13 @@ static int ssl_client_hello_write(mbedtls_ssl_context* ssl,
 
 	MBEDTLS_SSL_DEBUG_MSG(3, ("client hello, got %d ciphersuites", ciphersuite_count));
 
-	/* For every TLS 1.3 ClientHello, this vector MUST contain exactly 
-	 * one byte set to zero, which corresponds to the 'null' compression 
+	/* For every TLS 1.3 ClientHello, this vector MUST contain exactly
+	 * one byte set to zero, which corresponds to the 'null' compression
 	 * method in prior versions of TLS.
-	 * 
-	 * For cTLS this field is elided. 
-     */ 
-#if defined(MBEDTLS_CTLS) 
+	 *
+	 * For cTLS this field is elided.
+     */
+#if defined(MBEDTLS_CTLS)
 	if (ssl->handshake->ctls == MBEDTLS_CTLS_DO_NOT_USE)
 #endif /* MBEDTLS_CTLS */
 	{
@@ -1536,14 +1536,14 @@ static int ssl_client_hello_write(mbedtls_ssl_context* ssl,
 	// First write extensions, then the total length
 	extension_start = buf;
 	total_ext_len = 0;
-	buf += 2; 
+	buf += 2;
 
 	/* Supported Versions Extension is mandatory with TLS 1.3.
-	 * 
+	 *
      * For cTLS we only need to provide it if there is more than one version
 	 * and currently there is only one.
      */
-#if defined(MBEDTLS_CTLS) 
+#if defined(MBEDTLS_CTLS)
 	if (ssl->handshake->ctls == MBEDTLS_CTLS_DO_NOT_USE)
 #endif /* MBEDTLS_CTLS */
 	{
@@ -1552,7 +1552,7 @@ static int ssl_client_hello_write(mbedtls_ssl_context* ssl,
 		buf += cur_ext_len;
 	}
 
-	/* For TLS / DTLS 1.3 we need to support the use of cookies 
+	/* For TLS / DTLS 1.3 we need to support the use of cookies
 	 * (if the server provided them) */
 	ssl_write_cookie_ext(ssl, buf, end, &cur_ext_len);
 	total_ext_len += cur_ext_len;
@@ -1576,7 +1576,7 @@ static int ssl_client_hello_write(mbedtls_ssl_context* ssl,
 	buf += cur_ext_len;
 #endif /* MBEDTLS_ZERO_RTT */
 
-#if defined(MBEDTLS_SSL_SERVER_NAME_INDICATION) 
+#if defined(MBEDTLS_SSL_SERVER_NAME_INDICATION)
 	// For PSK-based ciphersuites we don't really need the SNI extension
 	if (ssl->conf->key_exchange_modes == KEY_EXCHANGE_MODE_ECDHE_ECDSA ||
 		ssl->conf->key_exchange_modes == KEY_EXCHANGE_MODE_ALL) {
@@ -1590,7 +1590,7 @@ static int ssl_client_hello_write(mbedtls_ssl_context* ssl,
 	ssl_write_cid_ext(ssl, buf, end, &cur_ext_len);
 	total_ext_len += cur_ext_len;
 	buf += cur_ext_len;
-#endif 
+#endif
 
 #if defined(MBEDTLS_KEY_EXCHANGE__SOME__PSK_ENABLED)
 	/* For PSK-based ciphersuites we need the pre-shared-key extension
@@ -1618,7 +1618,7 @@ static int ssl_client_hello_write(mbedtls_ssl_context* ssl,
 	 */
     if (ssl->conf->key_exchange_modes == KEY_EXCHANGE_MODE_ECDHE_ECDSA ||
 		ssl->conf->key_exchange_modes == KEY_EXCHANGE_MODE_PSK_DHE_KE ||
-		ssl->conf->key_exchange_modes == KEY_EXCHANGE_MODE_PSK_ALL || 
+		ssl->conf->key_exchange_modes == KEY_EXCHANGE_MODE_PSK_ALL ||
 		ssl->conf->key_exchange_modes == KEY_EXCHANGE_MODE_ALL) {
 
 		ret = ssl_write_supported_groups_ext(ssl, buf, end, &cur_ext_len);
@@ -1632,7 +1632,7 @@ static int ssl_client_hello_write(mbedtls_ssl_context* ssl,
 	* certificate authenticated ciphersuites.
 	*/
 
-	if (ssl->conf->key_exchange_modes == KEY_EXCHANGE_MODE_ECDHE_ECDSA || 
+	if (ssl->conf->key_exchange_modes == KEY_EXCHANGE_MODE_ECDHE_ECDSA ||
 		ssl->conf->key_exchange_modes == KEY_EXCHANGE_MODE_ALL) {
 		ret = ssl_write_signature_algorithms_ext(ssl, buf, end, &cur_ext_len);
 		total_ext_len += cur_ext_len;
@@ -1647,7 +1647,7 @@ static int ssl_client_hello_write(mbedtls_ssl_context* ssl,
 	 *    psk_key_exchange_modes has been added as the last extension.
 	 * 3) Or, in case all ciphers are supported (which includes #1 and #2 from above)
 	 */
-	if (ssl->conf->key_exchange_modes == KEY_EXCHANGE_MODE_PSK_DHE_KE || 
+	if (ssl->conf->key_exchange_modes == KEY_EXCHANGE_MODE_PSK_DHE_KE ||
 		ssl->conf->key_exchange_modes == KEY_EXCHANGE_MODE_PSK_ALL ||
 		ssl->conf->key_exchange_modes == KEY_EXCHANGE_MODE_ALL) {
 		// We are using a PSK-based key exchange with DHE
@@ -1656,7 +1656,7 @@ static int ssl_client_hello_write(mbedtls_ssl_context* ssl,
 		buf += cur_ext_len;
 
 		if (ret == 0) ssl->handshake->extensions_present += KEY_SHARE_EXTENSION;
-	} 	
+	}
 	else if (ssl->handshake->extensions_present & SUPPORTED_GROUPS_EXTENSION && ssl->handshake->extensions_present & SIGNATURE_ALGORITHM_EXTENSION) {
 		// We are using a certificate-based key exchange
 		ret = ssl_write_key_shares_ext(ssl, buf, end, &cur_ext_len);
@@ -1674,8 +1674,8 @@ static int ssl_client_hello_write(mbedtls_ssl_context* ssl,
 		ssl->conf->key_exchange_modes == KEY_EXCHANGE_MODE_PSK_DHE_KE ||
 		ssl->conf->key_exchange_modes == KEY_EXCHANGE_MODE_ALL) {
 
-		/* We need to save the pointer to the pre-shared key extension  
-		 * because it has to be updated later. 
+		/* We need to save the pointer to the pre-shared key extension
+		 * because it has to be updated later.
 		 */
 		ssl->handshake->ptr_to_psk_ext = buf;
 		ret = ssl_write_pre_shared_key_ext(ssl, buf, end, &cur_ext_len,0 );
@@ -1683,16 +1683,16 @@ static int ssl_client_hello_write(mbedtls_ssl_context* ssl,
 		buf += cur_ext_len;
 
 		if (ret == 0) ssl->handshake->extensions_present += PRE_SHARED_KEY_EXTENSION;
-	} 
+	}
 #endif /* MBEDTLS_KEY_EXCHANGE__SOME__PSK_ENABLED */
-	
+
 
 	MBEDTLS_SSL_DEBUG_MSG(3, ("client hello, total extension length: %d",
 		total_ext_len));
 
 	MBEDTLS_SSL_DEBUG_BUF(3, "client hello extensions", extension_start, total_ext_len);
 
-	// Write extension length	
+	// Write extension length
 	*extension_start++ = (unsigned char)((total_ext_len >> 8) & 0xFF);
 	*extension_start++ = (unsigned char)((total_ext_len) & 0xFF);
 	buflen -= 2 + total_ext_len;
@@ -1701,17 +1701,12 @@ static int ssl_client_hello_write(mbedtls_ssl_context* ssl,
 	return(0);
 }
 
-static int ssl_client_hello_postprocess(mbedtls_ssl_context* ssl)
-{
-	return (0);
-}
-
 static int ssl_parse_supported_version_ext(mbedtls_ssl_context* ssl,
 	const unsigned char* buf,
 	size_t len)
 {
-	
-#if defined(MBEDTLS_SSL_PROTO_DTLS) 
+
+#if defined(MBEDTLS_SSL_PROTO_DTLS)
 	if (ssl->conf->transport == MBEDTLS_SSL_TRANSPORT_DATAGRAM) {
 		if (len != 2 && buf[0] != 254 && buf[1] != 253) {
 			MBEDTLS_SSL_DEBUG_MSG(1, ("unexpected version"));
@@ -1726,8 +1721,8 @@ static int ssl_parse_supported_version_ext(mbedtls_ssl_context* ssl,
 			return(MBEDTLS_ERR_SSL_BAD_HS_SERVER_HELLO);
 		}
 	}
-	
-	
+
+
 	return(0);
 }
 
@@ -1753,7 +1748,7 @@ static int ssl_parse_max_fragment_length_ext(mbedtls_ssl_context *ssl,
 #endif /* MBEDTLS_SSL_MAX_FRAGMENT_LENGTH */
 
 
-#if defined(MBEDTLS_KEY_EXCHANGE__SOME__PSK_ENABLED) 
+#if defined(MBEDTLS_KEY_EXCHANGE__SOME__PSK_ENABLED)
 
 /*
  * struct {
@@ -1829,11 +1824,11 @@ is correct and stores the provided key shares.
 
 */
 
-/* The ssl_parse_key_shares_ext() function is used 
-*  by the client to parse a KeyShare extension in 
-*  a ServerHello message. 
-* 
-*  The server only provides a single KeyShareEntry. 
+/* The ssl_parse_key_shares_ext() function is used
+*  by the client to parse a KeyShare extension in
+*  a ServerHello message.
+*
+*  The server only provides a single KeyShareEntry.
 */
 static int ssl_parse_key_shares_ext(mbedtls_ssl_context *ssl,
 	const unsigned char *buf,
@@ -1848,7 +1843,7 @@ static int ssl_parse_key_shares_ext(mbedtls_ssl_context *ssl,
 	int match_found = 0;
 	mbedtls_ecp_group_id gid;
 
-	// Is there a key share available at the server config? 
+	// Is there a key share available at the server config?
 	/* if (ssl->conf->keyshare_ctx == NULL)
 	{
 	MBEDTLS_SSL_DEBUG_MSG(1, ("got no key share context"));
@@ -1863,7 +1858,7 @@ static int ssl_parse_key_shares_ext(mbedtls_ssl_context *ssl,
 	// read named group
 	named_group = (buf[0] << 8) | buf[1];
 
-	/* We need to find out which key share the server had selected from 
+	/* We need to find out which key share the server had selected from
 	 * those sent out.
 	 */
 
@@ -1885,7 +1880,7 @@ static int ssl_parse_key_shares_ext(mbedtls_ssl_context *ssl,
 	}
 
 	if (match_found == 0)
-	{	
+	{
 		MBEDTLS_SSL_DEBUG_MSG(1, ("no matching curve for ECDHE"));
 		return MBEDTLS_ERR_SSL_BAD_HS_SERVER_HELLO;
 	}
@@ -1912,7 +1907,7 @@ static int ssl_parse_key_shares_ext(mbedtls_ssl_context *ssl,
 	return ret;
 }
 #endif /* MBEDTLS_ECDH_C || MBEDTLS_ECDSA_C */
- 
+
 
 #if defined(MBEDTLS_SSL_ALPN)
 static int ssl_parse_alpn_ext(mbedtls_ssl_context *ssl,
@@ -2297,7 +2292,7 @@ static int ssl_encrypted_extensions_process(mbedtls_ssl_context* ssl)
 
 static int ssl_encrypted_extensions_prepare(mbedtls_ssl_context* ssl) {
 
-	int ret; 
+	int ret;
 	KeySet traffic_keys;
 
 	if (ssl->transform_in == NULL) {
@@ -2324,7 +2319,7 @@ static int ssl_encrypted_extensions_prepare(mbedtls_ssl_context* ssl) {
 	 */
 	ssl->in_epoch = 2;
 	ssl->out_epoch = 2;
-#endif /* MBEDTLS_SSL_PROTO_DTLS */ 
+#endif /* MBEDTLS_SSL_PROTO_DTLS */
 
 	return 0;
 }
@@ -2456,12 +2451,12 @@ static int ssl_encrypted_extensions_postprocess(mbedtls_ssl_context* ssl) {
 	{
 #if defined(MBEDTLS_COMPATIBILITY_MODE)
 		mbedtls_ssl_handshake_set_state(ssl, MBEDTLS_SSL_CLIENT_CCS_BEFORE_CERTIFICATE_REQUEST);
-#else 
+#else
 		mbedtls_ssl_handshake_set_state(ssl, MBEDTLS_SSL_CERTIFICATE_REQUEST);
 #endif /* MBEDTLS_COMPATIBILITY_MODE */
 	}
 
-	return 0; 
+	return 0;
 }
 
 
@@ -2498,7 +2493,7 @@ static int ssl_hrr_parse(mbedtls_ssl_context* ssl,
 	const unsigned char* buf,
 	size_t buflen);
 
-static int ssl_hrr_postprocess(mbedtls_ssl_context* ssl, 
+static int ssl_hrr_postprocess(mbedtls_ssl_context* ssl,
 		const unsigned char* buf,
 	size_t buflen);
 
@@ -2623,13 +2618,13 @@ static int ssl_server_hello_parse(mbedtls_ssl_context* ssl,
 	size_t buflen)
 {
 
-	int ret; // return value 
-	int i; // scratch value 
+	int ret; // return value
+	int i; // scratch value
 	const unsigned char* msg_end = buf + buflen; // pointer to the end of the buffer for length checks
 
 	size_t ext_len; // stores length of all extensions
 	unsigned int ext_id; // id of an extension
-	const unsigned char* ext; // pointer to an individual extension 
+	const unsigned char* ext; // pointer to an individual extension
 	unsigned int ext_size; // size of an individual extension
 
 	const mbedtls_ssl_ciphersuite_t* suite_info; // pointer to ciphersuite
@@ -2639,8 +2634,8 @@ static int ssl_server_hello_parse(mbedtls_ssl_context* ssl,
 #if defined(MBEDTLS_CTLS)
 	if (ssl->handshake->ctls == MBEDTLS_CTLS_USE)
 	{
-		// TBD: Add message header figure here. 
-		// 18 = 16 (random bytes) + 1 (ciphersuite) + 1 (version) + 
+		// TBD: Add message header figure here.
+		// 18 = 16 (random bytes) + 1 (ciphersuite) + 1 (version) +
 		if (buflen < 18 + mbedtls_ssl_hs_hdr_len(ssl)) {
 			MBEDTLS_SSL_DEBUG_MSG(1, ("bad server hello message - min size not reached"));
 			SSL_PEND_FATAL_ALERT(MBEDTLS_SSL_ALERT_MSG_DECODE_ERROR);
@@ -2676,7 +2671,7 @@ static int ssl_server_hello_parse(mbedtls_ssl_context* ssl,
 	// skip header
 	buf += mbedtls_ssl_hs_hdr_len(ssl);
 
-#if defined(MBEDTLS_CTLS) 
+#if defined(MBEDTLS_CTLS)
 	if (ssl->handshake->ctls == MBEDTLS_CTLS_DO_NOT_USE)
 #endif /* MBEDTLS_CTLS */
 	{
@@ -2693,7 +2688,7 @@ static int ssl_server_hello_parse(mbedtls_ssl_context* ssl,
 			return(MBEDTLS_ERR_SSL_BAD_HS_PROTOCOL_VERSION);
 		}
 
-		// skip version 
+		// skip version
 		buf += 2;
 	}
 
@@ -2742,7 +2737,7 @@ static int ssl_server_hello_parse(mbedtls_ssl_context* ssl,
 			SSL_PEND_FATAL_ALERT(MBEDTLS_SSL_ALERT_MSG_ILLEGAL_PARAMETER);
 			return(MBEDTLS_ERR_SSL_BAD_HS_SERVER_HELLO);
 		}
-		buf += ssl->session_negotiate->id_len; // skip session id 
+		buf += ssl->session_negotiate->id_len; // skip session id
 
 		MBEDTLS_SSL_DEBUG_MSG(3, ("session id length (%d)", ssl->session_negotiate->id_len));
 		MBEDTLS_SSL_DEBUG_BUF(3, "session id", ssl->session_negotiate->id, ssl->session_negotiate->id_len);
@@ -2777,9 +2772,9 @@ static int ssl_server_hello_parse(mbedtls_ssl_context* ssl,
 		buf += 2;
 	}
 
-	// TBD: Check whether we have offered this ciphersuite 
-	// Via the force_ciphersuite version we may have instructed the client 
-	// to use a difference ciphersuite. 
+	// TBD: Check whether we have offered this ciphersuite
+	// Via the force_ciphersuite version we may have instructed the client
+	// to use a difference ciphersuite.
 
 	// Configure ciphersuites
 	ssl->transform_negotiate->ciphersuite_info = mbedtls_ssl_ciphersuite_from_id(i);
@@ -2838,12 +2833,12 @@ static int ssl_server_hello_parse(mbedtls_ssl_context* ssl,
 			return(MBEDTLS_ERR_SSL_BAD_HS_SERVER_HELLO);
 		}
 
-		// skip compression 
+		// skip compression
 		buf++;
 	}
 
 
-	// Are we reading beyond the message buffer? 
+	// Are we reading beyond the message buffer?
 	if ((buf + 2) > msg_end) {
 		MBEDTLS_SSL_DEBUG_MSG(1, ("bad server hello message"));
 		SSL_PEND_FATAL_ALERT(MBEDTLS_SSL_ALERT_MSG_ILLEGAL_PARAMETER);
@@ -2853,7 +2848,7 @@ static int ssl_server_hello_parse(mbedtls_ssl_context* ssl,
 	ext_len = ((buf[0] << 8) | (buf[1]));
 	buf += 2; // skip extension length
 
-	// Are we reading beyond the message buffer? 
+	// Are we reading beyond the message buffer?
 	if ((buf + ext_len) > msg_end) {
 		MBEDTLS_SSL_DEBUG_MSG(1, ("bad server hello message"));
 		SSL_PEND_FATAL_ALERT(MBEDTLS_SSL_ALERT_MSG_ILLEGAL_PARAMETER);
@@ -2912,7 +2907,7 @@ static int ssl_server_hello_parse(mbedtls_ssl_context* ssl,
 			break;
 #endif /* MBEDTLS_KEY_EXCHANGE_PSK_ENABLED */
 
-#if defined(MBEDTLS_ECDH_C) || defined(MBEDTLS_ECDSA_C) 
+#if defined(MBEDTLS_ECDH_C) || defined(MBEDTLS_ECDSA_C)
 		case MBEDTLS_TLS_EXT_KEY_SHARES:
 			MBEDTLS_SSL_DEBUG_MSG(3, ("found key_shares extension"));
 
@@ -2944,16 +2939,14 @@ static int ssl_server_hello_parse(mbedtls_ssl_context* ssl,
 
 static int ssl_server_hello_postprocess(mbedtls_ssl_context* ssl)
 {
-	int handshake_failure = 0;
-
 	/* We need to set the key exchange algorithm based on the
 	 * following rules:
-	 * 
-	 *   1) IF PRE_SHARED_KEY extension was received 
+	 *
+	 *   1) IF PRE_SHARED_KEY extension was received
 	 *      THEN set MBEDTLS_KEY_EXCHANGE_PSK
-	 *   2) IF PRE_SHARED_KEY extension && KEY_SHARE was received 
+	 *   2) IF PRE_SHARED_KEY extension && KEY_SHARE was received
 	 *      THEN set MBEDTLS_KEY_EXCHANGE_ECDHE_PSK
-	 *   3) IF KEY_SHARES extension was received && SIG_ALG extension received 
+	 *   3) IF KEY_SHARES extension was received && SIG_ALG extension received
 	 *      THEN set MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA
 	 *   ELSE unknown key exchange mechanism.
 	 */
@@ -2989,14 +2982,14 @@ static int ssl_server_hello_postprocess(mbedtls_ssl_context* ssl)
 static int ssl_hrr_parse(mbedtls_ssl_context* ssl,
 	const unsigned char* buf, size_t buflen)
 {
-	int ret; // return value 
-	int i; // scratch value 
+	int ret; // return value
+	int i; // scratch value
 	int found = 0;
 	const unsigned char* msg_end = buf + buflen; // pointer to the end of the buffer for length checks
 
 	size_t ext_len; // stores length of all extensions
 	unsigned int ext_id; // id of an extension
-	const unsigned char* ext; // pointer to an individual extension 
+	const unsigned char* ext; // pointer to an individual extension
 	unsigned int ext_size; // size of an individual extension
 
 	const mbedtls_ssl_ciphersuite_t* suite_info; // pointer to ciphersuite
@@ -3012,8 +3005,8 @@ static int ssl_hrr_parse(mbedtls_ssl_context* ssl,
 #if defined(MBEDTLS_CTLS)
 	if (ssl->handshake->ctls == MBEDTLS_CTLS_USE)
 	{
-		// TBD: Add message header figure here. 
-		// 18 = 16 (random bytes) + 1 (ciphersuite) + 1 (version) + 
+		// TBD: Add message header figure here.
+		// 18 = 16 (random bytes) + 1 (ciphersuite) + 1 (version) +
 		if (buflen < 18 + mbedtls_ssl_hs_hdr_len(ssl)) {
 			MBEDTLS_SSL_DEBUG_MSG(1, ("bad hello retry request - min size not reached"));
 			SSL_PEND_FATAL_ALERT(MBEDTLS_SSL_ALERT_MSG_DECODE_ERROR);
@@ -3050,7 +3043,7 @@ static int ssl_hrr_parse(mbedtls_ssl_context* ssl,
 	// skip header
 	buf += mbedtls_ssl_hs_hdr_len(ssl);
 
-#if defined(MBEDTLS_CTLS) 
+#if defined(MBEDTLS_CTLS)
 	if (ssl->handshake->ctls == MBEDTLS_CTLS_DO_NOT_USE)
 #endif /* MBEDTLS_CTLS */
 	{
@@ -3067,7 +3060,7 @@ static int ssl_hrr_parse(mbedtls_ssl_context* ssl,
 			return(MBEDTLS_ERR_SSL_BAD_HS_PROTOCOL_VERSION);
 		}
 
-		// skip version 
+		// skip version
 		buf += 2;
 	}
 
@@ -3116,7 +3109,7 @@ static int ssl_hrr_parse(mbedtls_ssl_context* ssl,
 			SSL_PEND_FATAL_ALERT(MBEDTLS_SSL_ALERT_MSG_ILLEGAL_PARAMETER);
 			return(MBEDTLS_ERR_SSL_BAD_HS_HELLO_RETRY_REQUEST);
 		}
-		buf += ssl->session_negotiate->id_len; // skip session id 
+		buf += ssl->session_negotiate->id_len; // skip session id
 
 		MBEDTLS_SSL_DEBUG_MSG(3, ("session id length (%d)", ssl->session_negotiate->id_len));
 		MBEDTLS_SSL_DEBUG_BUF(3, "session id", ssl->session_negotiate->id, ssl->session_negotiate->id_len);
@@ -3151,9 +3144,9 @@ static int ssl_hrr_parse(mbedtls_ssl_context* ssl,
 		buf += 2;
 	}
 
-	// TBD: Check whether we have offered this ciphersuite 
-	// Via the force_ciphersuite version we may have instructed the client 
-	// to use a difference ciphersuite. 
+	// TBD: Check whether we have offered this ciphersuite
+	// Via the force_ciphersuite version we may have instructed the client
+	// to use a difference ciphersuite.
 
 	// Configure ciphersuites
 	ssl->transform_negotiate->ciphersuite_info = mbedtls_ssl_ciphersuite_from_id(i);
@@ -3211,11 +3204,11 @@ static int ssl_hrr_parse(mbedtls_ssl_context* ssl,
 			return(MBEDTLS_ERR_SSL_BAD_HS_HELLO_RETRY_REQUEST);
 		}
 
-		// skip compression 
+		// skip compression
 		buf++;
 	}
 
-	// Are we reading beyond the message buffer? 
+	// Are we reading beyond the message buffer?
 	if ((buf + 2) > msg_end) {
 		MBEDTLS_SSL_DEBUG_MSG(1, ("bad hello retry request message"));
 		SSL_PEND_FATAL_ALERT(MBEDTLS_SSL_ALERT_MSG_ILLEGAL_PARAMETER);
@@ -3225,7 +3218,7 @@ static int ssl_hrr_parse(mbedtls_ssl_context* ssl,
 	ext_len = ((buf[0] << 8) | (buf[1]));
 	buf += 2; // skip extension length
 
-	// Are we reading beyond the message buffer? 
+	// Are we reading beyond the message buffer?
 	if ((buf + ext_len) > msg_end) {
 		MBEDTLS_SSL_DEBUG_MSG(1, ("bad hello retry request message"));
 		SSL_PEND_FATAL_ALERT(MBEDTLS_SSL_ALERT_MSG_ILLEGAL_PARAMETER);
@@ -3280,7 +3273,7 @@ static int ssl_hrr_parse(mbedtls_ssl_context* ssl,
 				return(ret);
 			break;
 
-#if defined(MBEDTLS_ECDH_C) || defined(MBEDTLS_ECDSA_C) 
+#if defined(MBEDTLS_ECDH_C) || defined(MBEDTLS_ECDSA_C)
 		case MBEDTLS_TLS_EXT_KEY_SHARES:
 
 			MBEDTLS_SSL_DEBUG_BUF(3, "key_share extension", ext + 4, ext_size);
@@ -3312,7 +3305,7 @@ static int ssl_hrr_parse(mbedtls_ssl_context* ssl,
 				if (info == NULL) return(MBEDTLS_ERR_SSL_INTERNAL_ERROR);
 
 				if (info->tls_id == tls_id) {
-					// We found a match 
+					// We found a match
 					found = 1;
 					break;
 				}
@@ -3340,7 +3333,7 @@ static int ssl_hrr_parse(mbedtls_ssl_context* ssl,
 				if (info == NULL) return(MBEDTLS_ERR_SSL_INTERNAL_ERROR);
 
 				if (info->tls_id == tls_id) {
-					// We found a match 
+					// We found a match
 					found = 1;
 					break;
 				}
@@ -3389,7 +3382,7 @@ static int ssl_hrr_parse(mbedtls_ssl_context* ssl,
 	return(0);
 }
 
-static int ssl_hrr_postprocess(mbedtls_ssl_context* ssl, 
+static int ssl_hrr_postprocess(mbedtls_ssl_context* ssl,
 	const unsigned char* orig_buf,
 	size_t orig_msg_len)
 {
@@ -3440,7 +3433,7 @@ static int ssl_hrr_postprocess(mbedtls_ssl_context* ssl,
 	#endif
 	*/
 	if (ssl->transform_negotiate->ciphersuite_info->mac == MBEDTLS_MD_SHA256) {
-#if defined(MBEDTLS_SHA256_C) 
+#if defined(MBEDTLS_SHA256_C)
 		mbedtls_sha256_finish(&ssl->handshake->fin_sha256, &transcript[4]);
 		MBEDTLS_SSL_DEBUG_BUF(5, "Transcript-Hash(ClientHello1, HelloRetryRequest, ... MN)", &transcript[0], 32 + 4);
 
@@ -3448,7 +3441,7 @@ static int ssl_hrr_postprocess(mbedtls_ssl_context* ssl,
 		mbedtls_sha256_init(&ssl->handshake->fin_sha256);
 		mbedtls_sha256_starts(&ssl->handshake->fin_sha256, 0 /* = use SHA256 */);
 		//mbedtls_sha256_update(&ssl->handshake->fin_sha256, &transcript[0], hash_length + 4);
-#else 
+#else
 		MBEDTLS_SSL_DEBUG_MSG(1, ("mbedtls_ssl_derive_master_secret: Unknow hash function."));
 		return(MBEDTLS_ERR_SSL_INTERNAL_ERROR);
 #endif /* MBEDTLS_SHA256_C */
@@ -3462,7 +3455,7 @@ static int ssl_hrr_postprocess(mbedtls_ssl_context* ssl,
 		mbedtls_sha512_init(&ssl->handshake->fin_sha512);
 		mbedtls_sha512_starts(&ssl->handshake->fin_sha512, 1 /* = use SHA384 */);
 		//mbedtls_sha256_update(&ssl->handshake->fin_sha512, &transcript[0], hash_length + 4);
-#else 
+#else
 		MBEDTLS_SSL_DEBUG_MSG(1, ("mbedtls_ssl_derive_master_secret: Unknow hash function."));
 		return(MBEDTLS_ERR_SSL_INTERNAL_ERROR);
 #endif /* MBEDTLS_SHA512_C */
@@ -3475,10 +3468,10 @@ static int ssl_hrr_postprocess(mbedtls_ssl_context* ssl,
 		// reset transcript
 		mbedtls_sha512_init(&ssl->handshake->fin_sha512);
 		mbedtls_sha512_starts(&ssl->handshake->fin_sha512, 0 /* = use SHA512 */);
-		//mbedtls_sha256_update(&ssl->handshake->fin_sha512, &transcript[0], hash_length + 4); 
+		//mbedtls_sha256_update(&ssl->handshake->fin_sha512, &transcript[0], hash_length + 4);
 	}
 	else {
-#else 
+#else
 		MBEDTLS_SSL_DEBUG_MSG(1, ("mbedtls_ssl_derive_master_secret: Unknow hash function."));
 		return(MBEDTLS_ERR_SSL_INTERNAL_ERROR);
 #endif /* MBEDTLS_SHA512_C */
@@ -3504,7 +3497,7 @@ static void mbedtls_patch_pointers(mbedtls_ssl_context* ssl)
 {
 	((void)ssl);
 }
-#else 
+#else
 static void mbedtls_patch_pointers(mbedtls_ssl_context* ssl)
 {
 	/* In case we negotiated the use of CIDs then we need to
@@ -3513,11 +3506,11 @@ static void mbedtls_patch_pointers(mbedtls_ssl_context* ssl)
 	 * us not to add a CID value to the record header then the
 	 * out_cid_len or in_cid_len will be zero.
 	 */
-#if	defined(MBEDTLS_SSL_PROTO_DTLS) 
+#if	defined(MBEDTLS_SSL_PROTO_DTLS)
 #if defined(MBEDTLS_CID)
 	size_t out_cid_len = ssl->out_cid_len;
 	size_t in_cid_len = ssl->in_cid_len;
-#else 
+#else
 	size_t out_cid_len = 0;
 	size_t in_cid_len = 0;
 #endif /* MBEDTLS_CID */
@@ -3583,7 +3576,7 @@ int mbedtls_ssl_handshake_client_step(mbedtls_ssl_context *ssl)
 	{
 	case MBEDTLS_SSL_HELLO_REQUEST:
 		mbedtls_ssl_handshake_set_state(ssl, MBEDTLS_SSL_CLIENT_HELLO);
-		// Reset hello_retry_requests_receive since we have not seen an HRR msg yet. 
+		// Reset hello_retry_requests_receive since we have not seen an HRR msg yet.
 		ssl->handshake->hello_retry_requests_received = 0;
 
 #if defined(MBEDTLS_COMPATIBILITY_MODE)
@@ -3595,7 +3588,7 @@ int mbedtls_ssl_handshake_client_step(mbedtls_ssl_context *ssl)
 #if defined(MBEDTLS_ECP_C)
 		// We need to initialize the handshake->key_shares_curve_list.
 		if (ssl->handshake->key_shares_curve_list == NULL) {
-			// We need to allocate one additional key share for the delimiter. 
+			// We need to allocate one additional key share for the delimiter.
 			ssl->handshake->key_shares_curve_list = mbedtls_calloc(1, sizeof(mbedtls_ecp_group_id*) * (MBEDTLS_SSL_MAX_KEY_SHARES+1));
 			if (ssl->conf->key_shares_curve_list == NULL) {
 				MBEDTLS_SSL_DEBUG_MSG(1, ("should never happen"));
@@ -3604,7 +3597,7 @@ int mbedtls_ssl_handshake_client_step(mbedtls_ssl_context *ssl)
 			memcpy(ssl->handshake->key_shares_curve_list, ssl->conf->key_shares_curve_list, sizeof(mbedtls_ecp_group_id*) * (MBEDTLS_SSL_MAX_KEY_SHARES+1));
 
 			// We need to put a delimiter to the end of the key shares curve list
-			ssl->handshake->key_shares_curve_list[MBEDTLS_SSL_MAX_KEY_SHARES] = MBEDTLS_ECP_DP_NONE; 
+			ssl->handshake->key_shares_curve_list[MBEDTLS_SSL_MAX_KEY_SHARES] = MBEDTLS_ECP_DP_NONE;
 		}
 #endif /* MBEDTLS_ECP_C */
 
@@ -3642,8 +3635,8 @@ int mbedtls_ssl_handshake_client_step(mbedtls_ssl_context *ssl)
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
 		/* epoch value (0) is used with unencrypted messages */
 		ssl->in_epoch = 0;
-		ssl->out_epoch = 0; 
-#endif /* MBEDTLS_SSL_PROTO_DTLS */ 
+		ssl->out_epoch = 0;
+#endif /* MBEDTLS_SSL_PROTO_DTLS */
 
 		ret = ssl_client_hello_process(ssl);
 		if (ret != 0) {
@@ -3659,7 +3652,7 @@ int mbedtls_ssl_handshake_client_step(mbedtls_ssl_context *ssl)
 		if (ssl->handshake->early_data == MBEDTLS_SSL_EARLY_DATA_ON) {
 #if defined(MBEDTLS_COMPATIBILITY_MODE)
 			mbedtls_ssl_handshake_set_state(ssl, MBEDTLS_SSL_CLIENT_CCS_AFTER_CLIENT_HELLO);
-#else 
+#else
 			mbedtls_ssl_handshake_set_state(ssl, MBEDTLS_SSL_EARLY_APP_DATA);
 #endif /* MBEDTLS_COMPATIBILITY_MODE */
 		}
@@ -3714,9 +3707,9 @@ int mbedtls_ssl_handshake_client_step(mbedtls_ssl_context *ssl)
 		*/
 		ssl->in_epoch = 1;
 		ssl->out_epoch = 1;
-#endif /* MBEDTLS_SSL_PROTO_DTLS */ 
+#endif /* MBEDTLS_SSL_PROTO_DTLS */
 
-		// TBD: Add bounds check here. 
+		// TBD: Add bounds check here.
 		memcpy(ssl->out_msg, ssl->conf->early_data_buf, ssl->conf->early_data_len);
 		ssl->out_msglen = ssl->conf->early_data_len;
 		ssl->out_msg[ssl->out_msglen] = MBEDTLS_SSL_MSG_APPLICATION_DATA;
@@ -3725,7 +3718,7 @@ int mbedtls_ssl_handshake_client_step(mbedtls_ssl_context *ssl)
 
 		MBEDTLS_SSL_DEBUG_BUF(3, "Early Data", ssl->out_msg, ssl->out_msglen);
 
-		ret = mbedtls_ssl_write_record(ssl); 
+		ret = mbedtls_ssl_write_record(ssl);
 //		ret = mbedtls_ssl_write(ssl, buf, strlen(buf));
 
 		if (ret != 0) {
@@ -3775,7 +3768,7 @@ int mbedtls_ssl_handshake_client_step(mbedtls_ssl_context *ssl)
 			* ClientHello or before its encrypted handshake flight.
 			*/
 			mbedtls_ssl_handshake_set_state(ssl, MBEDTLS_SSL_CLIENT_CCS_BEFORE_2ND_CLIENT_HELLO);
-#else 
+#else
 			mbedtls_ssl_handshake_set_state(ssl, MBEDTLS_SSL_SECOND_CLIENT_HELLO);
 #endif /* MBEDTLS_COMPATIBILITY_MODE */
 		} else {
@@ -3784,7 +3777,7 @@ int mbedtls_ssl_handshake_client_step(mbedtls_ssl_context *ssl)
 			if (ssl->conf->transport == MBEDTLS_SSL_TRANSPORT_DATAGRAM)
 				mbedtls_ack_add_record(ssl, MBEDTLS_SSL_HS_SERVER_HELLO, MBEDTLS_SSL_ACK_RECORDS_RECEIVED);
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
-			mbedtls_patch_pointers(ssl); 
+			mbedtls_patch_pointers(ssl);
 
 			mbedtls_ssl_handshake_set_state(ssl, MBEDTLS_SSL_ENCRYPTED_EXTENSIONS);
 		}
@@ -3825,7 +3818,7 @@ int mbedtls_ssl_handshake_client_step(mbedtls_ssl_context *ssl)
 
 	case MBEDTLS_SSL_SECOND_SERVER_HELLO:
 		/* In this state the client is expecting a ServerHello
-		* message and not the HRR anymore. 
+		* message and not the HRR anymore.
 		*/
 		// reset extensions we have seen so far
 		ssl->handshake->extensions_present = NO_EXTENSION;
@@ -3854,7 +3847,7 @@ int mbedtls_ssl_handshake_client_step(mbedtls_ssl_context *ssl)
 		/* ----- READ ENCRYPTED EXTENSIONS ----*/
 
 	case MBEDTLS_SSL_ENCRYPTED_EXTENSIONS:
-		
+
 		ret = ssl_encrypted_extensions_process(ssl);
 		if (ret != 0) {
 			MBEDTLS_SSL_DEBUG_RET(1, "ssl_parse_encrypted_extensions", ret);
@@ -3909,7 +3902,7 @@ int mbedtls_ssl_handshake_client_step(mbedtls_ssl_context *ssl)
 		/* ----- READ FINISHED ----*/
 
 	case MBEDTLS_SSL_SERVER_FINISHED:
-        
+
 		ret = ssl_finished_in_process(ssl);
 
 		if (ret != 0) {
@@ -3959,7 +3952,7 @@ int mbedtls_ssl_handshake_client_step(mbedtls_ssl_context *ssl)
 	 	 */
 		ssl->in_epoch = 1;
 		ssl->out_epoch = 1;
-#endif /* MBEDTLS_SSL_PROTO_DTLS */ 
+#endif /* MBEDTLS_SSL_PROTO_DTLS */
 
 		ret = mbedtls_ssl_write_end_of_early_data(ssl);
 		if (ret != 0) {

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -1024,6 +1024,9 @@ static int ssl_write_key_shares_ext(mbedtls_ssl_context *ssl,
 	int nr;
 	//const int *ciphersuites;
 
+        /* TODO: Add bounds checks! Only then remove the next line. */
+        ((void) end);
+
 #if defined(MBEDTLS_CTLS)
 	if (ssl->handshake->ctls == MBEDTLS_CTLS_USE)
 	{
@@ -2093,6 +2096,9 @@ static int ssl_certificate_request_parse(mbedtls_ssl_context* ssl,
 	size_t ext_len = 0, total_len;
 	int context_len = 0;
 
+        /* TODO: Add bounds checks! Only then remove the next line. */
+        ((void) buflen);
+
 	/*
 	*
 	* struct {
@@ -2333,6 +2339,9 @@ static int ssl_encrypted_extensions_parse(mbedtls_ssl_context* ssl,
 	int ret=0;
 	size_t ext_len;
 	unsigned char *ext;
+
+        /* TODO: Add bounds checks! Only then remove the next line. */
+        ((void) buflen);
 
 	// skip handshake header
 	buf += mbedtls_ssl_hs_hdr_len(ssl);

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -1844,6 +1844,9 @@ static int ssl_read_certificate_verify_parse(mbedtls_ssl_context* ssl,
     mbedtls_pk_type_t pk_alg;
     mbedtls_md_type_t md_alg;
 
+    /* TODO: Why don't we use `hashlen` here? Look at this. */
+    ((void) hashlen);
+
     if (buflen < mbedtls_ssl_hs_hdr_len(ssl))
     {
         MBEDTLS_SSL_DEBUG_MSG(1, ("bad certificate verify message"));

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -1,5 +1,5 @@
 /*
- *  Handshake-related functions shared between the TLS/DTLS client 
+ *  Handshake-related functions shared between the TLS/DTLS client
  *  and server (ssl_tls13_client.c and ssl_tls13_server.c).
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
@@ -33,7 +33,7 @@
 
 
 
-#if defined(MBEDTLS_SSL_PROTO_DTLS) 
+#if defined(MBEDTLS_SSL_PROTO_DTLS)
 #include "mbedtls/aes.h"
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
 
@@ -94,24 +94,24 @@ static enum varint_length_enum set_varint_length(uint32_t input, uint32_t* outpu
 
 static uint8_t get_varint_length(const uint8_t input)
 {
-	// Is bit 8 set? 
+	// Is bit 8 set?
 	if (input & MBEDTLS_VARINT_HDR_1)
 	{
-		// Is bit 7 set? 
+		// Is bit 7 set?
 		if (input & MBEDTLS_VARINT_HDR_2)
 		{
-			// length = 3 bytes 
+			// length = 3 bytes
 			return (3);
 		}
 		else
 		{
-			// length = 2 bytes 
+			// length = 2 bytes
 			return (2);
 		}
 	}
 	else
 	{
-		// length = 1 bytes 
+		// length = 1 bytes
 		return (1);
 	}
 
@@ -121,27 +121,27 @@ static uint32_t get_varint_value(const uint32_t input)
 {
 	uint32_t output;
 
-	// Is bit 8 set? 
+	// Is bit 8 set?
 	if (input & MBEDTLS_VARINT_HDR_1)
 	{
-		// Is bit 7 set? 
+		// Is bit 7 set?
 		if (input & MBEDTLS_VARINT_HDR_2)
 		{
-			// length = 3 bytes 
+			// length = 3 bytes
 			output = input & ~(MBEDTLS_VARINT_HDR_1);
 			output = output & ~(MBEDTLS_VARINT_HDR_2);
 			return (output);
 		}
 		else
 		{
-			// length = 2 bytes 
+			// length = 2 bytes
 			output = input & ~(MBEDTLS_VARINT_HDR_1);
 			return (output);
 		}
 	}
 	else
 	{
-		// length = 1 bytes 
+		// length = 1 bytes
 		return (input);
 	}
 
@@ -437,7 +437,7 @@ void ssl_write_cid_ext(mbedtls_ssl_context *ssl,
 	// Length field set to MBEDTLS_CID_MAX_SIZE
 	*p++ = MBEDTLS_CID_MAX_SIZE;
 
-	// allocate CID value 
+	// allocate CID value
 	if ((ret = ssl->conf->f_rng(ssl->conf->p_rng, ssl->in_cid, MBEDTLS_CID_MAX_SIZE)) != 0) {
 		MBEDTLS_SSL_DEBUG_MSG(3, ("CID allocation failed."));
 		return;
@@ -465,7 +465,7 @@ int ssl_parse_cid_ext(mbedtls_ssl_context *ssl,
 		return(0);
 	}
 
-	// Read length of the CID 
+	// Read length of the CID
 	if (len > 1) len_inner = *p;
 
 	if (len_inner == 0) {
@@ -490,11 +490,11 @@ int ssl_parse_cid_ext(mbedtls_ssl_context *ssl,
 #endif 	/* MBEDTLS_SSL_SRV_C */
 	}
 
-	// skip the length field to read the cid value 
+	// skip the length field to read the cid value
 	p++;
 
-	// The other end provided us with the CID value it 
-	// would like us to use for packet sent to it. 
+	// The other end provided us with the CID value it
+	// would like us to use for packet sent to it.
 
 	if (ssl->conf->endpoint == MBEDTLS_SSL_IS_CLIENT) {
 		ssl->session_negotiate->cid = MBEDTLS_CID_CONF_ENABLED;
@@ -506,7 +506,7 @@ int ssl_parse_cid_ext(mbedtls_ssl_context *ssl,
 
 	return(0);
 }
-#endif /* MBEDTLS_CID */ 
+#endif /* MBEDTLS_CID */
 
 
 #if defined(MBEDTLS_COMPATIBILITY_MODE)
@@ -541,12 +541,12 @@ int mbedtls_ssl_write_change_cipher_spec(mbedtls_ssl_context *ssl)
 #endif /* MBEDTLS_COMPATIBILITY_MODE */
 
 
-#if defined(MBEDTLS_SSL_PROTO_DTLS) 
+#if defined(MBEDTLS_SSL_PROTO_DTLS)
 
 /***********************
- * 
- * ACK Message Handling 
- * 
+ *
+ * ACK Message Handling
+ *
  ***********************/
 void mbedtls_ack_clear_all(mbedtls_ssl_context* ssl, int mode)
 {
@@ -595,7 +595,7 @@ int mbedtls_ssl_parse_ack(mbedtls_ssl_context *ssl)
 	mbedtls_ssl_safer_memcmp(ssl->in_msg + mbedtls_ssl_hs_hdr_len(ssl),
 		record_numbers, sizeof(record_numbers));
 
-	// Determine whether we received every message or not. 
+	// Determine whether we received every message or not.
 	// TBD: Do ack processing here
 
 	if (ssl->conf->transport == MBEDTLS_SSL_TRANSPORT_DATAGRAM)
@@ -609,7 +609,7 @@ int mbedtls_ssl_parse_ack(mbedtls_ssl_context *ssl)
 int mbedtls_ssl_write_ack(mbedtls_ssl_context *ssl)
 {
 	int ret;
-	int size; 
+	int size;
 
 	MBEDTLS_SSL_DEBUG_MSG(2, ("=> write Ack msg"));
 
@@ -621,7 +621,7 @@ int mbedtls_ssl_write_ack(mbedtls_ssl_context *ssl)
 	size = sizeof(ssl->record_numbers_received);
 
 	/* Length = 8 bytes for record_numbers + 1 byte for content length */
-	ssl->out_msglen = 1+size; 
+	ssl->out_msglen = 1+size;
 	ssl->out_msgtype = MBEDTLS_SSL_MSG_ACK;
 	memcpy(ssl->out_msg, ssl->record_numbers_received, size);
 	ssl->out_msg[size] = MBEDTLS_SSL_MSG_ACK;
@@ -762,7 +762,7 @@ have_sig_alg:
 #endif /* MBEDTLS_KEY_EXCHANGE__WITH_CERT__ENABLED */
 
 
-/* mbedtls_ssl_derive_traffic_keys() generates keys necessary for 
+/* mbedtls_ssl_derive_traffic_keys() generates keys necessary for
  * protecting the handshake messages, as described in Section 7 of
  * TLS 1.3.
  */
@@ -777,7 +777,7 @@ int mbedtls_ssl_derive_traffic_keys(mbedtls_ssl_context *ssl, KeySet *traffic_ke
     const mbedtls_ssl_ciphersuite_t *suite_info;
 	unsigned char hash[MBEDTLS_MD_MAX_SIZE];
 
-#if defined(MBEDTLS_SHA256_C) 
+#if defined(MBEDTLS_SHA256_C)
 	mbedtls_sha256_context sha256;
 #endif
 #if defined(MBEDTLS_SHA512_C)
@@ -823,19 +823,19 @@ int mbedtls_ssl_derive_traffic_keys(mbedtls_ssl_context *ssl, KeySet *traffic_ke
 #if defined(MBEDTLS_SHA512_C)
 		handshake->calc_verify = ssl_calc_verify_tls_sha384;
 		handshake->calc_finished = ssl_calc_finished_tls_sha384;
-#else 
+#else
 		MBEDTLS_SSL_DEBUG_MSG(1, ("MBEDTLS_SHA512_C not set but ciphersuite with SHA384 negotiated"));
 		return(MBEDTLS_ERR_SSL_INTERNAL_ERROR);
 #endif /* MBEDTLS_SHA512_C */
 	}
 
-	if ((mbedtls_hash_size_for_ciphersuite(suite_info) != 32) && (mbedtls_hash_size_for_ciphersuite(suite_info) != 48) ) { 
+	if ((mbedtls_hash_size_for_ciphersuite(suite_info) != 32) && (mbedtls_hash_size_for_ciphersuite(suite_info) != 48) ) {
 		MBEDTLS_SSL_DEBUG_MSG(1, ("Unknown hash function negotiated."));
 		return(MBEDTLS_ERR_SSL_INTERNAL_ERROR);
 	}
 
 
-#if defined(MBEDTLS_SHA256_C) 
+#if defined(MBEDTLS_SHA256_C)
 	if (mbedtls_hash_size_for_ciphersuite(suite_info) == 32) {
 		mbedtls_sha256_clone(&sha256, &ssl->handshake->fin_sha256);
 		mbedtls_sha256_finish(&sha256, hash);
@@ -872,12 +872,12 @@ int mbedtls_ssl_derive_traffic_keys(mbedtls_ssl_context *ssl, KeySet *traffic_ke
 
 
 	/*
-     * Compute client_handshake_traffic_secret with 
-	 *	 Derive-Secret(., "c hs traffic", ClientHello...ServerHello) 
+     * Compute client_handshake_traffic_secret with
+	 *	 Derive-Secret(., "c hs traffic", ClientHello...ServerHello)
 	 */
 
 	ret = Derive_Secret(ssl, mbedtls_md_get_type(md_info),
-		(const unsigned char*) ssl->handshake->handshake_secret, (int) mbedtls_hash_size_for_ciphersuite(suite_info), 
+		(const unsigned char*) ssl->handshake->handshake_secret, (int) mbedtls_hash_size_for_ciphersuite(suite_info),
 		(const unsigned char*) "c hs traffic", strlen("c hs traffic"),
 		(const unsigned char *) hash, (int) mbedtls_hash_size_for_ciphersuite(suite_info),
 		(unsigned char *) ssl->handshake->client_handshake_traffic_secret, (int) mbedtls_hash_size_for_ciphersuite(suite_info));
@@ -954,23 +954,23 @@ int mbedtls_ssl_derive_traffic_keys(mbedtls_ssl_context *ssl, KeySet *traffic_ke
 
 	transform->minlen += 1;
 
-	MBEDTLS_SSL_DEBUG_MSG(3, ("-->>Calling makeTrafficKeys() with the following parameters:")); 
+	MBEDTLS_SSL_DEBUG_MSG(3, ("-->>Calling makeTrafficKeys() with the following parameters:"));
 	MBEDTLS_SSL_DEBUG_MSG(3, ("-- Hash Algorithm: %s", mbedtls_md_get_name(md_info)));
 	MBEDTLS_SSL_DEBUG_MSG(3, ("-- Handshake Traffic Secret Length: %d bytes", mbedtls_hash_size_for_ciphersuite(suite_info)));
 	MBEDTLS_SSL_DEBUG_MSG(3, ("-- Key Length: %d bytes", transform->keylen));
 	MBEDTLS_SSL_DEBUG_MSG(3, ("-- IV Length: %d bytes", transform->ivlen));
 
-	if ((ret = makeTrafficKeys(mbedtls_md_get_type(md_info), 
+	if ((ret = makeTrafficKeys(mbedtls_md_get_type(md_info),
 		ssl->handshake->client_handshake_traffic_secret,
 		ssl->handshake->server_handshake_traffic_secret,
-		mbedtls_hash_size_for_ciphersuite(suite_info), 
+		mbedtls_hash_size_for_ciphersuite(suite_info),
 		transform->keylen, transform->ivlen, traffic_keys)) != 0)
 	{
 		MBEDTLS_SSL_DEBUG_RET(1, "makeTrafficKeys failed", ret);
 		return(ret);
 	}
 
-	/* TEST 
+	/* TEST
 	if ((ret = makeTrafficKeys(mbedtls_md_get_type(md_info),
 		ssl->handshake->server_handshake_traffic_secret,
 		ssl->handshake->client_handshake_traffic_secret,
@@ -1008,7 +1008,7 @@ static int ssl_calc_verify_tls_sha256(mbedtls_ssl_context *ssl, unsigned char ha
 	unsigned char handshake_hash[32];
 	unsigned char *verify_buffer;
 	unsigned char *context_string;
-	size_t context_string_len; 
+	size_t context_string_len;
 
 	mbedtls_sha256_init(&sha256);
 
@@ -1019,17 +1019,17 @@ static int ssl_calc_verify_tls_sha256(mbedtls_ssl_context *ssl, unsigned char ha
 
 	MBEDTLS_SSL_DEBUG_BUF(3, "handshake hash", handshake_hash, 32);
 
-	/* 
+	/*
 	 * The digital signature is then computed using the signing key over the concatenation of:
 	 *    - 64 bytes of octet 32
 	 *    - The context string (which is either "TLS 1.3, client CertificateVerify" or "TLS 1.3, server CertificateVerify")
 	 *    - A single 0 byte which servers as the separator
 	 *    - The content to be signed, which is Hash(Handshake Context + Certificate) + Hash(resumption_context)
-	 * 
+	 *
  	 */
 
 	if (from == MBEDTLS_SSL_IS_CLIENT) {
-		context_string_len = strlen("TLS 1.3, client CertificateVerify"); 
+		context_string_len = strlen("TLS 1.3, client CertificateVerify");
 		context_string = mbedtls_calloc(context_string_len,1);
 
 		if (context_string == NULL) {
@@ -1051,13 +1051,13 @@ static int ssl_calc_verify_tls_sha256(mbedtls_ssl_context *ssl, unsigned char ha
 
 	if (verify_buffer == NULL) {
 		MBEDTLS_SSL_DEBUG_MSG(1, ("malloc failed in ssl_calc_verify_tls_sha256()"));
-		mbedtls_free(context_string); 
+		mbedtls_free(context_string);
 		return(MBEDTLS_ERR_SSL_ALLOC_FAILED);
 	}
 
 	memset(verify_buffer, 32, 64);
 	memcpy(verify_buffer + 64, context_string, context_string_len);
-	verify_buffer[64 + context_string_len] = 0x0; 
+	verify_buffer[64 + context_string_len] = 0x0;
 	memcpy(verify_buffer + 64 + context_string_len + 1, handshake_hash, 32);
 
 	MBEDTLS_SSL_DEBUG_BUF(3, "verify buffer", verify_buffer, 64 + context_string_len + 1 + 32);
@@ -1154,10 +1154,10 @@ static int ssl_calc_verify_tls_sha384(mbedtls_ssl_context *ssl, unsigned char ha
 #endif /* MBEDTLS_SHA512_C */
 
 
-/* mbedtls_ssl_derive_master_secret() 
- * 
+/* mbedtls_ssl_derive_master_secret()
+ *
  * Generates the keys based on the TLS 1.3 key hierachy:
- * 
+ *
  *     0
  *     |
  *     v
@@ -1175,15 +1175,15 @@ static int ssl_calc_verify_tls_sha384(mbedtls_ssl_context *ssl, unsigned char ha
  *     v
  *     0 -> HKDF-Extract = Master Secret
  *
- */ 
+ */
 int mbedtls_ssl_derive_master_secret(mbedtls_ssl_context *ssl) {
 
-#if defined(MBEDTLS_SHA256_C) && !defined(MBEDTLS_SHA512_C) 
+#if defined(MBEDTLS_SHA256_C) && !defined(MBEDTLS_SHA512_C)
 	unsigned char salt[32];
 	unsigned char ECDHE[32];
 	unsigned char null_ikm[32];
 	unsigned char intermediary_secret[32];
-#else // MBEDTLS_SHA512_C 
+#else // MBEDTLS_SHA512_C
 	unsigned char salt[64];
 	unsigned char ECDHE[66];
 	unsigned char null_ikm[64];
@@ -1191,13 +1191,13 @@ int mbedtls_ssl_derive_master_secret(mbedtls_ssl_context *ssl) {
 #endif
 
 #if defined(MBEDTLS_SHA256_C)
-	// SHA256 hash of "" string of length 0. 
+	// SHA256 hash of "" string of length 0.
 	static const unsigned char NULL_HASH_SHA256[32] =
 	{ 0xe3, 0xb0, 0xc4, 0x42, 0x98, 0xfc, 0x1c, 0x14, 0x9a, 0xfb, 0xf4, 0xc8, 0x99, 0x6f, 0xb9, 0x24, 0x27, 0xae, 0x41, 0xe4, 0x64, 0x9b, 0x93, 0x4c, 0xa4, 0x95, 0x99, 0x1b, 0x78, 0x52, 0xb8, 0x55 };
 #endif /* MBEDTLS_SHA256_C */
 
-#if defined(MBEDTLS_SHA512_C) 
-	// SHA384 hash of "" string of length 0. 
+#if defined(MBEDTLS_SHA512_C)
+	// SHA384 hash of "" string of length 0.
 	static const unsigned char NULL_HASH_SHA384[48] =
 	{ 0x38, 0xb0, 0x60, 0xa7, 0x51, 0xac, 0x96, 0x38, 0x4c, 0xd9, 0x32, 0x7e, 0xb1, 0xb1, 0xe3, 0x6a, 0x21, 0xfd, 0xb7, 0x11, 0x14, 0xbe, 0x07, 0x43, 0x4c, 0x0c, 0xc7, 0xbf, 0x63, 0xf6, 0xe1, 0xda, 0x27, 0x4e, 0xde, 0xbf, 0xe7, 0x6f, 0x65, 0xfb, 0xd5, 0x1a, 0xd2, 0xf1, 0x48, 0x98, 0xb9, 0x5b };
 #endif /* MBEDTLS_SHA512_C */
@@ -1208,9 +1208,9 @@ int mbedtls_ssl_derive_master_secret(mbedtls_ssl_context *ssl) {
 	const mbedtls_ssl_ciphersuite_t *suite_info;
 	unsigned char *psk;
 	size_t psk_len;
-	unsigned char *padbuf; 
+	unsigned char *padbuf;
 	unsigned int psk_allocated = 0;
-	int hash_size; 
+	int hash_size;
 
 #if defined(MBEDTLS_KEY_EXCHANGE__SOME__PSK_ENABLED)
 	psk = ssl->conf->psk;
@@ -1250,7 +1250,7 @@ int mbedtls_ssl_derive_master_secret(mbedtls_ssl_context *ssl) {
 
 #if defined(MBEDTLS_KEY_EXCHANGE__SOME__PSK_ENABLED)
 	/* If the psk callback was called, use its result */
-	if ((ssl->handshake->psk != NULL) && 
+	if ((ssl->handshake->psk != NULL) &&
 	   (ssl->session_negotiate->key_exchange == MBEDTLS_KEY_EXCHANGE_PSK ||
 		ssl->session_negotiate->key_exchange == MBEDTLS_KEY_EXCHANGE_ECDHE_PSK))
 	{
@@ -1270,7 +1270,7 @@ int mbedtls_ssl_derive_master_secret(mbedtls_ssl_context *ssl) {
 			MBEDTLS_SSL_DEBUG_MSG(1, ("malloc for psk == NULL, mbedtls_ssl_derive_master_secret failed"));
 			return(MBEDTLS_ERR_SSL_INTERNAL_ERROR);
 		}
-		psk_allocated = 1; 
+		psk_allocated = 1;
 		memset(psk, 0x0, hash_size);
 		psk_len = hash_size;
 	}
@@ -1280,16 +1280,16 @@ int mbedtls_ssl_derive_master_secret(mbedtls_ssl_context *ssl) {
 	if (hash_size == 32) {
 #if defined(MBEDTLS_SHA256_C)
 		padbuf = (unsigned char*) NULL_HASH_SHA256;
-#else 
+#else
 		MBEDTLS_SSL_DEBUG_MSG(1, ("MBEDTLS_SHA256_C not set but ciphersuite with SHA256 negotiated"));
-		if (psk_allocated == 1) mbedtls_free(psk); 
+		if (psk_allocated == 1) mbedtls_free(psk);
 		return(MBEDTLS_ERR_SSL_INTERNAL_ERROR);
 #endif /* MBEDTLS_SHA256_C */
-	} else 
+	} else
 	if (hash_size == 48) {
 #if defined(MBEDTLS_SHA512_C)
 		padbuf = (unsigned char*) NULL_HASH_SHA384;
-#else 
+#else
 		MBEDTLS_SSL_DEBUG_MSG(1, ("MBEDTLS_SHA512_C not set but ciphersuite with SHA384 negotiated"));
 		if (psk_allocated == 1) mbedtls_free(psk);
 		return(MBEDTLS_ERR_SSL_INTERNAL_ERROR);
@@ -1326,17 +1326,17 @@ int mbedtls_ssl_derive_master_secret(mbedtls_ssl_context *ssl) {
 /*
    if (mbedtls_hash_size_for_ciphersuite(suite_info) == 32) {
 #if defined(MBEDTLS_SHA256_C)
-	   mbedtls_sha256((const unsigned char*) "", 0, padbuf, 0); // / 0 = use SHA256 
-#else 
+	   mbedtls_sha256((const unsigned char*) "", 0, padbuf, 0); // / 0 = use SHA256
+#else
 	   MBEDTLS_SSL_DEBUG_MSG(1, ("MBEDTLS_SHA256_C not set but ciphersuite with SHA256 negotiated"));
 	   return(MBEDTLS_ERR_SSL_INTERNAL_ERROR);
-#endif 
+#endif
    }
 
    if (mbedtls_hash_size_for_ciphersuite(suite_info) == 48) {
 #if defined(MBEDTLS_SHA512_C)
-	   mbedtls_sha512((const unsigned char*) "", 0, padbuf, 1 ); // 1 = use SHA384 
-#else 
+	   mbedtls_sha512((const unsigned char*) "", 0, padbuf, 1 ); // 1 = use SHA384
+#else
 	   MBEDTLS_SSL_DEBUG_MSG(1, ("MBEDTLS_SHA512_C not set but ciphersuite with SHA384 negotiated"));
 	   return(MBEDTLS_ERR_SSL_INTERNAL_ERROR);
 #endif
@@ -1348,14 +1348,14 @@ int mbedtls_ssl_derive_master_secret(mbedtls_ssl_context *ssl) {
 		   (const unsigned char*)"derived", strlen("derived"),
 		   padbuf, hash_size,
 		   intermediary_secret, hash_size);
-   
+
   if (ret != 0) {
 	  MBEDTLS_SSL_DEBUG_RET(1, "Derive-Secret(., 'derived', ''): Error", ret);
 	  if (psk_allocated == 1) mbedtls_free(psk);
 	  return ret;
   }
 
-	/* 
+	/*
      * Compute Handshake Secret with HKDF-Extract(Intermediary Secret, ECDHE)
 	 */
 
@@ -1376,14 +1376,14 @@ int mbedtls_ssl_derive_master_secret(mbedtls_ssl_context *ssl) {
 
 		MBEDTLS_SSL_DEBUG_MPI(3, "ECDHE:", &ssl->handshake->ecdh_ctx[ssl->handshake->ecdh_ctx_selected].z);
 
-	} else 
+	} else
 #endif /* MBEDTLS_KEY_EXCHANGE__SOME__ECDHE_ENABLED */
 #if defined(MBEDTLS_KEY_EXCHANGE__SOME__PSK_ENABLED)
 	if (ssl->session_negotiate->key_exchange == MBEDTLS_KEY_EXCHANGE_PSK) {
 		memset(ECDHE, 0x0, hash_size);
 		MBEDTLS_SSL_DEBUG_BUF(3, "ECDHE", ECDHE, hash_size);
 		ECDHE_len=hash_size;
-	} else 
+	} else
 #endif	/* MBEDTLS_KEY_EXCHANGE__SOME__PSK_ENABLED */
     {
 		MBEDTLS_SSL_DEBUG_MSG(1, ("Unsupported key exchange -- mbedtls_ssl_derive_master_secret failed."));
@@ -1688,7 +1688,7 @@ static int ssl_certificate_verify_postprocess(mbedtls_ssl_context* ssl)
 
 #if defined(MBEDTLS_COMPATIBILITY_MODE)
         mbedtls_ssl_handshake_set_state(ssl, MBEDTLS_SSL_CLIENT_CCS_BEFORE_FINISHED);
-#else 
+#else
         mbedtls_ssl_handshake_set_state(ssl, MBEDTLS_SSL_CLIENT_FINISHED);
 #endif /* MBEDTLS_COMPATIBILITY_MODE */
 	}
@@ -1724,7 +1724,7 @@ static int ssl_read_certificate_verify_coordinate(mbedtls_ssl_context* ssl);
 #if defined(MBEDTLS_KEY_EXCHANGE__WITH_CERT__ENABLED)
 /* Parse and validate CertificateVerify message
  *
- * Note: The size of the hash buffer is assumed to be large enough to 
+ * Note: The size of the hash buffer is assumed to be large enough to
  *       hold the transcript given the selected hash algorithm.
  *       No bounds-checking is done inside the function.
  */
@@ -1755,13 +1755,13 @@ int ssl_read_certificate_verify_process(mbedtls_ssl_context* ssl)
 #if defined(MBEDTLS_KEY_EXCHANGE__WITH_CERT__ENABLED)
     if (ret == SSL_CERTIFICATE_VERIFY_READ)
     {
-        /* Need to calculate the hash of the transcript first 
-         * before reading the message since otherwise it gets 
-         *included in the transcript 
+        /* Need to calculate the hash of the transcript first
+         * before reading the message since otherwise it gets
+         *included in the transcript
          */
-        if (ssl->conf->endpoint == MBEDTLS_SSL_IS_SERVER) 
+        if (ssl->conf->endpoint == MBEDTLS_SSL_IS_SERVER)
             ssl->handshake->calc_verify(ssl, hash, MBEDTLS_SSL_IS_CLIENT);
-        else 
+        else
             ssl->handshake->calc_verify(ssl, hash, MBEDTLS_SSL_IS_SERVER);
 
         /* Read message */
@@ -1834,7 +1834,7 @@ static int ssl_read_certificate_verify_coordinate(mbedtls_ssl_context* ssl)
 #if defined(MBEDTLS_KEY_EXCHANGE__WITH_CERT__ENABLED)
 static int ssl_read_certificate_verify_parse(mbedtls_ssl_context* ssl,
     unsigned char const* buf,
-    size_t buflen, 
+    size_t buflen,
     unsigned char const* hash,
     size_t hashlen)
 {
@@ -1866,33 +1866,33 @@ static int ssl_read_certificate_verify_parse(mbedtls_ssl_context* ssl,
         MBEDTLS_SSL_DEBUG_MSG(1, ("bad certificate verify message"));
         return(MBEDTLS_ERR_SSL_BAD_HS_CERTIFICATE_VERIFY);
     }
-    
+
     signature_scheme = (buf[0] << 8) | buf[1];
 
     // We currently only support ECDSA-based signatures
     switch (signature_scheme) {
     case SIGNATURE_ECDSA_SECP256r1_SHA256:
-        md_alg = MBEDTLS_MD_SHA256; 
+        md_alg = MBEDTLS_MD_SHA256;
         pk_alg = MBEDTLS_PK_ECDSA;
         break;
     case SIGNATURE_ECDSA_SECP384r1_SHA384:
-        md_alg = MBEDTLS_MD_SHA384; 
+        md_alg = MBEDTLS_MD_SHA384;
         pk_alg = MBEDTLS_PK_ECDSA;
         break;
     case SIGNATURE_ECDSA_SECP521r1_SHA512:
         md_alg = MBEDTLS_MD_SHA512;
-        pk_alg = MBEDTLS_PK_ECDSA; 
+        pk_alg = MBEDTLS_PK_ECDSA;
         break;
-    default:  
+    default:
         MBEDTLS_SSL_DEBUG_MSG(1, ("Certificate Verify: Unknown signature algorithm."));
         return(MBEDTLS_ERR_SSL_BAD_HS_CERTIFICATE_VERIFY);
     }
 
     MBEDTLS_SSL_DEBUG_MSG(3, ("Certificate Verify: Signature algorithm (%04x)", signature_scheme));
-    
+
     buflen -= 2;
     buf += 2;
-    
+
     /*
     * Signature
     */
@@ -1921,10 +1921,10 @@ static int ssl_read_certificate_verify_parse(mbedtls_ssl_context* ssl,
         MBEDTLS_SSL_DEBUG_MSG(1, ("bad certificate verify message"));
         return(MBEDTLS_ERR_SSL_BAD_HS_CERTIFICATE_VERIFY);
     }
-    
+
     // hashlen set to 0 so that hash len is used from md_alg
     if ((ret = mbedtls_pk_verify(&ssl->session_negotiate->peer_cert->pk,
-        md_alg, hash, 0, 
+        md_alg, hash, 0,
         buf, sig_len)) != 0)
     {
         MBEDTLS_SSL_DEBUG_RET(1, "mbedtls_pk_verify", ret);
@@ -1948,7 +1948,7 @@ static int ssl_read_certificate_verify_postprocess(mbedtls_ssl_context* ssl)
     {
 
 #if	defined(MBEDTLS_SSL_PROTO_DTLS)
-        if (ssl->conf->transport == MBEDTLS_SSL_TRANSPORT_DATAGRAM) 
+        if (ssl->conf->transport == MBEDTLS_SSL_TRANSPORT_DATAGRAM)
         {
             mbedtls_ack_add_record(ssl, MBEDTLS_SSL_HS_CERTIFICATE_VERIFY, MBEDTLS_SSL_ACK_RECORDS_RECEIVED);
         }
@@ -2436,7 +2436,7 @@ static int ssl_read_certificate_parse(mbedtls_ssl_context* ssl,
 
 	i = mbedtls_ssl_hs_hdr_len(ssl);
 
-	// length information of certificate_request_context 
+	// length information of certificate_request_context
 	certificate_request_context_len = buf[i + 1];
 
 	// skip certificate_request_context
@@ -2521,10 +2521,10 @@ static int ssl_read_certificate_parse(mbedtls_ssl_context* ssl,
 
 		i += n;
 
-		// length information of certificate extensions 
+		// length information of certificate extensions
 		n = (buf[i] << 8) | buf[i + 1];
 
-		// we ignore the certificate extension right now		
+		// we ignore the certificate extension right now
 		i += 2 + n;
 		}
 
@@ -2534,7 +2534,7 @@ static int ssl_read_certificate_parse(mbedtls_ssl_context* ssl,
 }
 #endif /* MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED */
 
-#if defined(MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED) 
+#if defined(MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED)
 static int ssl_read_certificate_validate(mbedtls_ssl_context* ssl)
 {
 	int ret = 0;
@@ -2770,7 +2770,7 @@ int mbedtls_ssl_generate_resumption_master_secret(mbedtls_ssl_context *ssl) {
 	mbedtls_ssl_transform *transform = ssl->transform_negotiate;
 	unsigned char hash[MBEDTLS_MD_MAX_SIZE];
 
-#if defined(MBEDTLS_SHA256_C) 
+#if defined(MBEDTLS_SHA256_C)
 	mbedtls_sha256_context sha256;
 #endif
 
@@ -2793,7 +2793,7 @@ int mbedtls_ssl_generate_resumption_master_secret(mbedtls_ssl_context *ssl) {
 		return(MBEDTLS_ERR_SSL_BAD_HS_SERVER_HELLO);
 	}
 
-#if defined(MBEDTLS_SHA256_C) 
+#if defined(MBEDTLS_SHA256_C)
 	if (mbedtls_hash_size_for_ciphersuite(suite_info) == 32) {
 		mbedtls_sha256_clone(&sha256, &ssl->handshake->fin_sha256);
 		mbedtls_sha256_finish(&sha256, hash);
@@ -2847,7 +2847,7 @@ int mbedtls_ssl_generate_application_traffic_keys(mbedtls_ssl_context *ssl, KeyS
 
 	unsigned char padbuf[MBEDTLS_MD_MAX_SIZE];
 
-#if defined(MBEDTLS_SHA256_C) 
+#if defined(MBEDTLS_SHA256_C)
 	mbedtls_sha256_context sha256;
 #endif
 
@@ -2890,28 +2890,28 @@ int mbedtls_ssl_generate_application_traffic_keys(mbedtls_ssl_context *ssl, KeyS
 	transform->ivlen = cipher_info->iv_size;
 	transform->keylen = cipher_info->key_bitlen / 8;
 
-	/* Minimum length for an encrypted handshake message is 
-	 *  - Handshake header 
-	 *  - 1 byte for handshake type appended to the end of the message 
+	/* Minimum length for an encrypted handshake message is
+	 *  - Handshake header
+	 *  - 1 byte for handshake type appended to the end of the message
 	 *  - Authentication tag (which depends on the mode of operation)
 	 */
-	if (transform->ciphersuite_info->cipher == MBEDTLS_CIPHER_AES_128_CCM_8) transform->minlen = 8; 
-	else transform->minlen = 16; 
+	if (transform->ciphersuite_info->cipher == MBEDTLS_CIPHER_AES_128_CCM_8) transform->minlen = 8;
+	else transform->minlen = 16;
 
 	// TBD: Temporarily changed to test encrypted alert messages
 //	transform->minlen += mbedtls_ssl_hs_hdr_len(ssl);
 
-	transform->minlen += 1; 
+	transform->minlen += 1;
 
 	if (mbedtls_hash_size_for_ciphersuite(suite_info) == 32) {
 #if defined(MBEDTLS_SHA256_C)
 		mbedtls_sha256_init(&sha256);
 		mbedtls_sha256_clone(&sha256, &ssl->handshake->fin_sha256);
 		mbedtls_sha256_finish(&sha256, padbuf);
-#else 
+#else
 		MBEDTLS_SSL_DEBUG_MSG(1, ("MBEDTLS_SHA256_C not set but ciphersuite with SHA256 negotiated"));
 		return(MBEDTLS_ERR_SSL_INTERNAL_ERROR);
-#endif 
+#endif
 	}
 
 	if (mbedtls_hash_size_for_ciphersuite(suite_info) == 48) {
@@ -2920,20 +2920,20 @@ int mbedtls_ssl_generate_application_traffic_keys(mbedtls_ssl_context *ssl, KeyS
 		mbedtls_sha512_starts(&sha512, 1 /* = use SHA384 */);
 		mbedtls_sha512_clone(&sha512, &ssl->handshake->fin_sha512);
 		mbedtls_sha512_finish(&sha512, padbuf);
-#else 
+#else
 		MBEDTLS_SSL_DEBUG_MSG(1, ("MBEDTLS_SHA512_C not set but ciphersuite with SHA384 negotiated"));
 		return(MBEDTLS_ERR_SSL_INTERNAL_ERROR);
 #endif
 	}
 
 	/* Generate client_application_traffic_secret_0
-	 * 
+	 *
 	 * Master Secret
 	 * |
 	 * +-----> Derive-Secret(., "c ap traffic",
 	 * |                     ClientHello...server Finished)
 	 * |                     = client_application_traffic_secret_0
-	 */ 
+	 */
 
 	ret = Derive_Secret(ssl, mbedtls_md_get_type(md_info),
 		ssl->handshake->master_secret, mbedtls_hash_size_for_ciphersuite(suite_info),
@@ -2976,7 +2976,7 @@ int mbedtls_ssl_generate_application_traffic_keys(mbedtls_ssl_context *ssl, KeyS
 	MBEDTLS_SSL_DEBUG_MSG(3, ("-- Key Length: %d bytes", transform->keylen));
 	MBEDTLS_SSL_DEBUG_MSG(3, ("-- IV Length: %d bytes", transform->ivlen));
 
-	if ((ret = makeTrafficKeys(mbedtls_md_get_type(md_info), 
+	if ((ret = makeTrafficKeys(mbedtls_md_get_type(md_info),
 		ssl->handshake->client_traffic_secret,
 		ssl->handshake->server_traffic_secret,
 		mbedtls_hash_size_for_ciphersuite(suite_info), transform->keylen, transform->ivlen, traffic_keys)) != 0)
@@ -2996,21 +2996,21 @@ int mbedtls_ssl_generate_application_traffic_keys(mbedtls_ssl_context *ssl, KeyS
 }
 
 
-/* mbedtls_set_traffic_key() activates keys and IVs for 
- * the negotiated ciphersuite for use with encryption/decryption. 
+/* mbedtls_set_traffic_key() activates keys and IVs for
+ * the negotiated ciphersuite for use with encryption/decryption.
  * The sequence numbers are also set to zero.
- * 
- * mode: 
+ *
+ * mode:
  *   - Do not backup keys -- use 1
- *   - Backup keys -- use 0 
+ *   - Backup keys -- use 0
  */
 int mbedtls_set_traffic_key(mbedtls_ssl_context *ssl, KeySet *traffic_keys, mbedtls_ssl_transform *transform, int mode) {
 	mbedtls_cipher_info_t const *cipher_info;
-	int ret; 
+	int ret;
 	unsigned char *key1;
 	unsigned char *key2;
 	size_t out_cid_len;
-	size_t in_cid_len; 
+	size_t in_cid_len;
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
 	unsigned char *temp;
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
@@ -3152,10 +3152,10 @@ int mbedtls_set_traffic_key(mbedtls_ssl_context *ssl, KeySet *traffic_keys, mbed
 	 * out_cid_len or in_cid_len will be zero.
 	 */
 
-#if defined(MBEDTLS_CID) && defined(MBEDTLS_SSL_PROTO_DTLS) 
-	out_cid_len = ssl->out_cid_len; 
-#else 
-	out_cid_len = 0; 
+#if defined(MBEDTLS_CID) && defined(MBEDTLS_SSL_PROTO_DTLS)
+	out_cid_len = ssl->out_cid_len;
+#else
+	out_cid_len = 0;
 #endif /* MBEDTLS_CID && MBEDTLS_SSL_PROTO_DTLS */
 
 	if (ssl->conf->transport == MBEDTLS_SSL_TRANSPORT_DATAGRAM)
@@ -3166,12 +3166,12 @@ int mbedtls_set_traffic_key(mbedtls_ssl_context *ssl, KeySet *traffic_keys, mbed
 		ssl->out_iv = ssl->out_buf + mbedtls_ssl_hdr_len(ssl, MBEDTLS_SSL_DIRECTION_OUT, transform);
 		/* ssl->out_msg = ssl->out_buf + mbedtls_ssl_hdr_len(ssl, MBEDTLS_SSL_DIRECTION_OUT) + ssl->transform_negotiate->ivlen -
 			ssl->transform_negotiate->fixed_ivlen; */
-		ssl->out_msg = ssl->out_iv; 
+		ssl->out_msg = ssl->out_iv;
 	}
 
-#if defined(MBEDTLS_CID) && defined(MBEDTLS_SSL_PROTO_DTLS) 
+#if defined(MBEDTLS_CID) && defined(MBEDTLS_SSL_PROTO_DTLS)
 	in_cid_len = ssl->in_cid_len;
-#else 
+#else
 	in_cid_len = 0;
 #endif /* MBEDTLS_CID && MBEDTLS_SSL_PROTO_DTLS */
 
@@ -3179,11 +3179,11 @@ int mbedtls_set_traffic_key(mbedtls_ssl_context *ssl, KeySet *traffic_keys, mbed
 	{
 		ssl->in_hdr = ssl->in_buf;
 		ssl->in_ctr = ssl->in_buf + 1 + in_cid_len;
-		ssl->in_len = ssl->in_buf + mbedtls_ssl_hdr_len(ssl, MBEDTLS_SSL_DIRECTION_IN, transform) - 2; 
+		ssl->in_len = ssl->in_buf + mbedtls_ssl_hdr_len(ssl, MBEDTLS_SSL_DIRECTION_IN, transform) - 2;
 		ssl->in_iv = ssl->in_buf + mbedtls_ssl_hdr_len(ssl, MBEDTLS_SSL_DIRECTION_IN, transform);
 		/* ssl->in_msg = ssl->in_buf + mbedtls_ssl_hdr_len(ssl, MBEDTLS_SSL_DIRECTION_OUT) + ssl->transform_negotiate->ivlen -
 			ssl->transform_negotiate->fixed_ivlen; */
-		ssl->in_msg = ssl->in_iv; 
+		ssl->in_msg = ssl->in_iv;
 	}
 
 	return (0);
@@ -3200,7 +3200,7 @@ int mbedtls_set_traffic_key(mbedtls_ssl_context *ssl, KeySet *traffic_keys, mbed
 int mbedtls_ssl_early_data_key_derivation(mbedtls_ssl_context *ssl, KeySet *traffic_keys)
 {
 	int ret;
-	int hash_length; 
+	int hash_length;
 	const mbedtls_ssl_ciphersuite_t *ciphersuite_info;
 	const mbedtls_cipher_info_t *cipher_info;
 	const mbedtls_md_info_t *md;
@@ -3217,7 +3217,7 @@ int mbedtls_ssl_early_data_key_derivation(mbedtls_ssl_context *ssl, KeySet *traf
 
 	MBEDTLS_SSL_DEBUG_MSG(2, ("=> mbedtls_ssl_early_data_key_derivation"));
 
-	// sanity checks 
+	// sanity checks
 	if (ssl->transform_negotiate == NULL) {
 		MBEDTLS_SSL_DEBUG_MSG(1, ("transform_negotiate == NULL, mbedtls_ssl_early_data_key_derivation failed"));
 		return(MBEDTLS_ERR_SSL_INTERNAL_ERROR);
@@ -3301,21 +3301,21 @@ int mbedtls_ssl_early_data_key_derivation(mbedtls_ssl_context *ssl, KeySet *traf
 	}
 #endif /* MBEDTLS_SSL_PROTO_DTLS && MBEDTLS_SSL_DTLS_ANTI_REPLAY */
 
-	if (ciphersuite_info->hash == MBEDTLS_MD_SHA256) 
+	if (ciphersuite_info->hash == MBEDTLS_MD_SHA256)
 	{
-#if defined(MBEDTLS_SHA256_C) 
+#if defined(MBEDTLS_SHA256_C)
 		mbedtls_sha256_init(&sha256);
 		mbedtls_sha256_starts(&sha256, 0 /* = use SHA256 */);
 		mbedtls_sha256_clone(&sha256, &ssl->handshake->fin_sha256);
 		MBEDTLS_SSL_DEBUG_BUF(5, "finished sha256 state", (unsigned char *)sha256.state, sizeof(sha256.state));
 		mbedtls_sha256_finish(&sha256, padbuf);
 		MBEDTLS_SSL_DEBUG_BUF(5, "handshake hash", padbuf, 32);
-#else 
+#else
 		MBEDTLS_SSL_DEBUG_MSG(1, ("mbedtls_ssl_derive_master_secret: Unknow hash function."));
 		return(MBEDTLS_ERR_SSL_INTERNAL_ERROR);
-#endif 
+#endif
 	}
-	else if (ciphersuite_info->hash == MBEDTLS_MD_SHA384) 
+	else if (ciphersuite_info->hash == MBEDTLS_MD_SHA384)
 	{
 #if defined(MBEDTLS_SHA512_C)
 		mbedtls_sha512_init(&sha512);
@@ -3324,12 +3324,12 @@ int mbedtls_ssl_early_data_key_derivation(mbedtls_ssl_context *ssl, KeySet *traf
 		MBEDTLS_SSL_DEBUG_BUF(4, "finished sha384 state", (unsigned char *)sha512.state, 48);
 		mbedtls_sha512_finish(&sha512, padbuf);
 		MBEDTLS_SSL_DEBUG_BUF(5, "handshake hash", padbuf, 48);
-#else 
+#else
 		MBEDTLS_SSL_DEBUG_MSG(1, ("mbedtls_ssl_derive_master_secret: Unknow hash function."));
 		return(MBEDTLS_ERR_SSL_INTERNAL_ERROR);
-#endif 
+#endif
 	}
-	else if (ciphersuite_info->hash == MBEDTLS_MD_SHA512) 
+	else if (ciphersuite_info->hash == MBEDTLS_MD_SHA512)
 	{
 #if defined(MBEDTLS_SHA512_C)
 		mbedtls_sha512_init(&sha512);
@@ -3339,12 +3339,12 @@ int mbedtls_ssl_early_data_key_derivation(mbedtls_ssl_context *ssl, KeySet *traf
 		mbedtls_sha512_finish(&sha512, padbuf);
 		MBEDTLS_SSL_DEBUG_BUF(5, "handshake hash for psk binder", padbuf, 64);
 	}
-	else 
+	else
 	{
-#else 
+#else
 		MBEDTLS_SSL_DEBUG_MSG(1, ("mbedtls_ssl_derive_master_secret: Unknow hash function."));
 		return(MBEDTLS_ERR_SSL_INTERNAL_ERROR);
-#endif 
+#endif
 	}
 
 	/* Create client_early_traffic_secret */
@@ -3411,17 +3411,17 @@ int mbedtls_ssl_early_data_key_derivation(mbedtls_ssl_context *ssl, KeySet *traf
 }
 #endif /* MBEDTLS_ZERO_RTT */
 
-/* Key Derivation for TLS 1.3 
- * 
- * Three tasks: 
- *   - Switch transform for inbound data 
+/* Key Derivation for TLS 1.3
+ *
+ * Three tasks:
+ *   - Switch transform for inbound data
  *   - Generate master key
  *   - Generate handshake traffic keys
  */
 int mbedtls_ssl_key_derivation(mbedtls_ssl_context *ssl, KeySet *traffic_keys)
 {
 	int ret;
-	
+
 	MBEDTLS_SSL_DEBUG_MSG(2, ("=> mbedtls_ssl_key_derivation"));
 
 	MBEDTLS_SSL_DEBUG_MSG(3, ("switching to new transform spec for inbound data"));
@@ -3441,7 +3441,7 @@ int mbedtls_ssl_key_derivation(mbedtls_ssl_context *ssl, KeySet *traffic_keys)
 		MBEDTLS_SSL_DEBUG_RET(1, "mbedtls_ssl_derive_master_secret", ret);
 		return(ret);
 	}
-		
+
 	/* Creating the Traffic Keys (TLS 1.3) */
 	if ((ret = mbedtls_ssl_derive_traffic_keys(ssl, traffic_keys)) != 0)
 	{
@@ -3451,7 +3451,7 @@ int mbedtls_ssl_key_derivation(mbedtls_ssl_context *ssl, KeySet *traffic_keys)
 
 	/*
 	* Set the in_msg pointer to the correct location based on IV length
-	* For TLS 1.3 the record layer header has changed and hence we need to accomodate for it. 
+	* For TLS 1.3 the record layer header has changed and hence we need to accomodate for it.
 	*/
 	ssl->in_msg = ssl->in_iv;
 
@@ -3537,7 +3537,7 @@ int ssl_finished_out_process(mbedtls_ssl_context* ssl)
 
     memset((void*)&traffic_keys, 0, sizeof(KeySet));
 
-    ssl->handshake->state_local.finished_out.traffic_keys = &traffic_keys; 
+    ssl->handshake->state_local.finished_out.traffic_keys = &traffic_keys;
 
 	if (!ssl->handshake->state_local.finished_out.preparation_done)
 	{
@@ -3566,14 +3566,14 @@ cleanup:
 
 static int ssl_finished_out_prepare(mbedtls_ssl_context* ssl)
 {
-	int ret; 
-    KeySet* traffic_keys=ssl->handshake->state_local.finished_out.traffic_keys; 
+	int ret;
+    KeySet* traffic_keys=ssl->handshake->state_local.finished_out.traffic_keys;
 
 #if defined(MBEDTLS_SSL_CLI_C)
 	if (ssl->conf->endpoint == MBEDTLS_SSL_IS_CLIENT)
 	{
 #if defined(MBEDTLS_ZERO_RTT)
-		if (ssl->handshake->early_data == MBEDTLS_SSL_EARLY_DATA_ON) 
+		if (ssl->handshake->early_data == MBEDTLS_SSL_EARLY_DATA_ON)
 		{
 			ssl->transform_out = ssl->transform_negotiate;
 			ssl->session_out = ssl->session_negotiate;
@@ -3600,7 +3600,7 @@ static int ssl_finished_out_prepare(mbedtls_ssl_context* ssl)
 			*/
 			ssl->in_epoch = 2;
 			ssl->out_epoch = 2;
-#endif /* MBEDTLS_SSL_PROTO_DTLS */ 
+#endif /* MBEDTLS_SSL_PROTO_DTLS */
 		}
 #endif /* MBEDTLS_ZERO_RTT */
 
@@ -3650,7 +3650,7 @@ static int ssl_finished_out_prepare(mbedtls_ssl_context* ssl)
 
 static int ssl_finished_out_postprocess(mbedtls_ssl_context* ssl)
 {
-	int ret; 
+	int ret;
     KeySet* traffic_keys = ssl->handshake->state_local.finished_out.traffic_keys;
 
 #if defined(MBEDTLS_SSL_CLI_C)
@@ -3686,7 +3686,7 @@ static int ssl_finished_out_postprocess(mbedtls_ssl_context* ssl)
 		*/
 		ssl->in_epoch = 3;
 		ssl->out_epoch = 3;
-#endif /* MBEDTLS_SSL_PROTO_DTLS */ 
+#endif /* MBEDTLS_SSL_PROTO_DTLS */
 
 		if (ssl->conf->transport == MBEDTLS_SSL_TRANSPORT_DATAGRAM)
             mbedtls_ssl_handshake_set_state(ssl, MBEDTLS_SSL_HANDSHAKE_FINISH_ACK);
@@ -3775,7 +3775,7 @@ int mbedtls_ssl_write_finished( mbedtls_ssl_context *ssl )
 
 	hash_len = mbedtls_hash_size_for_ciphersuite(suite_info);
 
-	ssl->out_msglen = 4 /* 4 for the TLSCiphertext header */ + hash_len; 
+	ssl->out_msglen = 4 /* 4 for the TLSCiphertext header */ + hash_len;
 	/* We add the additional byte for the ContentType later */;
     ssl->out_msgtype = MBEDTLS_SSL_MSG_HANDSHAKE;
     ssl->out_msg[0]  = MBEDTLS_SSL_HS_FINISHED;
@@ -3804,7 +3804,7 @@ int mbedtls_ssl_write_finished( mbedtls_ssl_context *ssl )
     }
 
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "<= write finished" ) );
-	
+
 	return( 0 );
 }
 
@@ -3978,9 +3978,9 @@ void mbedtls_ssl_conf_early_data(mbedtls_ssl_config *conf, int early_data, char 
 	if (conf != NULL) {
 	  conf->early_data = early_data;
 	  if (buffer != NULL && len >0 && early_data==MBEDTLS_SSL_EARLY_DATA_ENABLED) {
-		  conf->early_data_buf = buffer; 
-		  conf->early_data_len = len; 
-		  conf->early_data_callback = early_data_callback; 
+		  conf->early_data_buf = buffer;
+		  conf->early_data_len = len;
+		  conf->early_data_callback = early_data_callback;
 	  }
 	}
 }
@@ -3989,24 +3989,24 @@ void mbedtls_ssl_conf_early_data(mbedtls_ssl_config *conf, int early_data, char 
 
 #if defined(MBEDTLS_SSL_NEW_SESSION_TICKET)
 
-/* The ssl_parse_new_session_ticket() function is used by the 
- * client to parse the NewSessionTicket message, which contains 
+/* The ssl_parse_new_session_ticket() function is used by the
+ * client to parse the NewSessionTicket message, which contains
  * the ticket and meta-data provided by the server in a post-
- * handshake message. 
- * 
+ * handshake message.
+ *
  * The code is located in ssl_tls.c since the function is called
- * mbedtls_ssl_read. It is a post-handshake message. 
+ * mbedtls_ssl_read. It is a post-handshake message.
  */
 int ssl_parse_new_session_ticket(mbedtls_ssl_context *ssl)
 {
-	int ret; 
+	int ret;
 	uint32_t lifetime, ticket_age_add;
-	uint8_t ticket_nonce_len; 
-	size_t ticket_len, ext_len; 
+	uint8_t ticket_nonce_len;
+	size_t ticket_len, ext_len;
 	unsigned char *ticket;
 	const unsigned char *msg, *extensions;
 	const mbedtls_ssl_ciphersuite_t *suite_info;
-	unsigned int msg_len; 
+	unsigned int msg_len;
 
 	MBEDTLS_SSL_DEBUG_MSG(2, ("=> parse new session ticket"));
 
@@ -4040,14 +4040,14 @@ int ssl_parse_new_session_ticket(mbedtls_ssl_context *ssl)
 	MBEDTLS_SSL_DEBUG_MSG(3, ("ticket->nonce_length: %d", ticket_nonce_len));
 	MBEDTLS_SSL_DEBUG_BUF(3, "ticket->nonce:", (unsigned char*)&msg[9], ticket_nonce_len);
 
-	/* Check if we previously received a ticket already. If we did, then we should 
+	/* Check if we previously received a ticket already. If we did, then we should
 	 * re-use already allocated nonce-space.
 	 */
 	if (ssl->session->ticket_nonce != NULL || ssl->session->ticket_nonce_len > 0) {
-		mbedtls_free(ssl->session->ticket_nonce); 
-		ssl->session->ticket_nonce = NULL; 
-		ssl->session->ticket_nonce_len = 0; 
-	} 
+		mbedtls_free(ssl->session->ticket_nonce);
+		ssl->session->ticket_nonce = NULL;
+		ssl->session->ticket_nonce_len = 0;
+	}
 
 	if ((ssl->session->ticket_nonce = mbedtls_calloc(1, ticket_nonce_len)) == NULL)
 	{
@@ -4056,14 +4056,14 @@ int ssl_parse_new_session_ticket(mbedtls_ssl_context *ssl)
 	}
 
 	memcpy(ssl->session->ticket_nonce, &msg[9], ticket_nonce_len);
-	
+
 	ssl->session->ticket_nonce_len = ticket_nonce_len;
-	
+
 	/* Ticket Length */
-	/* Check whether access to the ticket nonce length moves 
+	/* Check whether access to the ticket nonce length moves
 	*  out of the bounds of the buffer.
 	*/
-	if (&msg[10 + ticket_nonce_len] > (msg + msg_len)) 
+	if (&msg[10 + ticket_nonce_len] > (msg + msg_len))
 	{
 		MBEDTLS_SSL_DEBUG_MSG(1, ("Bad NewSessionTicket message: ticket nonce length field incorect"));
 		return(MBEDTLS_ERR_SSL_BAD_HS_NEW_SESSION_TICKET);
@@ -4073,7 +4073,7 @@ int ssl_parse_new_session_ticket(mbedtls_ssl_context *ssl)
 	MBEDTLS_SSL_DEBUG_MSG(3, ("ticket->length: %d", ticket_len));
 
 	/* Ticket Extension Length */
-	/* Check whether access to the ticket length moves out 
+	/* Check whether access to the ticket length moves out
 	 *  of the bounds of the buffer.
 	 */
 	if (&msg[12 + ticket_nonce_len + ticket_len] > (msg + msg_len))
@@ -4084,7 +4084,7 @@ int ssl_parse_new_session_ticket(mbedtls_ssl_context *ssl)
 	ext_len = (msg[11+ ticket_nonce_len +ticket_len] << 8) | (msg[12+ ticket_nonce_len + ticket_len]);
 
 	// Check whether the length field is correct
-	if ((ticket_len + ticket_nonce_len + ext_len + 13 + mbedtls_ssl_hs_hdr_len(ssl) != ssl->in_msglen) 
+	if ((ticket_len + ticket_nonce_len + ext_len + 13 + mbedtls_ssl_hs_hdr_len(ssl) != ssl->in_msglen)
 		&& ticket_len >0)
 	{
 		MBEDTLS_SSL_DEBUG_MSG(1, ("Bad NewSessionTicket message: ticket length field incorect"));
@@ -4094,7 +4094,7 @@ int ssl_parse_new_session_ticket(mbedtls_ssl_context *ssl)
 	/* Check if we previously received a ticket already. */
 	if (ssl->session->ticket != NULL || ssl->session->ticket_len > 0) {
 		mbedtls_free(ssl->session->ticket);
-		ssl->session->ticket = NULL; 
+		ssl->session->ticket = NULL;
 		ssl->session->ticket_len = 0;
 	}
 
@@ -4118,9 +4118,9 @@ int ssl_parse_new_session_ticket(mbedtls_ssl_context *ssl)
 		MBEDTLS_SSL_DEBUG_BUF(3, "ticket->extension", extensions, ext_len);
 	}
 
-	/* Compute PSK based on received nonce and resumption_master_secret 
-	 * in the following style: 
-	 * 
+	/* Compute PSK based on received nonce and resumption_master_secret
+	 * in the following style:
+	 *
 	 *  HKDF-Expand-Label(resumption_master_secret,
 	 *                    "resumption", ticket_nonce, Hash.length)
 	 */
@@ -4148,27 +4148,27 @@ int ssl_parse_new_session_ticket(mbedtls_ssl_context *ssl)
 
 #if defined(MBEDTLS_HAVE_TIME)
 	// Store ticket creation time
-	ssl->session->ticket_received = time(NULL); 
-#endif 
+	ssl->session->ticket_received = time(NULL);
+#endif
 
 	MBEDTLS_SSL_DEBUG_MSG(2, ("<= parse new session ticket"));
 
 	return(0);
 }
 
-/* mbedtls_ssl_conf_ticket_meta() allows to set a 32-bit value that is 
+/* mbedtls_ssl_conf_ticket_meta() allows to set a 32-bit value that is
  * used to obscure the age of the ticket. For externally configured PSKs
- * this value is zero. Additionally, the time when the ticket was 
+ * this value is zero. Additionally, the time when the ticket was
  * received will be set.
  */
 
 int mbedtls_ssl_conf_ticket_meta(mbedtls_ssl_config *conf,
-	const uint32_t ticket_age_add, 
+	const uint32_t ticket_age_add,
 	const time_t ticket_received)
 {
-	conf->ticket_age_add = ticket_age_add; 
+	conf->ticket_age_add = ticket_age_add;
 #if defined(MBEDTLS_HAVE_TIME)
-	conf->ticket_received = ticket_received; 
+	conf->ticket_received = ticket_received;
 #endif /* MBEDTLS_HAVE_TIME */
 	return 0;
 }
@@ -4213,17 +4213,17 @@ void mbedtls_ssl_del_client_ticket(mbedtls_ssl_ticket *ticket)
 
 int mbedtls_ssl_conf_client_ticket(const mbedtls_ssl_context *ssl, mbedtls_ssl_ticket *ticket) {
 
-	int ret; 
+	int ret;
 	mbedtls_ssl_config *conf = (mbedtls_ssl_config *) ssl->conf;
-	
-	// basic consistency checks 
-	if (conf == NULL) return -1;
-	if (ticket == NULL) return -1; 
-	if (ticket->key_len == 0) return -1; 
-	if (ticket->ticket_len == 0) return -1; 
-	if (ticket->ticket == NULL) return -1; 
 
-	/* We don't request another ticket from the server. 
+	// basic consistency checks
+	if (conf == NULL) return -1;
+	if (ticket == NULL) return -1;
+	if (ticket->key_len == 0) return -1;
+	if (ticket->ticket_len == 0) return -1;
+	if (ticket->ticket == NULL) return -1;
+
+	/* We don't request another ticket from the server.
 	 * TBD: This function could be moved to an application-visible API call.
 	 */
 	mbedtls_ssl_conf_session_tickets(conf, 0);
@@ -4231,12 +4231,12 @@ int mbedtls_ssl_conf_client_ticket(const mbedtls_ssl_context *ssl, mbedtls_ssl_t
 	// Set the psk and psk_identity
 	ret = mbedtls_ssl_conf_psk(conf, ticket->key, ticket->key_len,
 		(const unsigned char *)ticket->ticket,
-		ticket->ticket_len); 
+		ticket->ticket_len);
 
-	if (ret != 0) return -1; 
+	if (ret != 0) return -1;
 
 	/* Set the key exchange mode to PSK
-	 * TBD: Ideally, the application developer should have the option 
+	 * TBD: Ideally, the application developer should have the option
 	 * to decide between plain PSK-KE and PSK-KE-DH
 	 */
 	ret = mbedtls_ssl_conf_ke(conf, 0);
@@ -4244,23 +4244,23 @@ int mbedtls_ssl_conf_client_ticket(const mbedtls_ssl_context *ssl, mbedtls_ssl_t
 	if (ret != 0) return -1;
 
 	/* We set the ticket_age_add and the time we received the ticket */
-	ret = mbedtls_ssl_conf_ticket_meta(conf, ticket->ticket_age_add, ticket->start); 
+	ret = mbedtls_ssl_conf_ticket_meta(conf, ticket->ticket_age_add, ticket->start);
 
 	if (ret != 0) return -1;
 
-	return 0; 
+	return 0;
 }
 
 int mbedtls_ssl_get_client_ticket(const mbedtls_ssl_context *ssl, mbedtls_ssl_ticket *ticket)
 {
-	const mbedtls_ssl_ciphersuite_t *cur; 
-	int hash_size; 
+	const mbedtls_ssl_ciphersuite_t *cur;
+	int hash_size;
 
-	if (ssl->session == NULL) return -1; 
+	if (ssl->session == NULL) return -1;
 
 	// Check whether we got a ticket already
 	if (ssl->session->ticket != NULL) {
-		
+
 		// store ticket
 		ticket->ticket_len = ssl->session->ticket_len;
 		if (ticket->ticket_len == 0) return -1;
@@ -4270,9 +4270,9 @@ int mbedtls_ssl_get_client_ticket(const mbedtls_ssl_context *ssl, mbedtls_ssl_ti
 
 		// store ticket lifetime
 		ticket->ticket_lifetime = ssl->session->ticket_lifetime;
-		
-		// store psk key and key length 
-		cur = mbedtls_ssl_ciphersuite_from_id(ssl->session->ciphersuite); 
+
+		// store psk key and key length
+		cur = mbedtls_ssl_ciphersuite_from_id(ssl->session->ciphersuite);
 		if (cur == NULL) {
 			mbedtls_free(ticket->ticket);
 			return -1;
@@ -4285,16 +4285,16 @@ int mbedtls_ssl_get_client_ticket(const mbedtls_ssl_context *ssl, mbedtls_ssl_ti
 			return -1;
 		}
 		else {
-			ticket->key_len = hash_size; 
+			ticket->key_len = hash_size;
 		}
-		memcpy(ticket->key, ssl->session->key, ticket->key_len); 
-		ssl->session->key_len = ticket->key_len; 
+		memcpy(ticket->key, ssl->session->key, ticket->key_len);
+		ssl->session->key_len = ticket->key_len;
 
 		// store ticket_age_add
 		ticket->ticket_age_add = ssl->session->ticket_age_add;
 
 		// store time we received the ticket
-		ticket->start = ssl->session->ticket_received; 
+		ticket->start = ssl->session->ticket_received;
 
 		return 0;
 	}
@@ -4310,17 +4310,17 @@ void mbedtls_ssl_conf_client_ticket_enable(mbedtls_ssl_context *ssl)
 	if (ssl == NULL) return;
 	conf = (mbedtls_ssl_config *) ssl->conf;
 	if (conf == NULL) return;
-	conf->resumption_mode = 1; // enable resumption mode 
+	conf->resumption_mode = 1; // enable resumption mode
 }
 
 void mbedtls_ssl_conf_client_ticket_disable(mbedtls_ssl_context *ssl)
 {
 	mbedtls_ssl_config *conf;
 
-	if (ssl == NULL) return; 
+	if (ssl == NULL) return;
 	conf = (mbedtls_ssl_config *) ssl->conf;
-	if (conf == NULL) return; 
-	conf->resumption_mode = 0; // set full exchange 
+	if (conf == NULL) return;
+	conf->resumption_mode = 0; // set full exchange
 }
 
 #endif /* MBEDTLS_SSL_NEW_SESSION_TICKET */
@@ -4398,7 +4398,7 @@ int ssl_write_early_data_ext(mbedtls_ssl_context *ssl,
 
 	ssl->handshake->early_data = MBEDTLS_SSL_EARLY_DATA_ON;
 
-	// Write extension header 
+	// Write extension header
 	*p++ = (unsigned char)((MBEDTLS_TLS_EXT_EARLY_DATA >> 8) & 0xFF);
 	*p++ = (unsigned char)((MBEDTLS_TLS_EXT_EARLY_DATA) & 0xFF);
 
@@ -4415,4 +4415,3 @@ int ssl_write_early_data_ext(mbedtls_ssl_context *ssl,
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3 */
 
 #endif /* MBEDTLS_SSL_TLS_C */
-

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -37,6 +37,7 @@
 #include "mbedtls/aes.h"
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
 
+#include "mbedtls/ssl_ticket.h"
 #include "mbedtls/debug.h"
 #include "mbedtls/ssl.h"
 #include "mbedtls/ssl_internal.h"

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -3830,7 +3830,7 @@ static int ssl_finished_in_preprocess(mbedtls_ssl_context* ssl)
 
     hash_len = mbedtls_hash_size_for_ciphersuite(suite_info);
 
-    if (hash_len < 0)
+    if (hash_len == 0)
     {
         MBEDTLS_SSL_DEBUG_MSG(1, ("mbedtls_hash_size_for_ciphersuite in ssl_finished_in_preprocess failed"));
         return(MBEDTLS_ERR_SSL_INTERNAL_ERROR);

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -1619,6 +1619,9 @@ static int ssl_certificate_verify_write(mbedtls_ssl_context* ssl,
 	unsigned char* hash_start = hash;
 	unsigned int hashlen;
 
+        /* TODO: Add bounds checks! Only then remove the next line. */
+        ((void) buflen);
+
 	/*
 	* Make a signature of the handshake transcript
 	*/
@@ -2122,6 +2125,9 @@ static int ssl_write_certificate_write(mbedtls_ssl_context* ssl,
     size_t i, n, total_len;
     const mbedtls_x509_crt* crt;
     unsigned char* start;
+
+    /* TODO: Add bounds checks! Only then remove the next line. */
+    ((void) buflen);
 
     /*
      *  Handshake Header is 4 (before adding DTLS-specific fields, which is done later)

--- a/library/ssl_tls13_messaging.c
+++ b/library/ssl_tls13_messaging.c
@@ -1,5 +1,5 @@
 /*
- *  Messaging layer for use with TLS/DTLS 1.3 
+ *  Messaging layer for use with TLS/DTLS 1.3
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
@@ -19,10 +19,10 @@
  *  This file is part of mbed TLS (https://tls.mbed.org)
  */
 
-/* This code will be merged into MPS: 
- * https://github.com/hanno-arm/mbedtls/tree/mps_implementation/ 
+/* This code will be merged into MPS:
+ * https://github.com/hanno-arm/mbedtls/tree/mps_implementation/
  */
- 
+
 #if !defined(MBEDTLS_CONFIG_FILE)
 #include "mbedtls/config.h"
 #else
@@ -35,7 +35,7 @@
 
 
 
-#if defined(MBEDTLS_SSL_PROTO_DTLS) 
+#if defined(MBEDTLS_SSL_PROTO_DTLS)
 #include "mbedtls/aes.h"
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
 
@@ -225,7 +225,7 @@ static inline size_t ssl_ep_len(const mbedtls_ssl_context* ssl)
     return(0);
 }
 
-#if defined(MBEDTLS_SSL_PROTO_DTLS) 
+#if defined(MBEDTLS_SSL_PROTO_DTLS)
 
 
  /*
@@ -311,11 +311,11 @@ static int ssl_encrypt_buf( mbedtls_ssl_context *ssl )
 				/* TBD: We need to adjust the additional data calculation for CID use */
 
 				/* Adding the (fake) content type to additional data */
-				add_data[0] = 23; 
+				add_data[0] = 23;
 
 				/* Adding the version to additional data */
 				add_data[1] = 0xfe;
-				add_data[2] = 0xfd; 
+				add_data[2] = 0xfd;
 
 				/* Adding the length to additional data */
 				add_data[3] = ((ssl->out_msglen + taglen) >> 8) & 0xFF;
@@ -387,7 +387,7 @@ static int ssl_encrypt_buf( mbedtls_ssl_context *ssl )
 	 *                        (encrypted seqnr)
 	 */
 
-#if defined(MBEDTLS_SSL_PROTO_DTLS) 
+#if defined(MBEDTLS_SSL_PROTO_DTLS)
 	 // For DTLS 1.3 and encrypted payloads only
 			if ((ssl->conf->transport == MBEDTLS_SSL_TRANSPORT_DATAGRAM) &&
 				(ssl->transform_out != NULL))
@@ -435,7 +435,7 @@ static int ssl_encrypt_buf( mbedtls_ssl_context *ssl )
 			MBEDTLS_SSL_DEBUG_BUF(4, "Encrypted message (with tag): ", enc_msg, ssl->out_msglen);
 			MBEDTLS_SSL_DEBUG_BUF(4, "Tag", enc_msg + enc_msglen, taglen);
 			MBEDTLS_SSL_DEBUG_BUF(4, "Encrypted message (without tag): ", enc_msg, ssl->out_msglen - taglen);
-		} else 
+		} else
 #endif /* MBEDTLS_GCM_C || MBEDTLS_CCM_C */
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "should never happen" ) );
@@ -562,7 +562,7 @@ static int ssl_decrypt_buf( mbedtls_ssl_context *ssl )
 				MBEDTLS_SSL_DEBUG_BUF(4, "Encrypted message (with tag):", dec_msg, dec_msglen + taglen);
 				MBEDTLS_SSL_DEBUG_BUF(4, "Tag", dec_msg + dec_msglen, taglen);
 				MBEDTLS_SSL_DEBUG_BUF(4, "Encrypted message (without tag):", dec_msg, dec_msglen);
-			}				
+			}
 
 #if defined(MBEDTLS_SSL_PROTO_DTLS)  && defined(MBEDTLS_CID)
 		// For DTLS 1.3 and encrypted payloads we need to decrypt the sequence number
@@ -570,14 +570,14 @@ static int ssl_decrypt_buf( mbedtls_ssl_context *ssl )
 			(ssl->transform_out != NULL))
 		{
 			// TBD: Need to optimize this code section
-			// Need to find out whether this section is only executed when the CID extension has been agreed. 
+			// Need to find out whether this section is only executed when the CID extension has been agreed.
 
 			unsigned char mask[16];
 			mbedtls_aes_context aes_ctx;
 			mbedtls_aes_init(&aes_ctx);
 
 			/* For a working sequence number encryption solution we need 16 or more bytes
-			 * of encrypted payload. We do a sanity check for the message length. 
+			 * of encrypted payload. We do a sanity check for the message length.
 			 */
 			if (dec_msglen + taglen < 16)
 			{
@@ -621,9 +621,9 @@ static int ssl_decrypt_buf( mbedtls_ssl_context *ssl )
         auth_done++;
 
 		if ((ret = incrementSequenceNumber(&ssl->transform_in->sequence_number_dec[0], ssl->transform_in->iv_dec, ssl->transform_in->ivlen)) != 0) {
-		
+
 			MBEDTLS_SSL_DEBUG_RET(1, "Error in sequence number processing", ret);
-			return(ret); 
+			return(ret);
 		}
 
 		MBEDTLS_SSL_DEBUG_BUF(4, "Nonce (after)", ssl->transform_in->iv_dec, ssl->transform_in->ivlen);
@@ -632,7 +632,7 @@ static int ssl_decrypt_buf( mbedtls_ssl_context *ssl )
 
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
 
-		// always copy the most recent IV used for incoming data. 
+		// always copy the most recent IV used for incoming data.
 		memcpy(ssl->transform_in->traffic_keys_previous.iv, ssl->transform_in->iv_dec, ssl->transform_in->ivlen);
 
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
@@ -642,7 +642,7 @@ static int ssl_decrypt_buf( mbedtls_ssl_context *ssl )
             MBEDTLS_SSL_DEBUG_MSG( 1, ( "should never happen" ) );
             return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
         }
-		/* This is now the structure of the resulting decrypted message: 
+		/* This is now the structure of the resulting decrypted message:
 		 *    struct {
          *      opaque content[TLSPlaintext.length];
          *      ContentType type;
@@ -941,12 +941,12 @@ int mbedtls_ssl_flush_output( mbedtls_ssl_context *ssl )
 
     while( ssl->out_left > 0 )
     {
-       
+
         buf = ssl->out_hdr + mbedtls_ssl_hdr_len( ssl, MBEDTLS_SSL_DIRECTION_OUT, ssl->transform_out) +
               ssl->out_msglen - ssl->out_left;
         ret = ssl->f_send( ssl->p_bio, buf, ssl->out_left );
 
-        if( ret <= 0 ) 
+        if( ret <= 0 )
             return( ret );
 		else {
 			MBEDTLS_SSL_DEBUG_BUF(4, "SENT TO THE NETWORK",
@@ -960,7 +960,7 @@ int mbedtls_ssl_flush_output( mbedtls_ssl_context *ssl )
 
         ssl->out_left -= ret;
     }
-	
+
 	/* Increment record layer sequence number */
 	for (i = 8; i > ssl_ep_len(ssl); i--)
 		if (++ssl->out_ctr[i - 1] != 0)
@@ -1234,11 +1234,11 @@ int mbedtls_ssl_write_record(mbedtls_ssl_context *ssl)
 			 * TLS / DTLS 1.3 Handshake Message
 			 *
              * struct {
-		     *     HandshakeType msg_type;    // handshake type 
+		     *     HandshakeType msg_type;    // handshake type
 			 *     uint24 length;             // bytes in message
 			 *     uint16 message_seq;        // DTLS only
 			 *     uint24 fragment_offset;    // DTLS only
-			 *     uint24 fragment_length;    // DTLS-required field 
+			 *     uint24 fragment_length;    // DTLS-required field
 			 *     select(HandshakeType) {
              *         case client_hello:          ClientHello;
 			 *         case server_hello:          ServerHello;
@@ -1252,7 +1252,7 @@ int mbedtls_ssl_write_record(mbedtls_ssl_context *ssl)
 			 *         case key_update:            KeyUpdate;
 			 *     } body;
 		     * } Handshake;
-			 * 
+			 *
 			 */
 			/* Add handshake message length */
 			ssl->out_msg[1] = (unsigned char)((len - 4) >> 16);
@@ -1261,7 +1261,7 @@ int mbedtls_ssl_write_record(mbedtls_ssl_context *ssl)
 
 			if (ssl->transform_out != NULL) {
 				// We add the ContentType to the end of the payload
-				// and fake the one visible from the outside. 
+				// and fake the one visible from the outside.
 				ssl->out_msg[len] = MBEDTLS_SSL_MSG_HANDSHAKE;
 				len += 1;
 				ssl->out_msglen += 1;
@@ -1394,7 +1394,7 @@ int mbedtls_ssl_write_record(mbedtls_ssl_context *ssl)
 	if (!done)
 	{
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
-		size_t i=0; 
+		size_t i=0;
 
 		/*
 		 *
@@ -1473,9 +1473,9 @@ int mbedtls_ssl_write_record(mbedtls_ssl_context *ssl)
 
 					ssl->out_hdr[0] = ssl->out_hdr[0] | MBEDTLS_SSL_UNIFIED_HDR_CID;
 
-					// Write the CID of the outgoing datagram			
+					// Write the CID of the outgoing datagram
 					memcpy(&ssl->out_hdr[1], ssl->out_cid, ssl->out_cid_len);
-					i += ssl->out_cid_len; 
+					i += ssl->out_cid_len;
 				}
 #endif /* MBEDTLS_CID */
 
@@ -1549,7 +1549,7 @@ int mbedtls_ssl_write_record(mbedtls_ssl_context *ssl)
 			}
 
 			/* TLS 1.3 re-uses the version {3, 4} in the ClientHello, Serverhello,
-			 * etc. but the record layer uses {3, 3} (or {3,1} for compatibility reasons, 
+			 * etc. but the record layer uses {3, 3} (or {3,1} for compatibility reasons,
 			 * and hence we need to patch it.
 			 */
 			mbedtls_ssl_write_version(3, 3, ssl->conf->transport, ssl->out_hdr + 1);
@@ -1906,7 +1906,7 @@ static int ssl_prepare_handshake_record( mbedtls_ssl_context *ssl )
         ssl->handshake != NULL )
     {
 		/*
-		 * If the server responds with the HRR message then a special handling  
+		 * If the server responds with the HRR message then a special handling
 		 * with the modified transcript hash is necessary. We compute this hash later.
 		 */
         if ((ssl->in_msg[0] == MBEDTLS_SSL_HS_SERVER_HELLO) &&
@@ -1915,7 +1915,7 @@ static int ssl_prepare_handshake_record( mbedtls_ssl_context *ssl )
             MBEDTLS_SSL_DEBUG_MSG(5, ("--- Special HRR Checksum Processing"));
         }
         else {
-			MBEDTLS_SSL_DEBUG_MSG(5, ("--- Update Checksum (ssl_prepare_handshake_record)")); 
+			MBEDTLS_SSL_DEBUG_MSG(5, ("--- Update Checksum (ssl_prepare_handshake_record)"));
 			ssl->handshake->update_checksum(ssl, ssl->in_msg, ssl->in_hslen);
 		}
     }
@@ -2233,7 +2233,7 @@ static int ssl_parse_record_header(mbedtls_ssl_context* ssl)
 
 	}
 	else
-#endif /* MBEDTLS_SSL_PROTO_DTLS */ 
+#endif /* MBEDTLS_SSL_PROTO_DTLS */
 	{
 		MBEDTLS_SSL_DEBUG_BUF(4, "input record header", ssl->in_hdr, mbedtls_ssl_hdr_len(ssl, MBEDTLS_SSL_DIRECTION_IN, ssl->transform_in));
 
@@ -2270,7 +2270,7 @@ static int ssl_parse_record_header(mbedtls_ssl_context* ssl)
 
 
 
-#if defined(MBEDTLS_SSL_PROTO_DTLS) 
+#if defined(MBEDTLS_SSL_PROTO_DTLS)
 	if (ssl->conf->transport == MBEDTLS_SSL_TRANSPORT_DATAGRAM &&
 		ssl->transform_in != NULL) {
 
@@ -2433,9 +2433,9 @@ static int ssl_parse_record_header(mbedtls_ssl_context* ssl)
     }
     else
     {
-#if !defined(MBEDTLS_COMPATIBILITY_MODE) 
-		/* In compatibility mode we will receive 
-		 * Change Cipher Spec messages, which are 
+#if !defined(MBEDTLS_COMPATIBILITY_MODE)
+		/* In compatibility mode we will receive
+		 * Change Cipher Spec messages, which are
 		 * ssl->in_msglen = 1 in length. */
         if( ssl->in_msglen < ssl->transform_in->minlen )
         {
@@ -2447,9 +2447,9 @@ static int ssl_parse_record_header(mbedtls_ssl_context* ssl)
 		/*
          * TLS encrypted messages can have up to 256 bytes of padding
          */
-		if( 
+		if(
 #if defined(MBEDTLS_COMPATIBILITY_MODE)
-			ssl->in_msgtype != MBEDTLS_SSL_MSG_CHANGE_CIPHER_SPEC && 
+			ssl->in_msgtype != MBEDTLS_SSL_MSG_CHANGE_CIPHER_SPEC &&
 #endif /* MBEDTLS_COMPATIBILITY_MODE */
 			ssl->minor_ver >= MBEDTLS_SSL_MINOR_VERSION_1 &&
             ssl->in_msglen > ssl->transform_in->minlen +
@@ -2496,9 +2496,9 @@ static int ssl_prepare_record_content( mbedtls_ssl_context *ssl )
 		/* If we received an old record (based on the epoch value)
 		 * then we need to change the keys. */
 		if ((ssl->conf->transport == MBEDTLS_SSL_TRANSPORT_DATAGRAM) &&
-			(ssl->rec_epoch != ssl->in_epoch) && 
+			(ssl->rec_epoch != ssl->in_epoch) &&
 			(ssl->transform_in->traffic_keys_previous.epoch == ssl->rec_epoch))
-		{ 
+		{
 			ret = mbedtls_set_traffic_key(ssl, &ssl->transform_in->traffic_keys_previous, ssl->transform_in,1);
 			if (ret != 0) {
 				MBEDTLS_SSL_DEBUG_RET(1, "mbedtls_set_traffic_key", ret);
@@ -2507,7 +2507,7 @@ static int ssl_prepare_record_content( mbedtls_ssl_context *ssl )
 		}
 
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
-		
+
 #if defined(MBEDTLS_COMPATIBILITY_MODE)
 		if (ssl->in_msgtype == MBEDTLS_SSL_MSG_CHANGE_CIPHER_SPEC)
 			return(0);
@@ -2635,7 +2635,7 @@ read_record_header:
 
 
     /* Done reading this record, get ready for the next one */
-#if defined(MBEDTLS_SSL_PROTO_DTLS) 
+#if defined(MBEDTLS_SSL_PROTO_DTLS)
     if( ssl->conf->transport == MBEDTLS_SSL_TRANSPORT_DATAGRAM )
         ssl->next_record_offset = ssl->in_msglen + mbedtls_ssl_hdr_len( ssl, MBEDTLS_SSL_DIRECTION_IN, ssl->transform_in);
     else
@@ -2645,7 +2645,7 @@ read_record_header:
 	/*
 	* optionally decrypt message
 	*/
-	
+
     if( ( ret = ssl_prepare_record_content( ssl ) ) != 0 )
     {
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
@@ -2712,8 +2712,8 @@ read_record_header:
             return( ret );
     }
 
-	/* In TLS / DTLS 1.3 most of the messages are encrypted and appear to be 
-	 * application data payloads with the true message type hidden inside. 
+	/* In TLS / DTLS 1.3 most of the messages are encrypted and appear to be
+	 * application data payloads with the true message type hidden inside.
 	 */
 	if (ssl->in_msgtype == MBEDTLS_SSL_MSG_APPLICATION_DATA || ssl->in_msgtype == MBEDTLS_SSL_MSG_TLS_CID)
 	{
@@ -2729,26 +2729,26 @@ read_record_header:
 		 *
 		 * We will walk backwards in the decrypted message
 		 * to scan over eventually available padding bytes.
-		 * 
+		 *
 		 * A similiar structure is used for DTLS 1.3, namely
-		 * 
+		 *
 		 *    struct {
          *       opaque content[DTLSPlaintext.length];
          *       ContentType type;
          *       uint8 zeros[length_of_padding];
          *    } DTLSInnerPlaintext;
-		 * 
+		 *
 		 */
 
-		// Set handshake message to an invalid type 
-		ssl->in_msgtype = 0; 
+		// Set handshake message to an invalid type
+		ssl->in_msgtype = 0;
 
 		for (int i = ssl->in_msglen; i > 0; i--)
 		{
 				switch (ssl->in_msg[i - 1])
 				{
-				case 0: 
-					// This is padding. 
+				case 0:
+					// This is padding.
 					break;
 
 				case MBEDTLS_SSL_MSG_HANDSHAKE:
@@ -2790,7 +2790,7 @@ read_record_header:
 
 					mbedtls_ssl_send_alert_message(ssl,
 						MBEDTLS_SSL_ALERT_LEVEL_FATAL,
-						MBEDTLS_SSL_ALERT_MSG_UNEXPECTED_MESSAGE); 
+						MBEDTLS_SSL_ALERT_MSG_UNEXPECTED_MESSAGE);
 
 					return(MBEDTLS_ERR_SSL_BAD_HS_UNKNOWN_MSG);
 				}
@@ -2915,9 +2915,9 @@ int mbedtls_ssl_send_alert_message( mbedtls_ssl_context *ssl,
 	ssl->out_msg[0] = level;
 	ssl->out_msg[1] = message;
 
-	// TBD: We need to check what alert messages are sent encrypted. 
-	// Particularly for alerts that are send after cleaning the 
-	// handshake will potentially transmitted in cleartext. 
+	// TBD: We need to check what alert messages are sent encrypted.
+	// Particularly for alerts that are send after cleaning the
+	// handshake will potentially transmitted in cleartext.
 	if (ssl->transform != NULL || ssl->transform_out!=NULL) {
 		// If we encrypt then we add the content type and optionally padding
 		ssl->out_msglen = 3; // 3 includes the content type as well
@@ -2972,9 +2972,9 @@ int mbedtls_ssl_get_record_expansion( const mbedtls_ssl_context *ssl, int direct
             return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
     }
 
-	if (direction == MBEDTLS_SSL_DIRECTION_IN) 
+	if (direction == MBEDTLS_SSL_DIRECTION_IN)
 	    return( (int)( mbedtls_ssl_hdr_len( ssl, MBEDTLS_SSL_DIRECTION_IN, transform) + transform_expansion ) );
-	else 
+	else
 		return((int)(mbedtls_ssl_hdr_len(ssl, MBEDTLS_SSL_DIRECTION_OUT, transform) + transform_expansion));
 }
 
@@ -3040,7 +3040,7 @@ int mbedtls_ssl_read( mbedtls_ssl_context *ssl, unsigned char *buf, size_t len )
 					return(0);
 
 				if (ret == MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY)
-					return(ret); 
+					return(ret);
 
 				MBEDTLS_SSL_DEBUG_RET(1, "mbedtls_ssl_read_record", ret);
 				return(ret);
@@ -3076,10 +3076,10 @@ int mbedtls_ssl_read( mbedtls_ssl_context *ssl, unsigned char *buf, size_t len )
 				}
 			}
 #endif /* MBEDTLS_SSL_CLI_C */
-		} else 
+		} else
 #endif /* MBEDTLS_SSL_NEW_SESSION_TICKET */
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
-			if (ssl->in_msgtype == MBEDTLS_SSL_MSG_ACK) 
+			if (ssl->in_msgtype == MBEDTLS_SSL_MSG_ACK)
 			{
 				// We will not pass the Ack msg to the application
 				ssl->in_offt = NULL;
@@ -3088,7 +3088,7 @@ int mbedtls_ssl_read( mbedtls_ssl_context *ssl, unsigned char *buf, size_t len )
 				return(MBEDTLS_ERR_SSL_WANT_READ);
 			}
 			else
-#endif /* MBEDTLS_SSL_PROTO_DTLS */		
+#endif /* MBEDTLS_SSL_PROTO_DTLS */
         if( ssl->in_msgtype != MBEDTLS_SSL_MSG_APPLICATION_DATA )
         {
             MBEDTLS_SSL_DEBUG_MSG( 1, ( "bad application data message" ) );
@@ -3101,7 +3101,7 @@ int mbedtls_ssl_read( mbedtls_ssl_context *ssl, unsigned char *buf, size_t len )
 		{
 			// We will not pass a NewSessionTicket to the application
 			ssl->in_offt = NULL;
-			ssl->in_msglen = 0; 
+			ssl->in_msglen = 0;
 			n = MBEDTLS_ERR_SSL_RECEIVED_NEW_SESSION_TICKET;
 			MBEDTLS_SSL_DEBUG_MSG(2, ("<= read"));
 
@@ -3147,7 +3147,7 @@ static int ssl_write_real( mbedtls_ssl_context *ssl,
 #if defined(MBEDTLS_SSL_MAX_FRAGMENT_LENGTH)
     size_t max_len = mbedtls_ssl_get_max_frag_len( ssl );
 
-	
+
     if( len > max_len )
     {
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
@@ -3173,14 +3173,14 @@ static int ssl_write_real( mbedtls_ssl_context *ssl,
         }
     }
     else
-    {      
+    {
         ssl->out_msgtype = MBEDTLS_SSL_MSG_APPLICATION_DATA;
         memcpy( ssl->out_msg, buf, len );
 
 		/* Adding content type at the end of the data*/
-		ssl->out_msg[len] = MBEDTLS_SSL_MSG_APPLICATION_DATA; 
-		ssl->out_msglen = len + 1; 
-		len++; 
+		ssl->out_msg[len] = MBEDTLS_SSL_MSG_APPLICATION_DATA;
+		ssl->out_msglen = len + 1;
+		len++;
 
         if( ( ret = mbedtls_ssl_write_record( ssl ) ) != 0 )
         {
@@ -3263,5 +3263,3 @@ int mbedtls_ssl_close_notify( mbedtls_ssl_context *ssl )
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3 */
 
 #endif /* MBEDTLS_SSL_TLS_C */
-
-

--- a/library/ssl_tls13_messaging.c
+++ b/library/ssl_tls13_messaging.c
@@ -2950,8 +2950,8 @@ int mbedtls_ssl_get_record_expansion( const mbedtls_ssl_context *ssl, int direct
     if( transform == NULL && direction == MBEDTLS_SSL_DIRECTION_IN)
         return( (int) mbedtls_ssl_hdr_len( ssl, MBEDTLS_SSL_DIRECTION_IN, transform) );
 
-	if (transform == NULL && direction == MBEDTLS_SSL_DIRECTION_OUT)
-		return((int)mbedtls_ssl_hdr_len(ssl, MBEDTLS_SSL_DIRECTION_OUT, transform));
+    if (transform == NULL && direction == MBEDTLS_SSL_DIRECTION_OUT)
+        return((int)mbedtls_ssl_hdr_len(ssl, MBEDTLS_SSL_DIRECTION_OUT, transform));
 
     switch( mbedtls_cipher_get_cipher_mode( &transform->cipher_ctx_enc ) )
     {

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -1851,6 +1851,7 @@ static int ssl_client_hello_parse(mbedtls_ssl_context* ssl,
 	size_t buflen);
 
 /* Update the handshake state machine */
+/* TODO: At the moment, this doesn't update the state machine - why? */
 static int ssl_client_hello_postprocess(mbedtls_ssl_context* ssl, int ret);
 
 
@@ -1868,10 +1869,9 @@ static int ssl_client_hello_process(mbedtls_ssl_context* ssl)
 
 	MBEDTLS_SSL_PROC_CHK(ssl_client_hello_fetch(ssl, &buf, &buflen));
 
-	//MBEDTLS_SSL_PROC_CHK(ssl_client_hello_parse(ssl, buf, buflen));
-	ret=ssl_client_hello_parse(ssl, buf, buflen);
+	MBEDTLS_SSL_PROC_CHK(ssl_client_hello_parse(ssl, buf, buflen));
 
-	//MBEDTLS_SSL_PROC_CHK(ssl_client_hello_postprocess(ssl, ret));
+	MBEDTLS_SSL_PROC_CHK(ssl_client_hello_postprocess(ssl, ret));
 
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
 	if (ssl->conf->transport == MBEDTLS_SSL_TRANSPORT_DATAGRAM)

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -4199,6 +4199,7 @@ int mbedtls_ssl_handshake_server_step(mbedtls_ssl_context *ssl)
 #else
 		mbedtls_ssl_handshake_set_state(ssl, MBEDTLS_SSL_CLIENT_HELLO);
 #endif /* MBEDTLS_COMPATIBILITY_MODE */
+                break;
 
 		/* ----- WRITE CHANGE CIPHER SPEC ----*/
 

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -2913,6 +2913,8 @@ end_client_hello:
 
 static int ssl_client_hello_postprocess(mbedtls_ssl_context* ssl, int ret) {
 
+        ((void) ssl);
+        ((void) ret);
 	return (0);
 }
 

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -77,7 +77,7 @@ static int ssl_write_sni_server_ext(mbedtls_ssl_context *ssl,
 		return MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL;
 	}
 
-	// Write extension header 
+	// Write extension header
 	*p++ = (unsigned char)((MBEDTLS_TLS_EXT_SERVERNAME >> 8) & 0xFF);
 	*p++ = (unsigned char)((MBEDTLS_TLS_EXT_SERVERNAME) & 0xFF);
 
@@ -191,7 +191,7 @@ static int ssl_write_key_shares_ext(mbedtls_ssl_context *ssl,
 
 	MBEDTLS_SSL_DEBUG_ECP(3, "ECDHE: Q ", &ssl->handshake->ecdh_ctx[ssl->handshake->ecdh_ctx_selected].Q);
 
-	// Write extension header 
+	// Write extension header
 	*header++ = (unsigned char)((MBEDTLS_TLS_EXT_KEY_SHARES >> 8) & 0xFF);
 	*header++ = (unsigned char)((MBEDTLS_TLS_EXT_KEY_SHARES) & 0xFF);
 
@@ -376,7 +376,7 @@ static int ssl_parse_key_shares_ext(mbedtls_ssl_context *ssl,
 
 	const mbedtls_ecp_group_id *gid;
 
-	// Is there a key share available at the server config? 
+	// Is there a key share available at the server config?
 	/* if (ssl->conf->keyshare_ctx == NULL)
 	{
 	MBEDTLS_SSL_DEBUG_MSG(1, ("got no key share context"));
@@ -477,8 +477,8 @@ static int ssl_parse_key_shares_ext(mbedtls_ssl_context *ssl,
 			final_ret = MBEDTLS_ERR_SSL_BAD_HS_WRONG_KEY_SHARE;
 			extensions_available = 0;
 		}
-#else 
-		((void) buf); 
+#else
+		((void) buf);
 #endif /* MBEDTLS_CTLS */
 	}
 
@@ -501,7 +501,7 @@ int mbedtls_ssl_parse_new_session_ticket_server(mbedtls_ssl_context *ssl,
 	size_t len, mbedtls_ssl_ticket *ticket)
 {
 	int ret;
-	unsigned char *ticket_buffer; 
+	unsigned char *ticket_buffer;
 
 	MBEDTLS_SSL_DEBUG_MSG(2, ("=> parse new session ticket"));
 
@@ -515,17 +515,17 @@ int mbedtls_ssl_parse_new_session_ticket_server(mbedtls_ssl_context *ssl,
 
 	if (len == 0) return(0);
 
-	/* We create a copy of the encrypted ticket since decrypting 
-	 * it into the same buffer will wipe-out the original content. 
-	 * We do, however, need the original buffer for computing the 
-	 * psk binder value. 
+	/* We create a copy of the encrypted ticket since decrypting
+	 * it into the same buffer will wipe-out the original content.
+	 * We do, however, need the original buffer for computing the
+	 * psk binder value.
 	 */
 	ticket_buffer = mbedtls_calloc(len,1);
 	if (ticket_buffer == NULL) {
 		MBEDTLS_SSL_DEBUG_MSG(1, ("buffer too small"));
 		return (MBEDTLS_ERR_SSL_ALLOC_FAILED);
-	} else memcpy(ticket_buffer, buf, len); 
-	
+	} else memcpy(ticket_buffer, buf, len);
+
 	if ((ret = ssl->conf->f_ticket_parse(ssl->conf->p_ticket, ticket,
 		ticket_buffer, len)) != 0)
 	{
@@ -636,9 +636,9 @@ static int ssl_calc_binder(mbedtls_ssl_context *ssl, unsigned char *psk, size_t 
 	*/
 
 	if (suite_info->mac == MBEDTLS_MD_SHA256) {
-#if defined(MBEDTLS_SHA256_C) 
+#if defined(MBEDTLS_SHA256_C)
 		mbedtls_sha256((const unsigned char*)"", 0, hash, 0);
-#else 
+#else
 		MBEDTLS_SSL_DEBUG_MSG(1, ("mbedtls_ssl_derive_master_secret: Unknow hash function."));
 		return(MBEDTLS_ERR_SSL_INTERNAL_ERROR);
 #endif /* MBEDTLS_SHA256_C */
@@ -646,7 +646,7 @@ static int ssl_calc_binder(mbedtls_ssl_context *ssl, unsigned char *psk, size_t 
 	else if (suite_info->mac == MBEDTLS_MD_SHA384) {
 #if defined(MBEDTLS_SHA512_C)
 		mbedtls_sha512((const unsigned char*)"", 0, hash, 1 /* for SHA384 */);
-#else 
+#else
 		MBEDTLS_SSL_DEBUG_MSG(1, ("mbedtls_ssl_derive_master_secret: Unknow hash function."));
 		return(MBEDTLS_ERR_SSL_INTERNAL_ERROR);
 #endif /* MBEDTLS_SHA512_C */
@@ -678,7 +678,7 @@ if ((ssl->handshake->resume == 1) || (ssl->conf->resumption_mode == 1)) {
 
 
 	if (suite_info->mac == MBEDTLS_MD_SHA256) {
-#if defined(MBEDTLS_SHA256_C) 
+#if defined(MBEDTLS_SHA256_C)
 		mbedtls_sha256_init(&sha256);
 		mbedtls_sha256_starts(&sha256, 0 /* = use SHA256 */ );
 		//mbedtls_sha256_clone(&sha256, &ssl->handshake->fin_sha256);
@@ -687,7 +687,7 @@ if ((ssl->handshake->resume == 1) || (ssl->conf->resumption_mode == 1)) {
 		MBEDTLS_SSL_DEBUG_BUF(5, "input buffer for psk binder", buffer, blen);
 		mbedtls_sha256_finish(&sha256, padbuf);
 		MBEDTLS_SSL_DEBUG_BUF(5, "handshake hash for psk binder", padbuf, 32);
-#else 
+#else
 		MBEDTLS_SSL_DEBUG_MSG(1, ("mbedtls_ssl_derive_master_secret: Unknow hash function."));
 		return(MBEDTLS_ERR_SSL_INTERNAL_ERROR);
 #endif /* MBEDTLS_SHA256_C */
@@ -701,7 +701,7 @@ if ((ssl->handshake->resume == 1) || (ssl->conf->resumption_mode == 1)) {
 		mbedtls_sha512_update(&sha512, buffer, blen);
 		mbedtls_sha512_finish(&sha512, padbuf);
 		MBEDTLS_SSL_DEBUG_BUF(5, "handshake hash for psk binder", padbuf, 48);
-#else 
+#else
 		MBEDTLS_SSL_DEBUG_MSG(1, ("mbedtls_ssl_derive_master_secret: Unknow hash function."));
 		return(MBEDTLS_ERR_SSL_INTERNAL_ERROR);
 #endif /* MBEDTLS_SHA512_C */
@@ -753,9 +753,9 @@ if ((ssl->handshake->resume == 1) || (ssl->conf->resumption_mode == 1)) {
 		MBEDTLS_SSL_DEBUG_MSG(1, ("mbedtls_ssl_derive_master_secret: Unknow hash function."));
 		return(MBEDTLS_ERR_SSL_INTERNAL_ERROR);
 	}
-	
+
 	mbedtls_platform_zeroize(finished_key, hash_length);
-	
+
 	return ret;
 }
 
@@ -769,7 +769,7 @@ int ssl_parse_client_psk_identity_ext(mbedtls_ssl_context *ssl,
 	unsigned int item_array_length, item_length, sum, length_so_far;
 	unsigned char server_computed_binder[MBEDTLS_MD_MAX_SIZE];
 	uint32_t obfuscated_ticket_age;
-	mbedtls_ssl_ticket ticket; 
+	mbedtls_ssl_ticket ticket;
 #if defined(MBEDTLS_HAVE_TIME)
 	time_t now;
 	int64_t diff;
@@ -836,7 +836,7 @@ int ssl_parse_client_psk_identity_ext(mbedtls_ssl_context *ssl,
 				// skip obfuscated ticket age
 				// TBD: Process obfuscated ticket age (zero for externally configured PSKs?!)
 				buf = buf + item_length + 4; /* 4 for obfuscated ticket age */;
-				goto psk_parsing_successful; 
+				goto psk_parsing_successful;
 
 			}
 #if defined(MBEDTLS_SSL_NEW_SESSION_TICKET)
@@ -850,7 +850,7 @@ int ssl_parse_client_psk_identity_ext(mbedtls_ssl_context *ssl,
 				if (ssl->session_negotiate->ticket == NULL) {
 					MBEDTLS_SSL_DEBUG_MSG(1, ("alloc failed (%d bytes)", item_length));
 					return(MBEDTLS_ERR_SSL_ALLOC_FAILED);
-				}  
+				}
 				memcpy(ssl->session_negotiate->ticket, buf, item_length);
 				ssl->session_negotiate->ticket_len = item_length;
 
@@ -858,7 +858,7 @@ int ssl_parse_client_psk_identity_ext(mbedtls_ssl_context *ssl,
 				if (ret == 0) {
 					// found a match in the ticket cache; everything is OK
 					ssl->handshake->resume = 1;
-				
+
 					/* We put the resumption_master_secret into the handshake->psk
 					 *
 					 * Note: The key in the ticket is already the final PSK,
@@ -886,7 +886,7 @@ int ssl_parse_client_psk_identity_ext(mbedtls_ssl_context *ssl,
 					if (now < ticket.start) {
 						MBEDTLS_SSL_DEBUG_MSG(3, ("Ticket expired: now=%d, ticket.start=%d",now, ticket.start));
 						ret = MBEDTLS_ERR_SSL_SESSION_TICKET_EXPIRED;
-					} 
+					}
 
 					/* Check #2:
 					*   Is the ticket expired already?
@@ -894,14 +894,14 @@ int ssl_parse_client_psk_identity_ext(mbedtls_ssl_context *ssl,
 
 					if (now - ticket.start > ticket.ticket_lifetime) {
 						MBEDTLS_SSL_DEBUG_MSG(3, ("Ticket expired (now - ticket.start=%d, ticket.ticket_lifetime=%d", now - ticket.start, ticket.ticket_lifetime));
-						ret = MBEDTLS_ERR_SSL_SESSION_TICKET_EXPIRED; 
+						ret = MBEDTLS_ERR_SSL_SESSION_TICKET_EXPIRED;
 					}
 
 					/* Check #3:
-					*   Is the ticket age for the selected PSK identity (computed by subtracting ticket_age_add from PskIdentity.obfuscated_ticket_age modulo 2^32) 
+					*   Is the ticket age for the selected PSK identity (computed by subtracting ticket_age_add from PskIdentity.obfuscated_ticket_age modulo 2^32)
 					*   within a small tolerance of the time since the ticket was issued?
 					*/
-					
+
 					diff = (now - ticket.start) - (obfuscated_ticket_age - ticket.ticket_age_add);
 
 					if (diff > MBEDTLS_SSL_TICKET_AGE_TOLERANCE ) {
@@ -921,7 +921,7 @@ int ssl_parse_client_psk_identity_ext(mbedtls_ssl_context *ssl,
 					}
 #endif /* MBEDTLS_ZERO_RTT */
 #endif /* MBEDTLS_HAVE_TIME */
-					
+
 					// TBD: check ALPN, ciphersuite and SNI as well
 
 					/*
@@ -935,8 +935,8 @@ int ssl_parse_client_psk_identity_ext(mbedtls_ssl_context *ssl,
 #if defined(MBEDTLS_ZERO_RTT)
 						if (ssl->conf->early_data == MBEDTLS_SSL_EARLY_DATA_ENABLED) {
 							ssl->session_negotiate->process_early_data = MBEDTLS_SSL_EARLY_DATA_DISABLED;
-						} 
-#else 
+						}
+#else
 						((void)buf);
 #endif /* MBEDTLS_ZERO_RTT */
 					}
@@ -947,11 +947,11 @@ int ssl_parse_client_psk_identity_ext(mbedtls_ssl_context *ssl,
 		// skip the processed identity field and the obfuscated ticket age field
 		buf += item_length;
 		buf += 4;
-		sum = sum + 4; 
+		sum = sum + 4;
 	}
 
 	if (ret == MBEDTLS_ERR_SSL_SESSION_TICKET_EXPIRED) {
-		
+
 		MBEDTLS_SSL_DEBUG_MSG(1, ("Neither PSK nor ticket found."));
 		if ((ret = mbedtls_ssl_send_alert_message(ssl,
 			MBEDTLS_SSL_ALERT_LEVEL_FATAL,
@@ -963,7 +963,7 @@ int ssl_parse_client_psk_identity_ext(mbedtls_ssl_context *ssl,
 		return(ret);
 	}
 
-	if (ret == MBEDTLS_ERR_SSL_UNKNOWN_IDENTITY) 
+	if (ret == MBEDTLS_ERR_SSL_UNKNOWN_IDENTITY)
 	{
 		MBEDTLS_SSL_DEBUG_BUF(3, "Unknown PSK identity", buf, item_length);
 		if ((ret = mbedtls_ssl_send_alert_message(ssl,
@@ -983,7 +983,7 @@ int ssl_parse_client_psk_identity_ext(mbedtls_ssl_context *ssl,
 
 psk_parsing_successful:
 
-	/* Store this pointer since we need it to compute 
+	/* Store this pointer since we need it to compute
 	*  the psk binder.
 	*/
 	truncated_clienthello_end = (unsigned char*) buf;
@@ -999,7 +999,7 @@ psk_parsing_successful:
 		// Read to psk binder length
 		item_length = buf[0];
 		sum = sum + 1 + item_length;
-		buf += 1; 
+		buf += 1;
 
 		if (sum > item_array_length)
 		{
@@ -1056,7 +1056,7 @@ psk_parsing_successful:
 }
 #endif /* MBEDTLS_KEY_EXCHANGE__SOME__PSK_ENABLED*/
 
-#if defined(MBEDTLS_KEY_EXCHANGE__SOME__PSK_ENABLED) 
+#if defined(MBEDTLS_KEY_EXCHANGE__SOME__PSK_ENABLED)
 
 /*
 * struct {
@@ -1078,21 +1078,21 @@ static int ssl_write_server_pre_shared_key_ext(mbedtls_ssl_context *ssl,
 	unsigned char *p = (unsigned char*)buf;
 	size_t selected_identity;
 	int ret=0;
-	
+
 	*olen = 0;
-	
-	// Are we using an external PSK?  
+
+	// Are we using an external PSK?
 	if (ssl->conf->psk == NULL || ssl->conf->psk_identity == NULL ||
 		ssl->conf->psk_identity_len == 0 || ssl->conf->psk_len == 0)
 		ret = MBEDTLS_ERR_SSL_PRIVATE_KEY_REQUIRED;
 
-	// Are we using resumption? 
-	if (ssl->handshake->resume == 0 && ret == MBEDTLS_ERR_SSL_PRIVATE_KEY_REQUIRED)  	
+	// Are we using resumption?
+	if (ssl->handshake->resume == 0 && ret == MBEDTLS_ERR_SSL_PRIVATE_KEY_REQUIRED)
 	{
 		MBEDTLS_SSL_DEBUG_MSG(3, ("No pre-shared-key available."));
 		return(MBEDTLS_ERR_SSL_PRIVATE_KEY_REQUIRED);
 	}
-	
+
 	MBEDTLS_SSL_DEBUG_MSG(3, ("server hello, adding pre_shared_key extension"));
 
 
@@ -1150,7 +1150,7 @@ int mbedtls_ssl_set_client_transport_id(mbedtls_ssl_context *ssl,
 void mbedtls_ssl_conf_cookies(mbedtls_ssl_config *conf,
 	mbedtls_ssl_cookie_write_t *f_cookie_write,
 	mbedtls_ssl_cookie_check_t *f_cookie_check,
-	void *p_cookie, 
+	void *p_cookie,
 	unsigned int rr_config)
 {
 	conf->f_cookie_write = f_cookie_write;
@@ -1269,8 +1269,8 @@ static int ssl_parse_early_data_ext(mbedtls_ssl_context *ssl,
 	const unsigned char *buf,
 	size_t len)
 {
-        ((void*)ssl); 
-        ((void*)buf); 
+        ((void*)ssl);
+        ((void*)buf);
 	return(0);
 }
 */
@@ -1294,7 +1294,7 @@ static int ssl_parse_max_fragment_length_ext(mbedtls_ssl_context *ssl,
 }
 #endif /* MBEDTLS_SSL_MAX_FRAGMENT_LENGTH */
 
-#if defined(MBEDTLS_KEY_EXCHANGE__SOME__PSK_ENABLED) 
+#if defined(MBEDTLS_KEY_EXCHANGE__SOME__PSK_ENABLED)
 
 /*
 * ssl_parse_key_exchange_modes_ext() structure:
@@ -1312,7 +1312,7 @@ static int ssl_parse_key_exchange_modes_ext(mbedtls_ssl_context *ssl,
 {
 	int ret = 0;
 
-	// Length has to be either 1 or 2 based on the currently defined psk key exchange modes 
+	// Length has to be either 1 or 2 based on the currently defined psk key exchange modes
 	if (len < 2 || len >3)
 	{
 		MBEDTLS_SSL_DEBUG_MSG(1, ("bad psk key exchange modes extension in client hello message"));
@@ -1357,7 +1357,7 @@ static int ssl_parse_key_exchange_modes_ext(mbedtls_ssl_context *ssl,
  * ssl_write_supported_version_ext():
  * (as sent by server)
  *
- * case server_hello: 
+ * case server_hello:
  *          ProtocolVersion selected_version;
  */
 
@@ -1381,11 +1381,11 @@ static int ssl_write_supported_version_ext(mbedtls_ssl_context *ssl,
 	*p++ = (unsigned char)((MBEDTLS_TLS_EXT_SUPPORTED_VERSIONS >> 8) & 0xFF);
 	*p++ = (unsigned char)((MBEDTLS_TLS_EXT_SUPPORTED_VERSIONS) & 0xFF);
 
-	// length 
+	// length
 	*p++ = 0x00;
 	*p++ = 2;
 
-	// For TLS 1.3 and for DTLS 1.3 we use 0x0304 
+	// For TLS 1.3 and for DTLS 1.3 we use 0x0304
 	*p++ = 0x03;
 	*p++ = 0x04;
 	MBEDTLS_SSL_DEBUG_MSG(3, ("version [%d:%d]", *(p-2), *(p-1)));
@@ -1409,7 +1409,7 @@ static int ssl_parse_supported_versions_ext(mbedtls_ssl_context *ssl,
 
 	while (len > 0) {
 //		list_len = (buf[0] << 8) | buf[1];
-		list_len = buf[0]; 
+		list_len = buf[0];
 
 		// length has to be at least 2 bytes long
 		if (list_len < 2) {
@@ -1428,10 +1428,10 @@ static int ssl_parse_supported_versions_ext(mbedtls_ssl_context *ssl,
 		{
 			// we found a supported version
 			goto found_version;
-		} else 
+		} else
 		{
 			// if no match found, check next entry
-			buf += 2; 
+			buf += 2;
 			len -= 3;
 		}
 	}
@@ -1531,7 +1531,7 @@ static int ssl_parse_alpn_ext(mbedtls_ssl_context *ssl,
 * does not indicate whether there is a match or a mismatch.
 */
 
-/* We are not using this function anymore. 
+/* We are not using this function anymore.
 
 static int ssl_ciphersuite_match(mbedtls_ssl_context *ssl, int suite_id,
 	const mbedtls_ssl_ciphersuite_t **ciphersuite_info)
@@ -1583,10 +1583,10 @@ static int ssl_ciphersuite_match(mbedtls_ssl_context *ssl, int suite_id,
 */
 
 #if defined(MBEDTLS_SSL_NEW_SESSION_TICKET)
-/* This function creates a NewSessionTicket message in the following format. 
- * The ticket inside the NewSessionTicket is an encrypted container carrying 
+/* This function creates a NewSessionTicket message in the following format.
+ * The ticket inside the NewSessionTicket is an encrypted container carrying
  * the necessary information so that the server is later able to restore the
- * required parameters. 
+ * required parameters.
  *
  * struct {
  *    uint32 ticket_lifetime;
@@ -1595,9 +1595,9 @@ static int ssl_ciphersuite_match(mbedtls_ssl_context *ssl, int suite_id,
  *    opaque ticket<1..2^16-1>;
  *    Extension extensions<0..2^16-2>;
  * } NewSessionTicket;
- * 
- * The following fields are populated in the ticket:  
- * 
+ *
+ * The following fields are populated in the ticket:
+ *
  *  - creation time (start)
  *  - flags (flags)
  *  - lifetime (ticket_lifetime)
@@ -1606,14 +1606,14 @@ static int ssl_ciphersuite_match(mbedtls_ssl_context *ssl, int suite_id,
  *  - key length (key_len)
  *  - ciphersuite (ciphersuite)
  *  - certificate of the peer (peer_cert)
- * 
- */ 
+ *
+ */
 static int ssl_write_new_session_ticket(mbedtls_ssl_context *ssl)
 {
 	int ret;
 	size_t tlen;
 	size_t ext_len = 0;
-	mbedtls_ssl_ciphersuite_t *suite_info; 
+	mbedtls_ssl_ciphersuite_t *suite_info;
 	int hash_length;
 	mbedtls_ssl_ticket ticket;
 	mbedtls_ssl_ticket_context *ctx = ssl->conf->p_ticket;
@@ -1621,7 +1621,7 @@ static int ssl_write_new_session_ticket(mbedtls_ssl_context *ssl)
 	// Check whether the use of session tickets is enabled
 	if (ssl->conf->session_tickets == 0) {
 		MBEDTLS_SSL_DEBUG_MSG(3, ("Use of tickets disabled."));
-		return (0); 
+		return (0);
 	}
 
 	MBEDTLS_SSL_DEBUG_MSG(2, ("=> write NewSessionTicket msg"));
@@ -1649,7 +1649,7 @@ static int ssl_write_new_session_ticket(mbedtls_ssl_context *ssl)
 	}
 
 #if defined(MBEDTLS_HAVE_TIME)
-	// Store time when ticket was created. 
+	// Store time when ticket was created.
 	ticket.start = time(NULL);
 #endif /* MBEDTLS_HAVE_TIME */
 
@@ -1661,10 +1661,10 @@ static int ssl_write_new_session_ticket(mbedtls_ssl_context *ssl)
 
 #if defined(MBEDTLS_X509_CRT_PARSE_C)
 	// Check whether the client provided a certificate during the exchange
-	if (ssl->session->peer_cert != NULL) 
-		ticket.peer_cert = ssl->session->peer_cert; 
-	else 
-		ticket.peer_cert = NULL; 
+	if (ssl->session->peer_cert != NULL)
+		ticket.peer_cert = ssl->session->peer_cert;
+	else
+		ticket.peer_cert = NULL;
 #endif /* MBEDTLS_X509_CRT_PARSE_C */
 
 	/*
@@ -1750,8 +1750,8 @@ static int ssl_write_new_session_ticket(mbedtls_ssl_context *ssl)
 #endif /* MBEDTLS_SSL_NEW_SESSION_TICKET */
 
 #if defined(MBEDTLS_ZERO_RTT)
-/* ssl_parse_early_data() parses application data 
- * provided by the client following the ClientHello msg. 
+/* ssl_parse_early_data() parses application data
+ * provided by the client following the ClientHello msg.
  */
 static int ssl_parse_early_data(mbedtls_ssl_context *ssl)
 {
@@ -1772,7 +1772,7 @@ static int ssl_parse_early_data(mbedtls_ssl_context *ssl)
 			// copy data to staging area
 			memcpy(ssl->conf->early_data_buf, ssl->in_msg, ssl->in_msglen);
 			// execute callback to process application data
-			ssl->conf->early_data_callback(ssl, (unsigned char *) ssl->conf->early_data_buf, ssl->in_msglen); 
+			ssl->conf->early_data_callback(ssl, (unsigned char *) ssl->conf->early_data_buf, ssl->in_msglen);
 		}
 		else {
 			MBEDTLS_SSL_DEBUG_MSG(1, ("Buffer too small"));
@@ -1786,8 +1786,8 @@ static int ssl_parse_early_data(mbedtls_ssl_context *ssl)
 
 	MBEDTLS_SSL_DEBUG_MSG(2, ("<= parse early application data"));
 
-	return 0; 
-} 
+	return 0;
+}
 #endif /* MBEDTLS_ZERO_RTT */
 
 
@@ -1867,7 +1867,7 @@ static int ssl_client_hello_process(mbedtls_ssl_context* ssl)
 	MBEDTLS_SSL_DEBUG_MSG(2, ("=> parse client hello"));
 
 	MBEDTLS_SSL_PROC_CHK(ssl_client_hello_fetch(ssl, &buf, &buflen));
-	
+
 	//MBEDTLS_SSL_PROC_CHK(ssl_client_hello_parse(ssl, buf, buflen));
 	ret=ssl_client_hello_parse(ssl, buf, buflen);
 
@@ -1889,7 +1889,7 @@ static int ssl_client_hello_fetch(mbedtls_ssl_context* ssl,
 	size_t* dstlen)
 {
 	int ret;
-	unsigned char* buf; 
+	unsigned char* buf;
 	size_t msg_len;
 
 #if defined(MBEDTLS_SSL_DTLS_ANTI_REPLAY)
@@ -1943,7 +1943,7 @@ static int ssl_client_hello_fetch(mbedtls_ssl_context* ssl,
 			if (ssl->in_msg[0] == 1) {
 				MBEDTLS_SSL_DEBUG_MSG(3, ("Change Cipher Spec message received and ignoring it."));
 
-				// Done reading this record, get ready for the next one 
+				// Done reading this record, get ready for the next one
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
 				if (ssl->conf->transport == MBEDTLS_SSL_TRANSPORT_DATAGRAM) {
 					ssl->next_record_offset = msg_len + mbedtls_ssl_hdr_len(ssl, MBEDTLS_SSL_DIRECTION_IN);
@@ -2170,11 +2170,11 @@ static int ssl_client_hello_parse(mbedtls_ssl_context* ssl,
 	*/
 #if defined(MBEDTLS_CTLS)
 	if (ssl->handshake->ctls == MBEDTLS_CTLS_USE) {
-		buf += 1; // skip version 
+		buf += 1; // skip version
 	} else
 #endif /* MBEDTLS_CTLS */
 	{
-		buf += 2; // skip version 
+		buf += 2; // skip version
 	}
 
 
@@ -2186,14 +2186,14 @@ static int ssl_client_hello_parse(mbedtls_ssl_context* ssl,
 		MBEDTLS_SSL_DEBUG_BUF(3, "client hello, random bytes", buf, 16);
 
 		memcpy(&ssl->handshake->randbytes[0], buf, 16);
-		buf += 16; // skip random bytes 
+		buf += 16; // skip random bytes
 	} else
 #endif /* MBEDTLS_CTLS */
 	{
 		MBEDTLS_SSL_DEBUG_BUF(3, "client hello, random bytes", buf, 32);
 
 		memcpy(&ssl->handshake->randbytes[0], buf, 32);
-		buf += 32; // skip random bytes 
+		buf += 32; // skip random bytes
 	}
 
 
@@ -2236,7 +2236,7 @@ static int ssl_client_hello_parse(mbedtls_ssl_context* ssl,
 	{
 		cookie_len = buf[0];
 
-		// Length check 
+		// Length check
 		if (buf + cookie_len > msg_end)
 		{
 			MBEDTLS_SSL_DEBUG_MSG(1, ("bad client hello message"));
@@ -2285,7 +2285,7 @@ static int ssl_client_hello_parse(mbedtls_ssl_context* ssl,
 
 	ciph_len = (buf[0] << 8) | (buf[1]);
 
-	// Length check 
+	// Length check
 	if (buf + ciph_len > end)
 	{
 		MBEDTLS_SSL_DEBUG_MSG(1, ("bad client hello message"));
@@ -2295,13 +2295,13 @@ static int ssl_client_hello_parse(mbedtls_ssl_context* ssl,
 	// store pointer to ciphersuite list
 	ciph_offset = buf;
 
-	// skip cipher length 
+	// skip cipher length
 	buf += 2;
 
 	MBEDTLS_SSL_DEBUG_BUF(3, "client hello, ciphersuitelist",
 		buf, ciph_len);
 
-	// skip ciphersuites for now 
+	// skip ciphersuites for now
 	buf += ciph_len;
 
 #if defined(MBEDTLS_CTLS)
@@ -2351,7 +2351,7 @@ static int ssl_client_hello_parse(mbedtls_ssl_context* ssl,
 		return(MBEDTLS_ERR_SSL_BAD_HS_CLIENT_HELLO);
 	}
 
-	buf += 2; 
+	buf += 2;
 
 	ext = buf;
 	MBEDTLS_SSL_DEBUG_BUF(3, "client hello extensions", ext, ext_len);
@@ -2405,9 +2405,9 @@ static int ssl_client_hello_parse(mbedtls_ssl_context* ssl,
 			MBEDTLS_SSL_DEBUG_MSG(3, ("found cookie extension"));
 
 			ret = ssl_parse_cookie_ext(ssl, ext + 4, ext_size);
-			
+
 			// if cookie verification failed then we return a hello retry message
-			if (ret == MBEDTLS_ERR_SSL_BAD_HS_COOKIE_EXT) 
+			if (ret == MBEDTLS_ERR_SSL_BAD_HS_COOKIE_EXT)
 			{
 				final_ret = MBEDTLS_ERR_SSL_BAD_HS_COOKIE_EXT;
 			}
@@ -2433,9 +2433,9 @@ static int ssl_client_hello_parse(mbedtls_ssl_context* ssl,
 #endif /* MBEDTLS_KEY_EXCHANGE_PSK_ENABLED */
 
 #if defined(MBEDTLS_ZERO_RTT)
-		case MBEDTLS_TLS_EXT_EARLY_DATA: 
+		case MBEDTLS_TLS_EXT_EARLY_DATA:
 			MBEDTLS_SSL_DEBUG_MSG(3, ("found early_data extension"));
-			
+
 			/* There is nothing really to process with this extension.
 
 			ret = ssl_parse_early_data_ext(ssl, ext + 4, ext_size);
@@ -2445,15 +2445,15 @@ static int ssl_client_hello_parse(mbedtls_ssl_context* ssl,
 			}
 			*/
 			ssl->handshake->extensions_present += EARLY_DATA_EXTENSION;
-			break; 
+			break;
 #endif /* MBEDTLS_ZERO_RTT */
 
-#if defined(MBEDTLS_ECDH_C) || defined(MBEDTLS_ECDSA_C) 
+#if defined(MBEDTLS_ECDH_C) || defined(MBEDTLS_ECDSA_C)
 		case MBEDTLS_TLS_EXT_SUPPORTED_GROUPS:
 			MBEDTLS_SSL_DEBUG_MSG(3, ("found supported group extension"));
 
 			/* Supported Groups Extension
-			 * 
+			 *
 			 * When sent by the client, the "supported_groups" extension
              * indicates the named groups which the client supports,
              * ordered from most preferred to least preferred.
@@ -2503,7 +2503,7 @@ static int ssl_client_hello_parse(mbedtls_ssl_context* ssl,
 			else if (ret == MBEDTLS_ERR_SSL_BAD_HS_WRONG_KEY_SHARE) {
 				/* We need to send a HelloRetryRequest message
 				 * but we still have to determine the ciphersuite.
-				 * Note: We got the key share - we just didn't like 
+				 * Note: We got the key share - we just didn't like
 				 *       the content of it.
 				 */
 				final_ret = MBEDTLS_ERR_SSL_BAD_HS_WRONG_KEY_SHARE;
@@ -2712,7 +2712,7 @@ have_ciphersuite:
 			(ssl->handshake->extensions_present & PSK_KEY_EXCHANGE_MODES_EXTENSION)) {
 			// Test whether we are allowed to use this mode (server-side check)
 			if (ssl->conf->key_exchange_modes == KEY_EXCHANGE_MODE_PSK_DHE_KE || ssl->conf->key_exchange_modes == KEY_EXCHANGE_MODE_PSK_ALL || ssl->conf->key_exchange_modes == KEY_EXCHANGE_MODE_ALL) {
-				// Test whether we are allowed to use this mode (client-side check)		
+				// Test whether we are allowed to use this mode (client-side check)
 				if (ssl->session_negotiate->key_exchange_modes == KEY_EXCHANGE_MODE_PSK_DHE_KE || ssl->session_negotiate->key_exchange_modes == KEY_EXCHANGE_MODE_PSK_ALL) {
 
 					if ((ret = ssl_parse_client_psk_identity_ext(ssl, ext_psk_ptr, ext_len_psk_ext)) != 0)
@@ -2731,12 +2731,12 @@ have_ciphersuite:
 	}
 #endif /* MBEDTLS_ZERO_RTT*/
 
-	/* The order of preference is 
+	/* The order of preference is
 	 *  1) Plain PSK Mode
 	 *  2) (EC)DHE-PSK Mode
 	 *  3) Certificate Mode
-	 * 
-	 * Currently, the preference order is hard-coded - not configurable. 
+	 *
+	 * Currently, the preference order is hard-coded - not configurable.
 	 */
 	/*
 	* 1) Plain PSK-based key exchange
@@ -2769,7 +2769,7 @@ have_ciphersuite:
 	if ((ssl->handshake->extensions_present & PRE_SHARED_KEY_EXTENSION) && (ssl->handshake->extensions_present & KEY_SHARE_EXTENSION) && (ssl->handshake->extensions_present & PSK_KEY_EXCHANGE_MODES_EXTENSION)) {
 		// Test whether we are allowed to use this mode (server-side check)
 		if (ssl->conf->key_exchange_modes == KEY_EXCHANGE_MODE_PSK_DHE_KE || ssl->conf->key_exchange_modes == KEY_EXCHANGE_MODE_PSK_ALL || ssl->conf->key_exchange_modes == KEY_EXCHANGE_MODE_ALL) {
-			// Test whether we are allowed to use this mode (client-side check)		
+			// Test whether we are allowed to use this mode (client-side check)
 			if (ssl->session_negotiate->key_exchange_modes == KEY_EXCHANGE_MODE_PSK_DHE_KE || ssl->session_negotiate->key_exchange_modes == KEY_EXCHANGE_MODE_PSK_ALL) {
 
 				if ((ret = ssl_parse_client_psk_identity_ext(ssl, ext_psk_ptr, ext_len_psk_ext)) != 0)
@@ -2783,7 +2783,7 @@ have_ciphersuite:
 				goto end_client_hello;
 			}
 		}
-	} 
+	}
 
 	/*
 	* 3) Certificate-based key exchange
@@ -2819,7 +2819,7 @@ end_client_hello:
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
 
 #if defined(MBEDTLS_SSL_COOKIE_C)
-   /* If we failed to see a cookie extension, and we required it through the 
+   /* If we failed to see a cookie extension, and we required it through the
 	* configuration settings (rr_config), then we need to send a HRR msg.
 	* Conceptually, this is similiar to having received a cookie that failed
 	* the verification check.
@@ -2827,7 +2827,7 @@ end_client_hello:
 	if ((ssl->conf->rr_config == MBEDTLS_SSL_FORCE_RR_CHECK_ON) &&
 		!(ssl->handshake->extensions_present & COOKIE_EXTENSION)) {
 		MBEDTLS_SSL_DEBUG_MSG(2, ("Cookie extension missing. Need to send a HRR."));
-		final_ret = MBEDTLS_ERR_SSL_BAD_HS_MISSING_COOKIE_EXT; 
+		final_ret = MBEDTLS_ERR_SSL_BAD_HS_MISSING_COOKIE_EXT;
 	}
 #endif /* MBEDTLS_SSL_COOKIE_C */
 
@@ -2862,13 +2862,13 @@ end_client_hello:
 
 
 		if (ssl->transform_negotiate->ciphersuite_info->mac == MBEDTLS_MD_SHA256) {
-#if defined(MBEDTLS_SHA256_C) 
+#if defined(MBEDTLS_SHA256_C)
 			mbedtls_sha256_init(&sha256);
 			mbedtls_sha256_starts(&sha256, 0 /* = use SHA256 */);
 			mbedtls_sha256_update(&sha256, orig_buf, orig_msg_len); // hash ClientHello message
 			mbedtls_sha256_finish(&sha256, &transcript[4]);
 			MBEDTLS_SSL_DEBUG_BUF(5, "Transcript-Hash(ClientHello1, HelloRetryRequest, ... MN)", &transcript[0], 32+4);
-#else 
+#else
 			MBEDTLS_SSL_DEBUG_MSG(1, ("mbedtls_ssl_derive_master_secret: Unknow hash function."));
 			return(MBEDTLS_ERR_SSL_INTERNAL_ERROR);
 #endif /* MBEDTLS_SHA256_C */
@@ -2880,7 +2880,7 @@ end_client_hello:
 			mbedtls_sha512_update(&sha512, orig_buf, orig_msg_len); // hash ClientHello message
 			mbedtls_sha512_finish(&sha512, &transcript[4]);
 			MBEDTLS_SSL_DEBUG_BUF(5, "Transcript-Hash(ClientHello1, HelloRetryRequest, ... MN)", &transcript[0], 48+4);
-#else 
+#else
 			MBEDTLS_SSL_DEBUG_MSG(1, ("mbedtls_ssl_derive_master_secret: Unknow hash function."));
 			return(MBEDTLS_ERR_SSL_INTERNAL_ERROR);
 #endif /* MBEDTLS_SHA512_C */
@@ -2894,7 +2894,7 @@ end_client_hello:
 			MBEDTLS_SSL_DEBUG_BUF(5, "ClientHello hash", &transcript[4], 64);
 		}
 		else {
-#else 
+#else
 			MBEDTLS_SSL_DEBUG_MSG(1, ("mbedtls_ssl_derive_master_secret: Unknow hash function."));
 			return(MBEDTLS_ERR_SSL_INTERNAL_ERROR);
 #endif  /* MBEDTLS_SHA512_C*/
@@ -2902,10 +2902,10 @@ end_client_hello:
 		ssl->handshake->update_checksum(ssl, &transcript[0], hash_length + 4);
 	}
 	else {
-		// create normal transcript hash 
+		// create normal transcript hash
 		MBEDTLS_SSL_DEBUG_MSG(5, ("--- Checksum (ssl_parse_client_hello, normal transcript hash)"));
 		ssl->handshake->update_checksum(ssl, orig_buf, orig_msg_len);
-	} 
+	}
 	mbedtls_ssl_optimize_checksum(ssl, ssl->transform_negotiate->ciphersuite_info);
 
 	return(final_ret);
@@ -3052,7 +3052,7 @@ cleanup:
 
 static int ssl_encrypted_extensions_prepare(mbedtls_ssl_context* ssl)
 {
-	int ret; 
+	int ret;
 	KeySet traffic_keys;
 
 	ret = mbedtls_ssl_key_derivation(ssl, &traffic_keys);
@@ -3069,7 +3069,7 @@ static int ssl_encrypted_extensions_prepare(mbedtls_ssl_context* ssl)
 		ssl->handshake->alt_transform_out = ssl->transform_out;
 		memcpy(ssl->handshake->alt_out_ctr, ssl->out_ctr, 8);
 	}
-#endif 
+#endif
 
 	ssl->transform_out = ssl->transform_negotiate;
 	ssl->session_out = ssl->session_negotiate;
@@ -3141,9 +3141,9 @@ static int ssl_encrypted_extensions_prepare(mbedtls_ssl_context* ssl)
 	*/
 	ssl->in_epoch = 2;
 	ssl->out_epoch = 2;
-#endif /* MBEDTLS_SSL_PROTO_DTLS */ 
+#endif /* MBEDTLS_SSL_PROTO_DTLS */
 
-	return 0; 
+	return 0;
 }
 
 static int ssl_encrypted_extensions_write(mbedtls_ssl_context* ssl,
@@ -3156,7 +3156,7 @@ static int ssl_encrypted_extensions_write(mbedtls_ssl_context* ssl,
 	unsigned char *p, *end;
 
 	/* If all extensions are disabled then olen is 0. */
-	*olen = 0; 
+	*olen = 0;
 
 	end = buf + buflen;
 
@@ -3165,7 +3165,7 @@ static int ssl_encrypted_extensions_write(mbedtls_ssl_context* ssl,
 		return(MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL);
 	}
 
-	// Skip HS header 
+	// Skip HS header
 	p = buf + 4;
 
 	/*
@@ -3174,7 +3174,7 @@ static int ssl_encrypted_extensions_write(mbedtls_ssl_context* ssl,
 	* } EncryptedExtensions;
 	*
 	*/
-	
+
 	// Skip extension length; first write extensions, then update length
 	p += 2;
 
@@ -3217,7 +3217,7 @@ static int ssl_encrypted_extensions_write(mbedtls_ssl_context* ssl,
 
 	*(buf + 4 ) = (unsigned char)(((*olen - 4 - 2 ) >> 8) & 0xFF);
 	*(buf + 5) = (unsigned char)((*olen - 4 - 2) & 0xFF);
-	
+
 	return(0);
 }
 
@@ -3247,7 +3247,7 @@ static int ssl_write_hello_retry_request(mbedtls_ssl_context *ssl)
 	unsigned char *extension_start;
 	const char magic_hrr_string[32] = { 0xCF, 0x21, 0xAD, 0x74, 0xE5, 0x9A, 0x61, 0x11, 0xBE, 0x1D, 0x8C, 0x02, 0x1E, 0x65, 0xB8, 0x91, 0xC2, 0xA2, 0x11, 0x16, 0x7A, 0xBB, 0x8C, 0x5E, 0x07, 0x9E, 0x09, 0xE2, 0xC8, 0xA8, 0x33 ,0x9C };
 
-#if defined(MBEDTLS_ECDH_C) 
+#if defined(MBEDTLS_ECDH_C)
 	const mbedtls_ecp_group_id *gid;
 	const mbedtls_ecp_curve_info **curve = NULL;
 #endif /* MBEDTLS_ECDH_C */
@@ -3257,7 +3257,7 @@ static int ssl_write_hello_retry_request(mbedtls_ssl_context *ssl)
 
 	/*
 	* struct {
-	*    ProtocolVersion legacy_version = 0x0303;    
+	*    ProtocolVersion legacy_version = 0x0303;
 	*    Random random (with magic value);
 	*    opaque legacy_session_id_echo<0..32>;
 	*    CipherSuite cipher_suite;
@@ -3266,7 +3266,7 @@ static int ssl_write_hello_retry_request(mbedtls_ssl_context *ssl)
 	* } ServerHello; --- aka HelloRetryRequest
 	*/
 
-	
+
 	/* For TLS 1.3 we use the legacy version number {0x03, 0x03}
 	*  instead of the true version number.
 	*
@@ -3287,7 +3287,7 @@ static int ssl_write_hello_retry_request(mbedtls_ssl_context *ssl)
 			MBEDTLS_SSL_DEBUG_BUF(3, "server version", p - 2, 2);
 		}
 		else
-#else 
+#else
 		{
 			*p++ = 0x03;
 			*p++ = 0x03;
@@ -3295,7 +3295,7 @@ static int ssl_write_hello_retry_request(mbedtls_ssl_context *ssl)
 		}
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
 	}
-	
+
 	if (ssl->transform_negotiate == NULL) {
 		MBEDTLS_SSL_DEBUG_MSG(1, ("ssl_write_hello_retry_request: ssl->transform_negotiate == NULL"));
 		return(MBEDTLS_ERR_SSL_INTERNAL_ERROR);
@@ -3308,22 +3308,22 @@ static int ssl_write_hello_retry_request(mbedtls_ssl_context *ssl)
 	MBEDTLS_SSL_DEBUG_BUF(3, "random bytes", p, 32);
 	p += 32;
 
-	// write legacy_session_id_echo 
+	// write legacy_session_id_echo
 	*p++ = (unsigned char) ssl->session_negotiate->id_len;
 	memcpy(p, &ssl->session_negotiate->id[0], ssl->session_negotiate->id_len);
 	MBEDTLS_SSL_DEBUG_BUF(3, "session id", p, ssl->session_negotiate->id_len);
 	p += ssl->session_negotiate->id_len;
 
-	// write ciphersuite (2 bytes) 
+	// write ciphersuite (2 bytes)
 	*p++ = (unsigned char)(ssl->session_negotiate->ciphersuite >> 8);
 	*p++ = (unsigned char)(ssl->session_negotiate->ciphersuite);
 	MBEDTLS_SSL_DEBUG_BUF(3, "ciphersuite", p-2, 2);
 
-	// write legacy_compression_method (0) 
+	// write legacy_compression_method (0)
 	*p++ = 0x0;
 	MBEDTLS_SSL_DEBUG_MSG(3, ("legacy compression method: [%d]", *(p-1)));
 
-	// write extensions 
+	// write extensions
 	extension_start = p;
 	// Extension starts with a 2 byte length field; we skip it and write it later
 	p += 2;
@@ -3374,7 +3374,7 @@ static int ssl_write_hello_retry_request(mbedtls_ssl_context *ssl)
 	total_ext_len += ext_length + 4  /* 2 bytes for extension_type and 2 bytes for length field */;
 #endif /* MBEDTLS_SSL_COOKIE_C */
 
-#if defined(MBEDTLS_ECDH_C) 
+#if defined(MBEDTLS_ECDH_C)
 
 	/* key_share Extension
 	*
@@ -3394,7 +3394,7 @@ static int ssl_write_hello_retry_request(mbedtls_ssl_context *ssl)
 	*/
 
 	/* For a pure PSK-based ciphersuite there is no key share to declare.
-	 * Hence, we focus on ECDHE-EDSA and ECDHE-PSK. 
+	 * Hence, we focus on ECDHE-EDSA and ECDHE-PSK.
 	 */
 	if (ssl->session_negotiate->key_exchange == MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA || ssl->session_negotiate->key_exchange == MBEDTLS_KEY_EXCHANGE_ECDHE_PSK ) {
 
@@ -3478,7 +3478,7 @@ static int ssl_server_hello_process(mbedtls_ssl_context* ssl) {
 	MBEDTLS_SSL_DEBUG_MSG(2, ("=> write server hello"));
 
 	/* Coordination */
-	
+
 	/* Preprocessing */
 
 	/* This might lead to ssl_process_server_hello() being called multiple
@@ -3557,14 +3557,14 @@ static int ssl_server_hello_prepare(mbedtls_ssl_context* ssl)
 #endif /* MBEDTLS_HAVE_TIME */
 
 
-	/* Check for session resumption 
+	/* Check for session resumption
 	 * <TBD>
 	 */
 
 	return(0);
 }
 
-static int ssl_server_hello_write(mbedtls_ssl_context* ssl,	
+static int ssl_server_hello_write(mbedtls_ssl_context* ssl,
 	unsigned char* buf,
 	size_t buflen,
 	size_t* olen)
@@ -3583,7 +3583,7 @@ static int ssl_server_hello_write(mbedtls_ssl_context* ssl,
 	size_t total_ext_len;        /* Size of list of extensions    */
 	size_t rand_bytes_len;
 
-	// Buffer management 
+	// Buffer management
 	unsigned char* start = buf;
 	unsigned char* end = buf + buflen;
 
@@ -3607,18 +3607,18 @@ static int ssl_server_hello_write(mbedtls_ssl_context* ssl,
 	/*
 	 *  TLS 1.3
 	 *     0  .   0   handshake type
-     *     1  .   3   handshake length           
+     *     1  .   3   handshake length
 	 *
-	 *  cTLS 
+	 *  cTLS
 	 *     0  .   0   handshake type
-	 * 
+	 *
      * The header is set by ssl_write_record.
-	 * For DTLS 1.3 the other fields are adjusted. 
+	 * For DTLS 1.3 the other fields are adjusted.
 	 */
 #if defined(MBEDTLS_CTLS)
 	if (ssl->handshake->ctls == MBEDTLS_CTLS_USE)
 	{
-		buf++; // skip handshake type 
+		buf++; // skip handshake type
 		buflen--;
 	} else
 #endif /* MBEDTLS_CTLS */
@@ -3633,12 +3633,12 @@ static int ssl_server_hello_write(mbedtls_ssl_context* ssl,
 	if (ssl->handshake->ctls == MBEDTLS_CTLS_DO_NOT_USE)
 	{
 #endif /* MBEDTLS_CTLS */
-#if defined(MBEDTLS_SSL_PROTO_DTLS) 
+#if defined(MBEDTLS_SSL_PROTO_DTLS)
 		if (ssl->conf->transport == MBEDTLS_SSL_TRANSPORT_DATAGRAM) {
 			*buf++ = (unsigned char)0xfe;
 			*buf++ = (unsigned char)0xfd;
 			MBEDTLS_SSL_DEBUG_MSG(3, ("server hello, chosen version: [0xfe:0xfd]"));
-		} else 
+		} else
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
 		{
 			*buf++ = (unsigned char)0x3;
@@ -3646,14 +3646,14 @@ static int ssl_server_hello_write(mbedtls_ssl_context* ssl,
 			MBEDTLS_SSL_DEBUG_MSG(3, ("server hello, chosen version: [0x3:0x3]"));
 		}
 		buflen -= 2;
-#if defined(MBEDTLS_CTLS) 
+#if defined(MBEDTLS_CTLS)
 	}
 #endif /* MBEDTLS_CTLS */
 
-	// Write random bytes 
+	// Write random bytes
 	memcpy(buf, ssl->handshake->randbytes, rand_bytes_len);
 	MBEDTLS_SSL_DEBUG_BUF(3, "server hello, random bytes", buf, rand_bytes_len);
-	
+
 	buf += rand_bytes_len;
 	buflen -= rand_bytes_len;
 
@@ -3661,13 +3661,13 @@ static int ssl_server_hello_write(mbedtls_ssl_context* ssl,
 	ssl->session_negotiate->start = time(NULL);
 #endif /* MBEDTLS_HAVE_TIME */
 
-	// Write legacy session id 
+	// Write legacy session id
 #if defined(MBEDTLS_CTLS)
 	if (ssl->handshake->ctls == MBEDTLS_CTLS_DO_NOT_USE)
 #endif /* MBEDTLS_CTLS */
 	{
 		*buf++ = (unsigned char)ssl->session_negotiate->id_len;
-		buflen--; 
+		buflen--;
 		memcpy(buf, &ssl->session_negotiate->id[0], ssl->session_negotiate->id_len);
 		buf += ssl->session_negotiate->id_len;
 		MBEDTLS_SSL_DEBUG_MSG(3, ("session id length (%d)", ssl->session_negotiate->id_len));
@@ -3675,7 +3675,7 @@ static int ssl_server_hello_write(mbedtls_ssl_context* ssl,
 		buflen -= ssl->session_negotiate->id_len;
 	}
 
-	// write selected ciphersuite (2 bytes) 
+	// write selected ciphersuite (2 bytes)
 	*buf++ = (unsigned char)(ssl->session_negotiate->ciphersuite >> 8);
 	*buf++ = (unsigned char)(ssl->session_negotiate->ciphersuite);
 	buflen -= 2;
@@ -3685,7 +3685,7 @@ static int ssl_server_hello_write(mbedtls_ssl_context* ssl,
 	if (ssl->handshake->ctls == MBEDTLS_CTLS_DO_NOT_USE)
 #endif /* MBEDTLS_CTLS */
 	{
-		// write legacy_compression_method (0) 
+		// write legacy_compression_method (0)
 		*buf++ = 0x0;
 		buflen--;
 	}
@@ -3722,7 +3722,7 @@ static int ssl_server_hello_write(mbedtls_ssl_context* ssl,
 			MBEDTLS_SSL_DEBUG_RET(1, "ssl_write_key_shares_ext", ret);
 			return(ret);
 		}
-		
+
 		total_ext_len += cur_ext_len;
 		buf += cur_ext_len;
 	}
@@ -3762,7 +3762,7 @@ static int ssl_server_hello_write(mbedtls_ssl_context* ssl,
 	buflen -= 2 + total_ext_len;
 
 	*olen = buf - start;
-	
+
 	MBEDTLS_SSL_DEBUG_BUF(3, "server hello", start, *olen);
 
 	return(ret);
@@ -3770,10 +3770,10 @@ static int ssl_server_hello_write(mbedtls_ssl_context* ssl,
 
 static int ssl_server_hello_postprocess(mbedtls_ssl_context* ssl)
 {
-	int ret;
-	
-	ret = 0;
-	return(0);
+	int ret = 0;
+        ((void) ssl);
+
+	return( ret );
 }
 
 
@@ -3876,8 +3876,6 @@ cleanup:
 static int ssl_certificate_request_coordinate(mbedtls_ssl_context* ssl)
 {
 	int authmode;
-	const mbedtls_ssl_ciphersuite_t* ciphersuite_info =
-		ssl->transform_negotiate->ciphersuite_info;
 
 	if ((ssl->session_negotiate->key_exchange == MBEDTLS_KEY_EXCHANGE_PSK ||
 		ssl->session_negotiate->key_exchange == MBEDTLS_KEY_EXCHANGE_ECDHE_PSK))
@@ -3943,8 +3941,8 @@ static int ssl_certificate_request_write(mbedtls_ssl_context* ssl,
 	* Write certificate_request_context
 	*/
 
-	/* 
-	 * We use a zero length context for the normal handshake 
+	/*
+	 * We use a zero length context for the normal handshake
 	 * messages. For post-authentication handshake messages
 	 * this request context would be set to a non-zero value.
 	*/
@@ -3959,10 +3957,10 @@ static int ssl_certificate_request_write(mbedtls_ssl_context* ssl,
 	* Write extensions
 	*/
 
-	// The extensions must contain the signature_algorithms.  	
+	// The extensions must contain the signature_algorithms.
 	// Currently we don't use any other extension
-	ret = ssl_write_signature_algorithms_ext(ssl, p+2, end, olen); 	
-	if (ret != 0) return ret; 
+	ret = ssl_write_signature_algorithms_ext(ssl, p+2, end, olen);
+	if (ret != 0) return ret;
 
 	// length field for all extensions
 	*p++ = (unsigned char)((*olen >> 8) & 0xFF);
@@ -4018,7 +4016,7 @@ int mbedtls_ssl_handshake_server_step(mbedtls_ssl_context *ssl)
 		/* epoch value (0) is used with unencrypted messages */
 		ssl->out_epoch = 0;
 		ssl->in_epoch = 0;
-#endif /* MBEDTLS_SSL_PROTO_DTLS */ 
+#endif /* MBEDTLS_SSL_PROTO_DTLS */
 
 #if defined(MBEDTLS_COMPATIBILITY_MODE)
 		ssl->handshake->ccs_sent = 0;
@@ -4061,7 +4059,7 @@ int mbedtls_ssl_handshake_server_step(mbedtls_ssl_context *ssl)
 			if (ssl->handshake->hello_retry_requests_sent == 0 &&
 				ssl->conf->rr_config == MBEDTLS_SSL_FORCE_RR_CHECK_ON)
 			{
-				// Transmit Hello Retry Request 
+				// Transmit Hello Retry Request
 				mbedtls_ssl_handshake_set_state(ssl, MBEDTLS_SSL_HELLO_RETRY_REQUEST);
 			}
 			else
@@ -4085,7 +4083,7 @@ int mbedtls_ssl_handshake_server_step(mbedtls_ssl_context *ssl)
 			ret = 0;
 			break;
 		case MBEDTLS_ERR_SSL_BAD_HS_CLIENT_KEY_SHARE:
-			// Failed to parse the key share correctly --> send HRR 
+			// Failed to parse the key share correctly --> send HRR
 			mbedtls_ssl_handshake_set_state(ssl, MBEDTLS_SSL_HELLO_RETRY_REQUEST);
 			ret = 0;
 			break;
@@ -4164,7 +4162,7 @@ int mbedtls_ssl_handshake_server_step(mbedtls_ssl_context *ssl)
 		  */
 		ssl->in_epoch = 1;
 		ssl->out_epoch = 1;
-#endif /* MBEDTLS_SSL_PROTO_DTLS */ 
+#endif /* MBEDTLS_SSL_PROTO_DTLS */
 
 		ret = ssl_parse_early_data(ssl);
 		if (ret != 0) {
@@ -4196,7 +4194,7 @@ int mbedtls_ssl_handshake_server_step(mbedtls_ssl_context *ssl)
 
 #if defined(MBEDTLS_COMPATIBILITY_MODE)
 		mbedtls_ssl_handshake_set_state(ssl, MBEDTLS_SSL_SERVER_CCS_AFTER_HRR);
-#else 
+#else
 		mbedtls_ssl_handshake_set_state(ssl, MBEDTLS_SSL_CLIENT_HELLO);
 #endif /* MBEDTLS_COMPATIBILITY_MODE */
 
@@ -4262,7 +4260,7 @@ int mbedtls_ssl_handshake_server_step(mbedtls_ssl_context *ssl)
 		{
 			mbedtls_ssl_handshake_set_state(ssl, MBEDTLS_SSL_ENCRYPTED_EXTENSIONS);
 		}
-#else 
+#else
 		mbedtls_ssl_handshake_set_state(ssl, MBEDTLS_SSL_ENCRYPTED_EXTENSIONS);
 #endif /* MBEDTLS_COMPATIBILITY_MODE */
 
@@ -4437,18 +4435,18 @@ int mbedtls_ssl_handshake_server_step(mbedtls_ssl_context *ssl)
 		*/
 		ssl->in_epoch = 3;
 		ssl->out_epoch = 3;
-#endif /* MBEDTLS_SSL_PROTO_DTLS */ 
+#endif /* MBEDTLS_SSL_PROTO_DTLS */
 
-		if (ssl->conf->transport == MBEDTLS_SSL_TRANSPORT_DATAGRAM) 
+		if (ssl->conf->transport == MBEDTLS_SSL_TRANSPORT_DATAGRAM)
 			mbedtls_ssl_handshake_set_state(ssl, MBEDTLS_SSL_HANDSHAKE_FINISH_ACK);
-		else 
+		else
 			mbedtls_ssl_handshake_set_state(ssl, MBEDTLS_SSL_HANDSHAKE_WRAPUP);
 		break;
 
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
 	case MBEDTLS_SSL_HANDSHAKE_FINISH_ACK:
-		/* The server needs to reply with an ACK message after parsing 
-		 * the Finish message from the client. 
+		/* The server needs to reply with an ACK message after parsing
+		 * the Finish message from the client.
 		 */
 		ret = mbedtls_ssl_write_ack(ssl);
 		if (ret != 0) {
@@ -4456,7 +4454,7 @@ int mbedtls_ssl_handshake_server_step(mbedtls_ssl_context *ssl)
 			return (ret);
 		}
 		mbedtls_ssl_handshake_set_state(ssl, MBEDTLS_SSL_HANDSHAKE_WRAPUP);
-		break; 
+		break;
 #endif  /* MBEDTLS_SSL_PROTO_DTLS  */
 
 	case MBEDTLS_SSL_HANDSHAKE_WRAPUP:


### PR DESCRIPTION
This commit fixes various compiler warnings when compiling the TLS 1.3 prototype out of the box. See the commit messages for details.

It also removes various trailing white spaces - this was an unavoidable but useful side-effect of the editing because my editor removes trailing white spaces automatically on saving.