### PR TITLE
Fix deprecated calls to hash API

### DIFF
--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -2936,6 +2936,7 @@ void mbedtls_ssl_reset_checksum( mbedtls_ssl_context *ssl )
 static void ssl_update_checksum_start( mbedtls_ssl_context *ssl,
                                        const unsigned char *buf, size_t len )
 {
+    int ret = 0;
 
 #if defined(MBEDTLS_SHA256_C)
 #if defined(MBEDTLS_SSL_DEBUG_HANDSHAKE_HASHES)
@@ -2965,14 +2966,26 @@ static void ssl_update_checksum_start( mbedtls_ssl_context *ssl,
 #if defined(MBEDTLS_SHA256_C)
             MBEDTLS_SSL_DEBUG_BUF( 4, "Transcript state ( before )", ( unsigned char* )
                 ssl->handshake->fin_sha256.state, 32 );
-            mbedtls_sha256_update( &ssl->handshake->fin_sha256, buf, len );
+            if( ( ret = mbedtls_sha256_update_ret( &ssl->handshake->fin_sha256,
+                                                   buf,
+                                                   len ) ) != 0 )
+            {
+                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha256_update_ret", ret );
+                goto exit;
+            }
             MBEDTLS_SSL_DEBUG_BUF( 4, "Input to handshake hash", buf, len );
             MBEDTLS_SSL_DEBUG_BUF( 4, "Transcript state ( after )", ( unsigned char* )
                 ssl->handshake->fin_sha256.state, 32 );
 #if defined(MBEDTLS_SSL_DEBUG_HANDSHAKE_HASHES)
             mbedtls_sha256_init( &sha256_debug );
             mbedtls_sha256_clone( &sha256_debug, &ssl->handshake->fin_sha256 );
-            mbedtls_sha256_finish( &sha256_debug, padbuf );
+
+            if( ( ret = mbedtls_sha256_finish_ret( &sha256_debug,
+                                                   padbuf ) ) != 0 )
+            {
+                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha256_finish_ret", ret );
+                goto exit;
+            }
             MBEDTLS_SSL_DEBUG_BUF( 4, "Handshake hash", ( unsigned char* )
                 padbuf, 32 );
 #endif // MBEDTLS_SSL_DEBUG_HANDSHAKE_HASHES
@@ -2985,16 +2998,35 @@ static void ssl_update_checksum_start( mbedtls_ssl_context *ssl,
 #if defined(MBEDTLS_SHA512_C)
             MBEDTLS_SSL_DEBUG_BUF( 4, "Transcript state ( before )", ( unsigned char* )
                 ssl->handshake->fin_sha512.state, 48 );
-            mbedtls_sha512_update( &ssl->handshake->fin_sha512, buf, len );
+            if( ( ret = mbedtls_sha512_update_ret( &ssl->handshake->fin_sha512,
+                                                   buf,
+                                                   len ) ) != 0 )
+            {
+                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha512_update_ret", ret );
+                goto exit;
+            }
             MBEDTLS_SSL_DEBUG_BUF( 4, "Input to handshake hash", buf, len );
             MBEDTLS_SSL_DEBUG_BUF( 4, "Transcript state ( after )", ( unsigned char* )
                 ssl->handshake->fin_sha512.state, 48 );
 
 #if defined(MBEDTLS_SSL_DEBUG_HANDSHAKE_HASHES)
             mbedtls_sha512_init( &sha512_debug );
-            mbedtls_sha512_starts( &sha512_debug, 1 /* = use SHA384 */ );
+
+            if( ( ret = mbedtls_sha512_starts_ret( &sha512_debug,
+                                                   1 ) ) != 0 )
+            {
+                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha512_starts_ret", ret );
+                goto exit;
+            }
+
             mbedtls_sha512_clone( &sha512_debug, &ssl->handshake->fin_sha512 );
-            mbedtls_sha512_finish( &sha512_debug, padbuf );
+
+            if( ( ret = mbedtls_sha512_finish_ret( &sha512_debug,
+                                                   padbuf ) ) != 0 )
+            {
+                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha512_finish_ret", ret );
+                goto exit;
+            }
             MBEDTLS_SSL_DEBUG_BUF( 4, "Handshake hash", ( unsigned char* )
                 padbuf, 48 );
 #endif // MBEDTLS_SSL_DEBUG_HANDSHAKE_HASHES
@@ -3013,7 +3045,13 @@ static void ssl_update_checksum_start( mbedtls_ssl_context *ssl,
 #if defined(MBEDTLS_SHA256_C)
         MBEDTLS_SSL_DEBUG_BUF( 4, "Transcript state ( before )", ( unsigned char* )
             ssl->handshake->fin_sha256.state, 32 );
-        mbedtls_sha256_update( &ssl->handshake->fin_sha256, buf, len );
+        if( ( ret = mbedtls_sha256_update_ret( &ssl->handshake->fin_sha256,
+                                               buf,
+                                               len ) ) != 0 )
+        {
+            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha256_update_ret", ret );
+            goto exit;
+        }
         MBEDTLS_SSL_DEBUG_BUF( 4, "Input to handshake hash", buf, len );
         MBEDTLS_SSL_DEBUG_BUF( 4, "Transcript state ( after )", ( unsigned char* )
             ssl->handshake->fin_sha256.state, 32 );
@@ -3021,7 +3059,13 @@ static void ssl_update_checksum_start( mbedtls_ssl_context *ssl,
 #if defined(MBEDTLS_SSL_DEBUG_HANDSHAKE_HASHES)
         mbedtls_sha256_init( &sha256_debug );
         mbedtls_sha256_clone( &sha256_debug, &ssl->handshake->fin_sha256 );
-        mbedtls_sha256_finish( &sha256_debug, padbuf );
+
+        if( ( ret = mbedtls_sha256_finish_ret( &sha256_debug,
+                                               padbuf ) ) != 0 )
+        {
+            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha256_finish_ret", ret );
+            goto exit;
+        }
         MBEDTLS_SSL_DEBUG_BUF( 4, "Handshake hash", ( unsigned char* )
             padbuf, 32 );
 #endif // MBEDTLS_SSL_DEBUG_HANDSHAKE_HASHES
@@ -3030,21 +3074,62 @@ static void ssl_update_checksum_start( mbedtls_ssl_context *ssl,
 #if defined(MBEDTLS_SHA512_C)
         MBEDTLS_SSL_DEBUG_BUF( 4, "Transcript state ( before )", ( unsigned char* )
             ssl->handshake->fin_sha512.state, 48 );
-        mbedtls_sha512_update( &ssl->handshake->fin_sha512, buf, len );
+        if( ( ret = mbedtls_sha512_update_ret( &ssl->handshake->fin_sha512,
+                                               buf,
+                                               len ) ) != 0 )
+        {
+            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha512_update_ret", ret );
+            goto exit;
+        }
         MBEDTLS_SSL_DEBUG_BUF( 4, "Input to handshake hash", buf, len );
         MBEDTLS_SSL_DEBUG_BUF( 4, "Transcript state ( after )", ( unsigned char* )
             ssl->handshake->fin_sha512.state, 48 );
 
 #if defined(MBEDTLS_SSL_DEBUG_HANDSHAKE_HASHES)
         mbedtls_sha512_init( &sha512_debug );
-        mbedtls_sha512_starts( &sha512_debug, 1 /* = use SHA384 */ );
+
+        if( ( ret = mbedtls_sha512_starts_ret( &sha512_debug,
+                                               1 ) ) != 0 )
+        {
+            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha512_starts_ret", ret );
+            goto exit;
+        }
+
         mbedtls_sha512_clone( &sha512_debug, &ssl->handshake->fin_sha512 );
-        mbedtls_sha512_finish( &sha512_debug, padbuf );
+
+        if( ( ret = mbedtls_sha512_finish_ret( &sha512_debug,
+                                               padbuf ) ) != 0 )
+        {
+            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha512_finish_ret", ret );
+            goto exit;
+        }
         MBEDTLS_SSL_DEBUG_BUF( 4, "Handshake hash", ( unsigned char* )
             padbuf, 48 );
 #endif // MBEDTLS_SSL_DEBUG_HANDSHAKE_HASHES
 #endif /* MBEDTLS_SHA512_C */
     }
+
+exit:;
+#if defined(MBEDTLS_SSL_DEBUG_HANDSHAKE_HASHES)
+#if defined(MBEDTLS_SHA256_C)
+    if( suite_info->mac == MBEDTLS_MD_SHA256 )
+    {
+        mbedtls_sha256_free( &sha256_debug );
+    }
+    else
+#endif
+#if defined(MBEDTLS_SHA512_C)
+    if( suite_info->mac == MBEDTLS_MD_SHA384 )
+    {
+        mbedtls_sha512_free( &sha512_debug );
+    }
+    else
+#endif
+    {
+        MBEDTLS_SSL_DEBUG_MSG( 1, ( "ssl_update_checksum_start: Unknow hash function." ) );
+        return;
+    }
+#endif /* MBEDTLS_SSL_DEBUG_HANDSHAKE_HASHES */
 }
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 
@@ -3140,13 +3225,21 @@ static void ssl_update_checksum_sha384( mbedtls_ssl_context *ssl,
 static void ssl_update_checksum_sha256( mbedtls_ssl_context* ssl,
     const unsigned char* buf, size_t len )
 {
+    int ret = 0;
+
 #if defined(MBEDTLS_SSL_DEBUG_HANDSHAKE_HASHES)
     mbedtls_sha256_context sha256;
     unsigned char padbuf[32];
 
 #endif /* MBEDTLS_SSL_DEBUG_HANDSHAKE_HASHES */
 
-    mbedtls_sha256_update( &ssl->handshake->fin_sha256, buf, len );
+    if( ( ret = mbedtls_sha256_update_ret( &ssl->handshake->fin_sha256,
+                                           buf,
+                                           len ) ) != 0 )
+    {
+        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha256_update_ret", ret );
+        goto exit;
+    }
     MBEDTLS_SSL_DEBUG_BUF( 4, "Input to handshake hash", buf, len );
     MBEDTLS_SSL_DEBUG_BUF( 4, "Transcript state", ( unsigned char* )
         ssl->handshake->fin_sha256.state, 32 );
@@ -3154,12 +3247,22 @@ static void ssl_update_checksum_sha256( mbedtls_ssl_context* ssl,
 #if defined(MBEDTLS_SSL_DEBUG_HANDSHAKE_HASHES)
     mbedtls_sha256_init( &sha256 );
     mbedtls_sha256_clone( &sha256, &ssl->handshake->fin_sha256 );
-    mbedtls_sha256_finish( &sha256, padbuf );
 
+    if( ( ret = mbedtls_sha256_finish_ret( &sha256,
+                                           padbuf ) ) != 0 )
+    {
+        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha256_finish_ret", ret );
+        goto exit;
+    }
     MBEDTLS_SSL_DEBUG_BUF( 4, "Handshake hash", ( unsigned char* )
         padbuf, 32 );
 #endif /* MBEDTLS_SSL_DEBUG_HANDSHAKE_HASHES */
 
+
+exit:;
+#if defined(MBEDTLS_SSL_DEBUG_HANDSHAKE_HASHES)
+    mbedtls_sha256_free( &sha256 );
+#endif /* MBEDTLS_SSL_DEBUG_HANDSHAKE_HASHES */
 }
 #endif /* MBEDTLS_SHA256_C */
 
@@ -3167,26 +3270,47 @@ static void ssl_update_checksum_sha256( mbedtls_ssl_context* ssl,
 static void ssl_update_checksum_sha384( mbedtls_ssl_context* ssl,
     const unsigned char* buf, size_t len )
 {
+    int ret = 0;
 
 #if defined(MBEDTLS_SSL_DEBUG_HANDSHAKE_HASHES)
     mbedtls_sha512_context sha512;
     unsigned char padbuf[48];
 #endif /* MBEDTLS_SSL_DEBUG_HANDSHAKE_HASHES */
 
-    mbedtls_sha512_update( &ssl->handshake->fin_sha512, buf, len );
+    if( ( ret = mbedtls_sha512_update_ret( &ssl->handshake->fin_sha512,
+                                           buf,
+                                           len ) ) != 0 )
+    {
+        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha512_update_ret", ret );
+        goto exit;
+    }
     MBEDTLS_SSL_DEBUG_BUF( 4, "Input to handshake hash", buf, len );
     MBEDTLS_SSL_DEBUG_BUF( 4, "Transcript hash", ( unsigned char* )
         ssl->handshake->fin_sha512.state, 48 );
 
 #if defined(MBEDTLS_SSL_DEBUG_HANDSHAKE_HASHES)
     mbedtls_sha512_init( &sha512 );
-    mbedtls_sha512_starts( &sha512, 1 /* = use SHA384 */ );
-    mbedtls_sha512_clone( &sha512, &ssl->handshake->fin_sha512 );
-    mbedtls_sha512_finish( &sha512, padbuf );
 
+    if( ( ret = mbedtls_sha512_starts_ret( &sha512, 1 ) ) != 0 )
+    {
+        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha512_starts_ret", ret );
+        goto exit;
+    }
+
+    mbedtls_sha512_clone( &sha512, &ssl->handshake->fin_sha512 );
+
+    if( ( ret = mbedtls_sha512_finish_ret( &sha512, padbuf ) ) != 0 )
+    {
+        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha512_finish_ret", ret );
+        goto exit;
+    }
     MBEDTLS_SSL_DEBUG_BUF( 4, "Handshake hash", ( unsigned char* )padbuf, 48 );
 #endif /* MBEDTLS_SSL_DEBUG_HANDSHAKE_HASHES */
 
+exit:;
+#if defined(MBEDTLS_SSL_DEBUG_HANDSHAKE_HASHES)
+    mbedtls_sha512_free( &sha512);
+#endif /* MBEDTLS_SSL_DEBUG_HANDSHAKE_HASHES */
 }
 #endif /* MBEDTLS_SHA512_C */
 

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -819,15 +819,32 @@ int mbedtls_ssl_create_binder( mbedtls_ssl_context *ssl, unsigned char *psk, siz
     if( suite_info->mac == MBEDTLS_MD_SHA256 )
     {
 #if defined(MBEDTLS_SHA256_C)
-
         mbedtls_sha256_init( &sha256 );
-        mbedtls_sha256_starts( &sha256, 0 /* = use SHA256 */ );
+
+        if( ( ret = mbedtls_sha256_starts_ret( &sha256, 0 ) ) != 0 )
+        {
+            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha256_starts_ret", ret );
+            goto exit;
+        }
+        MBEDTLS_SSL_DEBUG_BUF( 5, "finished sha256 state",
+                               (unsigned char *) sha256.state,
+                               sizeof( sha256.state ) );
+
         /* TBD: Should we clone the hash? */
         /*		mbedtls_sha256_clone( &sha256, &ssl->handshake->fin_sha256 ); */
-        MBEDTLS_SSL_DEBUG_BUF( 5, "finished sha256 state", ( unsigned char * )sha256.state, sizeof( sha256.state ) );
-        mbedtls_sha256_update( &sha256, buffer, blen );
+
         MBEDTLS_SSL_DEBUG_BUF( 5, "input buffer for psk binder", buffer, blen );
-        mbedtls_sha256_finish( &sha256, padbuf );
+        if( ( ret = mbedtls_sha256_update_ret( &sha256, buffer, blen ) ) != 0 )
+        {
+            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha256_update_ret", ret );
+            goto exit;
+        }
+
+        if( ( ret = mbedtls_sha256_finish_ret( &sha256, padbuf ) ) != 0 )
+        {
+            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha256_finish_ret", ret );
+            goto exit;
+        }
         MBEDTLS_SSL_DEBUG_BUF( 5, "handshake hash for psk binder", padbuf, 32 );
 #else
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "mbedtls_ssl_tls1_3_derive_master_secret: Unknow hash function." ) );
@@ -838,21 +855,55 @@ int mbedtls_ssl_create_binder( mbedtls_ssl_context *ssl, unsigned char *psk, siz
     {
 #if defined(MBEDTLS_SHA512_C)
         mbedtls_sha512_init( &sha512 );
-        mbedtls_sha512_starts( &sha512, 1 /* = use SHA384 */ );
+
+        if( ( ret = mbedtls_sha512_starts_ret( &sha512, 1 ) ) != 0 )
+        {
+            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha512_starts_ret", ret );
+            goto exit;
+        }
+        MBEDTLS_SSL_DEBUG_BUF( 5, "finished sha384 state", ( unsigned char * )sha512.state, 48 );
+
         mbedtls_sha512_clone( &sha512, &ssl->handshake->fin_sha512 );
-        MBEDTLS_SSL_DEBUG_BUF( 4, "finished sha384 state", ( unsigned char * )sha512.state, 48 );
-        mbedtls_sha512_update( &sha512, buffer, blen );
-        mbedtls_sha512_finish( &sha512, padbuf );
+
+        MBEDTLS_SSL_DEBUG_BUF( 5, "input buffer for psk binder", buffer, blen );
+        if( ( ret = mbedtls_sha512_update_ret( &sha512, buffer, blen ) ) != 0 )
+        {
+            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha512_update_ret", ret );
+            goto exit;
+        }
+
+        if( ( ret = mbedtls_sha512_finish_ret( &sha512, padbuf ) ) != 0 )
+        {
+            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha512_finish_ret", ret );
+            goto exit;
+        }
         MBEDTLS_SSL_DEBUG_BUF( 5, "handshake hash for psk binder", padbuf, 48 );
     }
     else if( suite_info->mac == MBEDTLS_MD_SHA512 )
     {
         mbedtls_sha512_init( &sha512 );
-        mbedtls_sha512_starts( &sha512, 0 /* = use SHA512 */ );
+
+        if( ( ret = mbedtls_sha512_starts_ret( &sha512, 0 ) ) != 0 )
+        {
+            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha512_starts_ret", ret );
+            goto exit;
+        }
+        MBEDTLS_SSL_DEBUG_BUF( 5, "finished sha512state", ( unsigned char * )sha512.state, 64 );
+
         mbedtls_sha512_clone( &sha512, &ssl->handshake->fin_sha512 );
-        MBEDTLS_SSL_DEBUG_BUF( 4, "finished sha512 state", ( unsigned char * )sha512.state, 64 );
-        mbedtls_sha512_update( &sha512, buffer, blen );
-        mbedtls_sha512_finish( &sha512, padbuf );
+
+        MBEDTLS_SSL_DEBUG_BUF( 5, "input buffer for psk binder", buffer, blen );
+        if( ( ret = mbedtls_sha512_update_ret( &sha512, buffer, blen ) ) != 0 )
+        {
+            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha512_update_ret", ret );
+            goto exit;
+        }
+
+        if( ( ret = mbedtls_sha512_finish_ret( &sha512, padbuf ) ) != 0 )
+        {
+            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha512_finish_ret", ret );
+            goto exit;
+        }
         MBEDTLS_SSL_DEBUG_BUF( 5, "handshake hash for psk binder", padbuf, 64 );
     }
     else
@@ -880,7 +931,7 @@ int mbedtls_ssl_create_binder( mbedtls_ssl_context *ssl, unsigned char *psk, siz
     if( ret != 0 )
     {
         MBEDTLS_SSL_DEBUG_RET( 2, "Creating the finished_key failed", ret );
-        return( ret );
+        goto exit;
     }
 
     MBEDTLS_SSL_DEBUG_BUF( 3, "finished_key", finished_key, hash_length );
@@ -891,7 +942,7 @@ int mbedtls_ssl_create_binder( mbedtls_ssl_context *ssl, unsigned char *psk, siz
     if( ret != 0 )
     {
         MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_md_hmac", ret );
-        return( ret );
+        goto exit;
     }
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "verify_data of psk binder" ) );
@@ -899,6 +950,7 @@ int mbedtls_ssl_create_binder( mbedtls_ssl_context *ssl, unsigned char *psk, siz
     MBEDTLS_SSL_DEBUG_BUF( 3, "Key", finished_key, hash_length );
     MBEDTLS_SSL_DEBUG_BUF( 3, "Output", result, hash_length );
 
+exit:
 #if defined(MBEDTLS_SHA256_C)
     if( suite_info->mac == MBEDTLS_MD_SHA256 )
     {
@@ -907,16 +959,17 @@ int mbedtls_ssl_create_binder( mbedtls_ssl_context *ssl, unsigned char *psk, siz
     else
 #endif
 #if defined(MBEDTLS_SHA512_C)
-        if( suite_info->mac == MBEDTLS_MD_SHA384 )
-        {
-            mbedtls_sha512_free( &sha512 );
-        }
-        else
+    if( suite_info->mac == MBEDTLS_MD_SHA384 ||
+        suite_info->mac == MBEDTLS_MD_SHA512 )
+    {
+        mbedtls_sha512_free( &sha512 );
+    }
+    else
 #endif
-        {
-            MBEDTLS_SSL_DEBUG_MSG( 1, ( "mbedtls_ssl_tls1_3_derive_master_secret: Unknow hash function." ) );
-            return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
-        }
+    {
+        MBEDTLS_SSL_DEBUG_MSG( 1, ( "mbedtls_ssl_tls1_3_derive_master_secret: Unknow hash function." ) );
+        return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
+    }
 
     mbedtls_platform_zeroize( finished_key, hash_length );
 
@@ -3693,6 +3746,7 @@ static int ssl_hrr_postprocess( mbedtls_ssl_context* ssl,
                                 const unsigned char* orig_buf,
                                 size_t orig_msg_len )
 {
+    int ret = 0;
     unsigned char transcript[MBEDTLS_MD_MAX_SIZE + 4]; /* used to store the ClientHello1 msg */
     int hash_length;
 
@@ -3743,12 +3797,22 @@ static int ssl_hrr_postprocess( mbedtls_ssl_context* ssl,
     if( ssl->handshake->ciphersuite_info->mac == MBEDTLS_MD_SHA256 )
     {
 #if defined(MBEDTLS_SHA256_C)
-        mbedtls_sha256_finish( &ssl->handshake->fin_sha256, &transcript[4] );
+        if( ( ret = mbedtls_sha256_finish_ret( &ssl->handshake->fin_sha256,
+                                               &transcript[4]) ) != 0 )
+        {
+            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha256_finish_ret", ret );
+            goto exit;
+        }
         MBEDTLS_SSL_DEBUG_BUF( 5, "Transcript-Hash( ClientHello1, HelloRetryRequest, ... MN )", &transcript[0], 32 + 4 );
 
         /* reset transcript */
         mbedtls_sha256_init( &ssl->handshake->fin_sha256 );
-        mbedtls_sha256_starts( &ssl->handshake->fin_sha256, 0 /* = use SHA256 */ );
+        if( ( ret = mbedtls_sha256_starts_ret( &ssl->handshake->fin_sha256,
+                                               0 ) ) != 0 )
+        {
+            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha256_starts_ret", ret );
+            goto exit;
+        }
         /*mbedtls_sha256_update( &ssl->handshake->fin_sha256, &transcript[0], hash_length + 4 ); */
 #else
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "mbedtls_ssl_tls1_3_derive_master_secret: Unknow hash function." ) );
@@ -3758,12 +3822,22 @@ static int ssl_hrr_postprocess( mbedtls_ssl_context* ssl,
     else if( ssl->handshake->ciphersuite_info->mac == MBEDTLS_MD_SHA384 )
     {
 #if defined(MBEDTLS_SHA512_C)
-        mbedtls_sha512_finish( &ssl->handshake->fin_sha512, &transcript[4] );
+        if( ( ret = mbedtls_sha512_finish_ret( &ssl->handshake->fin_sha512,
+                                               &transcript[4]) ) != 0 )
+        {
+            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha512_finish_ret", ret );
+            goto exit;
+        }
         MBEDTLS_SSL_DEBUG_BUF( 5, "Transcript-Hash( ClientHello1, HelloRetryRequest, ... MN )", &transcript[0], 48 + 4 );
 
         /* reset transcript */
         mbedtls_sha512_init( &ssl->handshake->fin_sha512 );
-        mbedtls_sha512_starts( &ssl->handshake->fin_sha512, 1 /* = use SHA384 */ );
+        if( ( ret = mbedtls_sha512_starts_ret( &ssl->handshake->fin_sha512,
+                                               1 ) ) != 0 )
+        {
+            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha512_starts_ret", ret );
+            goto exit;
+        }
         /*mbedtls_sha256_update( &ssl->handshake->fin_sha512, &transcript[0], hash_length + 4 ); */
 #else
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "mbedtls_ssl_tls1_3_derive_master_secret: Unknow hash function." ) );
@@ -3773,12 +3847,22 @@ static int ssl_hrr_postprocess( mbedtls_ssl_context* ssl,
     else if( ssl->handshake->ciphersuite_info->mac == MBEDTLS_MD_SHA512 )
     {
 #if defined(MBEDTLS_SHA512_C)
-        mbedtls_sha512_finish( &ssl->handshake->fin_sha512, &transcript[4] );
+        if( ( ret = mbedtls_sha512_finish_ret( &ssl->handshake->fin_sha512,
+                                               &transcript[4]) ) != 0 )
+        {
+            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha512_finish_ret", ret );
+            goto exit;
+        }
         MBEDTLS_SSL_DEBUG_BUF( 5, "Transcript-Hash( ClientHello1, HelloRetryRequest, ... MN )", &transcript[0], 64 + 4 );
 
         /* reset transcript */
         mbedtls_sha512_init( &ssl->handshake->fin_sha512 );
-        mbedtls_sha512_starts( &ssl->handshake->fin_sha512, 0 /* = use SHA512 */ );
+        if( ( ret = mbedtls_sha512_starts_ret( &ssl->handshake->fin_sha512,
+                                               0 ) ) != 0 )
+        {
+            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha512_starts_ret", ret );
+            goto exit;
+        }
         /*mbedtls_sha256_update( &ssl->handshake->fin_sha512, &transcript[0], hash_length + 4 ); */
     }
     else
@@ -3797,7 +3881,29 @@ static int ssl_hrr_postprocess( mbedtls_ssl_context* ssl,
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
     mbedtls_ssl_recv_flight_completed( ssl );
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
-    return( 0 );
+
+exit:
+#if defined(MBEDTLS_SHA256_C)
+    if( ssl->transform_negotiate->ciphersuite_info->mac == MBEDTLS_MD_SHA256 )
+    {
+        mbedtls_sha256_free( &ssl->handshake->fin_sha256 );
+    }
+    else
+#endif
+#if defined(MBEDTLS_SHA512_C)
+    if( ssl->transform_negotiate->ciphersuite_info->mac == MBEDTLS_MD_SHA384 ||
+        ssl->transform_negotiate->ciphersuite_info->mac == MBEDTLS_MD_SHA512 )
+    {
+        mbedtls_sha512_free( &ssl->handshake->fin_sha512 );
+    }
+    else
+#endif
+    {
+        MBEDTLS_SSL_DEBUG_MSG( 1, ( "mbedtls_ssl_tls1_3_derive_master_secret: Unknow hash function." ) );
+        return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
+    }
+
+    return( ret );
 }
 
 

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -3884,15 +3884,15 @@ static int ssl_hrr_postprocess( mbedtls_ssl_context* ssl,
 
 exit:
 #if defined(MBEDTLS_SHA256_C)
-    if( ssl->transform_negotiate->ciphersuite_info->mac == MBEDTLS_MD_SHA256 )
+    if( ssl->handshake->ciphersuite_info->mac == MBEDTLS_MD_SHA256 )
     {
         mbedtls_sha256_free( &ssl->handshake->fin_sha256 );
     }
     else
 #endif
 #if defined(MBEDTLS_SHA512_C)
-    if( ssl->transform_negotiate->ciphersuite_info->mac == MBEDTLS_MD_SHA384 ||
-        ssl->transform_negotiate->ciphersuite_info->mac == MBEDTLS_MD_SHA512 )
+    if( ssl->handshake->ciphersuite_info->mac == MBEDTLS_MD_SHA384 ||
+        ssl->handshake->ciphersuite_info->mac == MBEDTLS_MD_SHA512 )
     {
         mbedtls_sha512_free( &ssl->handshake->fin_sha512 );
     }

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -3883,26 +3883,6 @@ static int ssl_hrr_postprocess( mbedtls_ssl_context* ssl,
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
 
 exit:
-#if defined(MBEDTLS_SHA256_C)
-    if( ssl->handshake->ciphersuite_info->mac == MBEDTLS_MD_SHA256 )
-    {
-        mbedtls_sha256_free( &ssl->handshake->fin_sha256 );
-    }
-    else
-#endif
-#if defined(MBEDTLS_SHA512_C)
-    if( ssl->handshake->ciphersuite_info->mac == MBEDTLS_MD_SHA384 ||
-        ssl->handshake->ciphersuite_info->mac == MBEDTLS_MD_SHA512 )
-    {
-        mbedtls_sha512_free( &ssl->handshake->fin_sha512 );
-    }
-    else
-#endif
-    {
-        MBEDTLS_SSL_DEBUG_MSG( 1, ( "mbedtls_ssl_tls1_3_derive_master_secret: Unknow hash function." ) );
-        return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
-    }
-
     return( ret );
 }
 

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -1895,7 +1895,7 @@ static int ssl_certificate_verify_write( mbedtls_ssl_context* ssl,
     buf[4] = (unsigned char)( ( ssl->handshake->signature_scheme >> 8 ) & 0xFF );
     buf[5] = (unsigned char)( ( ssl->handshake->signature_scheme ) & 0xFF );
 
-    /* Info from ssl->transform_negotiate->ciphersuite_info->mac will be used instead */
+    /* Info from ssl->handshake->ciphersuite_info->mac will be used instead */
     hashlen = 0;
     offset = 2;
 
@@ -3534,7 +3534,7 @@ int mbedtls_ssl_early_data_key_derivation( mbedtls_ssl_context *ssl, mbedtls_ssl
 
     if( ssl->handshake->ciphersuite_info == NULL )
     {
-        MBEDTLS_SSL_DEBUG_MSG( 1, ( "transform_negotiate->ciphersuite_info == NULL, mbedtls_ssl_early_data_key_derivation failed" ) );
+        MBEDTLS_SSL_DEBUG_MSG( 1, ( "handshake->ciphersuite_info == NULL, mbedtls_ssl_early_data_key_derivation failed" ) );
         return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
     }
 
@@ -4033,7 +4033,8 @@ static int ssl_finished_out_postprocess( mbedtls_ssl_context* ssl )
     int ret;
     mbedtls_ssl_key_set* traffic_keys = ssl->handshake->state_local.finished_out.traffic_keys;
 #if defined(MBEDTLS_SSL_SRV_C)
-    const mbedtls_ssl_ciphersuite_t *suite_info;
+    const mbedtls_ssl_ciphersuite_t *suite_info =
+        mbedtls_ssl_ciphersuite_from_id( ssl->session_negotiate->ciphersuite );
     const mbedtls_cipher_info_t *cipher_info;
 
 #if defined(MBEDTLS_SHA256_C)
@@ -4116,7 +4117,6 @@ static int ssl_finished_out_postprocess( mbedtls_ssl_context* ssl )
             return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
         }
 
-        suite_info = mbedtls_ssl_ciphersuite_from_id( ssl->session_negotiate->ciphersuite );
         if( suite_info == NULL )
         {
             MBEDTLS_SSL_DEBUG_MSG( 1, ( "mbedtls_ssl_ciphersuite_from_id in mbedtls_ssl_derive_traffic_keys failed" ) );
@@ -4173,7 +4173,6 @@ static int ssl_finished_out_postprocess( mbedtls_ssl_context* ssl )
 #endif /* MBEDTLS_SHA512_C */
         }
     }
-#endif /* MBEDTLS_SSL_SRV_C */
 
 exit:
 #if defined(MBEDTLS_SHA256_C)
@@ -4194,6 +4193,7 @@ exit:
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "mbedtls_ssl_tls1_3_derive_master_secret: Unknow hash function." ) );
         return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
     }
+#endif /* MBEDTLS_SSL_SRV_C */
 
     return( ret );
 }
@@ -4362,7 +4362,8 @@ static int ssl_finished_in_postprocess( mbedtls_ssl_context* ssl )
 	int ret = 0;
 
 #if defined(MBEDTLS_SSL_CLI_C)
-    const mbedtls_ssl_ciphersuite_t *suite_info;
+    const mbedtls_ssl_ciphersuite_t *suite_info =
+        mbedtls_ssl_ciphersuite_from_id( ssl->session_negotiate->ciphersuite );
     const mbedtls_cipher_info_t *cipher_info;
 
 #if defined(MBEDTLS_SHA256_C)
@@ -4387,7 +4388,6 @@ static int ssl_finished_in_postprocess( mbedtls_ssl_context* ssl )
             return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
         }
 
-        suite_info = mbedtls_ssl_ciphersuite_from_id( ssl->session_negotiate->ciphersuite );
         if( suite_info == NULL )
         {
             MBEDTLS_SSL_DEBUG_MSG( 1, ( "mbedtls_ssl_ciphersuite_from_id in mbedtls_ssl_derive_traffic_keys failed" ) );
@@ -4447,7 +4447,6 @@ static int ssl_finished_in_postprocess( mbedtls_ssl_context* ssl )
         }
 
     }
-#endif /* MBEDTLS_SSL_CLI_C */
 
 exit:
 #if defined(MBEDTLS_SHA256_C)
@@ -4468,6 +4467,7 @@ exit:
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "mbedtls_ssl_tls1_3_derive_master_secret: Unknow hash function." ) );
         return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
     }
+#endif /* MBEDTLS_SSL_CLI_C */
 
     return( ret );
 }

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -183,7 +183,11 @@ static int ssl_calc_finished_tls_sha256(
       #endif
     */
 
-    mbedtls_sha256_finish( &sha256, padbuf );
+    if( ( ret = mbedtls_sha256_finish_ret( &sha256, padbuf ) ) != 0 )
+    {
+        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha256_finish_ret", ret );
+        goto exit;
+    }
 
     MBEDTLS_SSL_DEBUG_BUF( 5, "handshake hash", padbuf, 32 );
 
@@ -222,7 +226,7 @@ static int ssl_calc_finished_tls_sha256(
     if( ret != 0 )
     {
         MBEDTLS_SSL_DEBUG_RET( 2, "Creating the client_finished_key failed", ret );
-        return ( ret );
+        goto exit;
     }
 
     MBEDTLS_SSL_DEBUG_BUF( 3, "client_finished_key", ssl->handshake->client_finished_key, 32 );
@@ -237,7 +241,7 @@ static int ssl_calc_finished_tls_sha256(
     if( ret != 0 )
     {
         MBEDTLS_SSL_DEBUG_RET( 2, "Creating the server_finished_key failed", ret );
-        return ( ret );
+        goto exit;
     }
 
     MBEDTLS_SSL_DEBUG_BUF( 3, "server_finished_key", ssl->handshake->server_finished_key, 32 );
@@ -267,7 +271,7 @@ static int ssl_calc_finished_tls_sha256(
     if( ret != 0 )
     {
         MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_md_hmac", ret );
-        return ( ret );
+        goto exit;
     }
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "verify_data of Finished message" ) );
@@ -275,11 +279,12 @@ static int ssl_calc_finished_tls_sha256(
     MBEDTLS_SSL_DEBUG_BUF( 3, "Key", finished_key, 32 );
     MBEDTLS_SSL_DEBUG_BUF( 3, "Output", buf, 32 );
 
+exit:
     mbedtls_sha256_free( &sha256 );
     mbedtls_platform_zeroize( padbuf, sizeof( padbuf ) );
 
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "<= calc  finished" ) );
-    return ( 0 );
+    return ( ret );
 }
 #endif /* MBEDTLS_SHA256_C */
 
@@ -303,7 +308,12 @@ static int ssl_calc_finished_tls_sha384(
 
 
     mbedtls_sha512_init( &sha512 );
-    mbedtls_sha512_starts( &sha512, 1 /* = use SHA384 */ );
+
+    if( ( ret = mbedtls_sha512_starts_ret( &sha512, 1 ) ) != 0 )
+    {
+        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha512_starts_ret", ret );
+        goto exit;
+    }
 
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> calc finished tls sha384" ) );
 
@@ -332,7 +342,11 @@ static int ssl_calc_finished_tls_sha384(
       #endif
     */
 
-    mbedtls_sha512_finish( &sha512, padbuf );
+    if( ( ret = mbedtls_sha512_finish_ret( &sha512, padbuf ) ) != 0 )
+    {
+        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha512_finish_ret", ret );
+        goto exit;
+    }
 
     MBEDTLS_SSL_DEBUG_BUF( 5, "handshake hash", padbuf, 48 );
 
@@ -346,7 +360,7 @@ static int ssl_calc_finished_tls_sha384(
     if( ret != 0 )
     {
         MBEDTLS_SSL_DEBUG_RET( 2, "Creating the client_finished_key failed", ret );
-        return ( ret );
+        goto exit;
     }
 
     MBEDTLS_SSL_DEBUG_BUF( 3, "client_finished_key", ssl->handshake->client_finished_key, 48 );
@@ -361,7 +375,7 @@ static int ssl_calc_finished_tls_sha384(
     if( ret != 0 )
     {
         MBEDTLS_SSL_DEBUG_RET( 2, "Creating the server_finished_key failed", ret );
-        return ( ret );
+        goto exit;
     }
 
     MBEDTLS_SSL_DEBUG_BUF( 3, "server_finished_key", ssl->handshake->server_finished_key, 48 );
@@ -392,7 +406,7 @@ static int ssl_calc_finished_tls_sha384(
     if( ret != 0 )
     {
         MBEDTLS_SSL_DEBUG_RET( 2, "mbedtls_md_hmac", ret );
-        return ( ret );
+        goto exit;
     }
 
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "verify_data of Finished message" ) );
@@ -400,6 +414,7 @@ static int ssl_calc_finished_tls_sha384(
     MBEDTLS_SSL_DEBUG_BUF( 3, "Key", finished_key, 48 );
     MBEDTLS_SSL_DEBUG_BUF( 3, "Output", buf, 48 );
 
+exit:
     mbedtls_sha512_free( &sha512 );
 
     mbedtls_platform_zeroize( padbuf, sizeof( padbuf ) );
@@ -1045,7 +1060,12 @@ int mbedtls_ssl_derive_traffic_keys( mbedtls_ssl_context *ssl, mbedtls_ssl_key_s
     if( mbedtls_hash_size_for_ciphersuite( suite_info ) == 32 )
     {
         mbedtls_sha256_clone( &sha256, &ssl->handshake->fin_sha256 );
-        mbedtls_sha256_finish( &sha256, hash );
+
+        if( ( ret = mbedtls_sha256_finish_ret( &sha256, hash ) ) != 0 )
+        {
+            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha256_finish_ret", ret );
+            goto exit;
+        }
     }
     else
 #endif /* MBEDTLS_SHA256_C */
@@ -1053,7 +1073,12 @@ int mbedtls_ssl_derive_traffic_keys( mbedtls_ssl_context *ssl, mbedtls_ssl_key_s
     if( mbedtls_hash_size_for_ciphersuite( suite_info ) == 48 )
     {
         mbedtls_sha512_clone( &sha512, &ssl->handshake->fin_sha512 );
-        mbedtls_sha512_finish( &sha512, hash );
+
+        if( ( ret = mbedtls_sha512_finish_ret( &sha512, hash ) ) != 0 )
+        {
+            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha512_finish_ret", ret );
+            goto exit;
+        }
     }
     else
 #endif /* MBEDTLS_SHA512_C */
@@ -1099,7 +1124,7 @@ int mbedtls_ssl_derive_traffic_keys( mbedtls_ssl_context *ssl, mbedtls_ssl_key_s
     {
         MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_tls1_3_derive_secret( ) with "
                                "client_handshake_traffic_secret: Error", ret );
-        return( ret );
+        goto exit;
     }
 
     /*
@@ -1135,7 +1160,7 @@ int mbedtls_ssl_derive_traffic_keys( mbedtls_ssl_context *ssl, mbedtls_ssl_key_s
                          ssl->handshake->server_handshake_traffic_secret,
                          mbedtls_hash_size_for_ciphersuite( suite_info ) );
     if( ret != 0 )
-        return( ret );
+        goto exit;
 
     /*
      * Export server handshake traffic secret
@@ -1170,7 +1195,7 @@ int mbedtls_ssl_derive_traffic_keys( mbedtls_ssl_context *ssl, mbedtls_ssl_key_s
                          ssl->handshake->exporter_secret,
                          mbedtls_hash_size_for_ciphersuite( suite_info ) );
     if( ret != 0 )
-        return( ret );
+        goto exit;
 
     /*
      * Export exporter master secret
@@ -1228,7 +1253,7 @@ int mbedtls_ssl_derive_traffic_keys( mbedtls_ssl_context *ssl, mbedtls_ssl_key_s
                                  transform->keylen, transform->ivlen, traffic_keys ) ) != 0 )
     {
         MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_tls1_3_make_traffic_keys failed", ret );
-        return( ret );
+        goto exit;
     }
 
     /* TEST
@@ -1244,7 +1269,27 @@ int mbedtls_ssl_derive_traffic_keys( mbedtls_ssl_context *ssl, mbedtls_ssl_key_s
     */
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "<= derive traffic keys" ) );
 
-    return( 0 );
+exit:
+#if defined(MBEDTLS_SHA256_C)
+    if( mbedtls_hash_size_for_ciphersuite( suite_info ) == 32 )
+    {
+        mbedtls_sha256_free( &sha256 );
+    }
+    else
+#endif
+#if defined(MBEDTLS_SHA512_C)
+    if( mbedtls_hash_size_for_ciphersuite( suite_info ) == 48 )
+    {
+        mbedtls_sha512_free( &sha512 );
+    }
+    else
+#endif
+    {
+        MBEDTLS_SSL_DEBUG_MSG( 2, ( "Unsupported hash function in mbedtls_ssl_derive_traffic_keys" ) );
+        return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
+    }
+
+    return( ret );
 }
 
 int mbedtls_increment_sequence_number( unsigned char *sequenceNumber, unsigned char *nonce, size_t ivlen ) {
@@ -1279,6 +1324,8 @@ int mbedtls_increment_sequence_number( unsigned char *sequenceNumber, unsigned c
      */
 static int ssl_calc_verify_tls_sha256( mbedtls_ssl_context *ssl, unsigned char output_hash[32], int from )
 {
+    int ret = 0;
+
     /* The length of context_string_[client|server] is
      * sizeof( "TLS 1.3, xxxxxx CertificateVerify" ) - 1, i.e. 33 bytes.
      */
@@ -1294,7 +1341,12 @@ static int ssl_calc_verify_tls_sha256( mbedtls_ssl_context *ssl, unsigned char o
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> calc verify sha256" ) );
 
     mbedtls_sha256_clone( &sha256, &ssl->handshake->fin_sha256 );
-    mbedtls_sha256_finish( &sha256, handshake_hash );
+
+    if( ( ret = mbedtls_sha256_finish_ret( &sha256, handshake_hash ) ) != 0 )
+    {
+        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha256_finish_ret", ret );
+        goto exit;
+    }
 
     MBEDTLS_SSL_DEBUG_BUF( 3, "handshake hash", handshake_hash, 32 );
 
@@ -1320,8 +1372,9 @@ static int ssl_calc_verify_tls_sha256( mbedtls_ssl_context *ssl, unsigned char o
 
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "<= calc verify" ) );
 
+exit:
     mbedtls_sha256_free( &sha256 );
-    return( 0 );
+    return( ret );
 }
 #endif /* MBEDTLS_SHA256_C */
 
@@ -1341,6 +1394,8 @@ static int ssl_calc_verify_tls_sha256( mbedtls_ssl_context *ssl, unsigned char o
      */
 static int ssl_calc_verify_tls_sha384( mbedtls_ssl_context *ssl, unsigned char output_hash[48], int from )
 {
+    int ret = 0;
+
     /* The length of context_string_[client|server] is
      * sizeof( "TLS 1.3, xxxxxx CertificateVerify" ) - 1, i.e. 33 bytes.
      */
@@ -1352,12 +1407,22 @@ static int ssl_calc_verify_tls_sha384( mbedtls_ssl_context *ssl, unsigned char o
     unsigned char verify_buffer[ 64 + 33 + 1 + 48 ];
 
     mbedtls_sha512_init( &sha384 );
-    mbedtls_sha512_starts( &sha384, 1 /* = use SHA384 */ );
+
+    if( ( ret = mbedtls_sha512_starts_ret( &sha384, 1 ) ) != 0 )
+    {
+        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha512_starts_ret", ret );
+        goto exit;
+    }
 
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> calc verify sha384" ) );
 
     mbedtls_sha512_clone( &sha384, &ssl->handshake->fin_sha512 );
-    mbedtls_sha512_finish( &sha384, handshake_hash );
+
+    if( ( ret = mbedtls_sha512_finish_ret( &sha384, handshake_hash ) ) != 0 )
+    {
+        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha512_finish_ret", ret );
+        goto exit;
+    }
 
     MBEDTLS_SSL_DEBUG_BUF( 3, "handshake hash", handshake_hash, 48 );
 
@@ -1377,14 +1442,22 @@ static int ssl_calc_verify_tls_sha384( mbedtls_ssl_context *ssl, unsigned char o
 
     MBEDTLS_SSL_DEBUG_BUF( 3, "verify buffer", verify_buffer, 64 + content_string_len + 1 + 48 );
 
-    mbedtls_sha512( verify_buffer, 64 + content_string_len + 1 + 48, output_hash, 1 /* 1 for SHA-384 */ );
+    if( ( ret = mbedtls_sha512_ret( verify_buffer,
+                                    64 + content_string_len + 1 + 48,
+                                    output_hash,
+                                    1 ) ) != 0 )
+    {
+        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha512_ret", ret );
+        goto exit;
+    }
 
     MBEDTLS_SSL_DEBUG_BUF( 3, "verify hash", output_hash, 48 );
 
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "<= calc verify" ) );
 
+exit:
     mbedtls_sha512_free( &sha384 );
-    return( 0 );
+    return( ret );
 }
 #endif /* MBEDTLS_SHA512_C */
 
@@ -2971,22 +3044,32 @@ int mbedtls_ssl_generate_resumption_master_secret( mbedtls_ssl_context *ssl )
     if( mbedtls_hash_size_for_ciphersuite( suite_info ) == 32 )
     {
         mbedtls_sha256_clone( &sha256, &ssl->handshake->fin_sha256 );
-        mbedtls_sha256_finish( &sha256, hash );
+
+        if( ( ret = mbedtls_sha256_finish_ret( &sha256, hash ) ) != 0 )
+        {
+            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha256_finish_ret", ret );
+            goto exit;
+        }
     }
     else
 #endif /* MBEDTLS_SHA256_C */
 #if defined(MBEDTLS_SHA512_C)
-        if( mbedtls_hash_size_for_ciphersuite( suite_info ) == 48 )
+    if( mbedtls_hash_size_for_ciphersuite( suite_info ) == 48 )
+    {
+        mbedtls_sha512_clone( &sha512, &ssl->handshake->fin_sha512 );
+
+        if( ( ret = mbedtls_sha512_finish_ret( &sha512, hash ) ) != 0 )
         {
-            mbedtls_sha512_clone( &sha512, &ssl->handshake->fin_sha512 );
-            mbedtls_sha512_finish( &sha512, hash );
+            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha512_finish_ret", ret );
+            goto exit;
         }
-        else
+    }
+    else
 #endif /* MBEDTLS_SHA512_C */
-        {
-            MBEDTLS_SSL_DEBUG_MSG( 2, ( "Unsupported hash function in mbedtls_ssl_derive_traffic_keys" ) );
-            return ( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
-        }
+    {
+        MBEDTLS_SSL_DEBUG_MSG( 2, ( "Unsupported hash function in mbedtls_ssl_derive_traffic_keys" ) );
+        return ( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
+    }
 
     /*
      * Compute resumption_master_secret with
@@ -3003,13 +3086,33 @@ int mbedtls_ssl_generate_resumption_master_secret( mbedtls_ssl_context *ssl )
                          mbedtls_hash_size_for_ciphersuite( suite_info ) );
 
     if( ret != 0 )
-        return( ret );
+        goto exit;
 
     MBEDTLS_SSL_DEBUG_BUF( 5, "resumption_master_secret",
                            ssl->session_negotiate->resumption_master_secret,
                            mbedtls_hash_size_for_ciphersuite( suite_info ) );
 
 #endif /* MBEDTLS_SSL_NEW_SESSION_TICKET */
+
+exit:
+#if defined(MBEDTLS_SHA256_C)
+    if( mbedtls_hash_size_for_ciphersuite( suite_info ) == 32 )
+    {
+        mbedtls_sha256_free( &sha256 );
+    }
+    else
+#endif
+#if defined(MBEDTLS_SHA512_C)
+    if( mbedtls_hash_size_for_ciphersuite( suite_info ) == 48 )
+    {
+        mbedtls_sha512_free( &sha512 );
+    }
+    else
+#endif
+    {
+        MBEDTLS_SSL_DEBUG_MSG( 2, ( "Unsupported hash function in mbedtls_ssl_derive_traffic_keys" ) );
+        return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
+    }
 
     return( ret );
 }
@@ -3520,10 +3623,23 @@ int mbedtls_ssl_early_data_key_derivation( mbedtls_ssl_context *ssl, mbedtls_ssl
     {
 #if defined(MBEDTLS_SHA256_C)
         mbedtls_sha256_init( &sha256 );
-        mbedtls_sha256_starts( &sha256, 0 /* = use SHA256 */ );
+
+        if( ( ret = mbedtls_sha256_starts_ret( &sha256, 0 ) ) != 0 )
+        {
+            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha256_starts_ret", ret );
+            goto exit;
+        }
+        MBEDTLS_SSL_DEBUG_BUF( 5, "finished sha256 state",
+                               (unsigned char *) sha256.state,
+                               sizeof( sha256.state ) );
+
         mbedtls_sha256_clone( &sha256, &ssl->handshake->fin_sha256 );
-        MBEDTLS_SSL_DEBUG_BUF( 5, "finished sha256 state", ( unsigned char * )sha256.state, sizeof( sha256.state ) );
-        mbedtls_sha256_finish( &sha256, padbuf );
+
+        if( ( ret = mbedtls_sha256_finish_ret( &sha256, padbuf ) ) != 0 )
+        {
+            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha256_finish_ret", ret );
+            goto exit;
+        }
         MBEDTLS_SSL_DEBUG_BUF( 5, "handshake hash", padbuf, 32 );
 #else
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "mbedtls_ssl_tls1_3_derive_master_secret: Unknow hash function." ) );
@@ -3534,10 +3650,21 @@ int mbedtls_ssl_early_data_key_derivation( mbedtls_ssl_context *ssl, mbedtls_ssl
     {
 #if defined(MBEDTLS_SHA512_C)
         mbedtls_sha512_init( &sha512 );
-        mbedtls_sha512_starts( &sha512, 1 /* = use SHA384 */ );
+
+        if( ( ret = mbedtls_sha512_starts_ret( &sha512, 1 ) ) != 0 )
+        {
+            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha512_starts_ret", ret );
+            goto exit;
+        }
+        MBEDTLS_SSL_DEBUG_BUF( 5, "finished sha384 state", ( unsigned char * )sha512.state, 48 );
+
         mbedtls_sha512_clone( &sha512, &ssl->handshake->fin_sha512 );
-        MBEDTLS_SSL_DEBUG_BUF( 4, "finished sha384 state", ( unsigned char * )sha512.state, 48 );
-        mbedtls_sha512_finish( &sha512, padbuf );
+
+        if( ( ret = mbedtls_sha512_finish_ret( &sha512, padbuf ) ) != 0 )
+        {
+            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha512_finish_ret", ret );
+            goto exit;
+        }
         MBEDTLS_SSL_DEBUG_BUF( 5, "handshake hash", padbuf, 48 );
 #else
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "mbedtls_ssl_tls1_3_derive_master_secret: Unknow hash function." ) );
@@ -3548,10 +3675,21 @@ int mbedtls_ssl_early_data_key_derivation( mbedtls_ssl_context *ssl, mbedtls_ssl
     {
 #if defined(MBEDTLS_SHA512_C)
         mbedtls_sha512_init( &sha512 );
-        mbedtls_sha512_starts( &sha512, 0 /* = use SHA512 */ );
+
+        if( ( ret = mbedtls_sha512_starts_ret( &sha512, 0 ) ) != 0 )
+        {
+            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha512_starts_ret", ret );
+            goto exit;
+        }
+        MBEDTLS_SSL_DEBUG_BUF( 5, "finished sha512state", ( unsigned char * )sha512.state, 64 );
+
         mbedtls_sha512_clone( &sha512, &ssl->handshake->fin_sha512 );
-        MBEDTLS_SSL_DEBUG_BUF( 4, "finished sha512 state", ( unsigned char * )sha512.state, 64 );
-        mbedtls_sha512_finish( &sha512, padbuf );
+
+        if( ( ret = mbedtls_sha512_finish_ret( &sha512, padbuf ) ) != 0 )
+        {
+            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha512_finish_ret", ret );
+            goto exit;
+        }
         MBEDTLS_SSL_DEBUG_BUF( 5, "handshake hash for psk binder", padbuf, 64 );
     }
     else
@@ -3577,7 +3715,7 @@ int mbedtls_ssl_early_data_key_derivation( mbedtls_ssl_context *ssl, mbedtls_ssl
     if( ret != 0 )
     {
         MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_tls1_3_derive_secret", ret );
-        return( ret );
+        goto exit;
     }
 
     /* Creating the Traffic Keys */
@@ -3614,7 +3752,7 @@ int mbedtls_ssl_early_data_key_derivation( mbedtls_ssl_context *ssl, mbedtls_ssl
                                  transform->keylen, transform->ivlen, traffic_keys ) ) != 0 )
     {
         MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_tls1_3_make_traffic_keys failed", ret );
-        return( ret );
+        goto exit;
     }
 
     MBEDTLS_SSL_DEBUG_BUF( 3, "[TLS 1.3, ] + handshake key expansion, client_write_key:", traffic_keys->client_write_key, transform->keylen );
@@ -3624,7 +3762,28 @@ int mbedtls_ssl_early_data_key_derivation( mbedtls_ssl_context *ssl, mbedtls_ssl
 
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "<= mbedtls_ssl_early_data_key_derivation" ) );
 
-    return( 0 );
+exit:
+#if defined(MBEDTLS_SHA256_C)
+    if( ciphersuite_info->mac == MBEDTLS_MD_SHA256 )
+    {
+        mbedtls_sha256_free( &sha256 );
+    }
+    else
+#endif
+#if defined(MBEDTLS_SHA512_C)
+    if( ciphersuite_info->mac == MBEDTLS_MD_SHA384 ||
+        ciphersuite_info->mac == MBEDTLS_MD_SHA512 )
+    {
+        mbedtls_sha512_free( &sha512 );
+    }
+    else
+#endif
+    {
+        MBEDTLS_SSL_DEBUG_MSG( 1, ( "mbedtls_ssl_tls1_3_derive_master_secret: Unknow hash function." ) );
+        return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
+    }
+
+    return( ret );
 }
 #endif /* MBEDTLS_ZERO_RTT */
 
@@ -3968,9 +4127,20 @@ static int ssl_finished_out_postprocess( mbedtls_ssl_context* ssl )
         {
 #if defined(MBEDTLS_SHA256_C)
             mbedtls_sha256_init( &sha256 );
-            mbedtls_sha256_starts( &sha256, 0 /* = use SHA256 */ );
+
+            if( ( ret = mbedtls_sha256_starts_ret( &sha256, 0 ) ) != 0 )
+            {
+                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha256_starts_ret", ret );
+                goto exit;
+            }
+
             mbedtls_sha256_clone( &sha256, &ssl->handshake->fin_sha256 );
-            mbedtls_sha256_finish( &sha256, ssl->handshake->server_finished_digest );
+
+            if( ( ret = mbedtls_sha256_finish_ret( &sha256, ssl->handshake->server_finished_digest ) ) != 0 )
+            {
+                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha256_finish_ret", ret );
+                goto exit;
+            }
             MBEDTLS_SSL_DEBUG_BUF( 3, "Transcript hash (including Server.Finished):", ssl->handshake->server_finished_digest , 32 );
 #else
             MBEDTLS_SSL_DEBUG_MSG( 1, ( "MBEDTLS_SHA256_C not set but ciphersuite with SHA256 negotiated" ) );
@@ -3982,9 +4152,20 @@ static int ssl_finished_out_postprocess( mbedtls_ssl_context* ssl )
         {
 #if defined(MBEDTLS_SHA512_C)
             mbedtls_sha512_init( &sha512 );
-            mbedtls_sha512_starts( &sha512, 1 /* = use SHA384 */ );
+
+            if( ( ret = mbedtls_sha512_starts_ret( &sha512, 1 ) ) != 0 )
+            {
+                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha512_starts_ret", ret );
+                goto exit;
+            }
+
             mbedtls_sha512_clone( &sha512, &ssl->handshake->fin_sha512 );
-            mbedtls_sha512_finish( &sha512, ssl->handshake->server_finished_digest );
+
+            if( ( ret = mbedtls_sha512_finish_ret( &sha512, ssl->handshake->server_finished_digest ) ) != 0 )
+            {
+                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha512_finish_ret", ret );
+                goto exit;
+            }
             MBEDTLS_SSL_DEBUG_BUF( 3, "Transcript hash (including Server.Finished):", ssl->handshake->server_finished_digest , 48 );
 #else
             MBEDTLS_SSL_DEBUG_MSG( 1, ( "MBEDTLS_SHA512_C not set but ciphersuite with SHA384 negotiated" ) );
@@ -3994,7 +4175,27 @@ static int ssl_finished_out_postprocess( mbedtls_ssl_context* ssl )
     }
 #endif /* MBEDTLS_SSL_SRV_C */
 
-    return( 0 );
+exit:
+#if defined(MBEDTLS_SHA256_C)
+    if( mbedtls_hash_size_for_ciphersuite( suite_info ) == 32 )
+    {
+        mbedtls_sha256_free( &sha256 );
+    }
+    else
+#endif
+#if defined(MBEDTLS_SHA512_C)
+    if( mbedtls_hash_size_for_ciphersuite( suite_info ) == 48 )
+    {
+        mbedtls_sha512_free( &sha512 );
+    }
+    else
+#endif
+    {
+        MBEDTLS_SSL_DEBUG_MSG( 1, ( "mbedtls_ssl_tls1_3_derive_master_secret: Unknow hash function." ) );
+        return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
+    }
+
+    return( ret );
 }
 
 static int ssl_finished_out_write( mbedtls_ssl_context* ssl,
@@ -4158,6 +4359,8 @@ static int ssl_finished_in_parse( mbedtls_ssl_context* ssl,
 
 static int ssl_finished_in_postprocess( mbedtls_ssl_context* ssl )
 {
+	int ret = 0;
+
 #if defined(MBEDTLS_SSL_CLI_C)
     const mbedtls_ssl_ciphersuite_t *suite_info;
     const mbedtls_cipher_info_t *cipher_info;
@@ -4195,9 +4398,21 @@ static int ssl_finished_in_postprocess( mbedtls_ssl_context* ssl )
         {
 #if defined(MBEDTLS_SHA256_C)
             mbedtls_sha256_init( &sha256 );
-            mbedtls_sha256_starts( &sha256, 0 /* = use SHA256 */ );
+
+            if( ( ret = mbedtls_sha256_starts_ret( &sha256, 0 ) ) != 0 )
+            {
+                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha256_starts_ret", ret );
+                goto exit;
+            }
+
             mbedtls_sha256_clone( &sha256, &ssl->handshake->fin_sha256 );
-            mbedtls_sha256_finish( &sha256, ssl->handshake->server_finished_digest );
+
+            if( ( ret = mbedtls_sha256_finish_ret( &sha256,
+                                                   ssl->handshake->server_finished_digest ) ) != 0 )
+            {
+                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha256_finish_ret", ret );
+                goto exit;
+            }
             MBEDTLS_SSL_DEBUG_BUF( 3, "Transcript hash (including Server.Finished):", ssl->handshake->server_finished_digest , 32 );
 #else
             MBEDTLS_SSL_DEBUG_MSG( 1, ( "MBEDTLS_SHA256_C not set but ciphersuite with SHA256 negotiated" ) );
@@ -4209,9 +4424,21 @@ static int ssl_finished_in_postprocess( mbedtls_ssl_context* ssl )
         {
 #if defined(MBEDTLS_SHA512_C)
             mbedtls_sha512_init( &sha512 );
-            mbedtls_sha512_starts( &sha512, 1 /* = use SHA384 */ );
+
+            if( ( ret = mbedtls_sha512_starts_ret( &sha512, 1 ) ) != 0 )
+            {
+                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha512_starts_ret", ret );
+                goto exit;
+            }
+
             mbedtls_sha512_clone( &sha512, &ssl->handshake->fin_sha512 );
-            mbedtls_sha512_finish( &sha512, ssl->handshake->server_finished_digest );
+
+            if( ( ret = mbedtls_sha512_finish_ret( &sha512,
+                                                   ssl->handshake->server_finished_digest ) ) != 0 )
+            {
+                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha256_finish_ret", ret );
+                goto exit;
+            }
             MBEDTLS_SSL_DEBUG_BUF( 3, "Transcript hash (including Server.Finished):", ssl->handshake->server_finished_digest , 48 );
 #else
             MBEDTLS_SSL_DEBUG_MSG( 1, ( "MBEDTLS_SHA512_C not set but ciphersuite with SHA384 negotiated" ) );
@@ -4222,7 +4449,27 @@ static int ssl_finished_in_postprocess( mbedtls_ssl_context* ssl )
     }
 #endif /* MBEDTLS_SSL_CLI_C */
 
-    return( 0 );
+exit:
+#if defined(MBEDTLS_SHA256_C)
+    if( mbedtls_hash_size_for_ciphersuite( suite_info ) == 32 )
+    {
+        mbedtls_sha256_free( &sha256 );
+    }
+    else
+#endif
+#if defined(MBEDTLS_SHA512_C)
+    if( mbedtls_hash_size_for_ciphersuite( suite_info ) == 48 )
+    {
+        mbedtls_sha512_free( &sha512 );
+    }
+    else
+#endif
+    {
+        MBEDTLS_SSL_DEBUG_MSG( 1, ( "mbedtls_ssl_tls1_3_derive_master_secret: Unknow hash function." ) );
+        return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
+    }
+
+    return( ret );
 }
 
 

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -3269,15 +3269,15 @@ static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
 
 cleanup:
 #if defined(MBEDTLS_SHA256_C)
-    if( ssl->transform_negotiate->ciphersuite_info->mac == MBEDTLS_MD_SHA256 )
+    if( ssl->handshake->ciphersuite_info->mac == MBEDTLS_MD_SHA256 )
     {
         mbedtls_sha256_free( &sha256 );
     }
     else
 #endif
 #if defined(MBEDTLS_SHA512_C)
-    if( ssl->transform_negotiate->ciphersuite_info->mac == MBEDTLS_MD_SHA384 ||
-        ssl->transform_negotiate->ciphersuite_info->mac == MBEDTLS_MD_SHA512 )
+    if( ssl->handshake->ciphersuite_info->mac == MBEDTLS_MD_SHA384 ||
+        ssl->handshake->ciphersuite_info->mac == MBEDTLS_MD_SHA512 )
     {
         mbedtls_sha512_free( &sha512 );
     }
@@ -3691,7 +3691,7 @@ static int ssl_write_hello_retry_request( mbedtls_ssl_context *ssl )
         return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
     }
 
-    /*ciphersuite_info = ssl->transform_negotiate->ciphersuite_info; */
+    /*ciphersuite_info = ssl->handshake->ciphersuite_info; */
 
     /* write magic string ( as a replacement for the random value ) */
     memcpy( p, &magic_hrr_string[0], 32 );

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -686,12 +686,30 @@ static int ssl_calc_binder( mbedtls_ssl_context *ssl, unsigned char *psk,
     {
 #if defined(MBEDTLS_SHA256_C)
         mbedtls_sha256_init( &sha256 );
-        mbedtls_sha256_starts( &sha256, 0 /* = use SHA256 */ );
+
+        if( ( ret = mbedtls_sha256_starts_ret( &sha256, 0 ) ) != 0 )
+        {
+            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha256_starts_ret", ret );
+            goto exit;
+        }
+        MBEDTLS_SSL_DEBUG_BUF( 5, "finished sha256 state",
+                               (unsigned char *) sha256.state,
+                               sizeof( sha256.state ) );
+
         /*mbedtls_sha256_clone( &sha256, &ssl->handshake->fin_sha256 ); */
-        MBEDTLS_SSL_DEBUG_BUF( 4, "finished sha256 state", ( unsigned char * )sha256.state, sizeof( sha256.state ) );
-        mbedtls_sha256_update( &sha256, buffer, blen );
+
         MBEDTLS_SSL_DEBUG_BUF( 5, "input buffer for psk binder", buffer, blen );
-        mbedtls_sha256_finish( &sha256, padbuf );
+        if( ( ret = mbedtls_sha256_update_ret( &sha256, buffer, blen ) ) != 0 )
+        {
+            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha256_update_ret", ret );
+            goto exit;
+        }
+
+        if( ( ret = mbedtls_sha256_finish_ret( &sha256, padbuf ) ) != 0 )
+        {
+            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha256_finish_ret", ret );
+            goto exit;
+        }
         MBEDTLS_SSL_DEBUG_BUF( 5, "handshake hash for psk binder", padbuf, 32 );
 #else
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "mbedtls_ssl_tls1_3_derive_master_secret: Unknow hash function." ) );
@@ -702,11 +720,28 @@ static int ssl_calc_binder( mbedtls_ssl_context *ssl, unsigned char *psk,
     {
 #if defined(MBEDTLS_SHA512_C)
         mbedtls_sha512_init( &sha512 );
-        mbedtls_sha512_starts( &sha512, 1 /* = use SHA384 */ );
+
+        if( ( ret = mbedtls_sha512_starts_ret( &sha512, 1 ) ) != 0 )
+        {
+            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha512_starts_ret", ret );
+            goto exit;
+        }
+        MBEDTLS_SSL_DEBUG_BUF( 5, "finished sha384 state", ( unsigned char * )sha512.state, 48 );
+
         /*mbedtls_sha512_clone( &sha512, &ssl->handshake->fin_sha512 ); */
-        MBEDTLS_SSL_DEBUG_BUF( 4, "finished sha384 state ", ( unsigned char * )sha512.state, 48 );
-        mbedtls_sha512_update( &sha512, buffer, blen );
-        mbedtls_sha512_finish( &sha512, padbuf );
+
+        MBEDTLS_SSL_DEBUG_BUF( 5, "input buffer for psk binder", buffer, blen );
+        if( ( ret = mbedtls_sha512_update_ret( &sha512, buffer, blen ) ) != 0 )
+        {
+            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha512_update_ret", ret );
+            goto exit;
+        }
+
+        if( ( ret = mbedtls_sha512_finish_ret( &sha512, padbuf ) ) != 0 )
+        {
+            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha512_finish_ret", ret );
+            goto exit;
+        }
         MBEDTLS_SSL_DEBUG_BUF( 5, "handshake hash for psk binder", padbuf, 48 );
 #else
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "mbedtls_ssl_tls1_3_derive_master_secret: Unknow hash function." ) );
@@ -731,7 +766,7 @@ static int ssl_calc_binder( mbedtls_ssl_context *ssl, unsigned char *psk,
     if( ret != 0 )
     {
         MBEDTLS_SSL_DEBUG_RET( 2, "Creating the finished_key failed", ret );
-        return ( ret );
+        goto exit;
     }
 
     MBEDTLS_SSL_DEBUG_BUF( 3, "finished_key", finished_key, hash_length );
@@ -742,7 +777,7 @@ static int ssl_calc_binder( mbedtls_ssl_context *ssl, unsigned char *psk,
     if( ret != 0 )
     {
         MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_md_hmac", ret );
-        return ( ret );
+        goto exit;
     }
 
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "verify_data of psk binder" ) );
@@ -750,6 +785,7 @@ static int ssl_calc_binder( mbedtls_ssl_context *ssl, unsigned char *psk,
     MBEDTLS_SSL_DEBUG_BUF( 3, "Key", finished_key, hash_length );
     MBEDTLS_SSL_DEBUG_BUF( 3, "Output", computed_binder, hash_length );
 
+exit:
 #if defined(MBEDTLS_SHA256_C)
     if( suite_info->mac == MBEDTLS_MD_SHA256 )
     {
@@ -758,15 +794,15 @@ static int ssl_calc_binder( mbedtls_ssl_context *ssl, unsigned char *psk,
     else
 #endif /* MBEDTLS_SHA256_C */
 #if defined(MBEDTLS_SHA512_C)
-        if( suite_info->mac == MBEDTLS_MD_SHA384 )
-        {
-            mbedtls_sha512_free( &sha512 );
-        }
-        else
+    if( suite_info->mac == MBEDTLS_MD_SHA384 )
+    {
+        mbedtls_sha512_free( &sha512 );
+    }
+    else
 #endif /* MBEDTLS_SHA512_C */
 	{
-            MBEDTLS_SSL_DEBUG_MSG( 1, ( "mbedtls_ssl_tls1_3_derive_master_secret: Unknow hash function." ) );
-            return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
+        MBEDTLS_SSL_DEBUG_MSG( 1, ( "mbedtls_ssl_tls1_3_derive_master_secret: Unknow hash function." ) );
+        return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
 	}
 
     mbedtls_platform_zeroize( finished_key, hash_length );
@@ -3120,9 +3156,31 @@ static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
         {
 #if defined(MBEDTLS_SHA256_C)
             mbedtls_sha256_init( &sha256 );
-            mbedtls_sha256_starts( &sha256, 0 /* = use SHA256 */ );
-            mbedtls_sha256_update( &sha256, orig_buf, orig_msg_len ); /* hash ClientHello message */
-            mbedtls_sha256_finish( &sha256, &transcript[4] );
+
+            if( ( ret = mbedtls_sha256_starts_ret( &sha256, 0 ) ) != 0 )
+            {
+                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha256_starts_ret", ret );
+                final_ret = ret;
+                goto cleanup;
+            }
+
+            /* Hash ClientHello message */
+            if( ( ret = mbedtls_sha256_update_ret( &sha256,
+                                                   orig_buf,
+                                                   orig_msg_len ) ) != 0 )
+            {
+                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha256_update_ret", ret );
+                final_ret = ret;
+                goto cleanup;
+            }
+
+            if( ( ret = mbedtls_sha256_finish_ret( &sha256,
+                                                   &transcript[4]) ) != 0 )
+            {
+                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha256_finish_ret", ret );
+                final_ret = ret;
+                goto cleanup;
+            }
             MBEDTLS_SSL_DEBUG_BUF( 5, "Transcript-Hash( ClientHello1, HelloRetryRequest, ... MN )", &transcript[0], 32+4 );
 #else
             MBEDTLS_SSL_DEBUG_MSG( 1, ( "mbedtls_ssl_tls1_3_derive_master_secret: Unknow hash function." ) );
@@ -3133,9 +3191,30 @@ static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
         {
 #if defined(MBEDTLS_SHA512_C)
             mbedtls_sha512_init( &sha512 );
-            mbedtls_sha512_starts( &sha512, 1 /* = use SHA384 */ );
-            mbedtls_sha512_update( &sha512, orig_buf, orig_msg_len ); /* hash ClientHello message */
-            mbedtls_sha512_finish( &sha512, &transcript[4] );
+
+            if( ( ret = mbedtls_sha512_starts_ret( &sha512, 1 ) ) != 0 )
+            {
+                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha512_starts_ret", ret );
+                final_ret = ret;
+                goto cleanup;
+            }
+
+            /* Hash ClientHello message */
+            if( ( ret = mbedtls_sha512_update_ret( &sha512,
+                                                   orig_buf,
+                                                   orig_msg_len ) ) != 0 )
+            {
+                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha512_update_ret", ret );
+                final_ret = ret;
+                goto cleanup;
+            }
+
+            if( ( ret = mbedtls_sha512_finish_ret( &sha512,
+                                                   &transcript[4] ) ) != 0 )
+            {
+                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha512_finish_ret", ret );
+                goto cleanup;
+            }
             MBEDTLS_SSL_DEBUG_BUF( 5, "Transcript-Hash( ClientHello1, HelloRetryRequest, ... MN )", &transcript[0], 48+4 );
 #else
             MBEDTLS_SSL_DEBUG_MSG( 1, ( "mbedtls_ssl_tls1_3_derive_master_secret: Unknow hash function." ) );
@@ -3146,16 +3225,38 @@ static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
         {
 #if defined(MBEDTLS_SHA512_C)
             mbedtls_sha512_init( &sha512 );
-            mbedtls_sha512_starts( &sha512, 0 /* = use SHA512 */ );
-            mbedtls_sha512_update( &sha512, orig_buf, orig_msg_len ); /* hash ClientHello message */
-            mbedtls_sha512_finish( &sha512, &transcript[4] );
+
+            if( ( ret = mbedtls_sha512_starts_ret( &sha512, 0 ) ) != 0 )
+            {
+                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha512_starts_ret", ret );
+                final_ret = ret;
+                goto cleanup;
+            }
+
+            /* Hash ClientHello message */
+            if( ( ret = mbedtls_sha512_update_ret( &sha512,
+                                                   orig_buf,
+                                                   orig_msg_len ) ) != 0 )
+            {
+                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha512_update_ret", ret );
+                final_ret = ret;
+                goto cleanup;
+            }
+
+            if( ( ret = mbedtls_sha512_finish_ret( &sha512,
+                                                   &transcript[4] ) ) != 0 )
+            {
+                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha512_finish_ret", ret );
+                final_ret = ret;
+                goto cleanup;
+            }
             MBEDTLS_SSL_DEBUG_BUF( 5, "ClientHello hash", &transcript[4], 64 );
         }
         else {
 #else
             MBEDTLS_SSL_DEBUG_MSG( 1, ( "mbedtls_ssl_tls1_3_derive_master_secret: Unknow hash function." ) );
             return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
-#endif  /* MBEDTLS_SHA512_C*/
+#endif  /* MBEDTLS_SHA512_C */
         }
         ssl->handshake->update_checksum( ssl, &transcript[0], hash_length + 4 );
     }
@@ -3165,6 +3266,27 @@ static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
         ssl->handshake->update_checksum( ssl, orig_buf, orig_msg_len );
     }
     mbedtls_ssl_optimize_checksum( ssl, ssl->handshake->ciphersuite_info );
+
+cleanup:
+#if defined(MBEDTLS_SHA256_C)
+    if( ssl->transform_negotiate->ciphersuite_info->mac == MBEDTLS_MD_SHA256 )
+    {
+        mbedtls_sha256_free( &sha256 );
+    }
+    else
+#endif
+#if defined(MBEDTLS_SHA512_C)
+    if( ssl->transform_negotiate->ciphersuite_info->mac == MBEDTLS_MD_SHA384 ||
+        ssl->transform_negotiate->ciphersuite_info->mac == MBEDTLS_MD_SHA512 )
+    {
+        mbedtls_sha512_free( &sha512 );
+    }
+    else
+#endif
+    {
+        MBEDTLS_SSL_DEBUG_MSG( 1, ( "mbedtls_ssl_tls1_3_derive_master_secret: Unknow hash function." ) );
+        return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
+    }
 
     return( final_ret );
 }


### PR DESCRIPTION
Fixes #37.

Future work:
* We might consider using a more generic API (`mbedtls_md_starts()`, `mbedtls_md_finish()`, etc.) instead of an API specific to hash functions (`mbedtls_md_starts()`, `mbedtls_sha256_finish_ret()`). Going further, we could unify `ssl_calc_*_tls_sha*()` and `ssl_update_checksum_sha*()` 