### PR TITLE
Fixing CertificateVerify handling and the use of signature algorithms

### DIFF
--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -468,6 +468,7 @@ struct mbedtls_ssl_handshake_params
      */
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
     int signature_scheme;                        /*!<  Signature scheme  */
+    int signature_scheme_client;  /*!<  Signature scheme to use by client-initiated CertificateVerify */
 #if defined(MBEDTLS_X509_CRT_PARSE_C) && defined(MBEDTLS_SSL_SRV_C)
     int *received_signature_schemes_list;              /*!<  Received signature algorithms */
 #endif /* MBEDTLS_X509_CRT_PARSE_C && MBEDTLS_SSL_SRV_C */
@@ -740,6 +741,20 @@ struct mbedtls_ssl_handshake_params
         } cli_key_exch_in;
 
 #endif /* MBEDTLS_SSL_SRV_C */
+
+        /* Incoming CertificateVerify */
+        struct
+        {
+            unsigned char verify_buffer[ 64 + 33 + 1 + MBEDTLS_MD_MAX_SIZE ];
+            size_t verify_buffer_len;
+        } certificate_verify_in;
+
+        /* Outgoing CertificateVerify */
+        struct
+        {
+            unsigned char handshake_hash[ MBEDTLS_MD_MAX_SIZE ];
+            size_t handshake_hash_len;
+        } certificate_verify_out;
 
     } state_local;
 

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -7380,7 +7380,8 @@ static int ssl_preset_suiteb_signature_algorithms_tls13[] = {
     SIGNATURE_ECDSA_SECP384r1_SHA384,
 #endif /* MBEDTLS_SHA512_C && MBEDTLS_ECP_DP_SECP384R1_ENABLED */
 #if defined(MBEDTLS_SHA512_C) && defined(MBEDTLS_ECP_DP_SECP521R1_ENABLED)
-    SIGNATURE_ECDSA_SECP521r1_SHA512,
+/* TBD: This signature algorithm is not yet fully implemented. */
+//    SIGNATURE_ECDSA_SECP521r1_SHA512,
 #endif /* MBEDTLS_SHA512_C && MBEDTLS_ECP_DP_SECP521R1_ENABLED */
     SIGNATURE_NONE
 }; 

--- a/library/ssl_tls13_keys.h
+++ b/library/ssl_tls13_keys.h
@@ -91,6 +91,23 @@ extern const struct mbedtls_ssl_tls1_3_labels_struct mbedtls_ssl_tls1_3_labels;
  * is never used with more than 255 Bytes of output. */
 #define MBEDTLS_SSL_TLS1_3_KEY_SCHEDULE_MAX_EXPANSION_LEN 255
 
+/* Macro to express the length of the verify structure length.
+ *
+ * The structure is computed per TLS 1.3 specification as:
+ *   - 64 bytes of octet 32,
+ *   - 33 bytes for the context string 
+ *        (which is either "TLS 1.3, client CertificateVerify"
+ *         or "TLS 1.3, server CertificateVerify"),
+ *   - 1 byte for the octet 0x0, which servers as a separator,
+ *   - 32 or 48 bytes for the Transcript-Hash(Handshake Context, Certificate)
+ *     (depending on the size of the transcript_hash)
+ */
+#define MBEDTLS_SSL_VERIFY_STRUCT_MAX_SIZE  ( 64 +                 \
+                                              33 +                 \
+                                               1 +                 \
+                                              MBEDTLS_MD_MAX_SIZE  \
+                                            )
+
 /**
  * \brief           The \c HKDF-Expand-Label function from
  *                  the TLS 1.3 standard RFC 8446.

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -331,8 +331,8 @@ int main( void )
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && defined(MBEDTLS_ECP_C)
 #define USAGE_SIG_ALGS \
-    "    sig_algs=a,b,c,d      default: \"default\" (library default: ecdsa_secp256r1_sha256)\n"  \
-    "                        example: \"ecdsa_secp256r1_sha256,ecdsa_secp384r1_sha384\"\n"
+    "    sig_algs=a,b,c,d      default: \"default\" (library default)\n"  \
+    "                          example: \"ecdsa_secp256r1_sha256,ecdsa_secp384r1_sha384\"\n"
 #else
 #define USAGE_SIG_ALGS ""
 #endif
@@ -1151,7 +1151,7 @@ static int ssl_sig_hashes_for_test_tls13[] = {
     SIGNATURE_ECDSA_SECP384r1_SHA384,
 #endif
 #if defined(MBEDTLS_SHA512_C) && defined(MBEDTLS_ECDSA_C) && defined(MBEDTLS_ECP_DP_SECP521R1_ENABLED)
-    SIGNATURE_ECDSA_SECP521r1_SHA512,
+//    SIGNATURE_ECDSA_SECP521r1_SHA512,
 #endif
     SIGNATURE_NONE
 };
@@ -2404,14 +2404,6 @@ int main( int argc, char *argv[] )
 
         sig_alg_list[i] = SIGNATURE_NONE;
     }
-    else
-    {
-        /* Configure default signature algorithm */
-        sig_alg_list[0] = SIGNATURE_ECDSA_SECP256r1_SHA256;
-        sig_alg_list[1] = SIGNATURE_NONE;
-    }
-
-    mbedtls_printf( "Number of signature algorithms: %d\n", i );
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL && MBEDTLS_ECP_C */
 
     /*
@@ -2848,7 +2840,7 @@ int main( int argc, char *argv[] )
 #endif /* MBEDTLS_ECP_C */
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && defined(MBEDTLS_ECP_C)
-    if( opt.sig_algs != NULL && strcmp( opt.sig_algs, "default" ) != 0 )
+    if( opt.sig_algs != NULL )
     {
         mbedtls_ssl_conf_signature_algorithms( &conf, sig_alg_list );
     }


### PR DESCRIPTION
Overview: 

The verify structure contains the transcript hash. The transcript hash length depends on the negotiated cipher.
This verify structure is then signed with a signature algorithm negotiated during the exchange. Prior to signing it, the verify structure is hashed with the hash function that is part of the agreed signature algorithm.

The PR reorganizes the code to
- create the transcript hash,
- create the verify structure, and
- to compute the signature and create the verify message. 