### PR TITLE
Various fixes towards building & running TLS 1.3 prototype with ASanDbg

### DIFF
--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -1980,6 +1980,7 @@ static int ssl_parse_supported_version_ext( mbedtls_ssl_context* ssl,
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
     if( ssl->conf->transport == MBEDTLS_SSL_TRANSPORT_DATAGRAM )
     {
+        /* TODO: Remove magic numbers */
         if( len != 2 && buf[0] != 254 && buf[1] != 253 )
         {
             MBEDTLS_SSL_DEBUG_MSG( 1, ( "unexpected version" ) );
@@ -1989,13 +1990,13 @@ static int ssl_parse_supported_version_ext( mbedtls_ssl_context* ssl,
     else
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
     {
+        /* TODO: Remove magic numbers */
         if( len != 2 && buf[0] != 0x3 && buf[1] != 0x3 )
         {
             MBEDTLS_SSL_DEBUG_MSG( 1, ( "unexpected version" ) );
             return( MBEDTLS_ERR_SSL_BAD_HS_SERVER_HELLO );
         }
     }
-
 
     return( 0 );
 }

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -1975,6 +1975,7 @@ static int ssl_parse_supported_version_ext( mbedtls_ssl_context* ssl,
                                             const unsigned char* buf,
                                             size_t len )
 {
+    ((void) ssl);
 
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
     if( ssl->conf->transport == MBEDTLS_SSL_TRANSPORT_DATAGRAM )

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -933,7 +933,7 @@ int mbedtls_ssl_parse_signature_algorithms_ext( mbedtls_ssl_context *ssl,
         return( MBEDTLS_ERR_SSL_ALLOC_FAILED );
     }
 
-    i = 0; 
+    i = 0;
     for( p = buf + 2; p < end; p += 2 )
     {
         signature_scheme = ( p[0] << 8 ) | p[1];
@@ -945,21 +945,21 @@ int mbedtls_ssl_parse_signature_algorithms_ext( mbedtls_ssl_context *ssl,
             if( *md_cur == signature_scheme )
             {
                 ssl->handshake->received_signature_schemes_list[i] = signature_scheme;
-                i++; 
+                i++;
                 got_common_sig_alg = 1;
             }
         }
-       
+
     }
 
     if( got_common_sig_alg == 0 )
     {
         MBEDTLS_SSL_DEBUG_MSG( 3, ( "no signature algorithm in common" ) );
-        mbedtls_free( ssl->handshake->received_signature_schemes_list ); 
+        mbedtls_free( ssl->handshake->received_signature_schemes_list );
         return( MBEDTLS_ERR_SSL_NO_USABLE_CIPHERSUITE );
-    } 
+    }
 
-    ssl->handshake->received_signature_schemes_list[i] = SIGNATURE_NONE; 
+    ssl->handshake->received_signature_schemes_list[i] = SIGNATURE_NONE;
 
     return( 0 );
 }
@@ -1260,24 +1260,24 @@ int mbedtls_increment_sequence_number( unsigned char *sequenceNumber, unsigned c
 
 #if defined(MBEDTLS_SHA256_C)
     /*
-     * ssl_calc_verify_tls_sha256() computes hash over a structure, 
-     * which is later digitally signed and placed into the CertificateVerify message. 
+     * ssl_calc_verify_tls_sha256() computes hash over a structure,
+     * which is later digitally signed and placed into the CertificateVerify message.
      *
-     * The structure computed in this function is: 
+     * The structure computed in this function is:
      *   - 64 bytes of octet 32,
      *   - 33 bytes for the context string (which is either "TLS 1.3, client CertificateVerify"
      *     or "TLS 1.3, server CertificateVerify"),
      *   - 1 byte for the octet 0x0, which servers as a separator,
      *   - 32 bytes for the Transcript-Hash(Handshake Context, Certificate)
      *
-     * The hash of the structure is returned in the variable output_hash. 
+     * The hash of the structure is returned in the variable output_hash.
      */
 static int ssl_calc_verify_tls_sha256( mbedtls_ssl_context *ssl, unsigned char output_hash[32], int from )
 {
-    /* The length of context_string_[client|server] is 
+    /* The length of context_string_[client|server] is
      * sizeof( "TLS 1.3, xxxxxx CertificateVerify" ) - 1, i.e. 33 bytes.
      */
-    const unsigned int content_string_len = sizeof( "TLS 1.3, xxxxxx CertificateVerify" ) - 1; 
+    const unsigned int content_string_len = sizeof( "TLS 1.3, xxxxxx CertificateVerify" ) - 1;
     const unsigned char context_string_client[] = "TLS 1.3, client CertificateVerify";
     const unsigned char context_string_server[] = "TLS 1.3, server CertificateVerify";
     mbedtls_sha256_context sha256;
@@ -1322,24 +1322,24 @@ static int ssl_calc_verify_tls_sha256( mbedtls_ssl_context *ssl, unsigned char o
 
 #if defined(MBEDTLS_SHA512_C)
     /*
-     * ssl_calc_verify_tls_sha384() computes hash over a structure, 
-     * which is later digitally signed and placed into the CertificateVerify message. 
+     * ssl_calc_verify_tls_sha384() computes hash over a structure,
+     * which is later digitally signed and placed into the CertificateVerify message.
      *
-     * The structure computed in this function is: 
+     * The structure computed in this function is:
      *   - 64 bytes of octet 32,
      *   - 33 bytes for the context string (which is either "TLS 1.3, client CertificateVerify"
      *     or "TLS 1.3, server CertificateVerify"),
      *   - 1 byte for the octet 0x0, which servers as a separator,
      *   - 48 bytes for the Transcript-Hash(Handshake Context, Certificate)
      *
-     * The hash of the structure is returned in the variable hash. 
+     * The hash of the structure is returned in the variable hash.
      */
 static int ssl_calc_verify_tls_sha384( mbedtls_ssl_context *ssl, unsigned char output_hash[48], int from )
 {
-    /* The length of context_string_[client|server] is 
+    /* The length of context_string_[client|server] is
      * sizeof( "TLS 1.3, xxxxxx CertificateVerify" ) - 1, i.e. 33 bytes.
      */
-    const unsigned int content_string_len = sizeof( "TLS 1.3, xxxxxx CertificateVerify" ) - 1; 
+    const unsigned int content_string_len = sizeof( "TLS 1.3, xxxxxx CertificateVerify" ) - 1;
     const unsigned char context_string_client[] = "TLS 1.3, client CertificateVerify";
     const unsigned char context_string_server[] = "TLS 1.3, server CertificateVerify";
     mbedtls_sha512_context sha384;
@@ -3076,7 +3076,7 @@ int mbedtls_ssl_generate_application_traffic_keys( mbedtls_ssl_context *ssl, mbe
     transform->minlen += 1;
 
     MBEDTLS_SSL_DEBUG_BUF( 5, "Transcript hash (including Server.Finished):",
-                              ssl->handshake->server_finished_digest, 
+                              ssl->handshake->server_finished_digest,
                               mbedtls_hash_size_for_ciphersuite( suite_info ) );
 
     /* Generate client_application_traffic_secret_0
@@ -3091,7 +3091,7 @@ int mbedtls_ssl_generate_application_traffic_keys( mbedtls_ssl_context *ssl, mbe
     ret = mbedtls_ssl_tls1_3_derive_secret( mbedtls_md_get_type( md_info ),
                          ssl->handshake->master_secret, mbedtls_hash_size_for_ciphersuite( suite_info ),
                          MBEDTLS_SSL_TLS1_3_LBL_WITH_LEN( c_ap_traffic ),
-                         ssl->handshake->server_finished_digest, mbedtls_hash_size_for_ciphersuite( suite_info ), 
+                         ssl->handshake->server_finished_digest, mbedtls_hash_size_for_ciphersuite( suite_info ),
                          MBEDTLS_SSL_TLS1_3_CONTEXT_HASHED,
                          ssl->handshake->client_traffic_secret, mbedtls_hash_size_for_ciphersuite( suite_info ) );
 
@@ -3127,7 +3127,7 @@ int mbedtls_ssl_generate_application_traffic_keys( mbedtls_ssl_context *ssl, mbe
     ret = mbedtls_ssl_tls1_3_derive_secret( mbedtls_md_get_type( md_info ),
                          ssl->handshake->master_secret, mbedtls_hash_size_for_ciphersuite( suite_info ),
                          MBEDTLS_SSL_TLS1_3_LBL_WITH_LEN( s_ap_traffic ),
-                         ssl->handshake->server_finished_digest, mbedtls_hash_size_for_ciphersuite( suite_info ), 
+                         ssl->handshake->server_finished_digest, mbedtls_hash_size_for_ciphersuite( suite_info ),
                          MBEDTLS_SSL_TLS1_3_CONTEXT_HASHED,
                          ssl->handshake->server_traffic_secret, mbedtls_hash_size_for_ciphersuite( suite_info ) );
 
@@ -3157,7 +3157,7 @@ int mbedtls_ssl_generate_application_traffic_keys( mbedtls_ssl_context *ssl, mbe
 
     MBEDTLS_SSL_DEBUG_MSG( 5, ( "-->> Calling mbedtls_ssl_tls1_3_make_traffic_keys( ):" ) );
     MBEDTLS_SSL_DEBUG_MSG( 5, ( "-- Hash Algorithm: %s", mbedtls_md_get_name( md_info ) ) );
-    MBEDTLS_SSL_DEBUG_MSG( 5, ( "-- Handshake Traffic Secret Length: %d bytes", 
+    MBEDTLS_SSL_DEBUG_MSG( 5, ( "-- Handshake Traffic Secret Length: %d bytes",
                               mbedtls_hash_size_for_ciphersuite( suite_info ) ) );
     MBEDTLS_SSL_DEBUG_BUF( 5, "-- Client_traffic_secret:",
                               ssl->handshake->client_traffic_secret,
@@ -3937,9 +3937,9 @@ static int ssl_finished_out_postprocess( mbedtls_ssl_context* ssl )
             mbedtls_ssl_handshake_set_state( ssl, MBEDTLS_SSL_CLIENT_CERTIFICATE );
         }
 
-        /* Compute hash over transcript of all messages sent up to the Finished message 
-         * sent by the server and store it in the digest variable of the handshake state. 
-         * This digest will be needed later when computing the application traffic secrets. 
+        /* Compute hash over transcript of all messages sent up to the Finished message
+         * sent by the server and store it in the digest variable of the handshake state.
+         * This digest will be needed later when computing the application traffic secrets.
          */
         cipher_info = mbedtls_cipher_info_from_type(ssl->transform_negotiate->ciphersuite_info->cipher );
         if( cipher_info == NULL )
@@ -4164,9 +4164,9 @@ static int ssl_finished_in_postprocess( mbedtls_ssl_context* ssl )
 
     if( ssl->conf->endpoint == MBEDTLS_SSL_IS_CLIENT )
     {
-        /* Compute hash over transcript of all messages sent up to the Finished message 
-         * sent by the server and store it in the digest variable of the handshake state. 
-         * This digest will be needed later when computing the application traffic secrets. 
+        /* Compute hash over transcript of all messages sent up to the Finished message
+         * sent by the server and store it in the digest variable of the handshake state.
+         * This digest will be needed later when computing the application traffic secrets.
          */
         cipher_info = mbedtls_cipher_info_from_type(ssl->transform_negotiate->ciphersuite_info->cipher );
         if( cipher_info == NULL )
@@ -4454,7 +4454,7 @@ int mbedtls_ssl_conf_ticket_meta( mbedtls_ssl_config *conf,
 void mbedtls_ssl_conf_signature_algorithms( mbedtls_ssl_config *conf,
                      const int* sig_algs )
 {
-    conf->sig_hashes = sig_algs; 
+    conf->sig_hashes = sig_algs;
 }
 #endif /* MBEDTLS_X509_CRT_PARSE_C */
 

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -3437,6 +3437,7 @@ int mbedtls_ssl_early_data_key_derivation( mbedtls_ssl_context *ssl, mbedtls_ssl
         ssl->session_in = ssl->session_negotiate;
         transform = ssl->transform_negotiate;
     }
+    else
 #endif
 #if defined(MBEDTLS_SSL_CLI_C)
     if( ssl->conf->endpoint == MBEDTLS_SSL_IS_CLIENT )
@@ -3446,7 +3447,12 @@ int mbedtls_ssl_early_data_key_derivation( mbedtls_ssl_context *ssl, mbedtls_ssl
         ssl->session_out = ssl->session_negotiate;
         transform = ssl->transform_negotiate;
     }
+    else
 #endif
+    {
+        /* should never happen */
+        return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
+    }
 
     ciphersuite_info = transform->ciphersuite_info;
     if( ciphersuite_info == NULL )

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -644,10 +644,12 @@ static int ssl_write_change_cipher_spec_coordinate( mbedtls_ssl_context* ssl )
 }
 
 static int ssl_write_change_cipher_spec_write( mbedtls_ssl_context* ssl,
-    unsigned char* buf,
-    size_t buflen,
-    size_t* olen )
+                                               unsigned char* buf,
+                                               size_t buflen,
+                                               size_t* olen )
 {
+    ((void) ssl);
+
     if( buflen < 1 )
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "buffer too small" ) );
@@ -655,9 +657,7 @@ static int ssl_write_change_cipher_spec_write( mbedtls_ssl_context* ssl,
     }
 
     buf[0] = 1;
-
     *olen = 1;
-
     return( 0 );
 }
 

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -4660,9 +4660,14 @@ int mbedtls_ssl_write_early_data_ext( mbedtls_ssl_context *ssl,
     unsigned char *p = buf;
     const unsigned char* end = buf + buflen;
 
+    *olen = 0;
+
 #if defined(MBEDTLS_SSL_SRV_C)
     if( ssl->conf->endpoint == MBEDTLS_SSL_IS_SERVER )
     {
+        if( ( ssl->handshake->extensions_present & EARLY_DATA_EXTENSION ) == 0 )
+            return( 0 );
+
         if( ssl->conf->key_exchange_modes != MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_KE ||
             ssl->conf->early_data == MBEDTLS_SSL_EARLY_DATA_DISABLED ) {
 

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -4287,8 +4287,10 @@ int mbedtls_ssl_parse_new_session_ticket( mbedtls_ssl_context *ssl )
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "ticket->lifetime: %d", lifetime ) );
 
     /* Ticket Age Add */
-    ticket_age_add = ( msg[4] << 24 ) | ( msg[5] << 16 ) |
-        ( msg[6] << 8 ) | ( msg[7] );
+    ticket_age_add = ( (unsigned) msg[4] << 24 ) |
+                     ( (unsigned) msg[5] << 16 ) |
+                     ( (unsigned) msg[6] << 8  ) |
+                     ( (unsigned) msg[7] << 0  );
 
     ssl->session->ticket_age_add = ticket_age_add;
 

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -90,7 +90,6 @@ int main( void )
 
 #define MAX_REQUEST_SIZE      20000
 #define MAX_REQUEST_SIZE_STR "20000"
-#define MAX_NAMED_GROUPS        4
 
 #define DFL_SERVER_NAME         "localhost"
 #define DFL_SERVER_ADDR         NULL
@@ -528,9 +527,10 @@ int main( void )
     " acceptable ciphersuite names:\n"
 
 
-#define ALPN_LIST_SIZE  10
-#define CURVE_LIST_SIZE 20
-#define SIG_ALG_LIST_SIZE 5
+#define ALPN_LIST_SIZE         10
+#define CURVE_LIST_SIZE        20
+#define SIG_ALG_LIST_SIZE      5
+#define NAMED_GROUPS_LIST_SIZE 4
 
 /*
  * global options
@@ -1344,9 +1344,9 @@ int main( int argc, char *argv[] )
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && \
     defined(MBEDTLS_ECP_C)
     /* list of named groups */
-    mbedtls_ecp_group_id named_groups_list[MAX_NAMED_GROUPS];
+    mbedtls_ecp_group_id named_groups_list[NAMED_GROUPS_LIST_SIZE];
     /* list of named groups for key share*/
-    mbedtls_ecp_group_id key_share_named_groups_list[MAX_NAMED_GROUPS];
+    mbedtls_ecp_group_id key_share_named_groups_list[NAMED_GROUPS_LIST_SIZE];
     char *start;
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL && MBEDTLS_ECP_C */
 
@@ -2273,7 +2273,7 @@ int main( int argc, char *argv[] )
         start = p;
 
         /* Leave room for a final NULL in named_groups_list */
-        while( i < (int) ( sizeof( named_groups_list ) - 1 ) && *p != '\0' )
+        while( i < NAMED_GROUPS_LIST_SIZE - 1 && *p != '\0' )
         {
             while( *p != ',' && *p != '\0' )
                 p++;
@@ -2312,7 +2312,7 @@ int main( int argc, char *argv[] )
         start = p;
 
         /* Leave room for a final NULL in named_groups_list */
-        while( i < (int) ( sizeof( key_share_named_groups_list ) - 1 ) && *p != '\0')
+        while( i < NAMED_GROUPS_LIST_SIZE - 1 && *p != '\0')
         {
             while( *p != ',' && *p != '\0' )
                 p++;

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -332,7 +332,7 @@ int main( void )
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && defined(MBEDTLS_ECP_C)
 #define USAGE_SIG_ALGS \
     "    sig_algs=a,b,c,d      default: \"default\" (library default: ecdsa_secp256r1_sha256)\n"  \
-    "                        example: \"ecdsa_secp256r1_sha256,ecdsa_secp384r1_sha384\"\n"  
+    "                        example: \"ecdsa_secp256r1_sha256,ecdsa_secp384r1_sha384\"\n"
 #else
 #define USAGE_SIG_ALGS ""
 #endif
@@ -1755,7 +1755,7 @@ int main( int argc, char *argv[] )
         }
         else if( strcmp( p, "curves" ) == 0 )
             opt.curves = q;
-#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && defined(MBEDTLS_ECP_C) 
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && defined(MBEDTLS_ECP_C)
         else if( strcmp( p, "sig_algs" ) == 0 )
             opt.sig_algs = q;
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL && MBEDTLS_ECP_C */
@@ -2403,13 +2403,14 @@ int main( int argc, char *argv[] )
         }
 
         sig_alg_list[i] = SIGNATURE_NONE;
-    } else 
+    }
+    else
     {
         /* Configure default signature algorithm */
         sig_alg_list[0] = SIGNATURE_ECDSA_SECP256r1_SHA256;
         sig_alg_list[1] = SIGNATURE_NONE;
     }
-        
+
     mbedtls_printf( "Number of signature algorithms: %d\n", i );
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL && MBEDTLS_ECP_C */
 
@@ -3437,14 +3438,14 @@ send_request:
                                        (unsigned) -ret );
             goto exit;
         }
-        else if( ret == 1 ) 
+        else if( ret == 1 )
         {
             // no ticket available - we cannot re-connect
             opt.reconnect = 0;
             mbedtls_printf( "no ticket available\n" );
 
         }
-        else if( ret == 0 ) 
+        else if( ret == 0 )
         {
             mbedtls_printf( "got ticket\n" );
         }

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -2406,8 +2406,8 @@ int main( int argc, char *argv[] )
     } else 
     {
         /* Configure default signature algorithm */
-        sig_alg_list[i++] = SIGNATURE_ECDSA_SECP256r1_SHA256;
-        sig_alg_list[i] = SIGNATURE_NONE;
+        sig_alg_list[0] = SIGNATURE_ECDSA_SECP256r1_SHA256;
+        sig_alg_list[1] = SIGNATURE_NONE;
     }
         
     mbedtls_printf( "Number of signature algorithms: %d\n", i );

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -3068,8 +3068,8 @@ int main( int argc, char *argv[] )
     } else 
     {
         /* Configure default signature algorithm */
-        sig_alg_list[i++] = SIGNATURE_ECDSA_SECP256r1_SHA256;
-        sig_alg_list[i] = SIGNATURE_NONE;
+        sig_alg_list[0] = SIGNATURE_ECDSA_SECP256r1_SHA256;
+        sig_alg_list[1] = SIGNATURE_NONE;
     }
         
     mbedtls_printf( "Number of signature algorithms: %d\n", i );

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -501,7 +501,7 @@ int main( void )
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && defined(MBEDTLS_ECP_C)
 #define USAGE_SIG_ALGS \
     "    sig_algs=a,b,c,d      default: \"default\" (library default: ecdsa_secp256r1_sha256)\n"  \
-    "                        example: \"ecdsa_secp256r1_sha256,ecdsa_secp384r1_sha384\"\n"  
+    "                        example: \"ecdsa_secp256r1_sha256,ecdsa_secp384r1_sha384\"\n"
 #else
 #define USAGE_SIG_ALGS ""
 #endif
@@ -3065,13 +3065,14 @@ int main( int argc, char *argv[] )
         }
 
         sig_alg_list[i] = SIGNATURE_NONE;
-    } else 
+    }
+    else
     {
         /* Configure default signature algorithm */
         sig_alg_list[0] = SIGNATURE_ECDSA_SECP256r1_SHA256;
         sig_alg_list[1] = SIGNATURE_NONE;
     }
-        
+
     mbedtls_printf( "Number of signature algorithms: %d\n", i );
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL && MBEDTLS_ECP_C */
 
@@ -3109,7 +3110,7 @@ int main( int argc, char *argv[] )
             /* Terminate the current string */
             while( *p != ',' && *p != '\0' )
                 p++;
-                
+
             if( *p == ',' )
                 *p++ = '\0';
 

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -3102,7 +3102,7 @@ int main( int argc, char *argv[] )
         i = 0;
         start = p;
         /* Leave room for a final NULL in named_groups_list */
-        while( i < (int) ( sizeof( named_groups_list ) - 1 ) && *p != '\0' )
+        while( i < NAMED_GROUPS_LIST_SIZE - 1 && *p != '\0' )
         {
             q = p;
 


### PR DESCRIPTION
This PR is a first step towards making the prototype compile & run with the address sanitizer enabled (`cmake -D CMAKE_BUILD_TYPE=ASanDbg`) by fixing numerous compilation warnings (which are treated as errors in this build mode) and some out of bounds accesses and other runtime issues spotted by the sanitizer.

With this patch, one can successfully run a TLS 1.3 handshake with address sanitizer enabled, but it will still fail in the end because of a number of memory leaks. The study and fix of those leaks is left for a later PR.