### PR TITLE
Add support for NSS keylog export to examples

### DIFF
--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -1994,7 +1994,7 @@
  *
  * Comment this macro to disable support for key export
  */
-//#define MBEDTLS_SSL_EXPORT_KEYS
+#define MBEDTLS_SSL_EXPORT_KEYS
 
 /**
  * \def MBEDTLS_SSL_SERVER_NAME_INDICATION

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -1275,7 +1275,7 @@ struct mbedtls_ssl_config
                 const unsigned char *, size_t, size_t, size_t,
                 const unsigned char[32], const unsigned char[32],
                 mbedtls_tls_prf_types );
-     void *p_export_keys;            /*!< context for key export callback    */ 
+    void *p_export_keys;            /*!< context for key export callback    */
 #endif /* MBEDTLS_SSL_PROTO_TLS1 || MBEDTLS_SSL_PROTO_TLS1_1 || \
           MBEDTLS_SSL_PROTO_TLS1_2 */
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -1279,7 +1279,7 @@ struct mbedtls_ssl_config
           MBEDTLS_SSL_PROTO_TLS1_2 */
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
     /** Callback to export TLS 1.3 secret                                   */
-    int (*f_export_secret_tls13)( void *, const unsigned char[32],
+    int (*f_export_secret)( void *, const unsigned char[32],
             mbedtls_ssl_tls1_3_secret_type type,
             const unsigned char *, size_t );
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -1275,6 +1275,7 @@ struct mbedtls_ssl_config
                 const unsigned char *, size_t, size_t, size_t,
                 const unsigned char[32], const unsigned char[32],
                 mbedtls_tls_prf_types );
+     void *p_export_keys;            /*!< context for key export callback    */ 
 #endif /* MBEDTLS_SSL_PROTO_TLS1 || MBEDTLS_SSL_PROTO_TLS1_1 || \
           MBEDTLS_SSL_PROTO_TLS1_2 */
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
@@ -1282,8 +1283,8 @@ struct mbedtls_ssl_config
     int (*f_export_secret)( void *, const unsigned char[32],
             mbedtls_ssl_tls1_3_secret_type type,
             const unsigned char *, size_t );
-#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
     void *p_export_secret; /*!< context for key export callback             */
+#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 #endif
 
 #if defined(MBEDTLS_SSL_DTLS_CONNECTION_ID)

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -1275,16 +1275,15 @@ struct mbedtls_ssl_config
                 const unsigned char *, size_t, size_t, size_t,
                 const unsigned char[32], const unsigned char[32],
                 mbedtls_tls_prf_types );
-    void *p_export_keys;            /*!< context for key export callback    */
 #endif /* MBEDTLS_SSL_PROTO_TLS1 || MBEDTLS_SSL_PROTO_TLS1_1 || \
           MBEDTLS_SSL_PROTO_TLS1_2 */
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
     /** Callback to export TLS 1.3 secret                                   */
-    int (*f_export_secret)( void *, const unsigned char[32],
+    int (*f_export_secret_tls13)( void *, const unsigned char[32],
             mbedtls_ssl_tls1_3_secret_type type,
             const unsigned char *, size_t );
-    void *p_export_secret; /*!< context for key export callback             */
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
+    void *p_export_secret; /*!< context for key export callback             */
 #endif
 
 #if defined(MBEDTLS_SSL_DTLS_CONNECTION_ID)

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -264,6 +264,7 @@ int main( void )
 
 #if defined(MBEDTLS_SSL_EXPORT_KEYS)
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+/* Support for EAP-TLS 1.3 has not been implemented yet. */
 #define USAGE_EAP_TLS ""
 #else
 #define USAGE_EAP_TLS                                       \

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -263,8 +263,12 @@ int main( void )
 #endif /* MBEDTLS_SSL_SESSION_TICKETS */
 
 #if defined(MBEDTLS_SSL_EXPORT_KEYS)
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+#define USAGE_EAP_TLS ""
+#else
 #define USAGE_EAP_TLS                                       \
     "    eap_tls=%%d          default: 0 (disabled)\n"
+#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 #define USAGE_NSS_KEYLOG                                    \
     "    nss_keylog=%%d          default: 0 (disabled)\n"               \
     "                             This cannot be used with eap_tls=1\n"
@@ -637,7 +641,7 @@ static int eap_tls_key_derivation ( void *p_expkey,
     }
     return( 0 );
 }
-#endif
+#endif /* !MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
 static int nss_keylog_export( void *p_expsecret,
@@ -1955,9 +1959,14 @@ int main( int argc, char *argv[] )
         }
         else if( strcmp( p, "eap_tls" ) == 0 )
         {
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+            mbedtls_printf( "Error: eap_tls is not supported in TLS 1.3.\n" );
+            goto usage;
+#else
             opt.eap_tls = atoi( q );
             if( opt.eap_tls < 0 || opt.eap_tls > 1 )
                 goto usage;
+#endif
         }
         else if( strcmp( p, "reproducible" ) == 0 )
         {
@@ -2592,14 +2601,15 @@ int main( int argc, char *argv[] )
 #endif
 
 #if defined(MBEDTLS_SSL_EXPORT_KEYS)
+#if !defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
     if( opt.eap_tls != 0 )
     {
-#if !defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
         mbedtls_ssl_conf_export_keys_ext_cb( &conf, eap_tls_key_derivation,
                                              &eap_tls_keying );
-#endif
     }
-    else if( opt.nss_keylog != 0 )
+    else
+#endif
+    if( opt.nss_keylog != 0 )
     {
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
         mbedtls_ssl_conf_export_secrets_cb( &conf,
@@ -2611,7 +2621,7 @@ int main( int argc, char *argv[] )
                                              NULL );
 #endif
     }
-#endif
+#endif /* MBEDTLS_SSL_EXPORT_KEYS */
 
 #if defined(MBEDTLS_SSL_CBC_RECORD_SPLITTING)
     if( opt.recsplit != DFL_RECSPLIT )
@@ -2973,8 +2983,8 @@ int main( int argc, char *argv[] )
         }
         mbedtls_printf("\n");
     }
-#endif
-#endif
+#endif /* !MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
+#endif /* MBEDTLS_SSL_EXPORT_KEYS */
 
 #if defined(MBEDTLS_X509_CRT_PARSE_C)
     /*

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -608,7 +608,9 @@ struct options
 int query_config( const char *config );
 
 #if defined(MBEDTLS_SSL_EXPORT_KEYS)
-#if !defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+
+#if defined(MBEDTLS_SSL_PROTO_TLS1) || defined(MBEDTLS_SSL_PROTO_TLS1_1) || \
+    defined(MBEDTLS_SSL_PROTO_TLS1_2)
 typedef struct eap_tls_keys
 {
     unsigned char master_secret[48];
@@ -642,7 +644,8 @@ static int eap_tls_key_derivation ( void *p_expkey,
     }
     return( 0 );
 }
-#endif /* !MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
+#endif /* MBEDTLS_SSL_PROTO_TLS1 || MBEDTLS_SSL_PROTO_TLS1_1 || \
+          MBEDTLS_SSL_PROTO_TLS1_2 */
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
 static int nss_keylog_export( void *p_expsecret,
@@ -731,7 +734,10 @@ exit:
                               sizeof( nss_keylog_line ) );
     return( ret );
 }
-#else
+#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
+
+#if defined(MBEDTLS_SSL_PROTO_TLS1) || defined(MBEDTLS_SSL_PROTO_TLS1_1) || \
+    defined(MBEDTLS_SSL_PROTO_TLS1_2)
 static int nss_keylog_export( void *p_expkey,
                               const unsigned char *ms,
                               const unsigned char *kb,
@@ -807,7 +813,8 @@ exit:
                               sizeof( nss_keylog_line ) );
     return( ret );
 }
-#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
+#endif /* MBEDTLS_SSL_PROTO_TLS1 || MBEDTLS_SSL_PROTO_TLS1_1 || \
+          MBEDTLS_SSL_PROTO_TLS1_2 */
 #endif /* MBEDTLS_SSL_EXPORT_KEYS */
 
 static void my_debug( void *ctx, int level,
@@ -1344,13 +1351,16 @@ int main( int argc, char *argv[] )
     size_t context_buf_len;
 #endif
 #if defined(MBEDTLS_SSL_EXPORT_KEYS)
-#if !defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+
+#if defined(MBEDTLS_SSL_PROTO_TLS1) || defined(MBEDTLS_SSL_PROTO_TLS1_1) || \
+    defined(MBEDTLS_SSL_PROTO_TLS1_2)
     unsigned char eap_tls_keymaterial[16];
     unsigned char eap_tls_iv[8];
     const char* eap_tls_label = "client EAP encryption";
     eap_tls_keys eap_tls_keying;
-#endif
-#endif
+#endif /* MBEDTLS_SSL_PROTO_TLS1 || MBEDTLS_SSL_PROTO_TLS1_1 || \
+          MBEDTLS_SSL_PROTO_TLS1_2 */
+#endif /* MBEDTLS_SSL_EXPORT_KEYS */
 
 #if defined(MBEDTLS_MEMORY_BUFFER_ALLOC_C)
     mbedtls_memory_buffer_alloc_init( alloc_buf, sizeof( alloc_buf ) );
@@ -2602,27 +2612,36 @@ int main( int argc, char *argv[] )
 #endif
 
 #if defined(MBEDTLS_SSL_EXPORT_KEYS)
-#if !defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+
+#if defined(MBEDTLS_SSL_PROTO_TLS1) || defined(MBEDTLS_SSL_PROTO_TLS1_1) || \
+    defined(MBEDTLS_SSL_PROTO_TLS1_2)
     if( opt.eap_tls != 0 )
     {
         mbedtls_ssl_conf_export_keys_ext_cb( &conf, eap_tls_key_derivation,
                                              &eap_tls_keying );
     }
     else
-#endif
-    if( opt.nss_keylog != 0 )
+#endif /* MBEDTLS_SSL_PROTO_TLS1 || MBEDTLS_SSL_PROTO_TLS1_1 || \
+          MBEDTLS_SSL_PROTO_TLS1_2 */
     {
-#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
-        mbedtls_ssl_conf_export_secrets_cb( &conf,
-                                            nss_keylog_export,
-                                            NULL );
-#else
-        mbedtls_ssl_conf_export_keys_ext_cb( &conf,
-                                             nss_keylog_export,
-                                             NULL );
-#endif
-    }
+        if( opt.nss_keylog != 0 )
+        {
+    #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+            mbedtls_ssl_conf_export_secrets_cb( &conf,
+                                                nss_keylog_export,
+                                                NULL );
+    #endif /* */
+
+    #if defined(MBEDTLS_SSL_PROTO_TLS1) || defined(MBEDTLS_SSL_PROTO_TLS1_1) || \
+        defined(MBEDTLS_SSL_PROTO_TLS1_2)
+            mbedtls_ssl_conf_export_keys_ext_cb( &conf,
+                                                 nss_keylog_export,
+                                                 NULL );
+    #endif /* MBEDTLS_SSL_PROTO_TLS1 || MBEDTLS_SSL_PROTO_TLS1_1 || \
+          MBEDTLS_SSL_PROTO_TLS1_2 */
+        }
 #endif /* MBEDTLS_SSL_EXPORT_KEYS */
+    }
 
 #if defined(MBEDTLS_SSL_CBC_RECORD_SPLITTING)
     if( opt.recsplit != DFL_RECSPLIT )
@@ -2934,7 +2953,8 @@ int main( int argc, char *argv[] )
 #endif
 
 #if defined(MBEDTLS_SSL_EXPORT_KEYS)
-#if !defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+#if defined(MBEDTLS_SSL_PROTO_TLS1) || defined(MBEDTLS_SSL_PROTO_TLS1_1) || \
+    defined(MBEDTLS_SSL_PROTO_TLS1_2)
     if( opt.eap_tls != 0 )
     {
         size_t j = 0;
@@ -2984,7 +3004,8 @@ int main( int argc, char *argv[] )
         }
         mbedtls_printf("\n");
     }
-#endif /* !MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
+#endif /* MBEDTLS_SSL_PROTO_TLS1 || MBEDTLS_SSL_PROTO_TLS1_1 || \
+          MBEDTLS_SSL_PROTO_TLS1_2 */
 #endif /* MBEDTLS_SSL_EXPORT_KEYS */
 
 #if defined(MBEDTLS_X509_CRT_PARSE_C)

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -1351,7 +1351,6 @@ int main( int argc, char *argv[] )
     size_t context_buf_len;
 #endif
 #if defined(MBEDTLS_SSL_EXPORT_KEYS)
-
 #if defined(MBEDTLS_SSL_PROTO_TLS1) || defined(MBEDTLS_SSL_PROTO_TLS1_1) || \
     defined(MBEDTLS_SSL_PROTO_TLS1_2)
     unsigned char eap_tls_keymaterial[16];
@@ -2626,18 +2625,18 @@ int main( int argc, char *argv[] )
     {
         if( opt.nss_keylog != 0 )
         {
-    #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
             mbedtls_ssl_conf_export_secrets_cb( &conf,
                                                 nss_keylog_export,
                                                 NULL );
-    #endif /* */
+#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 
-    #if defined(MBEDTLS_SSL_PROTO_TLS1) || defined(MBEDTLS_SSL_PROTO_TLS1_1) || \
-        defined(MBEDTLS_SSL_PROTO_TLS1_2)
+#if defined(MBEDTLS_SSL_PROTO_TLS1) || defined(MBEDTLS_SSL_PROTO_TLS1_1) || \
+    defined(MBEDTLS_SSL_PROTO_TLS1_2)
             mbedtls_ssl_conf_export_keys_ext_cb( &conf,
                                                  nss_keylog_export,
                                                  NULL );
-    #endif /* MBEDTLS_SSL_PROTO_TLS1 || MBEDTLS_SSL_PROTO_TLS1_1 || \
+#endif /* MBEDTLS_SSL_PROTO_TLS1 || MBEDTLS_SSL_PROTO_TLS1_1 || \
           MBEDTLS_SSL_PROTO_TLS1_2 */
         }
 #endif /* MBEDTLS_SSL_EXPORT_KEYS */

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -2639,8 +2639,8 @@ int main( int argc, char *argv[] )
 #endif /* MBEDTLS_SSL_PROTO_TLS1 || MBEDTLS_SSL_PROTO_TLS1_1 || \
           MBEDTLS_SSL_PROTO_TLS1_2 */
         }
-#endif /* MBEDTLS_SSL_EXPORT_KEYS */
     }
+#endif /* MBEDTLS_SSL_EXPORT_KEYS */
 
 #if defined(MBEDTLS_SSL_CBC_RECORD_SPLITTING)
     if( opt.recsplit != DFL_RECSPLIT )

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -603,6 +603,7 @@ struct options
 int query_config( const char *config );
 
 #if defined(MBEDTLS_SSL_EXPORT_KEYS)
+#if !defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
 typedef struct eap_tls_keys
 {
     unsigned char master_secret[48];
@@ -636,7 +637,96 @@ static int eap_tls_key_derivation ( void *p_expkey,
     }
     return( 0 );
 }
+#endif
 
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+static int nss_keylog_export( void *p_expsecret,
+                              const unsigned char client_random[32],
+                              mbedtls_ssl_tls1_3_secret_type type,
+                              const unsigned char *secret,
+                              size_t len )
+{
+    char label[ 64 ];
+    char nss_keylog_line[ 200 ];
+    size_t const client_random_len = 32;
+    size_t total_len = 0;
+    size_t j;
+    int ret = 0;
+
+    ((void) p_expsecret);
+
+    switch( type )
+    {
+        case MBEDTLS_SSL_TLS1_3_CLIENT_EARLY_TRAFFIC_SECRET:
+            strcpy(label, "CLIENT_EARLY_TRAFFIC_SECRET ");
+            break;
+        case MBEDTLS_SSL_TLS1_3_CLIENT_HANDSHAKE_TRAFFIC_SECRET:
+            strcpy(label, "CLIENT_HANDSHAKE_TRAFFIC_SECRET ");
+            break;
+        case MBEDTLS_SSL_TLS1_3_SERVER_HANDSHAKE_TRAFFIC_SECRET:
+            strcpy(label, "SERVER_HANDSHAKE_TRAFFIC_SECRET ");
+            break;
+        case MBEDTLS_SSL_TLS1_3_CLIENT_APPLICATION_TRAFFIC_SECRET_0:
+            strcpy(label, "CLIENT_TRAFFIC_SECRET_0 ");
+            break;
+        case MBEDTLS_SSL_TLS1_3_SERVER_APPLICATION_TRAFFIC_SECRET_0:
+            strcpy(label, "SERVER_TRAFFIC_SECRET_0 ");
+            break;
+        case MBEDTLS_SSL_TLS1_3_EXPORTER_MASTER_SECRET:
+            strcpy(label, "EXPORTER_SECRET ");
+            break;
+    }
+    total_len += sprintf( nss_keylog_line + total_len,
+                    "%s", label );
+
+    for( j = 0; j < client_random_len; j++ )
+    {
+        total_len += sprintf( nss_keylog_line + total_len,
+                        "%02x", client_random[j] );
+    }
+
+    total_len += sprintf( nss_keylog_line + total_len, " " );
+
+    for( j = 0; j < len; j++ )
+    {
+        total_len += sprintf( nss_keylog_line + total_len,
+                        "%02x", secret[j] );
+    }
+
+    total_len += sprintf( nss_keylog_line + total_len, "\n" );
+    nss_keylog_line[ total_len ] = '\0';
+
+    mbedtls_printf( "\n" );
+    mbedtls_printf( "---------------- NSS KEYLOG -----------------\n" );
+    mbedtls_printf( "%s", nss_keylog_line );
+    mbedtls_printf( "---------------------------------------------\n" );
+
+    if( opt.nss_keylog_file != NULL )
+    {
+        FILE *f;
+
+        if( ( f = fopen( opt.nss_keylog_file, "a" ) ) == NULL )
+        {
+            ret = -1;
+            goto exit;
+        }
+
+        if( fwrite( nss_keylog_line, 1, total_len, f ) != total_len )
+        {
+            ret = -1;
+            fclose( f );
+            goto exit;
+        }
+
+        fclose( f );
+    }
+
+exit:
+    mbedtls_platform_zeroize( nss_keylog_line,
+                              sizeof( nss_keylog_line ) );
+    return( ret );
+}
+#else
 static int nss_keylog_export( void *p_expkey,
                               const unsigned char *ms,
                               const unsigned char *kb,
@@ -712,7 +802,8 @@ exit:
                               sizeof( nss_keylog_line ) );
     return( ret );
 }
-#endif
+#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
+#endif /* MBEDTLS_SSL_EXPORT_KEYS */
 
 static void my_debug( void *ctx, int level,
                       const char *file, int line,
@@ -1248,10 +1339,12 @@ int main( int argc, char *argv[] )
     size_t context_buf_len;
 #endif
 #if defined(MBEDTLS_SSL_EXPORT_KEYS)
+#if !defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
     unsigned char eap_tls_keymaterial[16];
     unsigned char eap_tls_iv[8];
     const char* eap_tls_label = "client EAP encryption";
     eap_tls_keys eap_tls_keying;
+#endif
 #endif
 
 #if defined(MBEDTLS_MEMORY_BUFFER_ALLOC_C)
@@ -2501,14 +2594,22 @@ int main( int argc, char *argv[] )
 #if defined(MBEDTLS_SSL_EXPORT_KEYS)
     if( opt.eap_tls != 0 )
     {
+#if !defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
         mbedtls_ssl_conf_export_keys_ext_cb( &conf, eap_tls_key_derivation,
                                              &eap_tls_keying );
+#endif
     }
     else if( opt.nss_keylog != 0 )
     {
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+        mbedtls_ssl_conf_export_secrets_cb( &conf,
+                                            nss_keylog_export,
+                                            NULL );
+#else
         mbedtls_ssl_conf_export_keys_ext_cb( &conf,
                                              nss_keylog_export,
                                              NULL );
+#endif
     }
 #endif
 
@@ -2822,6 +2923,7 @@ int main( int argc, char *argv[] )
 #endif
 
 #if defined(MBEDTLS_SSL_EXPORT_KEYS)
+#if !defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
     if( opt.eap_tls != 0 )
     {
         size_t j = 0;
@@ -2871,6 +2973,7 @@ int main( int argc, char *argv[] )
         }
         mbedtls_printf("\n");
     }
+#endif
 #endif
 
 #if defined(MBEDTLS_X509_CRT_PARSE_C)

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -718,7 +718,8 @@ struct options
 int query_config( const char *config );
 
 #if defined(MBEDTLS_SSL_EXPORT_KEYS)
-#if !defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+#if defined(MBEDTLS_SSL_PROTO_TLS1) || defined(MBEDTLS_SSL_PROTO_TLS1_1) || \
+    defined(MBEDTLS_SSL_PROTO_TLS1_2)
 typedef struct eap_tls_keys
 {
     unsigned char master_secret[48];
@@ -752,7 +753,8 @@ static int eap_tls_key_derivation ( void *p_expkey,
     }
     return( 0 );
 }
-#endif /* !MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
+#endif /* MBEDTLS_SSL_PROTO_TLS1 || MBEDTLS_SSL_PROTO_TLS1_1 || \
+          MBEDTLS_SSL_PROTO_TLS1_2 */
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
 static int nss_keylog_export( void *p_expsecret,
@@ -2000,13 +2002,15 @@ int main( int argc, char *argv[] )
     psa_status_t status;
 #endif
 #if defined(MBEDTLS_SSL_EXPORT_KEYS)
-#if !defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+#if defined(MBEDTLS_SSL_PROTO_TLS1) || defined(MBEDTLS_SSL_PROTO_TLS1_1) || \
+    defined(MBEDTLS_SSL_PROTO_TLS1_2)
     unsigned char eap_tls_keymaterial[16];
     unsigned char eap_tls_iv[8];
     const char* eap_tls_label = "client EAP encryption";
     eap_tls_keys eap_tls_keying;
-#endif
-#endif
+#endif /* MBEDTLS_SSL_PROTO_TLS1 || MBEDTLS_SSL_PROTO_TLS1_1 || \
+          MBEDTLS_SSL_PROTO_TLS1_2 */
+#endif /* MBEDTLS_SSL_EXPORT_KEYS */
 
 #if defined(MBEDTLS_MEMORY_BUFFER_ALLOC_C)
     mbedtls_memory_buffer_alloc_init( alloc_buf, sizeof(alloc_buf) );
@@ -3409,25 +3413,33 @@ int main( int argc, char *argv[] )
 #endif
 
 #if defined(MBEDTLS_SSL_EXPORT_KEYS)
-#if !defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+#if defined(MBEDTLS_SSL_PROTO_TLS1) || defined(MBEDTLS_SSL_PROTO_TLS1_1) || \
+    defined(MBEDTLS_SSL_PROTO_TLS1_2)
     if( opt.eap_tls != 0 )
     {
         mbedtls_ssl_conf_export_keys_ext_cb( &conf, eap_tls_key_derivation,
                                              &eap_tls_keying );
     }
     else
-#endif
-    if( opt.nss_keylog != 0 )
+#endif /* MBEDTLS_SSL_PROTO_TLS1 || MBEDTLS_SSL_PROTO_TLS1_1 || \
+          MBEDTLS_SSL_PROTO_TLS1_2 */
     {
-#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
-        mbedtls_ssl_conf_export_secrets_cb( &conf,
-                                            nss_keylog_export,
-                                            NULL );
-#else
-        mbedtls_ssl_conf_export_keys_ext_cb( &conf,
-                                             nss_keylog_export,
-                                             NULL );
-#endif
+        if( opt.nss_keylog != 0 )
+        {
+    #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+            mbedtls_ssl_conf_export_secrets_cb( &conf,
+                                                nss_keylog_export,
+                                                NULL );
+    #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
+
+    #if defined(MBEDTLS_SSL_PROTO_TLS1) || defined(MBEDTLS_SSL_PROTO_TLS1_1) || \
+        defined(MBEDTLS_SSL_PROTO_TLS1_2)
+            mbedtls_ssl_conf_export_keys_ext_cb( &conf,
+                                                 nss_keylog_export,
+                                                 NULL );
+    #endif /* MBEDTLS_SSL_PROTO_TLS1 || MBEDTLS_SSL_PROTO_TLS1_1 || \
+              MBEDTLS_SSL_PROTO_TLS1_2 */
+        }
     }
 #endif /* MBEDTLS_SSL_EXPORT_KEYS */
 
@@ -4120,7 +4132,8 @@ handshake:
 #endif /* MBEDTLS_X509_CRT_PARSE_C */
 
 #if defined(MBEDTLS_SSL_EXPORT_KEYS)
-#if !defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+#if defined(MBEDTLS_SSL_PROTO_TLS1) || defined(MBEDTLS_SSL_PROTO_TLS1_1) || \
+    defined(MBEDTLS_SSL_PROTO_TLS1_2)
     if( opt.eap_tls != 0 )
     {
         size_t j = 0;
@@ -4170,7 +4183,8 @@ handshake:
         }
         mbedtls_printf("\n");
     }
-#endif /* !MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
+#endif /* MBEDTLS_SSL_PROTO_TLS1 || MBEDTLS_SSL_PROTO_TLS1_1 || \
+          MBEDTLS_SSL_PROTO_TLS1_2 */
 #endif /* MBEDTLS_SSL_EXPORT_KEYS */
 
 #if defined(MBEDTLS_SSL_DTLS_CONNECTION_ID)

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -3413,6 +3413,7 @@ int main( int argc, char *argv[] )
 #endif
 
 #if defined(MBEDTLS_SSL_EXPORT_KEYS)
+
 #if defined(MBEDTLS_SSL_PROTO_TLS1) || defined(MBEDTLS_SSL_PROTO_TLS1_1) || \
     defined(MBEDTLS_SSL_PROTO_TLS1_2)
     if( opt.eap_tls != 0 )
@@ -3426,19 +3427,19 @@ int main( int argc, char *argv[] )
     {
         if( opt.nss_keylog != 0 )
         {
-    #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
             mbedtls_ssl_conf_export_secrets_cb( &conf,
                                                 nss_keylog_export,
                                                 NULL );
-    #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
+#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 
-    #if defined(MBEDTLS_SSL_PROTO_TLS1) || defined(MBEDTLS_SSL_PROTO_TLS1_1) || \
-        defined(MBEDTLS_SSL_PROTO_TLS1_2)
+#if defined(MBEDTLS_SSL_PROTO_TLS1) || defined(MBEDTLS_SSL_PROTO_TLS1_1) || \
+    defined(MBEDTLS_SSL_PROTO_TLS1_2)
             mbedtls_ssl_conf_export_keys_ext_cb( &conf,
                                                  nss_keylog_export,
                                                  NULL );
-    #endif /* MBEDTLS_SSL_PROTO_TLS1 || MBEDTLS_SSL_PROTO_TLS1_1 || \
-              MBEDTLS_SSL_PROTO_TLS1_2 */
+#endif /* MBEDTLS_SSL_PROTO_TLS1 || MBEDTLS_SSL_PROTO_TLS1_1 || \
+          MBEDTLS_SSL_PROTO_TLS1_2 */
         }
     }
 #endif /* MBEDTLS_SSL_EXPORT_KEYS */

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -329,8 +329,12 @@ int main( void )
 #endif /* MBEDTLS_SSL_SESSION_TICKETS || MBEDTLS_SSL_NEW_SESSION_TICKET */
 
 #if defined(MBEDTLS_SSL_EXPORT_KEYS)
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+#define USAGE_EAP_TLS ""
+#else
 #define USAGE_EAP_TLS                                       \
     "    eap_tls=%%d          default: 0 (disabled)\n"
+#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 #define USAGE_NSS_KEYLOG                                    \
     "    nss_keylog=%%d          default: 0 (disabled)\n"   \
     "                             This cannot be used with eap_tls=1\n"
@@ -748,7 +752,7 @@ static int eap_tls_key_derivation ( void *p_expkey,
     }
     return( 0 );
 }
-#endif
+#endif /* !MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
 static int nss_keylog_export( void *p_expsecret,
@@ -913,7 +917,7 @@ exit:
                               sizeof( nss_keylog_line ) );
     return( ret );
 }
-#endif /* !MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
+#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 #endif /* MBEDTLS_SSL_EXPORT_KEYS */
 
 static void my_debug( void *ctx, int level,
@@ -2679,9 +2683,14 @@ int main( int argc, char *argv[] )
         }
         else if( strcmp( p, "eap_tls" ) == 0 )
         {
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+            mbedtls_printf( "Error: eap_tls is not supported in TLS 1.3.\n" );
+            goto usage;
+#else
             opt.eap_tls = atoi( q );
             if( opt.eap_tls < 0 || opt.eap_tls > 1 )
                 goto usage;
+#endif
         }
         else if( strcmp( p, "reproducible" ) == 0 )
         {
@@ -3400,14 +3409,15 @@ int main( int argc, char *argv[] )
 #endif
 
 #if defined(MBEDTLS_SSL_EXPORT_KEYS)
+#if !defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
     if( opt.eap_tls != 0 )
     {
-#if !defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
         mbedtls_ssl_conf_export_keys_ext_cb( &conf, eap_tls_key_derivation,
                                              &eap_tls_keying );
-#endif
     }
-    else if( opt.nss_keylog != 0 )
+    else
+#endif
+    if( opt.nss_keylog != 0 )
     {
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
         mbedtls_ssl_conf_export_secrets_cb( &conf,
@@ -3419,7 +3429,7 @@ int main( int argc, char *argv[] )
                                              NULL );
 #endif
     }
-#endif
+#endif /* MBEDTLS_SSL_EXPORT_KEYS */
 
 #if defined(MBEDTLS_SSL_ALPN)
     if( opt.alpn_string != NULL )
@@ -4160,8 +4170,8 @@ handshake:
         }
         mbedtls_printf("\n");
     }
-#endif
-#endif
+#endif /* !MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
+#endif /* MBEDTLS_SSL_EXPORT_KEYS */
 
 #if defined(MBEDTLS_SSL_DTLS_CONNECTION_ID)
     ret = report_cid_usage( &ssl, "initial handshake" );


### PR DESCRIPTION
The goal of this PR is to add support for NSS keylog export to examples, so that e.g. Wireshark can be used to capture and decrypt TLS 1.3 traffic.

How to decrypt TLS 1.3 traffic with Wireshark:
* Enable `MBEDTLS_SSL_EXPORT_KEYS`
* Remove the key log: `rm ./keylog.txt` (secrets are appended to it)
* Run Wireshark and start the capture:
  + In Wireshark >= 3.0: `wireshark -o tls.keylog_file:./keylog.txt -r <capture_file>`
  + Older: `wireshark -o ssl.keylog_file:./keylog.txt -r <capture_file>`
* Run the examples:
  + `programs/ssl/tls13_server server_port=443` (we set the port to 443 to make sure Wireshark detects TLS)
  + `programs/ssl/tls13_client nss_keylog=1 nss_keylog_file=./keylog.txt server_port=443`

NB: Starting from Wireshark 3.0 it's possible to embed the keylog in the capture file (https://wiki.wireshark.org/TLS#Embedding_decryption_secrets_in_a_pcapng_file)