### PR TITLE
Fix memory leaks to allow building & running prototype with address sanitizer

### DIFF
--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -1683,7 +1683,10 @@ struct mbedtls_ssl_context
     /*
      * Information for DTLS hello verify
      */
-#if (defined(MBEDTLS_SSL_DTLS_HELLO_VERIFY) || ( defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && defined(MBEDTLS_SSL_COOKIE_C)) ) && defined(MBEDTLS_SSL_SRV_C)
+#if ( defined(MBEDTLS_SSL_DTLS_HELLO_VERIFY) ||                         \
+      ( defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) &&               \
+        defined(MBEDTLS_SSL_COOKIE_C) ) )                               \
+    && defined(MBEDTLS_SSL_SRV_C)
     unsigned char  *cli_id;         /*!<  transport-level ID of the client  */
     size_t          cli_id_len;     /*!<  length of cli_id                  */
 #endif /* MBEDTLS_SSL_DTLS_HELLO_VERIFY && MBEDTLS_SSL_SRV_C */

--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -946,7 +946,6 @@ struct mbedtls_ssl_transform
     size_t taglen;                      /*!<  TAG(AEAD) len           */
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
-    const mbedtls_ssl_ciphersuite_t* ciphersuite_info;
     /*!<  Chosen cipersuite_info  */
     unsigned int keylen;                /*!<  symmetric key length (bytes)  */
 

--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -661,8 +661,8 @@ struct mbedtls_ssl_handshake_params
 
     mbedtls_ssl_tls_prf_cb *tls_prf;
 
-   /* Buffer holding the digest up to, and including, 
-     * the Finished message sent by the server. 
+   /* Buffer holding the digest up to, and including,
+     * the Finished message sent by the server.
      */
     unsigned char server_finished_digest[MBEDTLS_MD_MAX_SIZE];
 
@@ -950,7 +950,9 @@ struct mbedtls_ssl_transform
     unsigned int keylen;                /*!<  symmetric key length (bytes)  */
 
     mbedtls_ssl_key_set traffic_keys;
+#if defined(MBEDTLS_SSL_PROTO_DTLS)
     mbedtls_ssl_key_set traffic_keys_previous;
+#endif /* MBEDTL_SSL_PROTO_DTLS */
 
     unsigned char sequence_number_dec[12]; /* sequence number for incoming (decrypting) traffic */
     unsigned char sequence_number_enc[12]; /* sequence number for outgoing (encrypting) traffic */

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -6228,6 +6228,10 @@ void mbedtls_ssl_handshake_free( mbedtls_ssl_context *ssl )
     if( handshake == NULL )
         return;
 
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+    mbedtls_free( handshake->key_shares_curve_list );
+#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
+
 #if defined(MBEDTLS_SSL_ASYNC_PRIVATE)
     if( ssl->conf->f_async_cancel != NULL && handshake->async_in_progress != 0 )
     {
@@ -7155,7 +7159,10 @@ void mbedtls_ssl_free( mbedtls_ssl_context *ssl )
     }
 #endif
 
-#if defined(MBEDTLS_SSL_DTLS_HELLO_VERIFY) && defined(MBEDTLS_SSL_SRV_C)
+#if ( defined(MBEDTLS_SSL_DTLS_HELLO_VERIFY) ||                         \
+      ( defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) &&               \
+        defined(MBEDTLS_SSL_COOKIE_C) ) )                               \
+    && defined(MBEDTLS_SSL_SRV_C)
     mbedtls_free( ssl->cli_id );
 #endif
 

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -6337,8 +6337,12 @@ void mbedtls_ssl_handshake_free( mbedtls_ssl_context *ssl )
     mbedtls_pk_free( &handshake->peer_pubkey );
 #endif /* MBEDTLS_X509_CRT_PARSE_C && !MBEDTLS_SSL_KEEP_PEER_CERTIFICATE */
 
-#if defined(MBEDTLS_SSL_PROTO_DTLS)
+#if defined(MBEDTLS_SSL_PROTO_DTLS) ||                  \
+    defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
     mbedtls_free( handshake->verify_cookie );
+#endif
+
+#if defined(MBEDTLS_SSL_PROTO_DTLS)
     mbedtls_ssl_flight_free( handshake->flight );
     mbedtls_ssl_buffering_free( ssl );
 #endif

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -6298,6 +6298,12 @@ void mbedtls_ssl_handshake_free( mbedtls_ssl_context *ssl )
     }
 #endif
 
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+#if defined(MBEDTLS_X509_CRT_PARSE_C) && defined(MBEDTLS_SSL_SRV_C)
+    mbedtls_free( handshake->received_signature_schemes_list );
+#endif /* MBEDTLS_X509_CRT_PARSE_C && MBEDTLS_SSL_SRV_C */
+#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
+
 #if defined(MBEDTLS_X509_CRT_PARSE_C) && \
     defined(MBEDTLS_SSL_SERVER_NAME_INDICATION)
     /*

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -975,7 +975,7 @@ int mbedtls_ssl_write_pre_shared_key_ext( mbedtls_ssl_context *ssl,
 
         /* In this implementation we only add one pre-shared-key extension. */
         ssl->session_negotiate->ciphersuite = ciphersuites[i];
-        ssl->transform_negotiate->ciphersuite_info = suite_info;
+        ssl->handshake->ciphersuite_info = suite_info;
 #if defined(MBEDTLS_ZERO_RTT)
         /* Even if we include a key_share extension in the ClientHello
          * message it will not be used at this stage for the key derivation.
@@ -3065,16 +3065,16 @@ static int ssl_server_hello_parse( mbedtls_ssl_context* ssl,
     /* to use a difference ciphersuite. */
 
     /* Configure ciphersuites */
-    ssl->transform_negotiate->ciphersuite_info = mbedtls_ssl_ciphersuite_from_id( i );
+    ssl->handshake->ciphersuite_info = mbedtls_ssl_ciphersuite_from_id( i );
 
-    if( ssl->transform_negotiate->ciphersuite_info == NULL )
+    if( ssl->handshake->ciphersuite_info == NULL )
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "ciphersuite info for %04x not found", i ) );
         SSL_PEND_FATAL_ALERT( MBEDTLS_SSL_ALERT_MSG_INTERNAL_ERROR );
         return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
     }
 
-    mbedtls_ssl_optimize_checksum( ssl, ssl->transform_negotiate->ciphersuite_info );
+    mbedtls_ssl_optimize_checksum( ssl, ssl->handshake->ciphersuite_info );
 
     ssl->session_negotiate->ciphersuite = i;
 
@@ -3445,16 +3445,16 @@ static int ssl_hrr_parse( mbedtls_ssl_context* ssl,
     /* to use a difference ciphersuite. */
 
     /* Configure ciphersuites */
-    ssl->transform_negotiate->ciphersuite_info = mbedtls_ssl_ciphersuite_from_id( i );
+    ssl->handshake->ciphersuite_info = mbedtls_ssl_ciphersuite_from_id( i );
 
-    if( ssl->transform_negotiate->ciphersuite_info == NULL )
+    if( ssl->handshake->ciphersuite_info == NULL )
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "ciphersuite info for %04x not found", i ) );
         SSL_PEND_FATAL_ALERT( MBEDTLS_SSL_ALERT_MSG_INTERNAL_ERROR );
         return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
     }
 
-    mbedtls_ssl_optimize_checksum( ssl, ssl->transform_negotiate->ciphersuite_info );
+    mbedtls_ssl_optimize_checksum( ssl, ssl->handshake->ciphersuite_info );
 
     ssl->session_negotiate->ciphersuite = i;
 
@@ -3719,7 +3719,7 @@ static int ssl_hrr_postprocess( mbedtls_ssl_context* ssl,
     transcript[1] = 0;
     transcript[2] = 0;
 
-    hash_length = mbedtls_hash_size_for_ciphersuite( ssl->transform_negotiate->ciphersuite_info );
+    hash_length = mbedtls_hash_size_for_ciphersuite( ssl->handshake->ciphersuite_info );
 
     if( hash_length == -1 )
     {
@@ -3737,7 +3737,7 @@ static int ssl_hrr_postprocess( mbedtls_ssl_context* ssl,
        mbedtls_sha512_context sha512;
        #endif
     */
-    if( ssl->transform_negotiate->ciphersuite_info->mac == MBEDTLS_MD_SHA256 )
+    if( ssl->handshake->ciphersuite_info->mac == MBEDTLS_MD_SHA256 )
     {
 #if defined(MBEDTLS_SHA256_C)
         mbedtls_sha256_finish( &ssl->handshake->fin_sha256, &transcript[4] );
@@ -3752,7 +3752,7 @@ static int ssl_hrr_postprocess( mbedtls_ssl_context* ssl,
         return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
 #endif /* MBEDTLS_SHA256_C */
     }
-    else if( ssl->transform_negotiate->ciphersuite_info->mac == MBEDTLS_MD_SHA384 )
+    else if( ssl->handshake->ciphersuite_info->mac == MBEDTLS_MD_SHA384 )
     {
 #if defined(MBEDTLS_SHA512_C)
         mbedtls_sha512_finish( &ssl->handshake->fin_sha512, &transcript[4] );
@@ -3767,7 +3767,7 @@ static int ssl_hrr_postprocess( mbedtls_ssl_context* ssl,
         return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
 #endif /* MBEDTLS_SHA512_C */
     }
-    else if( ssl->transform_negotiate->ciphersuite_info->mac == MBEDTLS_MD_SHA512 )
+    else if( ssl->handshake->ciphersuite_info->mac == MBEDTLS_MD_SHA512 )
     {
 #if defined(MBEDTLS_SHA512_C)
         mbedtls_sha512_finish( &ssl->handshake->fin_sha512, &transcript[4] );

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -164,6 +164,7 @@ static int ssl_write_early_data_prepare( mbedtls_ssl_context* ssl )
     traffic_keys.epoch = 1;
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
 
+    mbedtls_ssl_transform_free( ssl->transform_negotiate );
     ret = mbedtls_set_traffic_key( ssl, &traffic_keys, ssl->transform_negotiate, 0 );
     if( ret != 0 )
     {
@@ -302,6 +303,7 @@ static int ssl_write_end_of_early_data_prepare( mbedtls_ssl_context* ssl )
     traffic_keys.epoch = 1;
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
 
+    mbedtls_ssl_transform_free( ssl->transform_negotiate );
     ret = mbedtls_set_traffic_key( ssl, &traffic_keys, ssl->transform_negotiate, 0 );
     if( ret != 0 )
     {
@@ -3899,7 +3901,8 @@ int mbedtls_ssl_handshake_client_step( mbedtls_ssl_context *ssl )
             if( ssl->handshake->key_shares_curve_list == NULL )
             {
                 /* We need to allocate one additional key share for the delimiter. */
-                ssl->handshake->key_shares_curve_list = mbedtls_calloc( 1, sizeof( mbedtls_ecp_group_id* ) * ( MBEDTLS_SSL_MAX_KEY_SHARES+1 ) );
+                ssl->handshake->key_shares_curve_list =
+                    mbedtls_calloc( 1, sizeof( mbedtls_ecp_group_id* ) * ( MBEDTLS_SSL_MAX_KEY_SHARES+1 ) );
                 if( ssl->conf->key_shares_curve_list == NULL )
                 {
                     MBEDTLS_SSL_DEBUG_MSG( 1, ( "should never happen" ) );

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -2590,6 +2590,7 @@ static int ssl_encrypted_extensions_prepare( mbedtls_ssl_context* ssl ) {
         traffic_keys.epoch = 2;
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
 
+        mbedtls_ssl_transform_free( ssl->transform_negotiate );
         ret = mbedtls_set_traffic_key( ssl, &traffic_keys, ssl->transform_negotiate, 0 );
         if( ret != 0 )
         {

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -3826,6 +3826,7 @@ static int ssl_finished_out_prepare( mbedtls_ssl_context* ssl )
             traffic_keys.epoch = 2;
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
 
+            mbedtls_ssl_transform_free( ssl->transform_out );
             ret = mbedtls_set_traffic_key( ssl, traffic_keys, ssl->transform_out, 0 );
             if( ret != 0 )
             {

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -3309,10 +3309,9 @@ int mbedtls_set_traffic_key( mbedtls_ssl_context *ssl,
 
         }
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
-
     }
+    else
 #endif /* MBEDTLS_SSL_SRV_C */
-
 #if defined(MBEDTLS_SSL_CLI_C)
     if( ssl->conf->endpoint == MBEDTLS_SSL_IS_CLIENT )
     {
@@ -3336,7 +3335,12 @@ int mbedtls_set_traffic_key( mbedtls_ssl_context *ssl,
         }
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
     }
+    else
 #endif /* MBEDTLS_SSL_CLI_C */
+    {
+        /* should not happen */
+        return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
+    }
 
     if( ( ret = mbedtls_cipher_setkey( &transform->cipher_ctx_enc, key1,
                                        cipher_info->key_bitlen,

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -3899,6 +3899,7 @@ static int ssl_finished_out_postprocess( mbedtls_ssl_context* ssl )
         traffic_keys.epoch = 3;
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
 
+        mbedtls_ssl_transform_free( ssl->transform_negotiate );
         ret = mbedtls_set_traffic_key( ssl, traffic_keys, ssl->transform_negotiate, 0 );
         if( ret != 0 )
         {

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -990,19 +990,19 @@ int mbedtls_ssl_derive_traffic_keys( mbedtls_ssl_context *ssl, mbedtls_ssl_key_s
 
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> derive traffic keys" ) );
 
-    cipher_info = mbedtls_cipher_info_from_type( transform->ciphersuite_info->cipher );
+    cipher_info = mbedtls_cipher_info_from_type( handshake->ciphersuite_info->cipher );
     if( cipher_info == NULL )
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "cipher info for %d not found",
-                                    transform->ciphersuite_info->cipher ) );
+                                    handshake->ciphersuite_info->cipher ) );
         return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
     }
 
-    md_info = mbedtls_md_info_from_type( transform->ciphersuite_info->mac );
+    md_info = mbedtls_md_info_from_type( handshake->ciphersuite_info->mac );
     if( md_info == NULL )
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "mbedtls_md info for %d not found",
-                                    transform->ciphersuite_info->mac ) );
+                                    handshake->ciphersuite_info->mac ) );
         return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
     }
 
@@ -1202,7 +1202,7 @@ int mbedtls_ssl_derive_traffic_keys( mbedtls_ssl_context *ssl, mbedtls_ssl_key_s
      *  - 1 byte for handshake type appended to the end of the message
      *  - Authentication tag ( which depends on the mode of operation )
      */
-    if( transform->ciphersuite_info->cipher == MBEDTLS_CIPHER_AES_128_CCM_8 ) transform->minlen = 8;
+    if( handshake->ciphersuite_info->cipher == MBEDTLS_CIPHER_AES_128_CCM_8 ) transform->minlen = 8;
     else transform->minlen = 16;
 
     /* TBD: Temporarily changed to test encrypted alert messages */
@@ -1435,7 +1435,7 @@ int mbedtls_ssl_tls1_3_derive_master_secret( mbedtls_ssl_context *ssl ) {
         return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
     }
 
-    md = mbedtls_md_info_from_type( ssl->transform_in->ciphersuite_info->mac );
+    md = mbedtls_md_info_from_type( ssl->handshake->ciphersuite_info->mac );
     if( md == NULL )
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "md == NULL, mbedtls_ssl_tls1_3_derive_master_secret failed" ) );
@@ -1538,7 +1538,7 @@ int mbedtls_ssl_tls1_3_derive_master_secret( mbedtls_ssl_context *ssl ) {
      * Compute EarlySecret
      */
 
-    ret = mbedtls_ssl_tls1_3_evolve_secret( ssl->transform_in->ciphersuite_info->mac,
+    ret = mbedtls_ssl_tls1_3_evolve_secret( ssl->handshake->ciphersuite_info->mac,
                                             NULL, /* use 0 as old secret */
                                             psk, psk_len,
                                             ssl->handshake->early_secret );
@@ -1559,7 +1559,7 @@ int mbedtls_ssl_tls1_3_derive_master_secret( mbedtls_ssl_context *ssl ) {
      */
 
     ret = mbedtls_ssl_tls1_3_evolve_secret(
-                              ssl->transform_in->ciphersuite_info->mac,
+                              ssl->handshake->ciphersuite_info->mac,
                               ssl->handshake->early_secret,
                               ECDHE, ECDHE_len,
                               ssl->handshake->handshake_secret );
@@ -1580,7 +1580,7 @@ int mbedtls_ssl_tls1_3_derive_master_secret( mbedtls_ssl_context *ssl ) {
      */
 
     ret = mbedtls_ssl_tls1_3_evolve_secret(
-                              ssl->transform_in->ciphersuite_info->mac,
+                              ssl->handshake->ciphersuite_info->mac,
                               ssl->handshake->handshake_secret,
                               NULL, 0,
                               ssl->handshake->master_secret );
@@ -1783,7 +1783,7 @@ static int ssl_certificate_verify_write( mbedtls_ssl_context* ssl,
                                          size_t* olen )
 {
     int ret;
-    const mbedtls_ssl_ciphersuite_t* ciphersuite_info = ssl->transform_negotiate->ciphersuite_info;
+    const mbedtls_ssl_ciphersuite_t* ciphersuite_info = ssl->handshake->ciphersuite_info;
     size_t n = 0, offset = 0;
 
     unsigned char hash[MBEDTLS_MD_MAX_SIZE];
@@ -2949,7 +2949,6 @@ int mbedtls_ssl_generate_resumption_master_secret( mbedtls_ssl_context *ssl ) {
 #if defined(MBEDTLS_SSL_NEW_SESSION_TICKET)
     const mbedtls_md_info_t *md_info;
     const mbedtls_ssl_ciphersuite_t *suite_info;
-    mbedtls_ssl_transform *transform = ssl->transform_negotiate;
     unsigned char hash[MBEDTLS_MD_MAX_SIZE];
 
 #if defined(MBEDTLS_SHA256_C)
@@ -2960,11 +2959,11 @@ int mbedtls_ssl_generate_resumption_master_secret( mbedtls_ssl_context *ssl ) {
     mbedtls_sha512_context sha512;
 #endif
 
-    md_info = mbedtls_md_info_from_type( transform->ciphersuite_info->mac );
+    md_info = mbedtls_md_info_from_type( ssl->handshake->ciphersuite_info->mac );
     if( md_info == NULL )
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "mbedtls_md info for %d not found",
-                                    transform->ciphersuite_info->mac ) );
+                                    ssl->handshake->ciphersuite_info->mac ) );
         return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
     }
 
@@ -3032,19 +3031,19 @@ int mbedtls_ssl_generate_application_traffic_keys( mbedtls_ssl_context *ssl, mbe
 
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> derive application traffic keys" ) );
 
-    cipher_info = mbedtls_cipher_info_from_type( transform->ciphersuite_info->cipher );
+    cipher_info = mbedtls_cipher_info_from_type( ssl->handshake->ciphersuite_info->cipher );
     if( cipher_info == NULL )
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "cipher info for %d not found",
-                                    transform->ciphersuite_info->cipher ) );
+                                    ssl->handshake->ciphersuite_info->cipher ) );
         return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
     }
 
-    md_info = mbedtls_md_info_from_type( transform->ciphersuite_info->mac );
+    md_info = mbedtls_md_info_from_type( ssl->handshake->ciphersuite_info->mac );
     if( md_info == NULL )
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "mbedtls_md info for %d not found",
-                                    transform->ciphersuite_info->mac ) );
+                                    ssl->handshake->ciphersuite_info->mac ) );
         return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
     }
 
@@ -3070,7 +3069,7 @@ int mbedtls_ssl_generate_application_traffic_keys( mbedtls_ssl_context *ssl, mbe
      *  - 1 byte for handshake type appended to the end of the message
      *  - Authentication tag ( which depends on the mode of operation )
      */
-    if( transform->ciphersuite_info->cipher == MBEDTLS_CIPHER_AES_128_CCM_8 ) transform->minlen = 8;
+    if( ssl->handshake->ciphersuite_info->cipher == MBEDTLS_CIPHER_AES_128_CCM_8 ) transform->minlen = 8;
     else transform->minlen = 16;
 
     transform->minlen += 1;
@@ -3225,17 +3224,17 @@ int mbedtls_set_traffic_key( mbedtls_ssl_context *ssl,
         return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
     }
 
-    if( transform->ciphersuite_info == NULL )
+    if( ssl->handshake->ciphersuite_info == NULL )
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "transform->ciphersuite_info == NULL" ) );
         return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
     }
 
-    cipher_info = mbedtls_cipher_info_from_type( transform->ciphersuite_info->cipher );
+    cipher_info = mbedtls_cipher_info_from_type( ssl->handshake->ciphersuite_info->cipher );
     if( cipher_info == NULL )
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "cipher info for %d not found",
-                                    transform->ciphersuite_info->cipher ) );
+                                    ssl->handshake->ciphersuite_info->cipher ) );
         return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
     }
 
@@ -3417,7 +3416,7 @@ int mbedtls_ssl_early_data_key_derivation( mbedtls_ssl_context *ssl, mbedtls_ssl
         return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
     }
 
-    if( ssl->transform_negotiate->ciphersuite_info == NULL )
+    if( ssl->handshake->ciphersuite_info == NULL )
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "transform_negotiate->ciphersuite_info == NULL, mbedtls_ssl_early_data_key_derivation failed" ) );
         return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
@@ -3454,7 +3453,7 @@ int mbedtls_ssl_early_data_key_derivation( mbedtls_ssl_context *ssl, mbedtls_ssl
         return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
     }
 
-    ciphersuite_info = transform->ciphersuite_info;
+    ciphersuite_info = ssl->handshake->ciphersuite_info;
     if( ciphersuite_info == NULL )
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "ciphersuite_info == NULL" ) );
@@ -3469,7 +3468,7 @@ int mbedtls_ssl_early_data_key_derivation( mbedtls_ssl_context *ssl, mbedtls_ssl
         return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
     }
 
-    md = mbedtls_md_info_from_type( transform->ciphersuite_info->mac );
+    md = mbedtls_md_info_from_type( ssl->handshake->ciphersuite_info->mac );
     if( md == NULL )
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "md == NULL, mbedtls_ssl_early_data_key_derivation failed" ) );
@@ -3581,7 +3580,7 @@ int mbedtls_ssl_early_data_key_derivation( mbedtls_ssl_context *ssl, mbedtls_ssl
      *  - 1 byte for handshake type appended to the end of the message
      *  - Authentication tag ( which depends on the mode of operation )
      */
-    if( transform->ciphersuite_info->cipher == MBEDTLS_CIPHER_AES_128_CCM_8 ) transform->minlen = 8;
+    if( ssl->handshake->ciphersuite_info->cipher == MBEDTLS_CIPHER_AES_128_CCM_8 ) transform->minlen = 8;
     else transform->minlen = 16;
 
     /* TBD: Temporarily changed to test encrypted alert messages */
@@ -3941,11 +3940,11 @@ static int ssl_finished_out_postprocess( mbedtls_ssl_context* ssl )
          * sent by the server and store it in the digest variable of the handshake state.
          * This digest will be needed later when computing the application traffic secrets.
          */
-        cipher_info = mbedtls_cipher_info_from_type(ssl->transform_negotiate->ciphersuite_info->cipher );
+        cipher_info = mbedtls_cipher_info_from_type(ssl->handshake->ciphersuite_info->cipher );
         if( cipher_info == NULL )
         {
             MBEDTLS_SSL_DEBUG_MSG( 1, ( "cipher info for %d not found",
-                                        ssl->transform_negotiate->ciphersuite_info->cipher ) );
+                                        ssl->handshake->ciphersuite_info->cipher ) );
             return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
         }
 
@@ -4168,11 +4167,11 @@ static int ssl_finished_in_postprocess( mbedtls_ssl_context* ssl )
          * sent by the server and store it in the digest variable of the handshake state.
          * This digest will be needed later when computing the application traffic secrets.
          */
-        cipher_info = mbedtls_cipher_info_from_type(ssl->transform_negotiate->ciphersuite_info->cipher );
+        cipher_info = mbedtls_cipher_info_from_type(ssl->handshake->ciphersuite_info->cipher );
         if( cipher_info == NULL )
         {
             MBEDTLS_SSL_DEBUG_MSG( 1, ( "cipher info for %d not found",
-                                        ssl->transform_negotiate->ciphersuite_info->cipher ) );
+                                        ssl->handshake->ciphersuite_info->cipher ) );
             return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
         }
 

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -3721,12 +3721,6 @@ void mbedtls_ssl_handshake_wrapup( mbedtls_ssl_context *ssl )
     ssl->session = ssl->session_negotiate;
     ssl->session_negotiate = NULL;
 
-#if defined(MBEDTLS_X509_CRT_PARSE_C) && defined(MBEDTLS_SSL_SRV_C)
-    /* Free signature_schemes_list allocated during handshake */
-    if( ssl->handshake->received_signature_schemes_list != NULL )
-        mbedtls_free(ssl->handshake->received_signature_schemes_list);
-#endif /* MBEDTLS_X509_CRT_PARSE_C && MBEDTLS_SSL_SRV_C */
-
     /* With DTLS 1.3 we keep the handshake and transform structures alive. */
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
     if( ssl->conf->transport == MBEDTLS_SSL_TRANSPORT_DATAGRAM )

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -990,7 +990,8 @@ int mbedtls_ssl_derive_traffic_keys( mbedtls_ssl_context *ssl, mbedtls_ssl_key_s
 
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> derive traffic keys" ) );
 
-    cipher_info = mbedtls_cipher_info_from_type( handshake->ciphersuite_info->cipher );
+    cipher_info = mbedtls_cipher_info_from_type(
+                                  handshake->ciphersuite_info->cipher );
     if( cipher_info == NULL )
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "cipher info for %d not found",
@@ -1006,12 +1007,10 @@ int mbedtls_ssl_derive_traffic_keys( mbedtls_ssl_context *ssl, mbedtls_ssl_key_s
         return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
     }
 
-    suite_info = mbedtls_ssl_ciphersuite_from_id( ssl->session_negotiate->ciphersuite );
+    suite_info = mbedtls_ssl_ciphersuite_from_id(
+                                  ssl->session_negotiate->ciphersuite );
     if( suite_info == NULL )
-    {
-        MBEDTLS_SSL_DEBUG_MSG( 1, ( "mbedtls_ssl_ciphersuite_from_id in mbedtls_ssl_derive_traffic_keys failed" ) );
         return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
-    }
 
     if( mbedtls_hash_size_for_ciphersuite( suite_info ) == 32 )
     {
@@ -1035,12 +1034,12 @@ int mbedtls_ssl_derive_traffic_keys( mbedtls_ssl_context *ssl, mbedtls_ssl_key_s
 #endif /* MBEDTLS_SHA512_C */
     }
 
-    if( ( mbedtls_hash_size_for_ciphersuite( suite_info ) != 32 ) && ( mbedtls_hash_size_for_ciphersuite( suite_info ) != 48 ) )
+    if( ( mbedtls_hash_size_for_ciphersuite( suite_info ) != 32 ) &&
+        ( mbedtls_hash_size_for_ciphersuite( suite_info ) != 48 ) )
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "Unknown hash function negotiated." ) );
         return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
     }
-
 
 #if defined(MBEDTLS_SHA256_C)
     if( mbedtls_hash_size_for_ciphersuite( suite_info ) == 32 )
@@ -1051,19 +1050,20 @@ int mbedtls_ssl_derive_traffic_keys( mbedtls_ssl_context *ssl, mbedtls_ssl_key_s
     else
 #endif /* MBEDTLS_SHA256_C */
 #if defined(MBEDTLS_SHA512_C)
-        if( mbedtls_hash_size_for_ciphersuite( suite_info ) == 48 )
-        {
-            mbedtls_sha512_clone( &sha512, &ssl->handshake->fin_sha512 );
-            mbedtls_sha512_finish( &sha512, hash );
-        }
-        else
+    if( mbedtls_hash_size_for_ciphersuite( suite_info ) == 48 )
+    {
+        mbedtls_sha512_clone( &sha512, &ssl->handshake->fin_sha512 );
+        mbedtls_sha512_finish( &sha512, hash );
+    }
+    else
 #endif /* MBEDTLS_SHA512_C */
-        {
-            MBEDTLS_SSL_DEBUG_MSG( 2, ( "Unsupported hash function in mbedtls_ssl_derive_traffic_keys" ) );
-            return ( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
-        }
+    {
+        MBEDTLS_SSL_DEBUG_MSG( 2, ( "Unsupported hash function in mbedtls_ssl_derive_traffic_keys" ) );
+        return ( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
+    }
 
-    MBEDTLS_SSL_DEBUG_BUF( 3, "rolling hash", hash, mbedtls_hash_size_for_ciphersuite( suite_info ) );
+    MBEDTLS_SSL_DEBUG_BUF( 3, "rolling hash", hash,
+                 mbedtls_hash_size_for_ciphersuite( suite_info ) );
 
     /*
      *
@@ -1086,16 +1086,19 @@ int mbedtls_ssl_derive_traffic_keys( mbedtls_ssl_context *ssl, mbedtls_ssl_key_s
      */
 
     ret = mbedtls_ssl_tls1_3_derive_secret( mbedtls_md_get_type( md_info ),
-                         (const unsigned char*) ssl->handshake->handshake_secret, ( int ) mbedtls_hash_size_for_ciphersuite( suite_info ),
-                         MBEDTLS_SSL_TLS1_3_LBL_WITH_LEN( c_hs_traffic ),
-                         ( const unsigned char * ) hash,
-                         ( int ) mbedtls_hash_size_for_ciphersuite( suite_info ),
-                         MBEDTLS_SSL_TLS1_3_CONTEXT_HASHED,
-                         ( unsigned char * ) ssl->handshake->client_handshake_traffic_secret, ( int ) mbedtls_hash_size_for_ciphersuite( suite_info ) );
+             (const unsigned char*) ssl->handshake->handshake_secret,
+             (int) mbedtls_hash_size_for_ciphersuite( suite_info ),
+             MBEDTLS_SSL_TLS1_3_LBL_WITH_LEN( c_hs_traffic ),
+             (const unsigned char * ) hash,
+             (int) mbedtls_hash_size_for_ciphersuite( suite_info ),
+             MBEDTLS_SSL_TLS1_3_CONTEXT_HASHED,
+             (unsigned char *) ssl->handshake->client_handshake_traffic_secret,
+             (int) mbedtls_hash_size_for_ciphersuite( suite_info ) );
 
     if( ret != 0 )
     {
-        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_tls1_3_derive_secret( ) with client_handshake_traffic_secret: Error", ret );
+        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_tls1_3_derive_secret( ) with "
+                               "client_handshake_traffic_secret: Error", ret );
         return( ret );
     }
 
@@ -1124,16 +1127,15 @@ int mbedtls_ssl_derive_traffic_keys( mbedtls_ssl_context *ssl, mbedtls_ssl_key_s
      */
 
     ret = mbedtls_ssl_tls1_3_derive_secret( mbedtls_md_get_type( md_info ),
-                         ssl->handshake->handshake_secret, mbedtls_hash_size_for_ciphersuite( suite_info ),
+                         ssl->handshake->handshake_secret,
+                         mbedtls_hash_size_for_ciphersuite( suite_info ),
                          MBEDTLS_SSL_TLS1_3_LBL_WITH_LEN( s_hs_traffic ),
-                         hash, mbedtls_hash_size_for_ciphersuite( suite_info ), MBEDTLS_SSL_TLS1_3_CONTEXT_HASHED,
-                         ssl->handshake->server_handshake_traffic_secret, mbedtls_hash_size_for_ciphersuite( suite_info ) );
-
+                         hash, mbedtls_hash_size_for_ciphersuite( suite_info ),
+                         MBEDTLS_SSL_TLS1_3_CONTEXT_HASHED,
+                         ssl->handshake->server_handshake_traffic_secret,
+                         mbedtls_hash_size_for_ciphersuite( suite_info ) );
     if( ret != 0 )
-    {
-        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_tls1_3_derive_secret( ) with server_handshake_traffic_secret: Error", ret );
         return( ret );
-    }
 
     /*
      * Export server handshake traffic secret
@@ -1160,16 +1162,15 @@ int mbedtls_ssl_derive_traffic_keys( mbedtls_ssl_context *ssl, mbedtls_ssl_key_s
      */
 
     ret = mbedtls_ssl_tls1_3_derive_secret( mbedtls_md_get_type( md_info ),
-                         ssl->handshake->master_secret, mbedtls_hash_size_for_ciphersuite( suite_info ),
+                         ssl->handshake->master_secret,
+                         mbedtls_hash_size_for_ciphersuite( suite_info ),
                          MBEDTLS_SSL_TLS1_3_LBL_WITH_LEN( exp_master ),
-                         hash, mbedtls_hash_size_for_ciphersuite( suite_info ), MBEDTLS_SSL_TLS1_3_CONTEXT_HASHED,
-                         ssl->handshake->exporter_secret, mbedtls_hash_size_for_ciphersuite( suite_info ) );
-
+                         hash, mbedtls_hash_size_for_ciphersuite( suite_info ),
+                         MBEDTLS_SSL_TLS1_3_CONTEXT_HASHED,
+                         ssl->handshake->exporter_secret,
+                         mbedtls_hash_size_for_ciphersuite( suite_info ) );
     if( ret != 0 )
-    {
-        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_tls1_3_derive_secret( ) with exporter_secret: Error", ret );
         return( ret );
-    }
 
     /*
      * Export exporter master secret
@@ -1185,7 +1186,9 @@ int mbedtls_ssl_derive_traffic_keys( mbedtls_ssl_context *ssl, mbedtls_ssl_key_s
     }
 #endif /* MBEDTLS_SSL_EXPORT_KEYS */
 
-    MBEDTLS_SSL_DEBUG_BUF( 5, "exporter_secret", ssl->handshake->exporter_secret, mbedtls_hash_size_for_ciphersuite( suite_info ) );
+    MBEDTLS_SSL_DEBUG_BUF( 5, "exporter_secret",
+                           ssl->handshake->exporter_secret,
+                           mbedtls_hash_size_for_ciphersuite( suite_info ) );
 
     /*
      * Compute keys to protect the handshake messages utilizing MakeTrafficKey
@@ -1202,8 +1205,10 @@ int mbedtls_ssl_derive_traffic_keys( mbedtls_ssl_context *ssl, mbedtls_ssl_key_s
      *  - 1 byte for handshake type appended to the end of the message
      *  - Authentication tag ( which depends on the mode of operation )
      */
-    if( handshake->ciphersuite_info->cipher == MBEDTLS_CIPHER_AES_128_CCM_8 ) transform->minlen = 8;
-    else transform->minlen = 16;
+    if( handshake->ciphersuite_info->cipher == MBEDTLS_CIPHER_AES_128_CCM_8 )
+        transform->minlen = 8;
+    else
+        transform->minlen = 16;
 
     /* TBD: Temporarily changed to test encrypted alert messages */
     /* transform->minlen += mbedtls_ssl_hs_hdr_len( ssl ); */
@@ -2943,7 +2948,8 @@ static int ssl_read_certificate_postprocess( mbedtls_ssl_context* ssl )
 
 
 /* Generate resumption_master_secret for use with the ticket exchange. */
-int mbedtls_ssl_generate_resumption_master_secret( mbedtls_ssl_context *ssl ) {
+int mbedtls_ssl_generate_resumption_master_secret( mbedtls_ssl_context *ssl )
+{
     int ret = 0;
 
 #if defined(MBEDTLS_SSL_NEW_SESSION_TICKET)
@@ -3001,18 +3007,20 @@ int mbedtls_ssl_generate_resumption_master_secret( mbedtls_ssl_context *ssl ) {
      */
 
     ret = mbedtls_ssl_tls1_3_derive_secret( mbedtls_md_get_type( md_info ),
-                         ssl->handshake->master_secret, mbedtls_hash_size_for_ciphersuite( suite_info ),
+                         ssl->handshake->master_secret,
+                         mbedtls_hash_size_for_ciphersuite( suite_info ),
                          MBEDTLS_SSL_TLS1_3_LBL_WITH_LEN( res_master ),
-                         hash, mbedtls_hash_size_for_ciphersuite( suite_info ), MBEDTLS_SSL_TLS1_3_CONTEXT_HASHED,
-                         ssl->session_negotiate->resumption_master_secret, mbedtls_hash_size_for_ciphersuite( suite_info ) );
+                         hash, mbedtls_hash_size_for_ciphersuite( suite_info ),
+                         MBEDTLS_SSL_TLS1_3_CONTEXT_HASHED,
+                         ssl->session_negotiate->resumption_master_secret,
+                         mbedtls_hash_size_for_ciphersuite( suite_info ) );
 
     if( ret != 0 )
-    {
-        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_tls1_3_derive_secret( ) with resumption_master_secret: Error", ret );
         return( ret );
-    }
 
-    MBEDTLS_SSL_DEBUG_BUF( 5, "resumption_master_secret", ssl->session_negotiate->resumption_master_secret, mbedtls_hash_size_for_ciphersuite( suite_info ) );
+    MBEDTLS_SSL_DEBUG_BUF( 5, "resumption_master_secret",
+                           ssl->session_negotiate->resumption_master_secret,
+                           mbedtls_hash_size_for_ciphersuite( suite_info ) );
 
 #endif /* MBEDTLS_SSL_NEW_SESSION_TICKET */
 
@@ -3022,7 +3030,10 @@ int mbedtls_ssl_generate_resumption_master_secret( mbedtls_ssl_context *ssl ) {
 /* Generate application traffic keys since any records following a 1-RTT Finished message
  * MUST be encrypted under the application traffic key.
  */
-int mbedtls_ssl_generate_application_traffic_keys( mbedtls_ssl_context *ssl, mbedtls_ssl_key_set *traffic_keys ) {
+int mbedtls_ssl_generate_application_traffic_keys(
+                                        mbedtls_ssl_context *ssl,
+                                        mbedtls_ssl_key_set *traffic_keys )
+{
     int ret;
     const mbedtls_md_info_t *md_info;
     const mbedtls_ssl_ciphersuite_t *suite_info;
@@ -3031,11 +3042,12 @@ int mbedtls_ssl_generate_application_traffic_keys( mbedtls_ssl_context *ssl, mbe
 
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> derive application traffic keys" ) );
 
-    cipher_info = mbedtls_cipher_info_from_type( ssl->handshake->ciphersuite_info->cipher );
+    cipher_info = mbedtls_cipher_info_from_type(
+                              ssl->handshake->ciphersuite_info->cipher );
     if( cipher_info == NULL )
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "cipher info for %d not found",
-                                    ssl->handshake->ciphersuite_info->cipher ) );
+                               ssl->handshake->ciphersuite_info->cipher ) );
         return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
     }
 
@@ -3043,16 +3055,13 @@ int mbedtls_ssl_generate_application_traffic_keys( mbedtls_ssl_context *ssl, mbe
     if( md_info == NULL )
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "mbedtls_md info for %d not found",
-                                    ssl->handshake->ciphersuite_info->mac ) );
+                               ssl->handshake->ciphersuite_info->mac ) );
         return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
     }
 
     suite_info = mbedtls_ssl_ciphersuite_from_id( ssl->session_negotiate->ciphersuite );
     if( suite_info == NULL )
-    {
-        MBEDTLS_SSL_DEBUG_MSG( 1, ( "mbedtls_ssl_ciphersuite_from_id in mbedtls_ssl_derive_traffic_keys failed" ) );
         return( MBEDTLS_ERR_SSL_BAD_HS_SERVER_HELLO );
-    }
 
     /*
      * Determine the appropriate key, IV and MAC length.
@@ -3088,11 +3097,14 @@ int mbedtls_ssl_generate_application_traffic_keys( mbedtls_ssl_context *ssl, mbe
      */
 
     ret = mbedtls_ssl_tls1_3_derive_secret( mbedtls_md_get_type( md_info ),
-                         ssl->handshake->master_secret, mbedtls_hash_size_for_ciphersuite( suite_info ),
+                         ssl->handshake->master_secret,
+                         mbedtls_hash_size_for_ciphersuite( suite_info ),
                          MBEDTLS_SSL_TLS1_3_LBL_WITH_LEN( c_ap_traffic ),
-                         ssl->handshake->server_finished_digest, mbedtls_hash_size_for_ciphersuite( suite_info ),
+                         ssl->handshake->server_finished_digest,
+                         mbedtls_hash_size_for_ciphersuite( suite_info ),
                          MBEDTLS_SSL_TLS1_3_CONTEXT_HASHED,
-                         ssl->handshake->client_traffic_secret, mbedtls_hash_size_for_ciphersuite( suite_info ) );
+                         ssl->handshake->client_traffic_secret,
+                         mbedtls_hash_size_for_ciphersuite( suite_info ) );
 
     if( ret != 0 )
     {
@@ -3124,17 +3136,16 @@ int mbedtls_ssl_generate_application_traffic_keys( mbedtls_ssl_context *ssl, mbe
      */
 
     ret = mbedtls_ssl_tls1_3_derive_secret( mbedtls_md_get_type( md_info ),
-                         ssl->handshake->master_secret, mbedtls_hash_size_for_ciphersuite( suite_info ),
+                         ssl->handshake->master_secret,
+                         mbedtls_hash_size_for_ciphersuite( suite_info ),
                          MBEDTLS_SSL_TLS1_3_LBL_WITH_LEN( s_ap_traffic ),
-                         ssl->handshake->server_finished_digest, mbedtls_hash_size_for_ciphersuite( suite_info ),
+                         ssl->handshake->server_finished_digest,
+                         mbedtls_hash_size_for_ciphersuite( suite_info ),
                          MBEDTLS_SSL_TLS1_3_CONTEXT_HASHED,
-                         ssl->handshake->server_traffic_secret, mbedtls_hash_size_for_ciphersuite( suite_info ) );
-
+                         ssl->handshake->server_traffic_secret,
+                         mbedtls_hash_size_for_ciphersuite( suite_info ) );
     if( ret != 0 )
-    {
-        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_tls1_3_derive_secret( ) with server_traffic_secret_0: Error", ret );
         return( ret );
-    }
 
     /*
      * Export server application traffic secret 0
@@ -3310,7 +3321,8 @@ int mbedtls_set_traffic_key( mbedtls_ssl_context *ssl,
         if( mode == 1 )
         {
             memcpy( transform->iv_dec,
-                    transform->traffic_keys_previous.server_write_iv, transform->ivlen );
+                    transform->traffic_keys_previous.server_write_iv,
+                    transform->ivlen );
         }
 
     }

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -3265,8 +3265,11 @@ int mbedtls_set_traffic_key( mbedtls_ssl_context *ssl,
 
     if( mode == 0 )
     {
+#if defined(MBEDTLS_SSL_PROTO_DTLS)
         /* Copy current traffic_key structure to previous */
         transform->traffic_keys_previous = transform->traffic_keys;
+#endif /* MBEDTLS_SSL_PROTO_DTLS */
+
         /* Store current traffic_key structure */
         transform->traffic_keys = *traffic_keys;
     }
@@ -3280,6 +3283,8 @@ int mbedtls_set_traffic_key( mbedtls_ssl_context *ssl,
                 traffic_keys->iv_len );
         memcpy( transform->iv_dec, traffic_keys->client_write_iv,
                 traffic_keys->iv_len );
+
+#if defined(MBEDTLS_SSL_PROTO_DTLS)
         /* Restore the most recent nonce */
         if( mode == 1 )
         {
@@ -3288,7 +3293,6 @@ int mbedtls_set_traffic_key( mbedtls_ssl_context *ssl,
                     transform->traffic_keys_previous.iv_len );
         }
 
-#if defined(MBEDTLS_SSL_PROTO_DTLS)
         /* TODO: Don't we want to check that we're running DTLS here? */
         {
             unsigned char temp[ MBEDTLS_MAX_KEY_LEN ];
@@ -3317,6 +3321,8 @@ int mbedtls_set_traffic_key( mbedtls_ssl_context *ssl,
                 traffic_keys->iv_len );
         memcpy( transform->iv_dec, traffic_keys->server_write_iv,
                 traffic_keys->iv_len );
+
+#if defined(MBEDTLS_SSL_PROTO_DTLS)
         /* Restore the most recent nonce */
         if( mode == 1 )
         {
@@ -3324,7 +3330,7 @@ int mbedtls_set_traffic_key( mbedtls_ssl_context *ssl,
                     transform->traffic_keys_previous.server_write_iv,
                     transform->ivlen );
         }
-
+#endif /* MBEDTLS_SSL_PROTO_DTLS */
     }
 #endif /* MBEDTLS_SSL_CLI_C */
 

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -3279,6 +3279,8 @@ int mbedtls_set_traffic_key( mbedtls_ssl_context *ssl,
         key1 = traffic_keys->server_write_key; /* encryption key for the server */
         key2 = traffic_keys->client_write_key; /* decryption key for the server */
 
+        transform->ivlen = traffic_keys->iv_len;
+
         memcpy( transform->iv_enc, traffic_keys->server_write_iv,
                 traffic_keys->iv_len );
         memcpy( transform->iv_dec, traffic_keys->client_write_iv,
@@ -3316,6 +3318,8 @@ int mbedtls_set_traffic_key( mbedtls_ssl_context *ssl,
     {
         key1 = traffic_keys->client_write_key; /* encryption key for the client */
         key2 = traffic_keys->server_write_key; /* decryption key for the client */
+
+        transform->ivlen = traffic_keys->iv_len;
 
         memcpy( transform->iv_enc, traffic_keys->client_write_iv,
                 traffic_keys->iv_len );

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -1411,12 +1411,8 @@ static int ssl_calc_verify_tls_sha384( mbedtls_ssl_context *ssl, unsigned char o
  *     0 -> HKDF-Extract = Master Secret
  *
  */
-int mbedtls_ssl_tls1_3_derive_master_secret( mbedtls_ssl_context *ssl ) {
-
-    unsigned char salt[MBEDTLS_MD_MAX_SIZE];
-    unsigned char null_ikm[MBEDTLS_MD_MAX_SIZE];
-    unsigned char intermediary_secret[MBEDTLS_MD_MAX_SIZE];
-
+int mbedtls_ssl_tls1_3_derive_master_secret( mbedtls_ssl_context *ssl )
+{
     unsigned char ECDHE[66];
 
     size_t ECDHE_len;
@@ -1554,10 +1550,7 @@ int mbedtls_ssl_tls1_3_derive_master_secret( mbedtls_ssl_context *ssl ) {
         return( ret );
     }
 
-    MBEDTLS_SSL_DEBUG_MSG( 5, ( "HKDF Extract -- early_secret" ) );
-    MBEDTLS_SSL_DEBUG_BUF( 5, "Salt", salt, hash_size );
-    MBEDTLS_SSL_DEBUG_BUF( 5, "Input", psk, psk_len );
-    MBEDTLS_SSL_DEBUG_BUF( 5, "Output", ssl->handshake->early_secret, hash_size );
+    MBEDTLS_SSL_DEBUG_BUF( 4, "Early secret", ssl->handshake->early_secret, hash_size );
 
     /*
      * Compute HandshakeSecret
@@ -1575,10 +1568,7 @@ int mbedtls_ssl_tls1_3_derive_master_secret( mbedtls_ssl_context *ssl ) {
         return( ret );
     }
 
-    MBEDTLS_SSL_DEBUG_MSG( 5, ( "HKDF Extract -- handshake_secret" ) );
-    MBEDTLS_SSL_DEBUG_BUF( 5, "Salt", intermediary_secret, hash_size );
-    MBEDTLS_SSL_DEBUG_BUF( 5, "Input ( ECDHE )", ECDHE, hash_size );
-    MBEDTLS_SSL_DEBUG_BUF( 5, "Output", ssl->handshake->handshake_secret, hash_size );
+    MBEDTLS_SSL_DEBUG_BUF( 4, "Handshake secret", ssl->handshake->handshake_secret, hash_size );
 
     /*
      * Compute MasterSecret
@@ -1596,10 +1586,7 @@ int mbedtls_ssl_tls1_3_derive_master_secret( mbedtls_ssl_context *ssl ) {
         return( ret );
     }
 
-    MBEDTLS_SSL_DEBUG_MSG( 5, ( "HKDF Extract -- master_secret" ) );
-    MBEDTLS_SSL_DEBUG_BUF( 5, "Salt", intermediary_secret, hash_size );
-    MBEDTLS_SSL_DEBUG_BUF( 5, "Input", null_ikm, hash_size );
-    MBEDTLS_SSL_DEBUG_BUF( 5, "Output", ssl->handshake->master_secret, hash_size );
+    MBEDTLS_SSL_DEBUG_BUF( 4, "Master secret", ssl->handshake->master_secret, hash_size );
 
     if( psk_allocated == 1 ) mbedtls_free( psk );
 
@@ -4285,7 +4272,7 @@ int mbedtls_ssl_parse_new_session_ticket( mbedtls_ssl_context *ssl )
     uint8_t ticket_nonce_len;
     size_t ticket_len, ext_len;
     unsigned char *ticket;
-    const unsigned char *msg, *extensions;
+    const unsigned char *msg;
     const mbedtls_ssl_ciphersuite_t *suite_info;
     unsigned int msg_len;
 
@@ -4398,11 +4385,9 @@ int mbedtls_ssl_parse_new_session_ticket( mbedtls_ssl_context *ssl )
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "ticket->extension length: %d", ext_len ) );
 
     /* We are not storing any extensions at the moment */
-    if( ext_len > 0 )
-    {
-        extensions = &msg[13 + ticket_nonce_len + ticket_len];
-        MBEDTLS_SSL_DEBUG_BUF( 3, "ticket->extension", extensions, ext_len );
-    }
+    MBEDTLS_SSL_DEBUG_BUF( 3, "ticket->extension",
+                           &msg[13 + ticket_nonce_len + ticket_len],
+                           ext_len );
 
     /* Compute PSK based on received nonce and resumption_master_secret
      * in the following style:

--- a/library/ssl_tls13_keys.c
+++ b/library/ssl_tls13_keys.c
@@ -293,7 +293,7 @@ int mbedtls_ssl_tls1_3_evolve_secret(
     int ret = MBEDTLS_ERR_SSL_INTERNAL_ERROR;
     size_t hlen, ilen;
     unsigned char tmp_secret[ MBEDTLS_MD_MAX_SIZE ] = { 0 };
-    unsigned char tmp_input [ MBEDTLS_MD_MAX_SIZE ] = { 0 };
+    unsigned char tmp_input [ MBEDTLS_SSL_TLS1_3_MAX_IKM_SIZE ] = { 0 };
 
     const mbedtls_md_info_t *md;
     md = mbedtls_md_info_from_type( hash_alg );

--- a/library/ssl_tls13_keys.h
+++ b/library/ssl_tls13_keys.h
@@ -19,6 +19,18 @@
 #if !defined(MBEDTLS_SSL_TLS1_3_KEYS_H)
 #define MBEDTLS_SSL_TLS1_3_KEYS_H
 
+/* The maximum size of the intermediate key material.
+ * The IKM can be a
+ * - 0-string of length corresponding to the size of the
+ *   underlying hash function, and hence can be bounded
+ *   in size by MBEDTLS_MD_MAX_SIZE.
+ * - the PSK, which is bounded in size by MBEDTLS_PREMASTER_SIZE
+ * - the (EC)DHE, which is bounded in size by MBEDTLS_PREMASTER_SIZE
+ */
+#define MBEDTLS_SSL_TLS1_3_MAX_IKM_SIZE \
+    ( MBEDTLS_PREMASTER_SIZE > MBEDTLS_MD_MAX_SIZE ? \
+      MBEDTLS_PREMASTER_SIZE : MBEDTLS_MD_MAX_SIZE )
+
 /* This requires MBEDTLS_SSL_TLS1_3_LABEL( idx, name, string ) to be defined at
  * the point of use. See e.g. the definition of mbedtls_ssl_tls1_3_labels_union
  * below. */
@@ -254,7 +266,8 @@ int mbedtls_ssl_tls1_3_derive_secret(
  *                    ephemeral (EC)DH secret). If not \c NULL, this must be
  *                    a readable buffer whose size \p input_len Bytes.
  *                    If \c NULL, an all \c 0 array will be used instead.
- * \param input_len   The length of \p input in Bytes.
+ * \param input_len   The length of \p input in Bytes. This must not be
+ *                    larger than MBEDTLS_SSL_TLS1_3_MAX_IKM_SIZE.
  * \param secret_new  The address of the buffer holding the new secret
  *                    on function exit. This must be a writable buffer
  *                    whose size matches the output size of the hash

--- a/library/ssl_tls13_messaging.c
+++ b/library/ssl_tls13_messaging.c
@@ -107,7 +107,7 @@ static int ssl_encrypt_buf( mbedtls_ssl_context *ssl )
         unsigned char taglen;
 
         /* Currently there is only one cipher with a short authentication tag defined */
-        if( ssl->transform_out->ciphersuite_info->cipher == MBEDTLS_CIPHER_AES_128_CCM_8 )
+        if( ssl->handshake->ciphersuite_info->cipher == MBEDTLS_CIPHER_AES_128_CCM_8 )
             taglen = 8;
         else taglen = 16;
 
@@ -300,7 +300,7 @@ static int ssl_decrypt_buf( mbedtls_ssl_context *ssl )
         size_t add_data_len;
 
         /* Currently there is only one cipher with a short authentication tag defined */
-        if( ssl->transform_in->ciphersuite_info->cipher == MBEDTLS_CIPHER_AES_128_CCM_8 )
+        if( ssl->handshake->ciphersuite_info->cipher == MBEDTLS_CIPHER_AES_128_CCM_8 )
             taglen = 8;
         else taglen = 16;
 

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -1048,7 +1048,7 @@ psk_parsing_successful:
         {
             /* Case 1: We are using the PSK from a ticket */
             ret = ssl_calc_binder( ssl, ssl->handshake->psk, ssl->handshake->psk_len,
-                                  mbedtls_md_info_from_type( ssl->transform_negotiate->ciphersuite_info->mac ), ssl->transform_negotiate->ciphersuite_info,
+                                  mbedtls_md_info_from_type( ssl->handshake->ciphersuite_info->mac ), ssl->handshake->ciphersuite_info,
                                   truncated_clienthello_start, truncated_clienthello_end - truncated_clienthello_start, server_computed_binder );
         }
         else {
@@ -1057,7 +1057,7 @@ psk_parsing_successful:
                 return( ret );
 
             ret = ssl_calc_binder( ssl, (unsigned char *) psk, psk_len,
-                                  mbedtls_md_info_from_type( ssl->transform_negotiate->ciphersuite_info->mac ), ssl->transform_negotiate->ciphersuite_info,
+                                  mbedtls_md_info_from_type( ssl->handshake->ciphersuite_info->mac ), ssl->handshake->ciphersuite_info,
                                   truncated_clienthello_start, truncated_clienthello_end - truncated_clienthello_start, server_computed_binder );
         }
 
@@ -1623,7 +1623,7 @@ static int ssl_write_new_session_ticket( mbedtls_ssl_context *ssl )
         return( ret );
     }
 
-    suite_info = ( mbedtls_ssl_ciphersuite_t * ) ssl->transform_negotiate->ciphersuite_info;
+    suite_info = ( mbedtls_ssl_ciphersuite_t * ) ssl->handshake->ciphersuite_info;
     hash_length = mbedtls_hash_size_for_ciphersuite( suite_info );
 
     if( hash_length == -1 )
@@ -1641,7 +1641,7 @@ static int ssl_write_new_session_ticket( mbedtls_ssl_context *ssl )
     ticket.ticket_lifetime = ctx->ticket_lifetime;
     /* In this code the psk key length equals the length of the hash */
     ticket.key_len = hash_length;
-    ticket.ciphersuite = ssl->transform_negotiate->ciphersuite_info->id;
+    ticket.ciphersuite = ssl->handshake->ciphersuite_info->id;
 
 #if defined(MBEDTLS_X509_CRT_PARSE_C)
     /* Check whether the client provided a certificate during the exchange */
@@ -2826,7 +2826,7 @@ static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
                                 ciphersuite_info->name ) );
 
     ssl->session_negotiate->ciphersuite = ciphersuites[i];
-    ssl->transform_negotiate->ciphersuite_info = ciphersuite_info;
+    ssl->handshake->ciphersuite_info = ciphersuite_info;
 
     /* List all the extensions we have received */
 
@@ -3099,7 +3099,7 @@ static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
         transcript[1] = 0;
         transcript[2] = 0;
 
-        hash_length = mbedtls_hash_size_for_ciphersuite( ssl->transform_negotiate->ciphersuite_info );
+        hash_length = mbedtls_hash_size_for_ciphersuite( ssl->handshake->ciphersuite_info );
 
         if( hash_length == -1 )
         {
@@ -3110,7 +3110,7 @@ static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
         transcript[3] = ( uint8_t )hash_length;
 
 
-        if( ssl->transform_negotiate->ciphersuite_info->mac == MBEDTLS_MD_SHA256 )
+        if( ssl->handshake->ciphersuite_info->mac == MBEDTLS_MD_SHA256 )
         {
 #if defined(MBEDTLS_SHA256_C)
             mbedtls_sha256_init( &sha256 );
@@ -3123,7 +3123,7 @@ static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
             return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
 #endif /* MBEDTLS_SHA256_C */
         }
-        else if( ssl->transform_negotiate->ciphersuite_info->mac == MBEDTLS_MD_SHA384 )
+        else if( ssl->handshake->ciphersuite_info->mac == MBEDTLS_MD_SHA384 )
         {
 #if defined(MBEDTLS_SHA512_C)
             mbedtls_sha512_init( &sha512 );
@@ -3136,7 +3136,7 @@ static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
             return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
 #endif /* MBEDTLS_SHA512_C */
         }
-        else if( ssl->transform_negotiate->ciphersuite_info->mac == MBEDTLS_MD_SHA512 )
+        else if( ssl->handshake->ciphersuite_info->mac == MBEDTLS_MD_SHA512 )
         {
 #if defined(MBEDTLS_SHA512_C)
             mbedtls_sha512_init( &sha512 );
@@ -3158,7 +3158,7 @@ static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
         MBEDTLS_SSL_DEBUG_MSG( 5, ( "--- Checksum ( ssl_parse_client_hello, normal transcript hash )" ) );
         ssl->handshake->update_checksum( ssl, orig_buf, orig_msg_len );
     }
-    mbedtls_ssl_optimize_checksum( ssl, ssl->transform_negotiate->ciphersuite_info );
+    mbedtls_ssl_optimize_checksum( ssl, ssl->handshake->ciphersuite_info );
 
     return( final_ret );
 }

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -1810,6 +1810,7 @@ static int ssl_read_end_of_early_data_preprocess( mbedtls_ssl_context* ssl )
         return( ret );
     }
 
+    mbedtls_ssl_transform_free( ssl->transform_negotiate );
     ret = mbedtls_set_traffic_key( ssl, &traffic_keys, ssl->transform_negotiate, 0 );
     if( ret != 0 )
     {
@@ -1910,6 +1911,7 @@ static int ssl_read_early_data_preprocess( mbedtls_ssl_context* ssl )
         return( ret );
     }
 
+    mbedtls_ssl_transform_free( ssl->transform_negotiate );
     ret = mbedtls_set_traffic_key( ssl, &traffic_keys, ssl->transform_negotiate, 0 );
     if( ret != 0 )
     {
@@ -3337,6 +3339,7 @@ static int ssl_encrypted_extensions_prepare( mbedtls_ssl_context* ssl )
     ssl->transform_out = ssl->transform_negotiate;
     ssl->session_out = ssl->session_negotiate;
 
+    mbedtls_ssl_transform_free( ssl->transform_negotiate );
     ret = mbedtls_set_traffic_key( ssl, &traffic_keys, ssl->transform_negotiate, 0 );
 
     if( ret != 0 )
@@ -4601,6 +4604,7 @@ int mbedtls_ssl_handshake_server_step( mbedtls_ssl_context *ssl )
                     return( ret );
                 }
 
+                mbedtls_ssl_transform_free( ssl->transform_negotiate );
                 ret = mbedtls_set_traffic_key( ssl, &traffic_keys, ssl->transform_negotiate,0 );
 
                 if( ret != 0 )
@@ -4636,6 +4640,7 @@ int mbedtls_ssl_handshake_server_step( mbedtls_ssl_context *ssl )
                 return( ret );
             }
 
+            mbedtls_ssl_transform_free( ssl->transform_negotiate );
             ret = mbedtls_set_traffic_key( ssl, &traffic_keys, ssl->transform_negotiate, 0 );
 
             if( ret != 0 )

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -3420,38 +3420,6 @@ send_request:
             }
         }
         while( 1 );
-#if defined(MBEDTLS_SSL_NEW_SESSION_TICKET)
-
-    /*
-    * Store ticket, which is sent by the server after the handshake is completed.
-    */
-    if( opt.reconnect != 0 )
-    {
-        mbedtls_printf( "  . Saving ticket...\n" );
-        fflush( stdout );
-
-        ret = mbedtls_ssl_get_client_ticket( &ssl, &ticket );
-
-        if( ret < 0 )
-        {
-            mbedtls_printf( " failed\n  ! mbedtls_ssl_get_ticket returned -0x%x\n\n",
-                                       (unsigned) -ret );
-            goto exit;
-        }
-        else if( ret == 1 )
-        {
-            // no ticket available - we cannot re-connect
-            opt.reconnect = 0;
-            mbedtls_printf( "no ticket available\n" );
-
-        }
-        else if( ret == 0 )
-        {
-            mbedtls_printf( "got ticket\n" );
-        }
-    }
-
-#endif /* MBEDTLS_SSL_NEW_SESSION_TICKET */
     }
     else /* Not stream, so datagram */
     {

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -1285,6 +1285,7 @@ run_test    "TLS_AES_256_GCM_SHA384 with ECDHE-ECDSA (mutual auth)" \
 # Server asks client for authentication with certificate request message,
 # client responds with empty certificate
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL
+requires_config_enabled MBEDTLS_DEBUG_C
 run_test    "TLS 1.3, TLS_AES_128_GCM_SHA256, ECDHE-ECDSA, empty client certificate, accepted" \
             "$P_SRV debug_level=5 force_version=tls1_3 auth_mode=optional key_exchange_modes=ecdhe_ecdsa" \
             "$P_CLI debug_level=5 force_version=tls1_3 server_name=localhost force_ciphersuite=TLS_AES_128_GCM_SHA256 key_exchange_modes=ecdhe_ecdsa auth_mode=none" \
@@ -1298,6 +1299,7 @@ run_test    "TLS 1.3, TLS_AES_128_GCM_SHA256, ECDHE-ECDSA, empty client certific
 
 # - Server does NOT accept the lack of client authentication
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL
+requires_config_enabled MBEDTLS_DEBUG_C
 run_test    "TLS 1.3, TLS_AES_128_CCM_SHA256, ECDHE-ECDSA, empty client certificate, rejected" \
             "$P_SRV debug_level=5 force_version=tls1_3 auth_mode=required key_exchange_modes=ecdhe_ecdsa" \
             "$P_CLI debug_level=5 force_version=tls1_3 server_name=localhost force_ciphersuite=TLS_AES_128_CCM_SHA256 key_exchange_modes=ecdhe_ecdsa auth_mode=none" \
@@ -1325,6 +1327,7 @@ run_test    "TLS 1.3 TLS_AES_256_GCM_SHA384, ECDHE-ECDSA, SRV auth" \
 	    -c "EC key size       : 384 bits"
 
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL
+requires_config_enabled MBEDTLS_DEBUG_C
 run_test    "TLS 1.3, TLS_AES_128_CCM_SHA256, ECDHE-ECDSA, CLI+SRV auth, with ticket" \
             "$P_SRV debug_level=5 force_version=tls1_3 auth_mode=required key_exchange_modes=all tickets=1" \
             "$P_CLI debug_level=5 force_version=tls1_3 server_name=localhost force_ciphersuite=TLS_AES_128_CCM_SHA256 key_exchange_modes=ecdhe_ecdsa reconnect=1 tickets=1" \
@@ -1342,6 +1345,7 @@ run_test    "TLS 1.3, TLS_AES_128_CCM_SHA256, ECDHE-ECDSA, CLI+SRV auth, with ti
 	    -s "<= write new session ticket"
 
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL
+requires_config_enabled MBEDTLS_DEBUG_C
 run_test    "TLS 1.3, TLS_AES_128_GCM_SHA256, ECDHE-ECDSA, CLI+SRV auth, with ticket" \
             "$P_SRV debug_level=5 force_version=tls1_3 auth_mode=required key_exchange_modes=all tickets=1" \
             "$P_CLI debug_level=5 force_version=tls1_3 server_name=localhost force_ciphersuite=TLS_AES_128_GCM_SHA256 key_exchange_modes=ecdhe_ecdsa reconnect=1 tickets=1" \
@@ -1359,6 +1363,7 @@ run_test    "TLS 1.3, TLS_AES_128_GCM_SHA256, ECDHE-ECDSA, CLI+SRV auth, with ti
 	    -s "<= write new session ticket"
 
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL
+requires_config_enabled MBEDTLS_DEBUG_C
 run_test    "TLS 1.3, TLS_AES_128_CCM_8_SHA256, ECDHE-ECDSA, CLI+SRV auth, with ticket" \
             "$P_SRV debug_level=5 force_version=tls1_3 auth_mode=required key_exchange_modes=all tickets=1" \
             "$P_CLI debug_level=5 force_version=tls1_3 server_name=localhost force_ciphersuite=TLS_AES_128_CCM_8_SHA256 key_exchange_modes=ecdhe_ecdsa reconnect=1 tickets=1" \
@@ -1376,6 +1381,7 @@ run_test    "TLS 1.3, TLS_AES_128_CCM_8_SHA256, ECDHE-ECDSA, CLI+SRV auth, with 
 	    -s "<= write new session ticket"
 
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL
+requires_config_enabled MBEDTLS_DEBUG_C
 run_test    "TLS 1.3, TLS_AES_256_GCM_SHA384, ECDHE-ECDSA, CLI+SRV auth, with ticket" \
             "$P_SRV debug_level=5 force_version=tls1_3 auth_mode=required key_exchange_modes=all tickets=1" \
             "$P_CLI debug_level=5 force_version=tls1_3 server_name=localhost force_ciphersuite=TLS_AES_256_GCM_SHA384 key_exchange_modes=ecdhe_ecdsa reconnect=1 tickets=1" \
@@ -1393,6 +1399,7 @@ run_test    "TLS 1.3, TLS_AES_256_GCM_SHA384, ECDHE-ECDSA, CLI+SRV auth, with ti
 	    -s "<= write new session ticket"
 
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL
+requires_config_enabled MBEDTLS_DEBUG_C
 run_test    "TLS 1.3, TLS_AES_256_GCM_SHA384 with ECDHE-ECDSA (server auth only) with ticket" \
             "$P_SRV debug_level=5 force_version=tls1_3 key_exchange_modes=all tickets=1 ca_file=certs/ca.crt crt_file=certs/server.crt key_file=certs/server.key" \
             "$P_CLI debug_level=5 force_version=tls1_3 server_name=localhost force_ciphersuite=TLS_AES_256_GCM_SHA384 key_exchange_modes=ecdhe_ecdsa ca_file=certs/ca.crt crt_file=none key_file=none reconnect=1 tickets=1" \
@@ -1412,6 +1419,7 @@ run_test    "TLS 1.3, TLS_AES_256_GCM_SHA384 with ECDHE-ECDSA (server auth only)
 	    -s "<= write new session ticket"
 
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL
+requires_config_enabled MBEDTLS_DEBUG_C
 run_test    "TLS 1.3, TLS_AES_256_GCM_SHA384, ext PSK, early data" \
             "$P_SRV debug_level=5 force_version=tls1_3 early_data=1 key_exchange_modes=psk psk=010203 psk_identity=0a0b0c" \
             "$P_CLI debug_level=5 force_version=tls1_3 force_ciphersuite=TLS_AES_256_GCM_SHA384 key_exchange_modes=psk early_data=1 psk=010203 psk_identity=0a0b0c" \
@@ -1427,6 +1435,7 @@ run_test    "TLS 1.3, TLS_AES_256_GCM_SHA384, ext PSK, early data" \
 	    -s "<= parse end_of_early_data"
 
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL
+requires_config_enabled MBEDTLS_DEBUG_C
 run_test    "TLS 1.3, TLS_AES_128_CCM_SHA256, ext PSK, early data" \
             "$P_SRV debug_level=5 force_version=tls1_3 early_data=1 key_exchange_modes=psk psk=010203 psk_identity=0a0b0c" \
             "$P_CLI debug_level=5 force_version=tls1_3 force_ciphersuite=TLS_AES_128_CCM_SHA256 key_exchange_modes=psk early_data=1 psk=010203 psk_identity=0a0b0c" \
@@ -1442,6 +1451,7 @@ run_test    "TLS 1.3, TLS_AES_128_CCM_SHA256, ext PSK, early data" \
 	    -s "<= parse end_of_early_data"
 
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL
+requires_config_enabled MBEDTLS_DEBUG_C
 run_test    "TLS 1.3, TLS_AES_128_GCM_SHA256, ext PSK, early data" \
             "$P_SRV debug_level=5 force_version=tls1_3 early_data=1 key_exchange_modes=psk psk=010203 psk_identity=0a0b0c" \
             "$P_CLI debug_level=5 force_version=tls1_3 force_ciphersuite=TLS_AES_128_GCM_SHA256 key_exchange_modes=psk early_data=1 psk=010203 psk_identity=0a0b0c" \
@@ -1457,6 +1467,7 @@ run_test    "TLS 1.3, TLS_AES_128_GCM_SHA256, ext PSK, early data" \
 	    -s "<= parse end_of_early_data"
 
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL
+requires_config_enabled MBEDTLS_DEBUG_C
 run_test    "TLS 1.3, TLS_AES_128_CCM_8_SHA256, ext PSK, early data" \
             "$P_SRV debug_level=5 force_version=tls1_3 early_data=1 key_exchange_modes=psk psk=010203 psk_identity=0a0b0c" \
             "$P_CLI debug_level=5 force_version=tls1_3 force_ciphersuite=TLS_AES_128_CCM_8_SHA256 key_exchange_modes=psk early_data=1 psk=010203 psk_identity=0a0b0c" \
@@ -1472,6 +1483,7 @@ run_test    "TLS 1.3, TLS_AES_128_CCM_8_SHA256, ext PSK, early data" \
 	    -s "<= parse end_of_early_data"
 
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL
+requires_config_enabled MBEDTLS_DEBUG_C
 run_test    "TLS 1.3, TLS_AES_128_CCM_8_SHA256, ECDHE-ECDSA, CLI+SRV auth, HRR enforcing cookie" \
             "$P_SRV debug_level=5 force_version=tls1_3 auth_mode=required key_exchange_modes=ecdhe_ecdsa tickets=0 cookies=2" \
             "$P_CLI debug_level=5 force_version=tls1_3 server_name=localhost force_ciphersuite=TLS_AES_128_CCM_8_SHA256 key_exchange_modes=ecdhe_ecdsa" \
@@ -1489,6 +1501,7 @@ run_test    "TLS 1.3, TLS_AES_128_CCM_8_SHA256, ECDHE-ECDSA, CLI+SRV auth, HRR e
 
 # configure client to initially sent incorrect group, which will be corrected with HRR from the server
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL
+requires_config_enabled MBEDTLS_DEBUG_C
 run_test    "TLS 1.3, TLS_AES_128_CCM_SHA256 with ECDHE-ECDSA, SRV auth, HRR enforcing group" \
             "$P_SRV debug_level=5 force_version=tls1_3 key_exchange_modes=ecdhe_ecdsa named_groups=secp256r1 cookies=1 tickets=0" \
             "$P_CLI debug_level=5 force_version=tls1_3 server_name=localhost force_ciphersuite=TLS_AES_128_CCM_SHA256 key_exchange_modes=ecdhe_ecdsa named_groups=secp256r1,secp384r1 key_share_named_groups=secp384r1" \


### PR DESCRIPTION
This PR continues #44, ultimately allowing to build and run the prototype with address sanitizer enabled (`cmake -D CMAKE_BUILD_TYPE=ASanDbg`).