### PR TITLE
Implement TLS 1.3 keying material export (secrets)

### DIFF
--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -1964,7 +1964,7 @@
  *
  * Comment this macro to disable support for key export
  */
-//#define MBEDTLS_SSL_EXPORT_KEYS
+#define MBEDTLS_SSL_EXPORT_KEYS
 
 /**
  * \def MBEDTLS_SSL_SERVER_NAME_INDICATION

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -1964,7 +1964,7 @@
  *
  * Comment this macro to disable support for key export
  */
-#define MBEDTLS_SSL_EXPORT_KEYS
+//#define MBEDTLS_SSL_EXPORT_KEYS
 
 /**
  * \def MBEDTLS_SSL_SERVER_NAME_INDICATION

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -805,7 +805,7 @@ typedef enum
     MBEDTLS_SSL_TLS1_3_SERVER_APPLICATION_TRAFFIC_SECRET_0,
     MBEDTLS_SSL_TLS1_3_EXPORTER_MASTER_SECRET
 } mbedtls_ssl_tls1_3_secret_type;
-#endif
+#endif /* MBEDTLS_SSL_EXPORT_KEYS && MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 
 /**
 * \brief  Ticket Structure

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -1278,6 +1278,8 @@ struct mbedtls_ssl_config
 #endif /* (MBEDTLS_SSL_SESSION_TICKETS || (MBEDTLS_SSL_NEW_SESSION_TICKET && MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) ) && MBEDTLS_SSL_SRV_C */
 
 #if defined(MBEDTLS_SSL_EXPORT_KEYS)
+#if defined(MBEDTLS_SSL_PROTO_TLS1) || defined(MBEDTLS_SSL_PROTO_TLS1_1) || \
+    defined(MBEDTLS_SSL_PROTO_TLS1_2)
     /** Callback to export key block and master secret                      */
     int (*f_export_keys)( void *, const unsigned char *,
             const unsigned char *, size_t, size_t, size_t );
@@ -1288,6 +1290,45 @@ struct mbedtls_ssl_config
                 const unsigned char[32], const unsigned char[32],
                 mbedtls_tls_prf_types );
     void *p_export_keys;            /*!< context for key export callback    */
+#endif /* MBEDTLS_SSL_PROTO_TLS1 || MBEDTLS_SSL_PROTO_TLS1_1 || \
+          MBEDTLS_SSL_PROTO_TLS1_2 */
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+    /** Callback to export client early traffic secret                      */
+    int (*f_export_client_early_traffic_secret)( void *, const unsigned char *,
+            size_t );
+    void *p_export_client_early_traffic_secret; /*!< context for key export
+                                                  callback                  */
+
+    /** Callback to export client handshake traffic secret                  */
+    int (*f_export_client_hs_traffic_secret)( void *, const unsigned char *,
+            size_t );
+    void *p_export_client_hs_traffic_secret; /*!< context for key export
+                                               callback                     */
+
+    /** Callback to export server handshake traffic secret                  */
+    int (*f_export_server_hs_traffic_secret)( void *, const unsigned char *,
+            size_t );
+    void *p_export_server_hs_traffic_secret; /*!< context for key export
+                                               callback                     */
+
+    /** Callback to export client application traffic secret 0              */
+    int (*f_export_client_app_traffic_secret_0)( void *, const unsigned char *,
+            size_t );
+    void *p_export_client_app_traffic_secret_0; /*!< context for key export
+                                              callback                      */
+
+    /** Callback to export server application traffic secret 0              */
+    int (*f_export_server_app_traffic_secret_0)( void *, const unsigned char *,
+            size_t);
+    void *p_export_server_app_traffic_secret_0; /*!< context for key export
+                                              callback                      */
+
+    /** Callback to export exporter master secret                           */
+    int (*f_export_exporter_master_secret)( void *, const unsigned char *,
+            size_t);
+    void *p_export_exporter_master_secret; /*!< context for key export
+                                              callback                      */
+#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 #endif
 
 #if defined(MBEDTLS_SSL_DTLS_CONNECTION_ID)
@@ -2363,6 +2404,8 @@ typedef int mbedtls_ssl_ticket_write_t( void *p_ticket,
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 
 #if defined(MBEDTLS_SSL_EXPORT_KEYS)
+#if defined(MBEDTLS_SSL_PROTO_TLS1) || defined(MBEDTLS_SSL_PROTO_TLS1_1) || \
+    defined(MBEDTLS_SSL_PROTO_TLS1_2)
 /**
  * \brief           Callback type: Export key block and master secret
  *
@@ -2424,6 +2467,32 @@ typedef int mbedtls_ssl_export_keys_ext_t( void *p_expkey,
                                            const unsigned char client_random[32],
                                            const unsigned char server_random[32],
                                            mbedtls_tls_prf_types tls_prf_type );
+#endif /* MBEDTLS_SSL_PROTO_TLS1 || MBEDTLS_SSL_PROTO_TLS1_1 || \
+          MBEDTLS_SSL_PROTO_TLS1_2 */
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+/**
+ * \brief           Callback type: Export TLS 1.3 secrets (client early traffic
+ *                  secret, client handshake traffic secret, server handshake
+ *                  traffic secret, client application 0 traffic secret, server
+ *                  application 0 traffic secret, exporter master secret)
+ *
+ * \note            This is required for certain uses of TLS, e.g. EAP-TLS
+ *                  (RFC 5216) and Thread. The key pointers are ephemeral and
+ *                  therefore must not be stored. The master secret and keys
+ *                  should not be used directly except as an input to a key
+ *                  derivation function.
+ *
+ * \param p_expkey  Context for the callback
+ * \param secret    Pointer to secret
+ * \param len       Secret length
+ *
+ * \return          0 if successful, or
+ *                  a specific MBEDTLS_ERR_XXX code.
+ */
+typedef int mbedtls_ssl_export_secret_t( void *p_expkey,
+                                                 const unsigned char *secret,
+                                                 size_t len );
+#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 #endif /* MBEDTLS_SSL_EXPORT_KEYS */
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
@@ -2531,6 +2600,8 @@ void mbedtls_ssl_conf_session_tickets_cb( mbedtls_ssl_config *conf,
 #endif /* MBEDTLS_SSL_SESSION_TICKETS && MBEDTLS_SSL_SRV_C */
 
 #if defined(MBEDTLS_SSL_EXPORT_KEYS)
+#if defined(MBEDTLS_SSL_PROTO_TLS1) || defined(MBEDTLS_SSL_PROTO_TLS1_1) || \
+    defined(MBEDTLS_SSL_PROTO_TLS1_2)
 /**
  * \brief           Configure key export callback.
  *                  (Default: none.)
@@ -2558,6 +2629,23 @@ void mbedtls_ssl_conf_export_keys_cb( mbedtls_ssl_config *conf,
 void mbedtls_ssl_conf_export_keys_ext_cb( mbedtls_ssl_config *conf,
         mbedtls_ssl_export_keys_ext_t *f_export_keys_ext,
         void *p_export_keys );
+#endif /* MBEDTLS_SSL_PROTO_TLS1 || MBEDTLS_SSL_PROTO_TLS1_1 || \
+          MBEDTLS_SSL_PROTO_TLS1_2 */
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+void mbedtls_ssl_conf_export_secrets_cb( mbedtls_ssl_config *conf,
+        mbedtls_ssl_export_secret_t *f_export_client_early_traffic_secret,
+        void *p_export_client_early_traffic_secret,
+        mbedtls_ssl_export_secret_t *f_export_client_hs_traffic_secret,
+        void *p_export_client_hs_traffic_secret,
+        mbedtls_ssl_export_secret_t *f_export_server_hs_traffic_secret,
+        void *p_export_server_hs_traffic_secret,
+        mbedtls_ssl_export_secret_t *f_export_client_app_traffic_secret_0,
+        void *p_export_client_app_traffic_secret_0,
+        mbedtls_ssl_export_secret_t *f_export_server_app_traffic_secret_0,
+        void *p_export_server_app_traffic_secret_0,
+        mbedtls_ssl_export_secret_t *f_export_exporter_master_secret,
+        void *p_export_exporter_master_secret );
+#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 #endif /* MBEDTLS_SSL_EXPORT_KEYS */
 
 #if defined(MBEDTLS_SSL_ASYNC_PRIVATE)

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -2453,14 +2453,19 @@ typedef int mbedtls_ssl_export_keys_ext_t( void *p_expkey,
           MBEDTLS_SSL_PROTO_TLS1_2 */
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
 /**
- * \brief           Callback type: Export TLS 1.3 secrets (client early traffic
- *                  secret, client handshake traffic secret, server handshake
- *                  traffic secret, client application 0 traffic secret, server
- *                  application 0 traffic secret, exporter master secret)
+ * \brief           Callback type: Export the client's randbytes
+ *                  (ClientHello.random) and TLS 1.3 secrets (client early
+ *                  traffic secret, client handshake traffic secret, server
+ *                  handshake traffic secret, client application traffic secret
+ *                  0, server application traffic secret 0, exporter master
+ *                  secret) used to derive keys.
+ *                  Follows the NSS Key Log format
  *
- * \param p_expkey  Context for the callback
- * \param secret    Pointer to secret
- * \param len       Secret length
+ * \param p_expkey      Context for the callback
+ * \param client_random ClientHello.random bytes
+ * \param type          Secret type
+ * \param secret        Pointer to secret
+ * \param len           Secret length
  *
  * \return          0 if successful, or
  *                  a specific MBEDTLS_ERR_XXX code.

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -2461,7 +2461,7 @@ typedef int mbedtls_ssl_export_keys_ext_t( void *p_expkey,
  *                  secret) used to derive keys.
  *                  Follows the NSS Key Log format
  *
- * \param p_expkey      Context for the callback
+ * \param p_expsecret   Context for the callback
  * \param client_random ClientHello.random bytes
  * \param type          Secret type
  * \param secret        Pointer to secret
@@ -2470,7 +2470,7 @@ typedef int mbedtls_ssl_export_keys_ext_t( void *p_expkey,
  * \return          0 if successful, or
  *                  a specific MBEDTLS_ERR_XXX code.
  */
-typedef int mbedtls_ssl_export_secret_t( void *p_expkey,
+typedef int mbedtls_ssl_export_secret_t( void *p_expsecret,
                                          const unsigned char client_random[32],
                                          mbedtls_ssl_tls1_3_secret_type type,
                                          const unsigned char *secret,

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -5153,31 +5153,11 @@ void mbedtls_ssl_conf_export_keys_ext_cb( mbedtls_ssl_config *conf,
           MBEDTLS_SSL_PROTO_TLS1_2 */
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
 void mbedtls_ssl_conf_export_secrets_cb( mbedtls_ssl_config *conf,
-        mbedtls_ssl_export_secret_t *f_export_client_early_traffic_secret,
-        void *p_export_client_early_traffic_secret,
-        mbedtls_ssl_export_secret_t *f_export_client_hs_traffic_secret,
-        void *p_export_client_hs_traffic_secret,
-        mbedtls_ssl_export_secret_t *f_export_server_hs_traffic_secret,
-        void *p_export_server_hs_traffic_secret,
-        mbedtls_ssl_export_secret_t *f_export_client_app_traffic_secret_0,
-        void *p_export_client_app_traffic_secret_0,
-        mbedtls_ssl_export_secret_t *f_export_server_app_traffic_secret_0,
-        void *p_export_server_app_traffic_secret_0,
-        mbedtls_ssl_export_secret_t *f_export_exporter_master_secret,
-        void *p_export_exporter_master_secret )
+        mbedtls_ssl_export_secret_t *f_export_secret,
+        void *p_export_secret )
 {
-    conf->f_export_client_early_traffic_secret = f_export_client_early_traffic_secret;
-    conf->p_export_client_early_traffic_secret = p_export_client_early_traffic_secret;
-    conf->f_export_client_hs_traffic_secret = f_export_client_hs_traffic_secret;
-    conf->p_export_client_hs_traffic_secret = p_export_client_hs_traffic_secret;
-    conf->f_export_server_hs_traffic_secret = f_export_server_hs_traffic_secret;
-    conf->p_export_server_hs_traffic_secret = p_export_server_hs_traffic_secret;
-    conf->f_export_client_app_traffic_secret_0 = f_export_client_app_traffic_secret_0;
-    conf->p_export_client_app_traffic_secret_0 = p_export_client_app_traffic_secret_0;
-    conf->f_export_server_app_traffic_secret_0 = f_export_server_app_traffic_secret_0;
-    conf->p_export_server_app_traffic_secret_0 = p_export_server_app_traffic_secret_0;
-    conf->f_export_exporter_master_secret = f_export_exporter_master_secret;
-    conf->p_export_exporter_master_secret = p_export_exporter_master_secret;
+    conf->f_export_secret = f_export_secret;
+    conf->p_export_secret = p_export_secret;
 }
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 #endif /* MBEDTLS_SSL_EXPORT_KEYS */

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -737,6 +737,7 @@ static int ssl_use_opaque_psk( mbedtls_ssl_context const *ssl )
 #endif /* MBEDTLS_USE_PSA_CRYPTO &&
           MBEDTLS_KEY_EXCHANGE_PSK_ENABLED */
 
+#if !defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
 #if defined(MBEDTLS_SSL_EXPORT_KEYS)
 static mbedtls_tls_prf_types tls_prf_get_type( mbedtls_ssl_tls_prf_cb *tls_prf )
 {
@@ -774,7 +775,6 @@ static mbedtls_tls_prf_types tls_prf_get_type( mbedtls_ssl_tls_prf_cb *tls_prf )
 }
 #endif /* MBEDTLS_SSL_EXPORT_KEYS */
 
-#if !defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
 int  mbedtls_ssl_tls_prf( const mbedtls_tls_prf_types prf,
                           const unsigned char *secret, size_t slen,
                           const char *label,
@@ -5132,6 +5132,8 @@ void mbedtls_ssl_conf_session_tickets_cb( mbedtls_ssl_config* conf,
 #endif /* MBEDTLS_SSL_SESSION_TICKETS || ( MBEDTLS_SSL_NEW_SESSION_TICKET && MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL ) */
 
 #if defined(MBEDTLS_SSL_EXPORT_KEYS)
+#if defined(MBEDTLS_SSL_PROTO_TLS1) || defined(MBEDTLS_SSL_PROTO_TLS1_1) || \
+    defined(MBEDTLS_SSL_PROTO_TLS1_2)
 void mbedtls_ssl_conf_export_keys_cb( mbedtls_ssl_config *conf,
         mbedtls_ssl_export_keys_t *f_export_keys,
         void *p_export_keys )
@@ -5147,7 +5149,38 @@ void mbedtls_ssl_conf_export_keys_ext_cb( mbedtls_ssl_config *conf,
     conf->f_export_keys_ext = f_export_keys_ext;
     conf->p_export_keys = p_export_keys;
 }
-#endif
+#endif /* MBEDTLS_SSL_PROTO_TLS1 || MBEDTLS_SSL_PROTO_TLS1_1 || \
+          MBEDTLS_SSL_PROTO_TLS1_2 */
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+void mbedtls_ssl_conf_export_secrets_cb( mbedtls_ssl_config *conf,
+        mbedtls_ssl_export_secret_t *f_export_client_early_traffic_secret,
+        void *p_export_client_early_traffic_secret,
+        mbedtls_ssl_export_secret_t *f_export_client_hs_traffic_secret,
+        void *p_export_client_hs_traffic_secret,
+        mbedtls_ssl_export_secret_t *f_export_server_hs_traffic_secret,
+        void *p_export_server_hs_traffic_secret,
+        mbedtls_ssl_export_secret_t *f_export_client_app_traffic_secret_0,
+        void *p_export_client_app_traffic_secret_0,
+        mbedtls_ssl_export_secret_t *f_export_server_app_traffic_secret_0,
+        void *p_export_server_app_traffic_secret_0,
+        mbedtls_ssl_export_secret_t *f_export_exporter_master_secret,
+        void *p_export_exporter_master_secret )
+{
+    conf->f_export_client_early_traffic_secret = f_export_client_early_traffic_secret;
+    conf->p_export_client_early_traffic_secret = p_export_client_early_traffic_secret;
+    conf->f_export_client_hs_traffic_secret = f_export_client_hs_traffic_secret;
+    conf->p_export_client_hs_traffic_secret = p_export_client_hs_traffic_secret;
+    conf->f_export_server_hs_traffic_secret = f_export_server_hs_traffic_secret;
+    conf->p_export_server_hs_traffic_secret = p_export_server_hs_traffic_secret;
+    conf->f_export_client_app_traffic_secret_0 = f_export_client_app_traffic_secret_0;
+    conf->p_export_client_app_traffic_secret_0 = p_export_client_app_traffic_secret_0;
+    conf->f_export_server_app_traffic_secret_0 = f_export_server_app_traffic_secret_0;
+    conf->p_export_server_app_traffic_secret_0 = p_export_server_app_traffic_secret_0;
+    conf->f_export_exporter_master_secret = f_export_exporter_master_secret;
+    conf->p_export_exporter_master_secret = p_export_exporter_master_secret;
+}
+#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
+#endif /* MBEDTLS_SSL_EXPORT_KEYS */
 
 #if defined(MBEDTLS_SSL_ASYNC_PRIVATE)
 void mbedtls_ssl_conf_async_private_cb(

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -1067,8 +1067,8 @@ int mbedtls_ssl_derive_traffic_keys( mbedtls_ssl_context *ssl, mbedtls_ssl_key_s
      * Export client handshake traffic secret
      */
 #if defined(MBEDTLS_SSL_EXPORT_KEYS)
-    if( ssl->conf->f_export_client_hs_traffic_secret != NULL )
-        ssl->conf->f_export_client_hs_traffic_secret( ssl->conf->p_export_client_hs_traffic_secret, ssl->handshake->client_handshake_traffic_secret, (size_t) mbedtls_hash_size_for_ciphersuite( suite_info ) );
+    if( ssl->conf->f_export_secret != NULL )
+        ssl->conf->f_export_secret( ssl->conf->p_export_secret, ssl->handshake->randbytes, MBEDTLS_SSL_TLS1_3_CLIENT_HANDSHAKE_TRAFFIC_SECRET, ssl->handshake->client_handshake_traffic_secret, (size_t) mbedtls_hash_size_for_ciphersuite( suite_info ) );
 #endif
 
     MBEDTLS_SSL_DEBUG_MSG( 5, ( "HKDF Expand: label=[TLS 1.3, c hs traffic], requested length %d", mbedtls_hash_size_for_ciphersuite( suite_info ) ) );
@@ -1097,8 +1097,8 @@ int mbedtls_ssl_derive_traffic_keys( mbedtls_ssl_context *ssl, mbedtls_ssl_key_s
      * Export server handshake traffic secret
      */
 #if defined(MBEDTLS_SSL_EXPORT_KEYS)
-    if( ssl->conf->f_export_server_hs_traffic_secret != NULL )
-        ssl->conf->f_export_server_hs_traffic_secret( ssl->conf->p_export_server_hs_traffic_secret, ssl->handshake->server_handshake_traffic_secret, (size_t) mbedtls_hash_size_for_ciphersuite( suite_info ) );
+    if( ssl->conf->f_export_secret != NULL )
+        ssl->conf->f_export_secret( ssl->conf->p_export_secret, ssl->handshake->randbytes, MBEDTLS_SSL_TLS1_3_SERVER_HANDSHAKE_TRAFFIC_SECRET, ssl->handshake->server_handshake_traffic_secret, (size_t) mbedtls_hash_size_for_ciphersuite( suite_info ) );
 #endif
 
     MBEDTLS_SSL_DEBUG_MSG( 5, ( "HKDF Expand: label=[TLS 1.3, s hs traffic], requested length %d", mbedtls_hash_size_for_ciphersuite( suite_info ) ) );
@@ -1127,8 +1127,8 @@ int mbedtls_ssl_derive_traffic_keys( mbedtls_ssl_context *ssl, mbedtls_ssl_key_s
      * Export exporter master secret
      */
 #if defined(MBEDTLS_SSL_EXPORT_KEYS)
-    if( ssl->conf->f_export_exporter_master_secret != NULL )
-        ssl->conf->f_export_exporter_master_secret( ssl->conf->p_export_exporter_master_secret, ssl->handshake->exporter_secret, (size_t) mbedtls_hash_size_for_ciphersuite( suite_info ) );
+    if( ssl->conf->f_export_secret != NULL )
+        ssl->conf->f_export_secret( ssl->conf->p_export_secret, ssl->handshake->randbytes, MBEDTLS_SSL_TLS1_3_EXPORTER_MASTER_SECRET, ssl->handshake->exporter_secret, (size_t) mbedtls_hash_size_for_ciphersuite( suite_info ) );
 #endif
 
     MBEDTLS_SSL_DEBUG_BUF( 5, "exporter_secret", ssl->handshake->exporter_secret, mbedtls_hash_size_for_ciphersuite( suite_info ) );
@@ -1541,8 +1541,8 @@ int mbedtls_ssl_derive_master_secret( mbedtls_ssl_context *ssl ) {
      * Export client early traffic secret
      */
 #if defined(MBEDTLS_SSL_EXPORT_KEYS)
-    if( ssl->conf->f_export_client_early_traffic_secret != NULL )
-        ssl->conf->f_export_client_early_traffic_secret( ssl->conf->p_export_client_early_traffic_secret, ssl->handshake->early_secret, hash_size );
+    if( ssl->conf->f_export_secret != NULL )
+        ssl->conf->f_export_secret( ssl->conf->p_export_secret, ssl->handshake->randbytes, MBEDTLS_SSL_TLS1_3_CLIENT_EARLY_TRAFFIC_SECRET, ssl->handshake->early_secret, hash_size );
 #endif
 
     MBEDTLS_SSL_DEBUG_MSG( 5, ( "HKDF Extract -- early_secret" ) );
@@ -3203,8 +3203,8 @@ int mbedtls_ssl_generate_application_traffic_keys( mbedtls_ssl_context *ssl, mbe
      * Export client application traffic secret 0
      */
 #if defined(MBEDTLS_SSL_EXPORT_KEYS)
-    if( ssl->conf->f_export_client_app_traffic_secret_0 != NULL )
-        ssl->conf->f_export_client_app_traffic_secret_0( ssl->conf->p_export_client_app_traffic_secret_0, ssl->handshake->client_traffic_secret, (size_t) mbedtls_hash_size_for_ciphersuite( suite_info ) );
+    if( ssl->conf->f_export_secret != NULL )
+        ssl->conf->f_export_secret( ssl->conf->p_export_secret, ssl->handshake->randbytes, MBEDTLS_SSL_TLS1_3_CLIENT_APPLICATION_TRAFFIC_SECRET_0, ssl->handshake->client_traffic_secret, (size_t) mbedtls_hash_size_for_ciphersuite( suite_info ) );
 #endif
 
     /* Generate server_application_traffic_secret_0
@@ -3232,8 +3232,8 @@ int mbedtls_ssl_generate_application_traffic_keys( mbedtls_ssl_context *ssl, mbe
      * Export server application traffic secret 0
      */
 #if defined(MBEDTLS_SSL_EXPORT_KEYS)
-    if( ssl->conf->f_export_server_app_traffic_secret_0 != NULL )
-        ssl->conf->f_export_server_app_traffic_secret_0( ssl->conf->p_export_server_app_traffic_secret_0, ssl->handshake->server_traffic_secret, (size_t) mbedtls_hash_size_for_ciphersuite( suite_info ) );
+    if( ssl->conf->f_export_secret != NULL )
+        ssl->conf->f_export_secret( ssl->conf->p_export_secret, ssl->handshake->randbytes, MBEDTLS_SSL_TLS1_3_SERVER_APPLICATION_TRAFFIC_SECRET_0, ssl->handshake->server_traffic_secret, (size_t) mbedtls_hash_size_for_ciphersuite( suite_info ) );
 #endif
 
     /* Generate application traffic keys since any records following a 1-RTT Finished message

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -1068,8 +1068,14 @@ int mbedtls_ssl_derive_traffic_keys( mbedtls_ssl_context *ssl, mbedtls_ssl_key_s
      */
 #if defined(MBEDTLS_SSL_EXPORT_KEYS)
     if( ssl->conf->f_export_secret != NULL )
-        ssl->conf->f_export_secret( ssl->conf->p_export_secret, ssl->handshake->randbytes, MBEDTLS_SSL_TLS1_3_CLIENT_HANDSHAKE_TRAFFIC_SECRET, ssl->handshake->client_handshake_traffic_secret, (size_t) mbedtls_hash_size_for_ciphersuite( suite_info ) );
-#endif
+    {
+        ssl->conf->f_export_secret( ssl->conf->p_export_secret,
+                ssl->handshake->randbytes,
+                MBEDTLS_SSL_TLS1_3_CLIENT_HANDSHAKE_TRAFFIC_SECRET,
+                ssl->handshake->client_handshake_traffic_secret,
+                (size_t) mbedtls_hash_size_for_ciphersuite( suite_info ) );
+    }
+#endif /* MBEDTLS_SSL_EXPORT_KEYS */
 
     MBEDTLS_SSL_DEBUG_MSG( 5, ( "HKDF Expand: label=[TLS 1.3, c hs traffic], requested length %d", mbedtls_hash_size_for_ciphersuite( suite_info ) ) );
     MBEDTLS_SSL_DEBUG_BUF( 5, "Secret: ", ssl->handshake->handshake_secret, mbedtls_hash_size_for_ciphersuite( suite_info ) );
@@ -1098,8 +1104,14 @@ int mbedtls_ssl_derive_traffic_keys( mbedtls_ssl_context *ssl, mbedtls_ssl_key_s
      */
 #if defined(MBEDTLS_SSL_EXPORT_KEYS)
     if( ssl->conf->f_export_secret != NULL )
-        ssl->conf->f_export_secret( ssl->conf->p_export_secret, ssl->handshake->randbytes, MBEDTLS_SSL_TLS1_3_SERVER_HANDSHAKE_TRAFFIC_SECRET, ssl->handshake->server_handshake_traffic_secret, (size_t) mbedtls_hash_size_for_ciphersuite( suite_info ) );
-#endif
+    {
+        ssl->conf->f_export_secret( ssl->conf->p_export_secret,
+                ssl->handshake->randbytes,
+                MBEDTLS_SSL_TLS1_3_SERVER_HANDSHAKE_TRAFFIC_SECRET,
+                ssl->handshake->server_handshake_traffic_secret,
+                (size_t) mbedtls_hash_size_for_ciphersuite( suite_info ) );
+    }
+#endif /* MBEDTLS_SSL_EXPORT_KEYS */
 
     MBEDTLS_SSL_DEBUG_MSG( 5, ( "HKDF Expand: label=[TLS 1.3, s hs traffic], requested length %d", mbedtls_hash_size_for_ciphersuite( suite_info ) ) );
     MBEDTLS_SSL_DEBUG_BUF( 5, "Secret: ", ssl->handshake->handshake_secret, mbedtls_hash_size_for_ciphersuite( suite_info ) );
@@ -1128,8 +1140,14 @@ int mbedtls_ssl_derive_traffic_keys( mbedtls_ssl_context *ssl, mbedtls_ssl_key_s
      */
 #if defined(MBEDTLS_SSL_EXPORT_KEYS)
     if( ssl->conf->f_export_secret != NULL )
-        ssl->conf->f_export_secret( ssl->conf->p_export_secret, ssl->handshake->randbytes, MBEDTLS_SSL_TLS1_3_EXPORTER_MASTER_SECRET, ssl->handshake->exporter_secret, (size_t) mbedtls_hash_size_for_ciphersuite( suite_info ) );
-#endif
+    {
+        ssl->conf->f_export_secret( ssl->conf->p_export_secret,
+                ssl->handshake->randbytes,
+                MBEDTLS_SSL_TLS1_3_EXPORTER_MASTER_SECRET,
+                ssl->handshake->exporter_secret,
+                (size_t) mbedtls_hash_size_for_ciphersuite( suite_info ) );
+    }
+#endif /* MBEDTLS_SSL_EXPORT_KEYS */
 
     MBEDTLS_SSL_DEBUG_BUF( 5, "exporter_secret", ssl->handshake->exporter_secret, mbedtls_hash_size_for_ciphersuite( suite_info ) );
 
@@ -1542,8 +1560,13 @@ int mbedtls_ssl_derive_master_secret( mbedtls_ssl_context *ssl ) {
      */
 #if defined(MBEDTLS_SSL_EXPORT_KEYS)
     if( ssl->conf->f_export_secret != NULL )
-        ssl->conf->f_export_secret( ssl->conf->p_export_secret, ssl->handshake->randbytes, MBEDTLS_SSL_TLS1_3_CLIENT_EARLY_TRAFFIC_SECRET, ssl->handshake->early_secret, hash_size );
-#endif
+    {
+        ssl->conf->f_export_secret( ssl->conf->p_export_secret,
+                ssl->handshake->randbytes,
+                MBEDTLS_SSL_TLS1_3_CLIENT_EARLY_TRAFFIC_SECRET,
+                ssl->handshake->early_secret, hash_size );
+    }
+#endif /* MBEDTLS_SSL_EXPORT_KEYS */
 
     MBEDTLS_SSL_DEBUG_MSG( 5, ( "HKDF Extract -- early_secret" ) );
     MBEDTLS_SSL_DEBUG_BUF( 5, "Salt", salt, hash_size );
@@ -3204,8 +3227,14 @@ int mbedtls_ssl_generate_application_traffic_keys( mbedtls_ssl_context *ssl, mbe
      */
 #if defined(MBEDTLS_SSL_EXPORT_KEYS)
     if( ssl->conf->f_export_secret != NULL )
-        ssl->conf->f_export_secret( ssl->conf->p_export_secret, ssl->handshake->randbytes, MBEDTLS_SSL_TLS1_3_CLIENT_APPLICATION_TRAFFIC_SECRET_0, ssl->handshake->client_traffic_secret, (size_t) mbedtls_hash_size_for_ciphersuite( suite_info ) );
-#endif
+    {
+        ssl->conf->f_export_secret( ssl->conf->p_export_secret,
+                ssl->handshake->randbytes,
+                MBEDTLS_SSL_TLS1_3_CLIENT_APPLICATION_TRAFFIC_SECRET_0,
+                ssl->handshake->client_traffic_secret,
+                (size_t) mbedtls_hash_size_for_ciphersuite( suite_info ) );
+    }
+#endif /* MBEDTLS_SSL_EXPORT_KEYS */
 
     /* Generate server_application_traffic_secret_0
      *
@@ -3233,8 +3262,14 @@ int mbedtls_ssl_generate_application_traffic_keys( mbedtls_ssl_context *ssl, mbe
      */
 #if defined(MBEDTLS_SSL_EXPORT_KEYS)
     if( ssl->conf->f_export_secret != NULL )
-        ssl->conf->f_export_secret( ssl->conf->p_export_secret, ssl->handshake->randbytes, MBEDTLS_SSL_TLS1_3_SERVER_APPLICATION_TRAFFIC_SECRET_0, ssl->handshake->server_traffic_secret, (size_t) mbedtls_hash_size_for_ciphersuite( suite_info ) );
-#endif
+    {
+        ssl->conf->f_export_secret( ssl->conf->p_export_secret,
+                ssl->handshake->randbytes,
+                MBEDTLS_SSL_TLS1_3_SERVER_APPLICATION_TRAFFIC_SECRET_0,
+                ssl->handshake->server_traffic_secret,
+                (size_t) mbedtls_hash_size_for_ciphersuite( suite_info ) );
+    }
+#endif /* MBEDTLS_SSL_EXPORT_KEYS */
 
     /* Generate application traffic keys since any records following a 1-RTT Finished message
      * MUST be encrypted under the application traffic key.

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -1063,6 +1063,14 @@ int mbedtls_ssl_derive_traffic_keys( mbedtls_ssl_context *ssl, mbedtls_ssl_key_s
         return( ret );
     }
 
+    /*
+     * Export client handshake traffic secret
+     */
+#if defined(MBEDTLS_SSL_EXPORT_KEYS)
+    if( ssl->conf->f_export_client_hs_traffic_secret != NULL )
+        ssl->conf->f_export_client_hs_traffic_secret( ssl->conf->p_export_client_hs_traffic_secret, ssl->handshake->client_handshake_traffic_secret, (size_t) mbedtls_hash_size_for_ciphersuite( suite_info ) );
+#endif
+
     MBEDTLS_SSL_DEBUG_MSG( 5, ( "HKDF Expand: label=[TLS 1.3, c hs traffic], requested length %d", mbedtls_hash_size_for_ciphersuite( suite_info ) ) );
     MBEDTLS_SSL_DEBUG_BUF( 5, "Secret: ", ssl->handshake->handshake_secret, mbedtls_hash_size_for_ciphersuite( suite_info ) );
     MBEDTLS_SSL_DEBUG_BUF( 5, "Hash:", hash, mbedtls_hash_size_for_ciphersuite( suite_info ) );
@@ -1085,6 +1093,14 @@ int mbedtls_ssl_derive_traffic_keys( mbedtls_ssl_context *ssl, mbedtls_ssl_key_s
         return( ret );
     }
 
+    /*
+     * Export server handshake traffic secret
+     */
+#if defined(MBEDTLS_SSL_EXPORT_KEYS)
+    if( ssl->conf->f_export_server_hs_traffic_secret != NULL )
+        ssl->conf->f_export_server_hs_traffic_secret( ssl->conf->p_export_server_hs_traffic_secret, ssl->handshake->server_handshake_traffic_secret, (size_t) mbedtls_hash_size_for_ciphersuite( suite_info ) );
+#endif
+
     MBEDTLS_SSL_DEBUG_MSG( 5, ( "HKDF Expand: label=[TLS 1.3, s hs traffic], requested length %d", mbedtls_hash_size_for_ciphersuite( suite_info ) ) );
     MBEDTLS_SSL_DEBUG_BUF( 5, "Secret: ", ssl->handshake->handshake_secret, mbedtls_hash_size_for_ciphersuite( suite_info ) );
     MBEDTLS_SSL_DEBUG_BUF( 5, "Hash:", hash, mbedtls_hash_size_for_ciphersuite( suite_info ) );
@@ -1106,6 +1122,14 @@ int mbedtls_ssl_derive_traffic_keys( mbedtls_ssl_context *ssl, mbedtls_ssl_key_s
         MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_tls1_3_derive_secret( ) with exporter_secret: Error", ret );
         return( ret );
     }
+
+    /*
+     * Export exporter master secret
+     */
+#if defined(MBEDTLS_SSL_EXPORT_KEYS)
+    if( ssl->conf->f_export_exporter_master_secret != NULL )
+        ssl->conf->f_export_exporter_master_secret( ssl->conf->p_export_exporter_master_secret, ssl->handshake->exporter_secret, (size_t) mbedtls_hash_size_for_ciphersuite( suite_info ) );
+#endif
 
     MBEDTLS_SSL_DEBUG_BUF( 5, "exporter_secret", ssl->handshake->exporter_secret, mbedtls_hash_size_for_ciphersuite( suite_info ) );
 
@@ -1512,6 +1536,14 @@ int mbedtls_ssl_derive_master_secret( mbedtls_ssl_context *ssl ) {
         if( psk_allocated == 1 ) mbedtls_free( psk );
         return( ret );
     }
+
+    /*
+     * Export client early traffic secret
+     */
+#if defined(MBEDTLS_SSL_EXPORT_KEYS)
+    if( ssl->conf->f_export_client_early_traffic_secret != NULL )
+        ssl->conf->f_export_client_early_traffic_secret( ssl->conf->p_export_client_early_traffic_secret, ssl->handshake->early_secret, hash_size );
+#endif
 
     MBEDTLS_SSL_DEBUG_MSG( 5, ( "HKDF Extract -- early_secret" ) );
     MBEDTLS_SSL_DEBUG_BUF( 5, "Salt", salt, hash_size );
@@ -3167,6 +3199,14 @@ int mbedtls_ssl_generate_application_traffic_keys( mbedtls_ssl_context *ssl, mbe
         return( ret );
     }
 
+    /*
+     * Export client application traffic secret 0
+     */
+#if defined(MBEDTLS_SSL_EXPORT_KEYS)
+    if( ssl->conf->f_export_client_app_traffic_secret_0 != NULL )
+        ssl->conf->f_export_client_app_traffic_secret_0( ssl->conf->p_export_client_app_traffic_secret_0, ssl->handshake->client_traffic_secret, (size_t) mbedtls_hash_size_for_ciphersuite( suite_info ) );
+#endif
+
     /* Generate server_application_traffic_secret_0
      *
      * Master Secret
@@ -3187,6 +3227,14 @@ int mbedtls_ssl_generate_application_traffic_keys( mbedtls_ssl_context *ssl, mbe
         MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_tls1_3_derive_secret( ) with server_traffic_secret_0: Error", ret );
         return( ret );
     }
+
+    /*
+     * Export server application traffic secret 0
+     */
+#if defined(MBEDTLS_SSL_EXPORT_KEYS)
+    if( ssl->conf->f_export_server_app_traffic_secret_0 != NULL )
+        ssl->conf->f_export_server_app_traffic_secret_0( ssl->conf->p_export_server_app_traffic_secret_0, ssl->handshake->server_traffic_secret, (size_t) mbedtls_hash_size_for_ciphersuite( suite_info ) );
+#endif
 
     /* Generate application traffic keys since any records following a 1-RTT Finished message
      * MUST be encrypted under the application traffic key.


### PR DESCRIPTION
Implement TLS 1.3 keying material export (secrets) as specified by the Key Log Format used in NSS and Wireshark:
https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/Key_Log_Format

Uncomment `MBEDTLS_SSL_EXPORT_KEYS` to compile.