### PR TITLE
Adjust namespace of KeySet and TicketFlags

### DIFF
--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -1077,7 +1077,7 @@ typedef struct mbedtls_ssl_key_set {
 	unsigned char *server_sn_key;
 	unsigned char *client_sn_key;
 } mbedtls_ssl_key_set;
-#endif /* MBEDTLS_SSL_PROTO_TLS1_3 */
+#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 
 /*
  * This structure is used for storing current session data.

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -790,7 +790,7 @@ typedef enum
     allow_early_data = 1,
     allow_dhe_resumption = 2,
     allow_psk_resumption = 4,
-} TicketFlags;
+} mbedtls_ssl_ticket_flags;
 
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL && MBEDTLS_SSL_NEW_SESSION_TICKET && MBEDTLS_SSL_CLI_C */
 
@@ -814,9 +814,9 @@ struct mbedtls_ssl_ticket {
     time_t start;
 #endif
 #if defined(MBEDTLS_X509_CRT_PARSE_C)
-    mbedtls_x509_crt* peer_cert;         /*!< entry peer_cert    */
+    mbedtls_x509_crt* peer_cert;    /*!< entry peer_cert */
 #endif
-    TicketFlags flags;          /*!< ticket flags */
+    mbedtls_ssl_ticket_flags flags; /*!< ticket flags    */
 };
 
 #if defined(MBEDTLS_SSL_ASYNC_PRIVATE)
@@ -1052,10 +1052,10 @@ typedef void mbedtls_ssl_async_cancel_t( mbedtls_ssl_context *ssl );
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
 /**
-* \brief          KeySet data structure holding client/server write keys
-*                 as well as the respective IVs.
+* \brief          mbedtls_ssl_key_set data structure holding client/server
+*                 write keys as well as the respective IVs.
 */
-typedef struct KeySet {
+typedef struct mbedtls_ssl_key_set {
 	unsigned char *clientWriteKey;
 	unsigned char *serverWriteKey;
 	unsigned char *clientWriteIV;
@@ -1076,8 +1076,8 @@ typedef struct KeySet {
 	 */
 	unsigned char *server_sn_key;
 	unsigned char *client_sn_key;
-} KeySet;
-#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
+} mbedtls_ssl_key_set;
+#endif /* MBEDTLS_SSL_PROTO_TLS1_3 */
 
 /*
  * This structure is used for storing current session data.
@@ -1138,14 +1138,14 @@ struct mbedtls_ssl_session
 #if defined(MBEDTLS_SSL_NEW_SESSION_TICKET) && defined(MBEDTLS_SSL_CLI_C)
 // TBD: Replace fields by ticket structure
 // We currently only store a single ticket on the client size
-    unsigned char* ticket;      /*!< TLS 1.3 session ticket acting as psk identity */
-    size_t ticket_len;          /*!< ticket length   */
-    uint32_t ticket_lifetime;   /*!< ticket lifetime hint    */
-    TicketFlags flags;          /*!< ticket flags */
-    uint32_t ticket_age_add;    /* A randomly generated 32-bit value that is used to obscure the age of the ticket */
-    unsigned char* ticket_nonce;/*!< ticket nonce value */
-    uint8_t ticket_nonce_len;   /*!< ticket nonce length */
-    size_t key_len;             /*!< psk key length */
+    unsigned char* ticket;          /*!< TLS 1.3 session ticket acting as psk identity */
+    size_t ticket_len;              /*!< ticket length   */
+    uint32_t ticket_lifetime;       /*!< ticket lifetime hint    */
+    mbedtls_ssl_ticket_flags flags; /*!< ticket flags */
+    uint32_t ticket_age_add;        /* A randomly generated 32-bit value that is used to obscure the age of the ticket */
+    unsigned char* ticket_nonce;    /*!< ticket nonce value */
+    uint8_t ticket_nonce_len;       /*!< ticket nonce length */
+    size_t key_len;                 /*!< psk key length */
 #if defined(MBEDTLS_SHA256_C) && !defined(MBEDTLS_SHA512_C)
     unsigned char key[32];
 #else /* MBEDTLS_SHA512_C */
@@ -1263,7 +1263,8 @@ struct mbedtls_ssl_config
     /** Callback to create & write a session ticket                         */
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
     int(*f_ticket_write)(void*, const mbedtls_ssl_ticket*,
-        unsigned char*, const unsigned char*, size_t*, uint32_t*, TicketFlags*);
+        unsigned char*, const unsigned char*, size_t*, uint32_t*,
+        mbedtls_ssl_ticket_flags*);
     /** Callback to parse a session ticket into a session structure         */
     int(*f_ticket_parse)(void*, mbedtls_ssl_ticket*, unsigned char*, size_t);
     void* p_ticket;                 /*!< context for the ticket callbacks   */
@@ -2330,7 +2331,7 @@ typedef int mbedtls_ssl_ticket_write_t(void* p_ticket,
     unsigned char* start,
     const unsigned char* end,
     size_t* tlen,
-    uint32_t* lifetime, TicketFlags* flags);
+    uint32_t* lifetime, mbedtls_ssl_ticket_flags* flags);
 
 #else
 

--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -561,7 +561,7 @@ struct mbedtls_ssl_handshake_params
              * but excluding the outgoing finished message. */
             unsigned char digest[MBEDTLS_MD_MAX_SIZE];
             size_t digest_len;
-            KeySet* traffic_keys;
+            mbedtls_ssl_key_set* traffic_keys;
         } finished_out;
 
         /* Incoming Finished message */
@@ -830,8 +830,8 @@ struct mbedtls_ssl_transform
     /*!<  Chosen cipersuite_info  */
     unsigned int keylen;                /*!<  symmetric key length (bytes)  */
 
-    KeySet traffic_keys;
-    KeySet traffic_keys_previous;
+    mbedtls_ssl_key_set traffic_keys;
+    mbedtls_ssl_key_set traffic_keys_previous;
 
     unsigned char* iv_enc;           /*!<  IV (encryption)         */
     unsigned char* iv_dec;           /*!<  IV (decryption)         */
@@ -1170,7 +1170,7 @@ static uint32_t get_varint_value(const uint32_t input);
 #endif /* MBEDTLS_SSL_TLS13_CTLS */
 
 
-int mbedtls_ssl_key_derivation(mbedtls_ssl_context* ssl, KeySet* traffic_keys);
+int mbedtls_ssl_key_derivation(mbedtls_ssl_context* ssl, mbedtls_ssl_key_set* traffic_keys);
 
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
@@ -1178,11 +1178,11 @@ int ssl_read_certificate_verify_process(mbedtls_ssl_context* ssl);
 int ssl_certificate_verify_process(mbedtls_ssl_context* ssl);
 
 int mbedtls_ssl_derive_master_secret(mbedtls_ssl_context* ssl);
-int mbedtls_set_traffic_key(mbedtls_ssl_context* ssl, KeySet* traffic_keys, mbedtls_ssl_transform* transform, int mode);
-int mbedtls_ssl_generate_application_traffic_keys(mbedtls_ssl_context* ssl, KeySet* traffic_keys);
+int mbedtls_set_traffic_key(mbedtls_ssl_context* ssl, mbedtls_ssl_key_set* traffic_keys, mbedtls_ssl_transform* transform, int mode);
+int mbedtls_ssl_generate_application_traffic_keys(mbedtls_ssl_context* ssl, mbedtls_ssl_key_set* traffic_keys);
 int mbedtls_ssl_generate_resumption_master_secret(mbedtls_ssl_context* ssl);
 int ssl_write_encrypted_extension(mbedtls_ssl_context* ssl);
-int mbedtls_ssl_derive_traffic_keys(mbedtls_ssl_context* ssl, KeySet* traffic_keys);
+int mbedtls_ssl_derive_traffic_keys(mbedtls_ssl_context* ssl, mbedtls_ssl_key_set* traffic_keys);
 int incrementSequenceNumber(unsigned char* sequenceNumber, unsigned char* nonce, size_t ivlen);
 
 #if defined(MBEDTLS_SSL_TLS13_COMPATIBILITY_MODE)
@@ -1198,7 +1198,7 @@ int ssl_parse_signature_algorithms_ext(mbedtls_ssl_context* ssl, const unsigned 
 int mbedtls_ssl_check_signature_scheme(const mbedtls_ssl_context* ssl, int signature_scheme);
 #endif /* MBEDTLS_KEY_EXCHANGE_WITH_CERT_ENABLED */
 #if defined(MBEDTLS_ZERO_RTT)
-int mbedtls_ssl_early_data_key_derivation(mbedtls_ssl_context* ssl, KeySet* traffic_keys);
+int mbedtls_ssl_early_data_key_derivation(mbedtls_ssl_context* ssl, mbedtls_ssl_key_set* traffic_keys);
 int ssl_write_early_data_ext(mbedtls_ssl_context* ssl, unsigned char* buf, size_t buflen, size_t* olen);
 #endif /* MBEDTLS_ZERO_RTT */
 #if (defined(MBEDTLS_ECDH_C) || defined(MBEDTLS_ECDSA_C))
@@ -1632,7 +1632,8 @@ int mbedtls_ssl_tls1_3_derive_secret(
 * \param slen      Length of hash value
 * \param keyLen	  Length of the key
 * \param ivLen    Length of IV
-* \param keys     KeySet structure containing client/server key and IVs
+* \param keys     mbedtls_ssl_key_set structure containing client/server key
+*                 and IVs
 *
 * \return          0 if successful,
 *                  or MBEDTLS_ERR_HKDF_BUFFER_TOO_SMALL
@@ -1645,7 +1646,8 @@ int mbedtls_ssl_tls1_3_make_traffic_keys(
                      mbedtls_md_type_t hash_alg,
                      const unsigned char *client_key,
                      const unsigned char *server_key,
-                     int slen, int keyLen, int ivLen, KeySet *keys );
+                     int slen, int keyLen, int ivLen,
+                     mbedtls_ssl_key_set *keys );
 
 /**
 * \brief           HKDF-Expand-Label( Secret, Label, HashValue, Length ) =

--- a/include/mbedtls/ssl_ticket.h
+++ b/include/mbedtls/ssl_ticket.h
@@ -68,7 +68,7 @@ typedef struct
 
     uint32_t ticket_lifetime;       /*!< lifetime of tickets in seconds     */
 #if defined(MBEDTLS_SSL_NEW_SESSION_TICKET) && defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
-    TicketFlags flags;              /*!< ticket flags                       */
+    mbedtls_ssl_ticket_flags flags; /*!< ticket flags                       */
 #endif /* MBEDTLS_SSL_NEW_SESSION_TICKET && MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL  */
     /** Callback for getting (pseudo-)random numbers                        */
     int  (*f_rng)(void *, unsigned char *, size_t);
@@ -124,7 +124,7 @@ int mbedtls_ssl_conf_client_ticket(const mbedtls_ssl_context* ssl, mbedtls_ssl_t
 int mbedtls_ssl_ticket_setup( mbedtls_ssl_ticket_context *ctx,
     int (*f_rng)(void *, unsigned char *, size_t), void *p_rng,
     mbedtls_cipher_type_t cipher,
-    uint32_t lifetime, TicketFlags flags);
+    uint32_t lifetime, mbedtls_ssl_ticket_flags flags);
 #else 
 int mbedtls_ssl_ticket_setup(mbedtls_ssl_ticket_context* ctx,
     int (*f_rng)(void*, unsigned char*, size_t), void* p_rng,

--- a/library/ssl_ticket.c
+++ b/library/ssl_ticket.c
@@ -133,7 +133,7 @@ static int ssl_ticket_update_keys( mbedtls_ssl_ticket_context *ctx )
 int mbedtls_ssl_ticket_setup( mbedtls_ssl_ticket_context* ctx,
     int (*f_rng)(void *, unsigned char *, size_t), void* p_rng,
     mbedtls_cipher_type_t cipher,
-    uint32_t lifetime, TicketFlags flags )
+    uint32_t lifetime, mbedtls_ssl_ticket_flags flags )
 #else
 int mbedtls_ssl_ticket_setup( mbedtls_ssl_ticket_context *ctx,
     int (*f_rng)(void *, unsigned char *, size_t), void *p_rng,
@@ -328,7 +328,7 @@ int mbedtls_ssl_ticket_write(void* p_ticket,
     const unsigned char* end,
     size_t* tlen,
     uint32_t* ticket_lifetime,
-    TicketFlags* flags)
+    mbedtls_ssl_ticket_flags* flags)
 #else
 int mbedtls_ssl_ticket_write( void *p_ticket,
                               const mbedtls_ssl_session *session,

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -150,7 +150,7 @@ cleanup:
 static int ssl_write_early_data_prepare( mbedtls_ssl_context* ssl )
 {
     int ret;
-    KeySet traffic_keys;
+    mbedtls_ssl_key_set traffic_keys;
 
     ret = mbedtls_ssl_early_data_key_derivation( ssl, &traffic_keys );
     if( ret != 0 )
@@ -288,7 +288,7 @@ cleanup:
 static int ssl_write_end_of_early_data_prepare( mbedtls_ssl_context* ssl )
 {
     int ret;
-    KeySet traffic_keys;
+    mbedtls_ssl_key_set traffic_keys;
 
     ret = mbedtls_ssl_early_data_key_derivation( ssl, &traffic_keys );
     if( ret != 0 )
@@ -2570,7 +2570,7 @@ cleanup:
 static int ssl_encrypted_extensions_prepare( mbedtls_ssl_context* ssl ) {
 
     int ret;
-    KeySet traffic_keys;
+    mbedtls_ssl_key_set traffic_keys;
 
     if( ssl->transform_in == NULL )
     {

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -937,7 +937,7 @@ have_sig_alg:
  * TLS 1.3.
  */
 
-int mbedtls_ssl_derive_traffic_keys( mbedtls_ssl_context *ssl, KeySet *traffic_keys )
+int mbedtls_ssl_derive_traffic_keys( mbedtls_ssl_context *ssl, mbedtls_ssl_key_set *traffic_keys )
 {
     int ret = 0;
     const mbedtls_cipher_info_t *cipher_info;
@@ -3056,7 +3056,7 @@ int mbedtls_ssl_generate_resumption_master_secret( mbedtls_ssl_context *ssl ) {
 /* Generate application traffic keys since any records following a 1-RTT Finished message
  * MUST be encrypted under the application traffic key.
  */
-int mbedtls_ssl_generate_application_traffic_keys( mbedtls_ssl_context *ssl, KeySet *traffic_keys ) {
+int mbedtls_ssl_generate_application_traffic_keys( mbedtls_ssl_context *ssl, mbedtls_ssl_key_set *traffic_keys ) {
     int ret;
     const mbedtls_md_info_t *md_info;
     const mbedtls_ssl_ciphersuite_t *suite_info;
@@ -3226,7 +3226,7 @@ int mbedtls_ssl_generate_application_traffic_keys( mbedtls_ssl_context *ssl, Key
  *   - Do not backup keys -- use 1
  *   - Backup keys -- use 0
  */
-int mbedtls_set_traffic_key( mbedtls_ssl_context *ssl, KeySet *traffic_keys, mbedtls_ssl_transform *transform, int mode ) {
+int mbedtls_set_traffic_key( mbedtls_ssl_context *ssl, mbedtls_ssl_key_set *traffic_keys, mbedtls_ssl_transform *transform, int mode ) {
     mbedtls_cipher_info_t const *cipher_info;
     int ret;
     unsigned char *key1;
@@ -3425,7 +3425,7 @@ int mbedtls_set_traffic_key( mbedtls_ssl_context *ssl, KeySet *traffic_keys, mbe
  *   - Generate client_early_traffic_secret
  *   - Generate traffic key material
  */
-int mbedtls_ssl_early_data_key_derivation( mbedtls_ssl_context *ssl, KeySet *traffic_keys )
+int mbedtls_ssl_early_data_key_derivation( mbedtls_ssl_context *ssl, mbedtls_ssl_key_set *traffic_keys )
 {
     int ret;
     int hash_length;
@@ -3651,7 +3651,7 @@ int mbedtls_ssl_early_data_key_derivation( mbedtls_ssl_context *ssl, KeySet *tra
  *   - Generate master key
  *   - Generate handshake traffic keys
  */
-int mbedtls_ssl_key_derivation( mbedtls_ssl_context *ssl, KeySet *traffic_keys )
+int mbedtls_ssl_key_derivation( mbedtls_ssl_context *ssl, mbedtls_ssl_key_set *traffic_keys )
 {
     int ret;
 
@@ -3765,11 +3765,11 @@ static int ssl_finished_out_postprocess( mbedtls_ssl_context* ssl );
 int ssl_finished_out_process( mbedtls_ssl_context* ssl )
 {
     int ret;
-    KeySet traffic_keys;
+    mbedtls_ssl_key_set traffic_keys;
 
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> write finished" ) );
 
-    memset( ( void* )&traffic_keys, 0, sizeof( KeySet ) );
+    memset( ( void* )&traffic_keys, 0, sizeof( mbedtls_ssl_key_set ) );
 
     ssl->handshake->state_local.finished_out.traffic_keys = &traffic_keys;
 
@@ -3801,7 +3801,7 @@ cleanup:
 static int ssl_finished_out_prepare( mbedtls_ssl_context* ssl )
 {
     int ret;
-    KeySet* traffic_keys=ssl->handshake->state_local.finished_out.traffic_keys;
+    mbedtls_ssl_key_set* traffic_keys=ssl->handshake->state_local.finished_out.traffic_keys;
 
 #if defined(MBEDTLS_SSL_CLI_C)
     if( ssl->conf->endpoint == MBEDTLS_SSL_IS_CLIENT )
@@ -3888,7 +3888,7 @@ static int ssl_finished_out_prepare( mbedtls_ssl_context* ssl )
 static int ssl_finished_out_postprocess( mbedtls_ssl_context* ssl )
 {
     int ret;
-    KeySet* traffic_keys = ssl->handshake->state_local.finished_out.traffic_keys;
+    mbedtls_ssl_key_set* traffic_keys = ssl->handshake->state_local.finished_out.traffic_keys;
 
 #if defined(MBEDTLS_SSL_CLI_C)
     if( ssl->conf->endpoint == MBEDTLS_SSL_IS_CLIENT )

--- a/library/ssl_tls13_keys.c
+++ b/library/ssl_tls13_keys.c
@@ -181,7 +181,7 @@ int mbedtls_ssl_tls1_3_make_traffic_keys(
                      const unsigned char *server_key,
                      int slen,
                      int keyLen, int ivLen,
-                     KeySet *keys )
+                     mbedtls_ssl_key_set *keys )
 {
     int ret = 0;
 

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -1789,7 +1789,7 @@ cleanup:
 static int ssl_read_end_of_early_data_preprocess( mbedtls_ssl_context* ssl )
 {
     int ret;
-    KeySet traffic_keys;
+    mbedtls_ssl_key_set traffic_keys;
 
     ret = mbedtls_ssl_early_data_key_derivation( ssl, &traffic_keys );
     if( ret != 0 )
@@ -1889,7 +1889,7 @@ cleanup:
 static int ssl_read_early_data_preprocess( mbedtls_ssl_context* ssl )
 {
     int ret;
-    KeySet traffic_keys;
+    mbedtls_ssl_key_set traffic_keys;
 
     ret = mbedtls_ssl_early_data_key_derivation( ssl, &traffic_keys );
     if( ret != 0 )
@@ -3290,7 +3290,7 @@ cleanup:
 static int ssl_encrypted_extensions_prepare( mbedtls_ssl_context* ssl )
 {
     int ret;
-    KeySet traffic_keys;
+    mbedtls_ssl_key_set traffic_keys;
 
     ret = mbedtls_ssl_key_derivation( ssl, &traffic_keys );
 
@@ -4241,7 +4241,7 @@ static int ssl_certificate_request_postprocess( mbedtls_ssl_context* ssl )
 int mbedtls_ssl_handshake_server_step( mbedtls_ssl_context *ssl )
 {
     int ret = 0;
-    KeySet traffic_keys;
+    mbedtls_ssl_key_set traffic_keys;
 
 
     if( ssl->state == MBEDTLS_SSL_HANDSHAKE_OVER || ssl->handshake == NULL )

--- a/programs/ssl/tls13_server.c
+++ b/programs/ssl/tls13_server.c
@@ -429,9 +429,9 @@ struct options
     unsigned char mfl_code;     /* code for maximum fragment length         */
     int trunc_hmac;             /* accept truncated hmac?                   */
     int tickets;                /* enable / disable session tickets         */
-    int ticket_lifetime;         /* session ticket lifetime                  */
+    int ticket_lifetime;        /* session ticket lifetime                  */
 #if defined(MBEDTLS_SSL_NEW_SESSION_TICKET)
-	TicketFlags ticket_flags;   /* ticket flags                             */
+	mbedtls_ssl_ticket_flags ticket_flags;   /* ticket flags                */
 #endif
     int cache_max;              /* max number of session cache entries      */
     int cache_timeout;          /* expiration delay of session cache entries */
@@ -1332,9 +1332,9 @@ int main( int argc, char *argv[] )
 #if defined(MBEDTLS_SSL_NEW_SESSION_TICKET)
 		else if (strcmp(p, "ticket_flags") == 0)
 		{
-			TicketFlags temp = atoi(q);
-			if ((temp & (TicketFlags)allow_early_data) || (temp & (TicketFlags)allow_dhe_resumption) || (temp & (TicketFlags)allow_psk_resumption)) {
-				opt.ticket_flags = temp & (TicketFlags)allow_early_data & (TicketFlags)allow_dhe_resumption & (TicketFlags)allow_psk_resumption;
+			mbedtls_ssl_ticket_flags temp = atoi(q);
+			if ((temp & (mbedtls_ssl_ticket_flags)allow_early_data) || (temp & (mbedtls_ssl_ticket_flags)allow_dhe_resumption) || (temp & (mbedtls_ssl_ticket_flags)allow_psk_resumption)) {
+				opt.ticket_flags = temp & (mbedtls_ssl_ticket_flags)allow_early_data & (mbedtls_ssl_ticket_flags)allow_dhe_resumption & (mbedtls_ssl_ticket_flags)allow_psk_resumption;
 			} else goto usage;
 		}
 #endif


### PR DESCRIPTION
Adjust namespace of `KeySet` and `TicketFlags`.
New namespace: `mbedtls_ssl_key_set` and `mbedtls_ssl_ticket_flags`