### PR TITLE
[tls13_mps] Fixes to clang 12 compilation issues, removing trailing whitespace

### DIFF
--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -1941,15 +1941,15 @@ void mbedtls_ssl_conf_verify( mbedtls_ssl_config *conf,
 /**
  * \brief          Configure signature algorithms (Optional).
  *
- *                 If set, the signature algorithms will be advertised in 
- *                 the signature_algorithms extension in the ClientHello of 
- *                 TLS/DTLS 1.3. 
+ *                 If set, the signature algorithms will be advertised in
+ *                 the signature_algorithms extension in the ClientHello of
+ *                 TLS/DTLS 1.3.
  *
  *
  * \param conf     The SSL configuration to use.
- * \param sig_algs A list of signature algorithms with the most preferred algorithm listed first.  
- *  
- *                 Note: sig_algs must be terminated with SIGNATURE_NONE. 
+ * \param sig_algs A list of signature algorithms with the most preferred algorithm listed first.
+ *
+ *                 Note: sig_algs must be terminated with SIGNATURE_NONE.
  */
 void mbedtls_ssl_conf_signature_algorithms( mbedtls_ssl_config *conf,
                      const int* sig_algs );
@@ -3656,7 +3656,7 @@ void mbedtls_ssl_conf_key_share_curves(mbedtls_ssl_config* conf,
     const mbedtls_ecp_group_id* curve_list);
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL && MBEDTLS_SSL_CLI_C && MBEDTLS_ECP_C */
 
-#if defined(MBEDTLS_KEY_EXCHANGE_WITH_CERT_ENABLED) 
+#if defined(MBEDTLS_KEY_EXCHANGE_WITH_CERT_ENABLED)
 /**
  * \brief          Set the allowed hashes for signatures during the handshake.
  *                 (Default: all available hashes except MD5.)

--- a/include/mbedtls/ssl_ticket.h
+++ b/include/mbedtls/ssl_ticket.h
@@ -48,7 +48,7 @@ extern "C" {
 /**
  * \brief   Information for session ticket protection
  */
-typedef struct 
+typedef struct
 {
     unsigned char name[4];          /*!< random key identifier              */
     uint32_t generation_time;       /*!< key generation timestamp (seconds) */
@@ -59,7 +59,7 @@ mbedtls_ssl_ticket_key;
 /**
  * \brief   Context for session ticket handling functions
  */
-typedef struct 
+typedef struct
 {
     mbedtls_ssl_ticket_key keys[2]; /*!< ticket protection keys             */
     unsigned char active;           /*!< index of the currently active key  */
@@ -123,7 +123,7 @@ int mbedtls_ssl_ticket_setup( mbedtls_ssl_ticket_context *ctx,
     int (*f_rng)(void *, unsigned char *, size_t), void *p_rng,
     mbedtls_cipher_type_t cipher,
     uint32_t lifetime, mbedtls_ssl_ticket_flags flags);
-#else 
+#else
 int mbedtls_ssl_ticket_setup(mbedtls_ssl_ticket_context* ctx,
     int (*f_rng)(void*, unsigned char*, size_t), void* p_rng,
     mbedtls_cipher_type_t cipher,

--- a/library/cipher.c
+++ b/library/cipher.c
@@ -1347,7 +1347,7 @@ int mbedtls_cipher_auth_encrypt( mbedtls_cipher_context_t *ctx,
     }
 #endif /* MBEDTLS_GCM_C */
 #if defined(MBEDTLS_CCM_C)
-    if( MBEDTLS_MODE_CCM == ctx->cipher_info->mode 
+    if( MBEDTLS_MODE_CCM == ctx->cipher_info->mode
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
         || ctx->cipher_info->mode == MBEDTLS_MODE_CCM_8
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
@@ -1462,8 +1462,8 @@ int mbedtls_cipher_auth_decrypt( mbedtls_cipher_context_t *ctx,
     }
 #endif /* MBEDTLS_GCM_C */
 #if defined(MBEDTLS_CCM_C)
-    if( MBEDTLS_MODE_CCM == ctx->cipher_info->mode 
-#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)        
+    if( MBEDTLS_MODE_CCM == ctx->cipher_info->mode
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
         || ctx->cipher_info->mode == MBEDTLS_MODE_CCM_8
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
         )

--- a/library/ecp.c
+++ b/library/ecp.c
@@ -1016,12 +1016,12 @@ int mbedtls_ecp_tls_read_point( const mbedtls_ecp_group *grp,
         return( MBEDTLS_ERR_ECP_BAD_INPUT_DATA );
 
     data_len = ( *( *buf ) << 8 ) | *( *buf+1 );
-    *buf += 2; 
+    *buf += 2;
 
     if (data_len < 1 || data_len > buf_len - 2 )
         return(MBEDTLS_ERR_ECP_BAD_INPUT_DATA);
 
-#else 
+#else
     /*
      * We must have at least two bytes (1 for length, at least one for data)
      */
@@ -1073,7 +1073,7 @@ int mbedtls_ecp_tls_write_point( const mbedtls_ecp_group *grp, const mbedtls_ecp
     *buf++ = (unsigned char)( ( *olen ) & 0xFF );
     *olen += 2;
 
-#else 
+#else
 
     /*
      * buffer length must be at least one, for our length byte
@@ -1130,7 +1130,7 @@ int mbedtls_ecp_tls_read_group_id( mbedtls_ecp_group_id *grp,
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
     if (len < 2)
         return(MBEDTLS_ERR_ECP_BAD_INPUT_DATA);
-#else 
+#else
     /*
      * We expect at least three bytes (see below)
      */
@@ -1181,7 +1181,7 @@ int mbedtls_ecp_tls_write_group( const mbedtls_ecp_group *grp, size_t *olen,
     // Two bytes for named curve
     buf[0] = curve_info->tls_id >> 8;
     buf[1] = curve_info->tls_id & 0xFF;
-#else 
+#else
     /*
      * We are going to write 3 bytes (see below)
      */

--- a/library/mps/mps.c
+++ b/library/mps/mps.c
@@ -2169,7 +2169,7 @@ MBEDTLS_MPS_STATIC int mps_retransmission_timer_check( mbedtls_mps *mps )
                              mps,
                              MBEDTLS_MPS_FLIGHT_FINALIZE,
                              MBEDTLS_MPS_FLIGHT_DONE ) );
-
+                break;
             default:
                 break;
         }

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -1613,6 +1613,9 @@ int mbedtls_ssl_decrypt_buf( mbedtls_ssl_context const *ssl,
         else
 #endif /* MBEDTLS_SSL_PROTO_TLS1 || MBEDTLS_SSL_PROTO_TLS1_1 || \
           MBEDTLS_SSL_PROTO_TLS1_2 */
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+        if( transform->minor_ver != MBEDTLS_SSL_MINOR_VERSION_4 )
+#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
         {
             MBEDTLS_SSL_DEBUG_MSG( 1, ( "should never happen" ) );
             return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
@@ -1710,6 +1713,9 @@ int mbedtls_ssl_decrypt_buf( mbedtls_ssl_context const *ssl,
         else
 #endif /* MBEDTLS_SSL_PROTO_TLS1 || MBEDTLS_SSL_PROTO_TLS1_1 || \
               MBEDTLS_SSL_PROTO_TLS1_2 */
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+        if( transform->minor_ver != MBEDTLS_SSL_MINOR_VERSION_4 )
+#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
         {
             MBEDTLS_SSL_DEBUG_MSG( 1, ( "should never happen" ) );
             return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -4991,7 +4991,7 @@ void mbedtls_ssl_conf_dhm_min_bitlen( mbedtls_ssl_config *conf,
 }
 #endif /* MBEDTLS_DHM_C && MBEDTLS_SSL_CLI_C */
 
-#if defined(MBEDTLS_KEY_EXCHANGE_WITH_CERT_ENABLED) 
+#if defined(MBEDTLS_KEY_EXCHANGE_WITH_CERT_ENABLED)
 /*
  * Set allowed/preferred hashes for handshake signatures
  */
@@ -7384,7 +7384,7 @@ static int ssl_preset_suiteb_signature_algorithms_tls13[] = {
 //    SIGNATURE_ECDSA_SECP521r1_SHA512,
 #endif /* MBEDTLS_SHA512_C && MBEDTLS_ECP_DP_SECP521R1_ENABLED */
     SIGNATURE_NONE
-}; 
+};
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 
 #endif /* MBEDTLS_KEY_EXCHANGE_WITH_CERT_ENABLED */
@@ -7813,10 +7813,10 @@ int mbedtls_ssl_check_curve( const mbedtls_ssl_context *ssl, mbedtls_ecp_group_i
 /*
  * Check if a hash proposed by the peer is in our list.
  * Return 0 if we're willing to use it, -1 otherwise.
- * 
- * Assumption: sig_hashes is terminated either with 
- * SIGNATURE_NONE or with MBEDTLS_MD_NONE and both 
- * equal 0x0. 
+ *
+ * Assumption: sig_hashes is terminated either with
+ * SIGNATURE_NONE or with MBEDTLS_MD_NONE and both
+ * equal 0x0.
  */
 int mbedtls_ssl_check_sig_hash( const mbedtls_ssl_context *ssl,
                                 mbedtls_md_type_t md )

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -1310,14 +1310,14 @@ int mbedtls_increment_sequence_number( unsigned char *sequenceNumber, unsigned c
      *
      * The structure is computed per TLS 1.3 specification as:
      *   - 64 bytes of octet 32,
-     *   - 33 bytes for the context string 
+     *   - 33 bytes for the context string
      *        (which is either "TLS 1.3, client CertificateVerify"
      *         or "TLS 1.3, server CertificateVerify"),
      *   - 1 byte for the octet 0x0, which servers as a separator,
      *   - 32 or 48 bytes for the Transcript-Hash(Handshake Context, Certificate)
      *     (depending on the size of the transcript_hash)
      *
-     * This results in a total size of 
+     * This results in a total size of
      * - 130 bytes for a SHA256-based transcript hash, or
      *   (64 + 33 + 1 + 32 bytes)
      * - 146 bytes for a SHA384-based transcript hash.
@@ -1353,7 +1353,7 @@ static void mbedtls_ssl_create_verify_structure(
     verify_buffer[64 + content_string_len] = 0x0;
     memcpy( verify_buffer + 64 + content_string_len + 1, transcript_hash, transcript_hash_len );
 
-    *verify_buffer_len = 64 + content_string_len + 1 + transcript_hash_len; 
+    *verify_buffer_len = 64 + content_string_len + 1 + transcript_hash_len;
 }
 
 
@@ -1746,7 +1746,7 @@ static int ssl_certificate_verify_coordinate( mbedtls_ssl_context* ssl )
 
 #if defined(MBEDTLS_SHA512_C)
     if( ssl->handshake->ciphersuite_info->mac == MBEDTLS_MD_SHA384 )
-    {        
+    {
         mbedtls_sha512_init( &sha384 );
 
         if( ( ret = mbedtls_sha512_starts_ret( &sha384, 1 ) ) != 0 )
@@ -1816,7 +1816,7 @@ static int ssl_certificate_verify_write( mbedtls_ssl_context* ssl,
             verify_buffer,
             &verify_buffer_len,
             ssl->conf->endpoint );
- 
+
     MBEDTLS_SSL_DEBUG_BUF( 5, "verify buffer structure", verify_buffer, verify_buffer_len );
 	
     /*
@@ -1852,7 +1852,7 @@ static int ssl_certificate_verify_write( mbedtls_ssl_context* ssl,
             MBEDTLS_SSL_DEBUG_MSG( 1, ( "should never happen" ) );
             return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
     }
-    
+
     /* Verify whether we can use signature algorithm */
     ssl->handshake->signature_scheme_client = SIGNATURE_NONE;
 
@@ -1873,7 +1873,7 @@ static int ssl_certificate_verify_write( mbedtls_ssl_context* ssl,
             MBEDTLS_SSL_DEBUG_MSG( 1, ( "should never happen" ) );
             return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
     }
- 
+
     buf[4] = (unsigned char)( ( ssl->handshake->signature_scheme_client >> 8 ) & 0xFF );
     buf[5] = (unsigned char)( ( ssl->handshake->signature_scheme_client ) & 0xFF );
     offset = 2;
@@ -2000,7 +2000,7 @@ int mbedtls_ssl_read_certificate_verify_process( mbedtls_ssl_context* ssl )
 {
     int ret;
     unsigned char verify_buffer[ MBEDTLS_SSL_VERIFY_STRUCT_MAX_SIZE ];
-    size_t verify_buffer_len; 
+    size_t verify_buffer_len;
     unsigned char transcript[ MBEDTLS_MD_MAX_SIZE ];
     unsigned int transcript_len;
 #if defined(MBEDTLS_SHA256_C)
@@ -2015,7 +2015,7 @@ int mbedtls_ssl_read_certificate_verify_process( mbedtls_ssl_context* ssl )
 
     MBEDTLS_SSL_PROC_CHK( ssl_read_certificate_verify_coordinate( ssl ) );
 
-#if defined(MBEDTLS_KEY_EXCHANGE_WITH_CERT_ENABLED) // TBD: double-check 
+#if defined(MBEDTLS_KEY_EXCHANGE_WITH_CERT_ENABLED) // TBD: double-check
     if( ret == SSL_CERTIFICATE_VERIFY_READ )
     {
         /* Need to calculate the hash of the transcript first
@@ -2025,7 +2025,7 @@ int mbedtls_ssl_read_certificate_verify_process( mbedtls_ssl_context* ssl )
 #if defined(MBEDTLS_SHA256_C)
         if( ssl->handshake->ciphersuite_info->mac == MBEDTLS_MD_SHA256 )
         {
-            transcript_len=32; 
+            transcript_len=32;
             mbedtls_sha256_init( &sha256 );
 
             mbedtls_sha256_clone( &sha256, &ssl->handshake->fin_sha256 );
@@ -2240,13 +2240,13 @@ static int ssl_read_certificate_verify_parse( mbedtls_ssl_context* ssl,
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "bad certificate verify message" ) );
         return( MBEDTLS_ERR_SSL_BAD_HS_CERTIFICATE_VERIFY );
     }
-    
+
     /* Hash verify buffer with indicated hash function */
 #if defined(MBEDTLS_SHA256_C)
     if( md_alg == MBEDTLS_MD_SHA256 )
     {
         verify_hash_len = 32;
-        if( ( ret = mbedtls_sha256_ret( verify_buffer, 
+        if( ( ret = mbedtls_sha256_ret( verify_buffer,
             verify_buffer_len, verify_hash, 0 /* 0 for SHA-256 instead of SHA-224 */ )  ) != 0 )
         {
             MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha256_ret", ret );


### PR DESCRIPTION
This commit prevents early return when TLS1_3 enabled,
TLS1_2 disabled and SOME_MODES_USE_MAC enabled.

Without the commit, the compilation fails due to unreachable code, e.g.

```
/Users/oshapira/git/mbedtls/library/ssl_msg.c:1723:13: error: code will never be executed [-Werror,-Wunreachable-code]
        if( mbedtls_ssl_safer_memcmp( mac_peer, mac_expect,
            ^~~~~~~~~~~~~~~~~~~~~~~~
/Users/oshapira/git/mbedtls/library/ssl_msg.c:1625:9: error: code will never be executed [-Werror,-Wunreachable-code]
        rec->data_len -= padlen;
        ^~~
2 errors generated.

```

Signed-off-by: Omer Shapira <omer.shapira@gmail.com>