### PR TITLE
Fix documentation and argument names of `mbedtls_ssl_tls1_3_make_traf…

### DIFF
--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -1626,14 +1626,14 @@ int mbedtls_ssl_tls1_3_derive_secret(
 * \brief           mbedtls_ssl_tls1_3_make_traffic_keys generates keys/IVs
 *                  for record layer encryption.
 *
-* \param hash_alg        Hash algorithm
-* \param client_key      Label Length
-* \param server_key Hash Value
-* \param slen      Length of hash value
-* \param keyLen	  Length of the key
-* \param ivLen    Length of IV
-* \param keys     mbedtls_ssl_key_set structure containing client/server key
-*                 and IVs
+* \param hash_alg      Hash algorithm
+* \param client_secret Client traffic secret
+* \param server_secret Server traffic secret
+* \param slen          Length of the secrets
+* \param keyLen        Length of the key
+* \param ivLen         Length of IV
+* \param keys          mbedtls_ssl_key_set structure containing client/server
+*                      keys and IVs
 *
 * \return          0 if successful,
 *                  or MBEDTLS_ERR_HKDF_BUFFER_TOO_SMALL
@@ -1644,8 +1644,8 @@ int mbedtls_ssl_tls1_3_derive_secret(
 
 int mbedtls_ssl_tls1_3_make_traffic_keys(
                      mbedtls_md_type_t hash_alg,
-                     const unsigned char *client_key,
-                     const unsigned char *server_key,
+                     const unsigned char *client_secret,
+                     const unsigned char *server_secret,
                      int slen, int keyLen, int ivLen,
                      mbedtls_ssl_key_set *keys );
 

--- a/library/ssl_tls13_keys.c
+++ b/library/ssl_tls13_keys.c
@@ -177,8 +177,8 @@ int mbedtls_ssl_tls1_3_derive_secret(
 */
 int mbedtls_ssl_tls1_3_make_traffic_keys(
                      mbedtls_md_type_t hash_alg,
-                     const unsigned char *client_key,
-                     const unsigned char *server_key,
+                     const unsigned char *client_secret,
+                     const unsigned char *server_secret,
                      int slen,
                      int keyLen, int ivLen,
                      mbedtls_ssl_key_set *keys )
@@ -192,7 +192,7 @@ int mbedtls_ssl_tls1_3_make_traffic_keys(
         return( ( MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL ) );
     }
 
-    ret = mbedtls_ssl_tls1_3_hkdf_expand_label( hash_alg, client_key, slen, (const unsigned char *) "key", 3,
+    ret = mbedtls_ssl_tls1_3_hkdf_expand_label( hash_alg, client_secret, slen, (const unsigned char *) "key", 3,
                           (const unsigned char *)"", 0, keyLen,
                           keys->clientWriteKey, keyLen );
 
@@ -209,7 +209,7 @@ int mbedtls_ssl_tls1_3_make_traffic_keys(
         return( ( ret ) );
     }
 
-    ret = mbedtls_ssl_tls1_3_hkdf_expand_label( hash_alg, server_key, slen, (const unsigned char *)"key", 3,
+    ret = mbedtls_ssl_tls1_3_hkdf_expand_label( hash_alg, server_secret, slen, (const unsigned char *)"key", 3,
                           (const unsigned char *)"", 0, keyLen,
                           keys->serverWriteKey, keyLen );
 
@@ -227,7 +227,7 @@ int mbedtls_ssl_tls1_3_make_traffic_keys(
         return( ( ret ) );
     }
 
-    ret = mbedtls_ssl_tls1_3_hkdf_expand_label( hash_alg, client_key, slen, (const unsigned char *) "iv", 2,
+    ret = mbedtls_ssl_tls1_3_hkdf_expand_label( hash_alg, client_secret, slen, (const unsigned char *) "iv", 2,
                           (const unsigned char *)"", 0, ivLen,
                           keys->clientWriteIV, ivLen );
 
@@ -245,7 +245,7 @@ int mbedtls_ssl_tls1_3_make_traffic_keys(
         return( ( ret ) );
     }
 
-    ret = mbedtls_ssl_tls1_3_hkdf_expand_label( hash_alg, server_key, slen, (const unsigned char *) "iv", 2,
+    ret = mbedtls_ssl_tls1_3_hkdf_expand_label( hash_alg, server_secret, slen, (const unsigned char *) "iv", 2,
                           (const unsigned char *)"", 0, ivLen,
                           keys->serverWriteIV, ivLen );
 
@@ -265,7 +265,7 @@ int mbedtls_ssl_tls1_3_make_traffic_keys(
         return( ( ret ) );
     }
 
-    ret = mbedtls_ssl_tls1_3_hkdf_expand_label( hash_alg, client_key, slen, (const unsigned char *) "sn", 2,
+    ret = mbedtls_ssl_tls1_3_hkdf_expand_label( hash_alg, client_secret, slen, (const unsigned char *) "sn", 2,
                           (const unsigned char *)"", 0, keyLen,
                           keys->client_sn_key, keyLen );
 
@@ -283,7 +283,7 @@ int mbedtls_ssl_tls1_3_make_traffic_keys(
         return( ( ret ) );
     }
 
-    ret = mbedtls_ssl_tls1_3_hkdf_expand_label( hash_alg, server_key, slen, (const unsigned char *) "sn", 2,
+    ret = mbedtls_ssl_tls1_3_hkdf_expand_label( hash_alg, server_secret, slen, (const unsigned char *) "sn", 2,
                           (const unsigned char *)"", 0, keyLen,
                           keys->server_sn_key, keyLen );
 


### PR DESCRIPTION
…fic_keys()`

According to the RFC, a (traffic) key contains write keys and IVs for each side, and is derived from a (traffic) secret