### PR TITLE
Fix namespace

### DIFF
--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -626,8 +626,8 @@ struct mbedtls_ssl_handshake_params
      */
 #if defined(MBEDTLS_SSL_PROTO_SSL3) || defined(MBEDTLS_SSL_PROTO_TLS1) || \
     defined(MBEDTLS_SSL_PROTO_TLS1_1)
-       mbedtls_md5_context fin_md5;
-      mbedtls_sha1_context fin_sha1;
+    mbedtls_md5_context fin_md5;
+    mbedtls_sha1_context fin_sha1;
 #endif
 #if defined(MBEDTLS_SSL_PROTO_TLS1_2) || defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
 #if defined(MBEDTLS_SHA256_C)
@@ -1245,30 +1245,30 @@ int mbedtls_ssl_flush_output( mbedtls_ssl_context *ssl );
 
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
-int ssl_read_certificate_process(mbedtls_ssl_context* ssl);
-int ssl_write_certificate_process(mbedtls_ssl_context* ssl);
+int mbedtls_ssl_read_certificate_process(mbedtls_ssl_context* ssl);
+int mbedtls_ssl_write_certificate_process(mbedtls_ssl_context* ssl);
 #else
 int mbedtls_ssl_parse_certificate( mbedtls_ssl_context *ssl );
 int mbedtls_ssl_write_certificate( mbedtls_ssl_context *ssl );
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && defined(MBEDTLS_SSL_TLS13_COMPATIBILITY_MODE)
-int ssl_write_change_cipher_spec_process( mbedtls_ssl_context* ssl );
+int mbedtls_ssl_write_change_cipher_spec_process( mbedtls_ssl_context* ssl );
 #else
 int mbedtls_ssl_parse_change_cipher_spec( mbedtls_ssl_context *ssl );
 int mbedtls_ssl_write_change_cipher_spec( mbedtls_ssl_context *ssl );
 #endif  /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL && MBEDTLS_SSL_TLS13_COMPATIBILITY_MODE */
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
-int ssl_finished_in_process(mbedtls_ssl_context* ssl);
-int ssl_finished_out_process(mbedtls_ssl_context* ssl);
+int mbedtls_ssl_finished_in_process(mbedtls_ssl_context* ssl);
+int mbedtls_ssl_finished_out_process(mbedtls_ssl_context* ssl);
 #else
 int mbedtls_ssl_parse_finished( mbedtls_ssl_context *ssl );
 int mbedtls_ssl_write_finished( mbedtls_ssl_context *ssl );
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
-int ssl_parse_new_session_ticket(mbedtls_ssl_context* ssl);
+int mbedtls_ssl_parse_new_session_ticket(mbedtls_ssl_context* ssl);
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 
 
@@ -1283,44 +1283,44 @@ int mbedtls_ssl_key_derivation(mbedtls_ssl_context* ssl, mbedtls_ssl_key_set* tr
 
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
-int ssl_read_certificate_verify_process(mbedtls_ssl_context* ssl);
-int ssl_certificate_verify_process(mbedtls_ssl_context* ssl);
+int mbedtls_ssl_read_certificate_verify_process(mbedtls_ssl_context* ssl);
+int mbedtls_ssl_certificate_verify_process(mbedtls_ssl_context* ssl);
 
 int mbedtls_ssl_tls1_3_derive_master_secret(mbedtls_ssl_context* ssl);
 int mbedtls_set_traffic_key(mbedtls_ssl_context* ssl, mbedtls_ssl_key_set* traffic_keys, mbedtls_ssl_transform* transform, int mode);
 int mbedtls_ssl_generate_application_traffic_keys(mbedtls_ssl_context* ssl, mbedtls_ssl_key_set* traffic_keys);
 int mbedtls_ssl_generate_resumption_master_secret(mbedtls_ssl_context* ssl);
-int ssl_write_encrypted_extension(mbedtls_ssl_context* ssl);
+int mbedtls_ssl_write_encrypted_extension(mbedtls_ssl_context* ssl);
 int mbedtls_ssl_derive_traffic_keys(mbedtls_ssl_context* ssl, mbedtls_ssl_key_set* traffic_keys);
-int incrementSequenceNumber(unsigned char* sequenceNumber, unsigned char* nonce, size_t ivlen);
+int mbedtls_increment_sequence_number(unsigned char* sequenceNumber, unsigned char* nonce, size_t ivlen);
 
 #if defined(MBEDTLS_SSL_TLS13_COMPATIBILITY_MODE)
 int mbedtls_ssl_write_change_cipher_spec(mbedtls_ssl_context* ssl);
 #endif /* MBEDTLS_SSL_TLS13_COMPATIBILITY_MODE */
 
 #if defined(MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED)
-int ssl_write_pre_shared_key_ext(mbedtls_ssl_context* ssl, unsigned char* buf, unsigned char* end, size_t* olen, int dummy_run);
+int mbedtls_ssl_write_pre_shared_key_ext(mbedtls_ssl_context* ssl, unsigned char* buf, unsigned char* end, size_t* olen, int dummy_run);
 #endif /* MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED */
 #if defined(MBEDTLS_KEY_EXCHANGE_WITH_CERT_ENABLED)
-int ssl_write_signature_algorithms_ext(mbedtls_ssl_context* ssl, unsigned char* buf, unsigned char* end, size_t* olen);
-int ssl_parse_signature_algorithms_ext(mbedtls_ssl_context* ssl, const unsigned char* buf, size_t len);
+int mbedtls_ssl_write_signature_algorithms_ext(mbedtls_ssl_context* ssl, unsigned char* buf, unsigned char* end, size_t* olen);
+int mbedtls_ssl_parse_signature_algorithms_ext(mbedtls_ssl_context* ssl, const unsigned char* buf, size_t len);
 int mbedtls_ssl_check_signature_scheme(const mbedtls_ssl_context* ssl, int signature_scheme);
 #endif /* MBEDTLS_KEY_EXCHANGE_WITH_CERT_ENABLED */
 #if defined(MBEDTLS_ZERO_RTT)
 int mbedtls_ssl_early_data_key_derivation(mbedtls_ssl_context* ssl, mbedtls_ssl_key_set* traffic_keys);
-int ssl_write_early_data_ext(mbedtls_ssl_context* ssl, unsigned char* buf, size_t buflen, size_t* olen);
+int mbedtls_ssl_write_early_data_ext(mbedtls_ssl_context* ssl, unsigned char* buf, size_t buflen, size_t* olen);
 #endif /* MBEDTLS_ZERO_RTT */
 #if (defined(MBEDTLS_ECDH_C) || defined(MBEDTLS_ECDSA_C))
-int ssl_parse_supported_groups_ext(mbedtls_ssl_context* ssl, const unsigned char* buf, size_t len);
+int mbedtls_ssl_parse_supported_groups_ext(mbedtls_ssl_context* ssl, const unsigned char* buf, size_t len);
 #endif /* MBEDTLS_ECDH_C ||  MBEDTLS_ECDSA_C */
 #if defined(MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED)
-int ssl_create_binder(mbedtls_ssl_context* ssl, unsigned char* psk, size_t psk_len, const mbedtls_md_info_t* md, const mbedtls_ssl_ciphersuite_t* suite_info, unsigned char* buffer, size_t blen, unsigned char* result);
+int mbedtls_ssl_create_binder(mbedtls_ssl_context* ssl, unsigned char* psk, size_t psk_len, const mbedtls_md_info_t* md, const mbedtls_ssl_ciphersuite_t* suite_info, unsigned char* buffer, size_t blen, unsigned char* result);
 #endif /* MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED */
 #if defined(MBEDTLS_SSL_NEW_SESSION_TICKET)
 int mbedtls_ssl_parse_new_session_ticket_server(mbedtls_ssl_context* ssl, unsigned char* buf, size_t len, mbedtls_ssl_ticket* ticket);
 #endif /* MBEDTLS_SSL_NEW_SESSION_TICKET */
 #if defined(MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED)
-int ssl_parse_client_psk_identity_ext(mbedtls_ssl_context* ssl, const unsigned char* buf, size_t len);
+int mbedtls_ssl_parse_client_psk_identity_ext(mbedtls_ssl_context* ssl, const unsigned char* buf, size_t len);
 #endif /* MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED */
 
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
@@ -1576,8 +1576,8 @@ int mbedtls_ssl_flight_transmit( mbedtls_ssl_context *ssl );
 
 
 #if defined(MBEDTLS_CID)
-int ssl_parse_cid_ext(mbedtls_ssl_context* ssl, const unsigned char* buf, size_t len);
-void ssl_write_cid_ext(mbedtls_ssl_context* ssl, unsigned char* buf, size_t* olen);
+int mbedtls_ssl_parse_cid_ext(mbedtls_ssl_context* ssl, const unsigned char* buf, size_t len);
+void mbedtls_ssl_write_cid_ext(mbedtls_ssl_context* ssl, unsigned char* buf, size_t* olen);
 #endif /* MBEDTLS_CID */
 
 /* Visible for testing purposes only */

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -660,7 +660,7 @@ static int ssl_write_psk_key_exchange_modes_ext( mbedtls_ssl_context *ssl,
 
 
 /*
- * ssl_write_pre_shared_key_ext( ) structure:
+ * mbedtls_ssl_write_pre_shared_key_ext( ) structure:
  *
  * struct {
  *   opaque identity<1..2^16-1>;
@@ -688,7 +688,7 @@ static int ssl_write_psk_key_exchange_modes_ext( mbedtls_ssl_context *ssl,
  */
 
 #if defined(MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED)
-/* ssl_create_binder( ):
+/* mbedtls_ssl_create_binder( ):
 
    0
    |
@@ -710,7 +710,7 @@ static int ssl_write_psk_key_exchange_modes_ext( mbedtls_ssl_context *ssl,
    |                     = client_early_traffic_secret
 */
 
-int ssl_create_binder( mbedtls_ssl_context *ssl, unsigned char *psk, size_t psk_len, const mbedtls_md_info_t *md, const mbedtls_ssl_ciphersuite_t *suite_info, unsigned char *buffer, size_t blen, unsigned char *result ) {
+int mbedtls_ssl_create_binder( mbedtls_ssl_context *ssl, unsigned char *psk, size_t psk_len, const mbedtls_md_info_t *md, const mbedtls_ssl_ciphersuite_t *suite_info, unsigned char *buffer, size_t blen, unsigned char *result ) {
     int ret = 0;
     int hash_length;
     unsigned char salt[MBEDTLS_MD_MAX_SIZE];
@@ -731,7 +731,7 @@ int ssl_create_binder( mbedtls_ssl_context *ssl, unsigned char *psk, size_t psk_
 
     if( hash_length == -1 )
     {
-        MBEDTLS_SSL_DEBUG_MSG( 1, ( "mbedtls_hash_size_for_ciphersuite == -1, ssl_create_binder failed" ) );
+        MBEDTLS_SSL_DEBUG_MSG( 1, ( "mbedtls_hash_size_for_ciphersuite == -1, mbedtls_ssl_create_binder failed" ) );
         return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
     }
 
@@ -922,7 +922,7 @@ int ssl_create_binder( mbedtls_ssl_context *ssl, unsigned char *psk, size_t psk_
 }
 
 
-int ssl_write_pre_shared_key_ext( mbedtls_ssl_context *ssl,
+int mbedtls_ssl_write_pre_shared_key_ext( mbedtls_ssl_context *ssl,
                                  unsigned char* buf, unsigned char* end, size_t* olen, int dummy_run )
 {
     unsigned char *p = ( unsigned char * ) buf, *truncated_clienthello_end, *truncated_clienthello_start = ssl->out_msg;
@@ -969,7 +969,7 @@ int ssl_write_pre_shared_key_ext( mbedtls_ssl_context *ssl,
 
         if( hash_len == -1 )
         {
-            MBEDTLS_SSL_DEBUG_MSG( 1, ( "mbedtls_hash_size_for_ciphersuite == -1, ssl_write_pre_shared_key_ext failed" ) );
+            MBEDTLS_SSL_DEBUG_MSG( 1, ( "mbedtls_hash_size_for_ciphersuite == -1, mbedtls_ssl_write_pre_shared_key_ext failed" ) );
             return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
         }
 
@@ -989,7 +989,7 @@ int ssl_write_pre_shared_key_ext( mbedtls_ssl_context *ssl,
     }
     if( hash_len == -1 )
     {
-        MBEDTLS_SSL_DEBUG_MSG( 1, ( "mbedtls_hash_size_for_ciphersuite == -1, ssl_write_pre_shared_key_ext failed" ) );
+        MBEDTLS_SSL_DEBUG_MSG( 1, ( "mbedtls_hash_size_for_ciphersuite == -1, mbedtls_ssl_write_pre_shared_key_ext failed" ) );
         return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
     }
 
@@ -1084,13 +1084,13 @@ int ssl_write_pre_shared_key_ext( mbedtls_ssl_context *ssl,
 
         MBEDTLS_SSL_DEBUG_BUF( 3, "ssl_calc_binder computed over ", truncated_clienthello_start, truncated_clienthello_end - truncated_clienthello_start );
 
-        ret = ssl_create_binder( ssl, ssl->conf->psk, ssl->conf->psk_len, mbedtls_md_info_from_type( suite_info->mac ),
+        ret = mbedtls_ssl_create_binder( ssl, ssl->conf->psk, ssl->conf->psk_len, mbedtls_md_info_from_type( suite_info->mac ),
                                 suite_info, truncated_clienthello_start, truncated_clienthello_end - truncated_clienthello_start, p );
 
 
         if( ret != 0 )
         {
-            MBEDTLS_SSL_DEBUG_RET( 1, "create_binder in ssl_write_pre_shared_key_ext failed: %d", ret );
+            MBEDTLS_SSL_DEBUG_RET( 1, "create_binder in mbedtls_ssl_write_pre_shared_key_ext failed: %d", ret );
             return( MBEDTLS_ERR_SSL_BAD_HS_CLIENT_HELLO );
         }
     }
@@ -1837,7 +1837,8 @@ static int ssl_client_hello_write( mbedtls_ssl_context* ssl,
 #endif /* MBEDTLS_SSL_MAX_FRAGMENT_LENGTH */
 
 #if defined(MBEDTLS_ZERO_RTT)
-    ssl_write_early_data_ext( ssl, buf, (size_t)( end - buf ), &cur_ext_len );
+    mbedtls_ssl_write_early_data_ext( ssl, buf, (size_t)( end - buf ),
+            &cur_ext_len );
     total_ext_len += cur_ext_len;
     buf += cur_ext_len;
 #endif /* MBEDTLS_ZERO_RTT */
@@ -1902,7 +1903,7 @@ static int ssl_client_hello_write( mbedtls_ssl_context* ssl,
 
     if( ssl->conf->key_exchange_modes == MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_ECDHE_ECDSA ||
         ssl->conf->key_exchange_modes == MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_ALL ) {
-        ret = ssl_write_signature_algorithms_ext( ssl, buf, end, &cur_ext_len );
+        ret = mbedtls_ssl_write_signature_algorithms_ext( ssl, buf, end, &cur_ext_len );
         total_ext_len += cur_ext_len;
         buf += cur_ext_len;
 
@@ -1947,7 +1948,7 @@ static int ssl_client_hello_write( mbedtls_ssl_context* ssl,
          * because it has to be updated later.
          */
         ssl->handshake->ptr_to_psk_ext = buf;
-        ret = ssl_write_pre_shared_key_ext( ssl, buf, end, &cur_ext_len,0 );
+        ret = mbedtls_ssl_write_pre_shared_key_ext( ssl, buf, end, &cur_ext_len,0 );
         total_ext_len += cur_ext_len;
         buf += cur_ext_len;
 
@@ -2463,9 +2464,9 @@ static int ssl_certificate_request_parse( mbedtls_ssl_context* ssl,
             case MBEDTLS_TLS_EXT_SIG_ALG:
                 MBEDTLS_SSL_DEBUG_MSG( 3, ( "found signature_algorithms extension" ) );
 
-                if( ( ret = ssl_parse_signature_algorithms_ext( ssl, ext + 4, (size_t)ext_size ) ) != 0 )
+                if( ( ret = mbedtls_ssl_parse_signature_algorithms_ext( ssl, ext + 4, (size_t)ext_size ) ) != 0 )
                 {
-                    MBEDTLS_SSL_DEBUG_MSG( 1, ( "ssl_parse_signature_algorithms_ext" ) );
+                    MBEDTLS_SSL_DEBUG_MSG( 1, ( "mbedtls_ssl_parse_signature_algorithms_ext" ) );
                     SSL_PEND_FATAL_ALERT( MBEDTLS_SSL_ALERT_MSG_DECODE_ERROR );
                     return( ret );
                 }
@@ -3987,11 +3988,11 @@ int mbedtls_ssl_handshake_client_step( mbedtls_ssl_context *ssl )
 #if defined(MBEDTLS_SSL_TLS13_COMPATIBILITY_MODE)
         case MBEDTLS_SSL_CLIENT_CCS_AFTER_CLIENT_HELLO:
 
-            ret = ssl_write_change_cipher_spec_process( ssl );
+            ret = mbedtls_ssl_write_change_cipher_spec_process( ssl );
 
             if( ret != 0 )
             {
-                MBEDTLS_SSL_DEBUG_RET( 1, "ssl_write_change_cipher_spec_process", ret );
+                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_write_change_cipher_spec_process", ret );
                 return( ret );
             }
 
@@ -4072,11 +4073,11 @@ int mbedtls_ssl_handshake_client_step( mbedtls_ssl_context *ssl )
 #if defined(MBEDTLS_SSL_TLS13_COMPATIBILITY_MODE)
         case MBEDTLS_SSL_CLIENT_CCS_BEFORE_2ND_CLIENT_HELLO:
 
-            ret = ssl_write_change_cipher_spec_process( ssl );
+            ret = mbedtls_ssl_write_change_cipher_spec_process( ssl );
 
             if( ret != 0 )
             {
-                MBEDTLS_SSL_DEBUG_RET( 1, "ssl_write_change_cipher_spec_process", ret );
+                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_write_change_cipher_spec_process", ret );
                 return( ret );
             }
 
@@ -4167,11 +4168,11 @@ int mbedtls_ssl_handshake_client_step( mbedtls_ssl_context *ssl )
             /* ----- READ SERVER CERTIFICATE ----*/
 
         case MBEDTLS_SSL_SERVER_CERTIFICATE:
-            ret = ssl_read_certificate_process( ssl );
+            ret = mbedtls_ssl_read_certificate_process( ssl );
 
             if( ret != 0 )
             {
-                MBEDTLS_SSL_DEBUG_RET( 1, "ssl_read_certificate_process", ret );
+                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_read_certificate_process", ret );
                 return( ret );
             }
             break;
@@ -4179,11 +4180,11 @@ int mbedtls_ssl_handshake_client_step( mbedtls_ssl_context *ssl )
             /* ----- READ CERTIFICATE VERIFY ----*/
 
         case MBEDTLS_SSL_CERTIFICATE_VERIFY:
-            ret = ssl_read_certificate_verify_process( ssl );
+            ret = mbedtls_ssl_read_certificate_verify_process( ssl );
 
             if( ret != 0 )
             {
-                MBEDTLS_SSL_DEBUG_RET( 1, "ssl_read_certificate_verify_process", ret );
+                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_read_certificate_verify_process", ret );
                 return( ret );
             }
 
@@ -4193,11 +4194,11 @@ int mbedtls_ssl_handshake_client_step( mbedtls_ssl_context *ssl )
 
         case MBEDTLS_SSL_SERVER_FINISHED:
 
-            ret = ssl_finished_in_process( ssl );
+            ret = mbedtls_ssl_finished_in_process( ssl );
 
             if( ret != 0 )
             {
-                MBEDTLS_SSL_DEBUG_RET( 1, "ssl_finished_in_process", ret );
+                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_finished_in_process", ret );
                 return( ret );
             }
 #if	defined(MBEDTLS_SSL_PROTO_DTLS)
@@ -4244,11 +4245,11 @@ int mbedtls_ssl_handshake_client_step( mbedtls_ssl_context *ssl )
 #if defined(MBEDTLS_SSL_TLS13_COMPATIBILITY_MODE)
         case MBEDTLS_SSL_CLIENT_CCS_AFTER_SERVER_FINISHED:
 
-            ret = ssl_write_change_cipher_spec_process( ssl );
+            ret = mbedtls_ssl_write_change_cipher_spec_process( ssl );
 
             if( ret != 0 )
             {
-                MBEDTLS_SSL_DEBUG_RET( 1, "ssl_write_change_cipher_spec_process", ret );
+                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_write_change_cipher_spec_process", ret );
                 return( ret );
             }
 
@@ -4260,11 +4261,11 @@ int mbedtls_ssl_handshake_client_step( mbedtls_ssl_context *ssl )
 
         case MBEDTLS_SSL_CLIENT_CERTIFICATE:
 
-            ret = ssl_write_certificate_process( ssl );
+            ret = mbedtls_ssl_write_certificate_process( ssl );
 
             if( ret != 0 )
             {
-                MBEDTLS_SSL_DEBUG_RET( 1, "ssl_write_certificate_process", ret );
+                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_write_certificate_process", ret );
                 return( ret );
             }
             break;
@@ -4272,11 +4273,11 @@ int mbedtls_ssl_handshake_client_step( mbedtls_ssl_context *ssl )
             /* ----- WRITE CLIENT CERTIFICATE VERIFY ----*/
 
         case MBEDTLS_SSL_CLIENT_CERTIFICATE_VERIFY:
-            ret = ssl_certificate_verify_process( ssl );
+            ret = mbedtls_ssl_certificate_verify_process( ssl );
 
             if( ret != 0 )
             {
-                MBEDTLS_SSL_DEBUG_RET( 1, "ssl_certificate_verify_process", ret );
+                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_certificate_verify_process", ret );
                 return( ret );
             }
             break;
@@ -4284,11 +4285,11 @@ int mbedtls_ssl_handshake_client_step( mbedtls_ssl_context *ssl )
             /* ----- WRITE CLIENT FINISHED ----*/
 
         case MBEDTLS_SSL_CLIENT_FINISHED:
-            ret = ssl_finished_out_process( ssl );
+            ret = mbedtls_ssl_finished_out_process( ssl );
 
             if( ret != 0 )
             {
-                MBEDTLS_SSL_DEBUG_RET( 1, "ssl_finished_out_process", ret );
+                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_finished_out_process", ret );
                 return( ret );
             }
             break;

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -557,7 +557,7 @@ int ssl_parse_cid_ext( mbedtls_ssl_context *ssl,
 #if defined(MBEDTLS_SSL_TLS13_COMPATIBILITY_MODE)
 
  /* Main entry point; orchestrates the other functions */
-int ssl_write_change_cipher_spec_process( mbedtls_ssl_context* ssl );
+int mbedtls_ssl_write_change_cipher_spec_process( mbedtls_ssl_context* ssl );
 
 #define SSL_WRITE_CCS_NEEDED     0
 #define SSL_WRITE_CCS_SKIP       1
@@ -573,7 +573,7 @@ static int ssl_write_change_cipher_spec_postprocess( mbedtls_ssl_context* ssl );
  * Implementation
  */
 
-int ssl_write_change_cipher_spec_process( mbedtls_ssl_context* ssl )
+int mbedtls_ssl_write_change_cipher_spec_process( mbedtls_ssl_context* ssl )
 {
     int ret;
 
@@ -813,7 +813,7 @@ int mbedtls_ssl_write_ack( mbedtls_ssl_context *ssl )
 
 
 /*
- * ssl_write_signature_algorithms_ext( )
+ * mbedtls_ssl_write_signature_algorithms_ext( )
  *
  * enum {
  *    ....
@@ -831,7 +831,7 @@ int mbedtls_ssl_write_ack( mbedtls_ssl_context *ssl )
  */
 
 #if defined(MBEDTLS_KEY_EXCHANGE_WITH_CERT_ENABLED)
-int ssl_write_signature_algorithms_ext( mbedtls_ssl_context *ssl,
+int mbedtls_ssl_write_signature_algorithms_ext( mbedtls_ssl_context *ssl,
                                         unsigned char* buf,
                                         unsigned char* end,
                                         size_t* olen )
@@ -888,7 +888,7 @@ int ssl_write_signature_algorithms_ext( mbedtls_ssl_context *ssl,
     return( 0 );
 }
 
-int ssl_parse_signature_algorithms_ext( mbedtls_ssl_context *ssl,
+int mbedtls_ssl_parse_signature_algorithms_ext( mbedtls_ssl_context *ssl,
                                         const unsigned char *buf,
                                         size_t len )
 {
@@ -1209,7 +1209,7 @@ int mbedtls_ssl_derive_traffic_keys( mbedtls_ssl_context *ssl, mbedtls_ssl_key_s
     return( 0 );
 }
 
-int incrementSequenceNumber( unsigned char *sequenceNumber, unsigned char *nonce, size_t ivlen ) {
+int mbedtls_increment_sequence_number( unsigned char *sequenceNumber, unsigned char *nonce, size_t ivlen ) {
 
     if( ivlen == 0 ) return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
 
@@ -1633,7 +1633,7 @@ int mbedtls_ssl_tls1_3_derive_master_secret( mbedtls_ssl_context *ssl ) {
  */
 
 /* Main entry point: orchestrates the other functions. */
-int ssl_certificate_verify_process( mbedtls_ssl_context* ssl );
+int mbedtls_ssl_certificate_verify_process( mbedtls_ssl_context* ssl );
 
 /* Coordinate: Check whether a certificate verify message should be sent.
  * Returns a negative value on failure, and otherwise
@@ -1656,7 +1656,7 @@ static int ssl_certificate_verify_postprocess( mbedtls_ssl_context* ssl );
  * Implementation
  */
 
-int ssl_certificate_verify_process( mbedtls_ssl_context* ssl )
+int mbedtls_ssl_certificate_verify_process( mbedtls_ssl_context* ssl )
 {
     int ret = 0;
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> write certificate verify" ) );
@@ -1886,7 +1886,7 @@ static int ssl_certificate_verify_postprocess( mbedtls_ssl_context* ssl )
  */
 
 /* Main entry point; orchestrates the other functions */
-int ssl_read_certificate_verify_process( mbedtls_ssl_context* ssl );
+int mbedtls_ssl_read_certificate_verify_process( mbedtls_ssl_context* ssl );
 
 /* Coordinate: Check whether a certificate verify message is expected.
  * Returns a negative value on failure, and otherwise
@@ -1919,7 +1919,7 @@ static int ssl_read_certificate_verify_postprocess( mbedtls_ssl_context* ssl );
  * Implementation
  */
 
-int ssl_read_certificate_verify_process( mbedtls_ssl_context* ssl )
+int mbedtls_ssl_read_certificate_verify_process( mbedtls_ssl_context* ssl )
 {
     int ret;
     unsigned char hash[MBEDTLS_MD_MAX_SIZE];
@@ -2151,7 +2151,7 @@ static int ssl_read_certificate_verify_postprocess( mbedtls_ssl_context* ssl )
  */
 
 /* Main state-handling entry point; orchestrates the other functions. */
-int ssl_write_certificate_process( mbedtls_ssl_context* ssl );
+int mbedtls_ssl_write_certificate_process( mbedtls_ssl_context* ssl );
 
 /* Check if a certificate should be written, and if yes,
  * if it is available.
@@ -2180,7 +2180,7 @@ static int ssl_write_certificate_postprocess( mbedtls_ssl_context* ssl );
  * Implementation
  */
 
-int ssl_write_certificate_process( mbedtls_ssl_context* ssl )
+int mbedtls_ssl_write_certificate_process( mbedtls_ssl_context* ssl )
 {
     int ret;
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> write certificate" ) );
@@ -2437,7 +2437,7 @@ static int ssl_write_certificate_postprocess( mbedtls_ssl_context* ssl )
  */
 
 /* Main state-handling entry point; orchestrates the other functions. */
-int ssl_read_certificate_process( mbedtls_ssl_context* ssl );
+int mbedtls_ssl_read_certificate_process( mbedtls_ssl_context* ssl );
 
 /* Coordination: Check if a certificate is expected.
  * Returns a negative error code on failure, and otherwise
@@ -2466,7 +2466,7 @@ static int ssl_read_certificate_postprocess( mbedtls_ssl_context* ssl );
  * Implementation
  */
 
-int ssl_read_certificate_process( mbedtls_ssl_context* ssl )
+int mbedtls_ssl_read_certificate_process( mbedtls_ssl_context* ssl )
 {
     int ret;
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> parse certificate" ) );
@@ -3738,7 +3738,7 @@ void mbedtls_ssl_handshake_wrapup( mbedtls_ssl_context *ssl )
  */
 
 /* Main entry point: orchestrates the other functions */
-int ssl_finished_out_process( mbedtls_ssl_context* ssl );
+int mbedtls_ssl_finished_out_process( mbedtls_ssl_context* ssl );
 
 static int ssl_finished_out_prepare( mbedtls_ssl_context* ssl );
 static int ssl_finished_out_write( mbedtls_ssl_context* ssl,
@@ -3753,7 +3753,7 @@ static int ssl_finished_out_postprocess( mbedtls_ssl_context* ssl );
  */
 
 
-int ssl_finished_out_process( mbedtls_ssl_context* ssl )
+int mbedtls_ssl_finished_out_process( mbedtls_ssl_context* ssl )
 {
     int ret;
     mbedtls_ssl_key_set traffic_keys;
@@ -3984,7 +3984,7 @@ static int ssl_finished_out_write( mbedtls_ssl_context* ssl,
  */
 
 /* Main entry point: orchestrates the other functions */
-int ssl_finished_in_process( mbedtls_ssl_context* ssl );
+int mbedtls_ssl_finished_in_process( mbedtls_ssl_context* ssl );
 
 static int ssl_finished_in_preprocess( mbedtls_ssl_context* ssl );
 static int ssl_finished_in_postprocess( mbedtls_ssl_context* ssl );
@@ -3996,7 +3996,7 @@ static int ssl_finished_in_parse( mbedtls_ssl_context* ssl,
  * Implementation
  */
 
-int ssl_finished_in_process( mbedtls_ssl_context* ssl )
+int mbedtls_ssl_finished_in_process( mbedtls_ssl_context* ssl )
 {
     int ret = 0;
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> parse finished" ) );
@@ -4156,7 +4156,7 @@ void mbedtls_ssl_conf_early_data( mbedtls_ssl_config *conf, int early_data, char
 
 #if defined(MBEDTLS_SSL_NEW_SESSION_TICKET)
 
-/* The ssl_parse_new_session_ticket( ) function is used by the
+/* The mbedtls_ssl_parse_new_session_ticket( ) function is used by the
  * client to parse the NewSessionTicket message, which contains
  * the ticket and meta-data provided by the server in a post-
  * handshake message.
@@ -4164,7 +4164,7 @@ void mbedtls_ssl_conf_early_data( mbedtls_ssl_config *conf, int early_data, char
  * The code is located in ssl_tls.c since the function is called
  * mbedtls_ssl_read. It is a post-handshake message.
  */
-int ssl_parse_new_session_ticket( mbedtls_ssl_context *ssl )
+int mbedtls_ssl_parse_new_session_ticket( mbedtls_ssl_context *ssl )
 {
     int ret;
     uint32_t lifetime, ticket_age_add;
@@ -4299,7 +4299,7 @@ int ssl_parse_new_session_ticket( mbedtls_ssl_context *ssl )
 
     if( suite_info == NULL )
     {
-        MBEDTLS_SSL_DEBUG_MSG( 1, ( "suite_info == NULL, ssl_parse_new_session_ticket failed" ) );
+        MBEDTLS_SSL_DEBUG_MSG( 1, ( "suite_info == NULL, mbedtls_ssl_parse_new_session_ticket failed" ) );
         return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
     }
 
@@ -4564,10 +4564,10 @@ void mbedtls_ssl_conf_client_ticket_disable( mbedtls_ssl_context *ssl )
  * } EarlyDataIndication;
  */
 #if defined(MBEDTLS_ZERO_RTT)
-int ssl_write_early_data_ext( mbedtls_ssl_context *ssl,
-                              unsigned char *buf,
-                              size_t buflen,
-                              size_t *olen )
+int mbedtls_ssl_write_early_data_ext( mbedtls_ssl_context *ssl,
+                                      unsigned char *buf,
+                                      size_t buflen,
+                                      size_t *olen )
 {
     unsigned char *p = buf;
     const unsigned char* end = buf + buflen;

--- a/library/ssl_tls13_messaging.c
+++ b/library/ssl_tls13_messaging.c
@@ -229,7 +229,7 @@ static int ssl_encrypt_buf( mbedtls_ssl_context *ssl )
         }
 #endif /* MBEDTLS_SSL_PROTO_DTLS   */
 
-        if( ( ret = incrementSequenceNumber( &ssl->transform_out->sequence_number_enc[0], ssl->transform_out->iv_enc, ssl->transform_out->ivlen ) ) != 0 )
+        if( ( ret = mbedtls_increment_sequence_number( &ssl->transform_out->sequence_number_enc[0], ssl->transform_out->iv_enc, ssl->transform_out->ivlen ) ) != 0 )
         {
 
             MBEDTLS_SSL_DEBUG_RET( 1, "Error in sequence number processing", ret );
@@ -427,7 +427,7 @@ static int ssl_decrypt_buf( mbedtls_ssl_context *ssl )
         }
         auth_done++;
 
-        if( ( ret = incrementSequenceNumber( &ssl->transform_in->sequence_number_dec[0], ssl->transform_in->iv_dec, ssl->transform_in->ivlen ) ) != 0 )
+        if( ( ret = mbedtls_increment_sequence_number( &ssl->transform_in->sequence_number_dec[0], ssl->transform_in->iv_dec, ssl->transform_in->ivlen ) ) != 0 )
         {
 
             MBEDTLS_SSL_DEBUG_RET( 1, "Error in sequence number processing", ret );
@@ -1147,7 +1147,7 @@ int mbedtls_ssl_write_record( mbedtls_ssl_context *ssl )
                   ssl->conf->key_exchange_modes == MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_KE ||
                   ssl->conf->key_exchange_modes == MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_DHE_KE ) ) {
 
-                ssl_write_pre_shared_key_ext( ssl, ssl->handshake->ptr_to_psk_ext, &ssl->out_msg[len], &dummy_length, 1 );
+                mbedtls_ssl_write_pre_shared_key_ext( ssl, ssl->handshake->ptr_to_psk_ext, &ssl->out_msg[len], &dummy_length, 1 );
             }
 #endif /* MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED */
 
@@ -2907,9 +2907,9 @@ int mbedtls_ssl_read( mbedtls_ssl_context *ssl, unsigned char *buf, size_t len )
                 ( ssl->in_msg[0] == MBEDTLS_SSL_HS_NEW_SESSION_TICKET ) ) {
                 MBEDTLS_SSL_DEBUG_MSG( 3, ( "NewSessionTicket received" ) );
 
-                if( ( ret = ssl_parse_new_session_ticket( ssl ) ) != 0 )
+                if( ( ret = mbedtls_ssl_parse_new_session_ticket( ssl ) ) != 0 )
                 {
-                    MBEDTLS_SSL_DEBUG_RET( 1, "ssl_parse_new_session_ticket", ret );
+                    MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_parse_new_session_ticket", ret );
                     return( ret );
                 }
             }

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -240,7 +240,7 @@ static int check_ecdh_params( const mbedtls_ssl_context *ssl )
 
 
 /*
-  ssl_parse_supported_groups_ext( ) processes the received
+  mbedtls_ssl_parse_supported_groups_ext( ) processes the received
   supported groups extension and copies the client provided
   groups into ssl->handshake->curves.
 
@@ -248,7 +248,7 @@ static int check_ecdh_params( const mbedtls_ssl_context *ssl )
   - MBEDTLS_ERR_SSL_BAD_HS_SUPPORTED_GROUPS
   - MBEDTLS_ERR_SSL_ALLOC_FAILED
 */
-int ssl_parse_supported_groups_ext(
+int mbedtls_ssl_parse_supported_groups_ext(
     mbedtls_ssl_context *ssl,
     const unsigned char *buf, size_t len ) {
 
@@ -769,9 +769,9 @@ static int ssl_calc_binder( mbedtls_ssl_context *ssl, unsigned char *psk,
 }
 
 #if defined(MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED)
-int ssl_parse_client_psk_identity_ext( mbedtls_ssl_context *ssl,
-                                       const unsigned char *buf,
-                                       size_t len )
+int mbedtls_ssl_parse_client_psk_identity_ext( mbedtls_ssl_context *ssl,
+                                               const unsigned char *buf,
+                                               size_t len )
 {
     int ret = 0;
     unsigned char *truncated_clienthello_end, *truncated_clienthello_start = ssl->in_msg;
@@ -2612,7 +2612,7 @@ static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
 
                    ret = ssl_parse_early_data_ext( ssl, ext + 4, ext_size );
                    if( ret != 0 ) {
-                   MBEDTLS_SSL_DEBUG_RET( 1, "ssl_parse_supported_groups_ext", ret );
+                   MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_parse_supported_groups_ext", ret );
                    return( MBEDTLS_ERR_SSL_BAD_HS_SUPPORTED_GROUPS );
                    }
                 */
@@ -2630,10 +2630,11 @@ static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
                  * indicates the named groups which the client supports,
                  * ordered from most preferred to least preferred.
                  */
-                ret = ssl_parse_supported_groups_ext( ssl, ext + 4, ext_size );
+                ret = mbedtls_ssl_parse_supported_groups_ext( ssl, ext + 4,
+                        ext_size );
                 if( ret != 0 )
                 {
-                    MBEDTLS_SSL_DEBUG_RET( 1, "ssl_parse_supported_groups_ext", ret );
+                    MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_parse_supported_groups_ext", ret );
                     return( MBEDTLS_ERR_SSL_BAD_HS_SUPPORTED_GROUPS );
                 }
 
@@ -2734,7 +2735,7 @@ static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
             case MBEDTLS_TLS_EXT_SIG_ALG:
                 MBEDTLS_SSL_DEBUG_MSG( 3, ( "found signature_algorithms extension" ) );
 
-                ret = ssl_parse_signature_algorithms_ext( ssl, ext + 4, ext_size );
+                ret = mbedtls_ssl_parse_signature_algorithms_ext( ssl, ext + 4, ext_size );
                 if( ret != 0 )
                 {
                     MBEDTLS_SSL_DEBUG_MSG( 1, ( "ssl_parse_supported_signature_algorithms_server_ext ( %d )", ret ) );
@@ -2882,8 +2883,9 @@ static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
                     ( ssl->session_negotiate->key_exchange_modes ==
                         MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_ALL ) )
                 {
-                    ret = ssl_parse_client_psk_identity_ext( ssl, ext_psk_ptr,
-                                                             ext_len_psk_ext );
+                    ret = mbedtls_ssl_parse_client_psk_identity_ext( ssl,
+                            ext_psk_ptr,
+                            ext_len_psk_ext );
                     if( ret != 0 )
                     {
                         MBEDTLS_SSL_DEBUG_RET( 1, ( "ssl_parse_client_psk_identity" ),
@@ -2917,8 +2919,9 @@ static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
                     ssl->session_negotiate->key_exchange_modes ==
                       MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_ALL )
                 {
-                    ret = ssl_parse_client_psk_identity_ext( ssl, ext_psk_ptr,
-                                                             ext_len_psk_ext );
+                    ret = mbedtls_ssl_parse_client_psk_identity_ext( ssl,
+                            ext_psk_ptr,
+                            ext_len_psk_ext );
                     if( ret != 0 )
                     {
                         MBEDTLS_SSL_DEBUG_RET( 1, ( "ssl_parse_client_psk_identity" ),
@@ -2965,8 +2968,9 @@ static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
                 ssl->session_negotiate->key_exchange_modes ==
                   MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_ALL )
             {
-                if( ( ret = ssl_parse_client_psk_identity_ext( ssl, ext_psk_ptr,
-                                                      ext_len_psk_ext ) ) != 0 )
+                if( ( ret = mbedtls_ssl_parse_client_psk_identity_ext( ssl,
+                                ext_psk_ptr,
+                                ext_len_psk_ext ) ) != 0 )
                 {
                     MBEDTLS_SSL_DEBUG_RET( 1, ( "ssl_parse_client_psk_identity" ), ret );
                     return( ret );
@@ -3001,8 +3005,9 @@ static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
                 ssl->session_negotiate->key_exchange_modes ==
                   MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_ALL )
             {
-                if( ( ret = ssl_parse_client_psk_identity_ext( ssl, ext_psk_ptr,
-                                                      ext_len_psk_ext ) ) != 0 )
+                if( ( ret = mbedtls_ssl_parse_client_psk_identity_ext( ssl,
+                                ext_psk_ptr,
+                                ext_len_psk_ext ) ) != 0 )
                 {
                     MBEDTLS_SSL_DEBUG_RET( 1, ( "ssl_parse_client_psk_identity" ), ret );
                     return( ret );
@@ -3459,7 +3464,8 @@ static int ssl_encrypted_extensions_write( mbedtls_ssl_context* ssl,
 #if defined(MBEDTLS_ZERO_RTT)
     if( ssl->handshake->extensions_present & EARLY_DATA_EXTENSION )
     {
-        ret = ssl_write_early_data_ext( ssl, p, (size_t)( end - p ), &n );
+        ret = mbedtls_ssl_write_early_data_ext( ssl, p, (size_t)( end - p ),
+                &n );
         if( ret != 0 )
             return( ret );
 
@@ -4220,7 +4226,7 @@ static int ssl_certificate_request_write( mbedtls_ssl_context* ssl,
 
     /* The extensions must contain the signature_algorithms. */
     /* Currently we don't use any other extension */
-    ret = ssl_write_signature_algorithms_ext( ssl, p+2, end, olen );
+    ret = mbedtls_ssl_write_signature_algorithms_ext( ssl, p+2, end, olen );
     if( ret != 0 ) return( ret );
 
     /* length field for all extensions */
@@ -4447,11 +4453,11 @@ int mbedtls_ssl_handshake_server_step( mbedtls_ssl_context *ssl )
 #if defined(MBEDTLS_SSL_TLS13_COMPATIBILITY_MODE)
         case MBEDTLS_SSL_SERVER_CCS_AFTER_HRR:
 
-            ret = ssl_write_change_cipher_spec_process( ssl );
+            ret = mbedtls_ssl_write_change_cipher_spec_process( ssl );
 
             if( ret != 0 )
             {
-                MBEDTLS_SSL_DEBUG_RET( 1, "ssl_write_change_cipher_spec_process", ret );
+                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_write_change_cipher_spec_process", ret );
                 return( ret );
             }
 
@@ -4521,11 +4527,11 @@ int mbedtls_ssl_handshake_server_step( mbedtls_ssl_context *ssl )
 #if defined(MBEDTLS_SSL_TLS13_COMPATIBILITY_MODE)
         case MBEDTLS_SSL_SERVER_CCS_AFTER_SERVER_HELLO:
 
-            ret = ssl_write_change_cipher_spec_process(ssl);
+            ret = mbedtls_ssl_write_change_cipher_spec_process(ssl);
 
             if( ret != 0 )
             {
-                MBEDTLS_SSL_DEBUG_RET( 1, "ssl_write_change_cipher_spec_process", ret );
+                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_write_change_cipher_spec_process", ret );
                 return( ret );
             }
 
@@ -4561,11 +4567,11 @@ int mbedtls_ssl_handshake_server_step( mbedtls_ssl_context *ssl )
             /* ----- WRITE SERVER CERTIFICATE ----*/
 
         case MBEDTLS_SSL_SERVER_CERTIFICATE:
-            ret = ssl_write_certificate_process( ssl );
+            ret = mbedtls_ssl_write_certificate_process( ssl );
 
             if( ret != 0 )
             {
-                MBEDTLS_SSL_DEBUG_RET( 1, "ssl_write_certificate_process", ret );
+                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_write_certificate_process", ret );
                 return( ret );
             }
 
@@ -4574,11 +4580,11 @@ int mbedtls_ssl_handshake_server_step( mbedtls_ssl_context *ssl )
             /* ----- WRITE SERVER CERTIFICATE VERIFY ----*/
 
         case MBEDTLS_SSL_CERTIFICATE_VERIFY:
-            ret = ssl_certificate_verify_process( ssl );
+            ret = mbedtls_ssl_certificate_verify_process( ssl );
 
             if( ret != 0 )
             {
-                MBEDTLS_SSL_DEBUG_RET( 1, "ssl_certificate_verify_process", ret );
+                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_certificate_verify_process", ret );
                 return( ret );
             }
             break;
@@ -4586,11 +4592,11 @@ int mbedtls_ssl_handshake_server_step( mbedtls_ssl_context *ssl )
             /* ----- WRITE FINISHED ----*/
 
         case MBEDTLS_SSL_SERVER_FINISHED:
-            ret = ssl_finished_out_process( ssl );
+            ret = mbedtls_ssl_finished_out_process( ssl );
 
             if( ret != 0 )
             {
-                MBEDTLS_SSL_DEBUG_RET( 1, "ssl_finished_out_process", ret );
+                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_finished_out_process", ret );
                 return( ret );
             }
             break;
@@ -4598,11 +4604,11 @@ int mbedtls_ssl_handshake_server_step( mbedtls_ssl_context *ssl )
             /* ----- READ CLIENT CERTIFICATE ----*/
 
         case MBEDTLS_SSL_CLIENT_CERTIFICATE:
-            ret = ssl_read_certificate_process( ssl );
+            ret = mbedtls_ssl_read_certificate_process( ssl );
 
             if( ret != 0 )
             {
-                MBEDTLS_SSL_DEBUG_RET( 1, "ssl_read_certificate_process", ret );
+                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_read_certificate_process", ret );
                 return( ret );
             }
             break;
@@ -4610,11 +4616,11 @@ int mbedtls_ssl_handshake_server_step( mbedtls_ssl_context *ssl )
             /* ----- READ CLIENT CERTIFICATE VERIFY ----*/
 
         case MBEDTLS_SSL_CLIENT_CERTIFICATE_VERIFY:
-            ret=ssl_read_certificate_verify_process( ssl );
+            ret=mbedtls_ssl_read_certificate_verify_process( ssl );
 
             if( ret != 0 )
             {
-                MBEDTLS_SSL_DEBUG_RET( 1, "ssl_read_certificate_verify_process", ret );
+                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_read_certificate_verify_process", ret );
                 return( ret );
             }
 
@@ -4665,11 +4671,11 @@ int mbedtls_ssl_handshake_server_step( mbedtls_ssl_context *ssl )
                 return( ret );
             }
 
-            ret = ssl_finished_in_process( ssl );
+            ret = mbedtls_ssl_finished_in_process( ssl );
 
             if( ret != 0 )
             {
-                MBEDTLS_SSL_DEBUG_RET( 1, "ssl_finished_in_process", ret );
+                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_finished_in_process", ret );
                 return( ret );
             }
 


### PR DESCRIPTION
Some functions introduced in the prototype are not part of Mbed TLS namespace.
Blast from the past: https://github.com/hannestschofenig/mbedtls/pull/2#pullrequestreview-414107447