### PR TITLE
Re-working Ticket Handling

### DIFF
--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -1806,76 +1806,78 @@
 //#define MBEDTLS_SSL_TLS13_CTLS
 
 
-/**
-*  \def MBEDTLS_SSL_EARLY_DATA_MAX_DELAY
-*
-* Tolerance window for ticket age value.
-* Outside this tolerance window, 0-RTT mode will be disabled.
-*
-*/
+ /**
+ *  \def MBEDTLS_SSL_EARLY_DATA_MAX_DELAY
+ *
+ * Tolerance window for ticket age value.
+ * Outside this tolerance window, 0-RTT mode will be disabled.
+ *
+ */
 
 #define MBEDTLS_SSL_EARLY_DATA_MAX_DELAY 10000
 
-/**
-*  \def MBEDTLS_SSL_MAX_KEY_SHARES
-*
-* Defines the maximum number of key share entires in a
-* key share extension advertised as part of the ClientHello.
-*
-* The impact of increasing the number of key shares is that
-* a client needs to store more ECDHE key pairs and the
-* transmission size of the ClientHello is increased as well.
-* On the positive side this allows more rapid session
-* establishment in case there is no prior knowledge between
-* the client and the server about the supported algorithms
-* and curves.
-*
-*/
+ /**
+ *  \def MBEDTLS_SSL_MAX_KEY_SHARES
+ *
+ * Defines the maximum number of key share entires in a
+ * key share extension advertised as part of the ClientHello.
+ *
+ * The impact of increasing the number of key shares is that
+ * a client needs to store more ECDHE key pairs and the
+ * transmission size of the ClientHello is increased as well.
+ * On the positive side this allows more rapid session
+ * establishment in case there is no prior knowledge between
+ * the client and the server about the supported algorithms
+ * and curves.
+ *
+ */
 
 #define MBEDTLS_SSL_MAX_KEY_SHARES 1
 
-/**
-* \def MBEDTLS_ZERO_RTT
-*
-* Allows to add functionality for TLS/DTLS 1.3 Zero-RTT.
-*
-*/
+ /**
+ * \def MBEDTLS_ZERO_RTT
+ *
+ * Allows to add functionality for TLS/DTLS 1.3 Zero-RTT.
+ *
+ */
 #define MBEDTLS_ZERO_RTT
 
-/**
-* \def MBEDTLS_SSL_DEBUG_HANDSHAKE_HASHES
-*
-* Enables debug output for handshake hashes
-*
-* Requires:
-*
-* Uncomment this macro to print handshake hash information
-*/
+ /**
+ * \def MBEDTLS_SSL_DEBUG_HANDSHAKE_HASHES
+ *
+ * Enables debug output for handshake hashes
+ *
+ * Requires:
+ *
+ * Uncomment this macro to print handshake hash information
+ */
 //#define MBEDTLS_SSL_DEBUG_HANDSHAKE_HASHES
 
-/*
-* \def MBEDTLS_SSL_TICKET_NONCE_LENGTH
-*
-* Allows adjusting the length of the nonce field in the ticket.
-*
-* The default value is 32 bytes.
-*/
+ /*
+ * \def MBEDTLS_SSL_TICKET_NONCE_LENGTH
+ *
+ * Allows adjusting the length of the nonce field in the ticket.
+ *
+ * The default value is 32 bytes.
+ */
 #define MBEDTLS_SSL_TICKET_NONCE_LENGTH 32
 
-/*
-* \def MBEDTLS_SSL_NEW_SESSION_TICKET
-*
-* Enable support for TLS 1.3 session tickets.
-* Client-side, provides full support for session tickets (maintainance of a
-* session store remains the responsibility of the application, though).
-* Server-side, you also need to provide callbacks for writing and parsing
-* tickets, including authenticated encryption and key management. Example
-* callbacks are provided by MBEDTLS_SSL_TICKET_C.
-*
-* Comment this macro to
-*  - be able to issue tickets by TLS 1.3 servers, and
-*  - use them in TLS 1.3 clients.
-*/
+ /*
+ * \def MBEDTLS_SSL_NEW_SESSION_TICKET
+ *
+ * Enable support for TLS 1.3 session tickets.
+ * Client-side, provides full support for session tickets (maintainance of a
+ * session store remains the responsibility of the application, though).
+ * Server-side, you also need to provide callbacks for writing and parsing
+ * tickets, including authenticated encryption and key management. Example
+ * callbacks are provided by MBEDTLS_SSL_TICKET_C.
+ *
+ * Comment this macro to
+ *  - be able to issue tickets by TLS 1.3 servers, and
+ *  - use them in TLS 1.3 clients.
+ *
+ * Requires: MBEDTLS_SSL_TICKET_C
+ */
 #define MBEDTLS_SSL_NEW_SESSION_TICKET
 
 /**

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -814,24 +814,24 @@ typedef enum
 * \brief  Ticket Structure
 */
 struct mbedtls_ssl_ticket {
-    unsigned char* ticket; // The ticket itself is the psk_identity
-    size_t ticket_len; // PSK identity length
+#if defined(MBEDTLS_HAVE_TIME)
+    time_t start;
+#endif
     int ciphersuite;
     uint32_t ticket_lifetime;
     uint32_t ticket_age_add;
-    size_t key_len;
+    uint8_t key_len;
 #if defined(MBEDTLS_SHA256_C) && !defined(MBEDTLS_SHA512_C)
     unsigned char key[32];
 #else
     unsigned char key[48];
 #endif
-#if defined(MBEDTLS_HAVE_TIME)
-    time_t start;
-#endif
-#if defined(MBEDTLS_X509_CRT_PARSE_C)
-    mbedtls_x509_crt* peer_cert;    /*!< entry peer_cert */
-#endif
+
     mbedtls_ssl_ticket_flags flags; /*!< ticket flags    */
+
+//#if defined(MBEDTLS_X509_CRT_PARSE_C)
+//    mbedtls_x509_crt* peer_cert;    /*!< entry peer_cert */
+//#endif
 };
 
 #if defined(MBEDTLS_SSL_ASYNC_PRIVATE)
@@ -1121,24 +1121,32 @@ struct mbedtls_ssl_session
 #endif /* MBEDTLS_SSL_SESSION_TICKETS && MBEDTLS_SSL_CLI_C */
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && defined(MBEDTLS_SSL_NEW_SESSION_TICKET)
-// TBD: Replace fields by ticket structure
-// We currently only store a single ticket on the client size
+
+#if defined(MBEDTLS_SSL_SRV_C)
+    mbedtls_ssl_ticket *ticket_t;  /*!< Storage of ticket info */
+    int minor_ver;                 /*!< Version information for selecting ticket format */
+#endif /* MBEDTLS_SSL_SRV_C */
+
     unsigned char* ticket;          /*!< TLS 1.3 session ticket acting as psk identity */
-    size_t ticket_len;              /*!< ticket length   */
-    uint32_t ticket_lifetime;       /*!< ticket lifetime hint    */
-    mbedtls_ssl_ticket_flags flags; /*!< ticket flags */
-    uint32_t ticket_age_add;        /* A randomly generated 32-bit value that is used to obscure the age of the ticket */
-    unsigned char* ticket_nonce;    /*!< ticket nonce value */
-    uint8_t ticket_nonce_len;       /*!< ticket nonce length */
-    size_t key_len;                 /*!< psk key length */
+    size_t ticket_len;              /*!< Ticket length */
+
+#if defined(MBEDTLS_SSL_CLI_C)
+    uint32_t ticket_lifetime;       /*!< Ticket lifetime hint */
+    mbedtls_ssl_ticket_flags flags; /*!< Ticket flags */
+    uint32_t ticket_age_add;        /*!< Randomly generated value used to obscure the age of the ticket */
+    unsigned char* ticket_nonce;    /*!< Ticket nonce value */
+    uint8_t ticket_nonce_len;       /*!< Ticket nonce length */
+    uint8_t key_len;                 /*!< PSK key length */
 #if defined(MBEDTLS_SHA256_C) && !defined(MBEDTLS_SHA512_C)
-    unsigned char key[32];
+    unsigned char key[32];          /*!< key (32 byte) */
 #else /* MBEDTLS_SHA512_C */
-    unsigned char key[48];
+    unsigned char key[48];          /*!< key (48 byte) */
 #endif /* MBEDTLS_SHA256_C && !MBEDTLS_SHA512_C */
 #if defined(MBEDTLS_HAVE_TIME)
-    time_t ticket_received;
+    time_t ticket_received;         /*!< time ticket was received */
 #endif /* MBEDTLS_HAVE_TIME */
+#endif /* MBEDTLS_SSL_CLI_C */
+
 #endif /* MBEDTLS_SSL_NEW_SESSION_TICKET && MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 
 #if defined(MBEDTLS_SSL_MAX_FRAGMENT_LENGTH)
@@ -1246,20 +1254,11 @@ struct mbedtls_ssl_config
 
 #if ((defined(MBEDTLS_SSL_SESSION_TICKETS) || (defined(MBEDTLS_SSL_NEW_SESSION_TICKET) && defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)) ) && defined(MBEDTLS_SSL_SRV_C))
     /* Callback to create and write a session ticket */
-#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
-    int(*f_ticket_write)(void*, const mbedtls_ssl_ticket*,
-        unsigned char*, const unsigned char*, size_t*, uint32_t*,
-        mbedtls_ssl_ticket_flags*);
-    /** Callback to parse a session ticket into a session structure         */
-    int(*f_ticket_parse)(void*, mbedtls_ssl_ticket*, unsigned char*, size_t);
-    void* p_ticket;                 /*!< context for the ticket callbacks   */
-#else
     int (*f_ticket_write)( void *, const mbedtls_ssl_session *,
             unsigned char *, const unsigned char *, size_t *, uint32_t * );
     /** Callback to parse a session ticket into a session structure         */
     int (*f_ticket_parse)( void *, mbedtls_ssl_session *, unsigned char *, size_t);
     void *p_ticket;                 /*!< context for the ticket callbacks   */
-#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 #endif /* (MBEDTLS_SSL_SESSION_TICKETS || (MBEDTLS_SSL_NEW_SESSION_TICKET && MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) ) && MBEDTLS_SSL_SRV_C */
 
 #if defined(MBEDTLS_SSL_EXPORT_KEYS)
@@ -1392,8 +1391,10 @@ struct mbedtls_ssl_config
 #endif /* MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED */
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && defined(MBEDTLS_SSL_NEW_SESSION_TICKET)
-    /*!< Variable to toggle the use of resumption vs. a full exchange.
-    Default value is 0 (for full exchange) and 1 is resumption with ticket.  */
+    /*!< This variable allows to distinugish externally configured PSKs from resumption PSKs.
+     *   0  -- externally configured PSK
+     *   1  -- resumption PSK
+     */
     int resumption_mode;
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL && MBEDTLS_SSL_NEW_SESSION_TICKET */
 
@@ -2328,7 +2329,6 @@ void mbedtls_ssl_set_timer_cb( mbedtls_ssl_context *ssl,
                                mbedtls_ssl_get_timer_t *f_get_timer );
 
 
-#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
 /**
  * \brief           Callback type: generate and write session ticket
  *
@@ -2336,7 +2336,8 @@ void mbedtls_ssl_set_timer_cb( mbedtls_ssl_context *ssl,
  *                  This callback should generate and encrypted and
  *                  authenticated ticket for the session and write it to the
  *                  output buffer. Here, ticket means the opaque ticket part
- *                  of the NewSessionTicket structure of RFC 5077.
+ *                  of the NewSessionTicket structure of RFC 5077 or of a 
+ *                  TLS 1.3 ticket.
  *
  * \param p_ticket  Context for the callback
  * \param session   SSL session to bo written in the ticket
@@ -2348,41 +2349,13 @@ void mbedtls_ssl_set_timer_cb( mbedtls_ssl_context *ssl,
  * \return          0 if successful, or
  *                  a specific MBEDTLS_ERR_XXX code.
  */
-typedef int mbedtls_ssl_ticket_write_t(void* p_ticket,
-    const mbedtls_ssl_ticket* session,
-    unsigned char* start,
-    const unsigned char* end,
-    size_t* tlen,
-    uint32_t* lifetime, mbedtls_ssl_ticket_flags* flags);
 
-#else
-
-/**
- * \brief           Callback type: generate and write session ticket
- *
- * \note            This describes what a callback implementation should do.
- *                  This callback should generate an encrypted and
- *                  authenticated ticket for the session and write it to the
- *                  output buffer. Here, ticket means the opaque ticket part
- *                  of the NewSessionTicket structure of RFC 5077.
- *
- * \param p_ticket  Context for the callback
- * \param session   SSL session to be written in the ticket
- * \param start     Start of the output buffer
- * \param end       End of the output buffer
- * \param tlen      On exit, holds the length written
- * \param lifetime  On exit, holds the lifetime of the ticket in seconds
- *
- * \return          0 if successful, or
- *                  a specific MBEDTLS_ERR_XXX code.
- */
 typedef int mbedtls_ssl_ticket_write_t( void *p_ticket,
                                         const mbedtls_ssl_session *session,
                                         unsigned char *start,
                                         const unsigned char *end,
                                         size_t *tlen,
                                         uint32_t *lifetime );
-#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 
 #if defined(MBEDTLS_SSL_EXPORT_KEYS)
 #if defined(MBEDTLS_SSL_PROTO_TLS1) || defined(MBEDTLS_SSL_PROTO_TLS1_1) || \
@@ -2477,35 +2450,6 @@ typedef int mbedtls_ssl_export_secret_t( void *p_expsecret,
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 #endif /* MBEDTLS_SSL_EXPORT_KEYS */
 
-#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
-/**
- * \brief           Callback type: parse and load session ticket
- *
- * \note            This describes what a callback implementation should do.
- *                  This callback should parse a session ticket as generated
- *                  by the corresponding mbedtls_ssl_ticket_write_t function,
- *                  and, if the ticket is authentic and valid, load the
- *                  session.
- *
- * \note            The implementation is allowed to modify the first len
- *                  bytes of the input buffer, eg to use it as a temporary
- *                  area for the decrypted ticket contents.
- *
- * \param p_ticket  Context for the callback
- * \param session   SSL session to be loaded
- * \param buf       Start of the buffer containing the ticket
- * \param len       Length of the ticket.
- *
- * \return          0 if successful, or
- *                  MBEDTLS_ERR_SSL_INVALID_MAC if not authentic, or
- *                  MBEDTLS_ERR_SSL_SESSION_TICKET_EXPIRED if expired, or
- *                  any other non-zero code for other failures.
- */
-typedef int mbedtls_ssl_ticket_parse_t(void* p_ticket,
-    mbedtls_ssl_ticket* session,
-    unsigned char* buf,
-    size_t len);
-#else
 /**
  * \brief           Callback type: parse and load session ticket
  *
@@ -2533,34 +2477,8 @@ typedef int mbedtls_ssl_ticket_parse_t( void *p_ticket,
                                         mbedtls_ssl_session *session,
                                         unsigned char *buf,
                                         size_t len );
-#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 
-
-#if (defined(MBEDTLS_SSL_SESSION_TICKETS) || defined(MBEDTLS_SSL_NEW_SESSION_TICKET)) && defined(MBEDTLS_SSL_SRV_C) && defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
-/**
- * \brief           Configure SSL session ticket callbacks (server only).
- *                  (Default: none.)
- *
- * \note            On server, session tickets are enabled by providing
- *                  non-NULL callbacks.
- *
- * \note            On client, use \c mbedtls_ssl_conf_session_tickets().
- *
- * \param conf      SSL configuration context
- * \param f_ticket_write    Callback for writing a ticket
- * \param f_ticket_parse    Callback for parsing a ticket
- * \param p_ticket          Context shared by the two callbacks
- * \param use_tickets       Enable or disable (MBEDTLS_SSL_SESSION_TICKETS_ENABLED or
- *                                         MBEDTLS_SSL_SESSION_TICKETS_DISABLED)
- */
-void mbedtls_ssl_conf_session_tickets_cb(mbedtls_ssl_config* conf,
-    mbedtls_ssl_ticket_write_t* f_ticket_write,
-    mbedtls_ssl_ticket_parse_t* f_ticket_parse,
-    void* p_ticket, int use_tickets);
-#endif /* ( MBEDTLS_SSL_SESSION_TICKETS || MBEDTLS_SSL_NEW_SESSION_TICKET ) && MBEDTLS_SSL_SRV_C && MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
-
-
-#if (defined(MBEDTLS_SSL_SESSION_TICKETS) && defined(MBEDTLS_SSL_SRV_C) && !defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL))
+#if (defined(MBEDTLS_SSL_SESSION_TICKETS) || defined(MBEDTLS_SSL_NEW_SESSION_TICKET)) && defined(MBEDTLS_SSL_SRV_C)
 /**
  * \brief           Configure SSL session ticket callbacks (server only).
  *                  (Default: none.)
@@ -2579,7 +2497,7 @@ void mbedtls_ssl_conf_session_tickets_cb( mbedtls_ssl_config *conf,
         mbedtls_ssl_ticket_write_t *f_ticket_write,
         mbedtls_ssl_ticket_parse_t *f_ticket_parse,
         void *p_ticket );
-#endif /* MBEDTLS_SSL_SESSION_TICKETS && MBEDTLS_SSL_SRV_C */
+#endif /* ( MBEDTLS_SSL_SESSION_TICKETS || MBEDTLS_SSL_NEW_SESSION_TICKET ) && MBEDTLS_SSL_SRV_C */
 
 #if defined(MBEDTLS_SSL_EXPORT_KEYS)
 #if defined(MBEDTLS_SSL_PROTO_TLS1) || defined(MBEDTLS_SSL_PROTO_TLS1_1) || \
@@ -2978,6 +2896,9 @@ void mbedtls_ssl_conf_session_cache( mbedtls_ssl_config *conf,
         int (*f_set_cache)(void *, const mbedtls_ssl_session *) );
 #endif /* MBEDTLS_SSL_SRV_C */
 
+#if defined(MBEDTLS_SSL_PROTO_TLS1_2) || defined(MBEDTLS_SSL_PROTO_TLS1_1) || \
+    defined(MBEDTLS_SSL_PROTO_TLS1) || ( defined(MBEDTLS_SSL_NEW_SESSION_TICKET) && defined(MBEDTLS_SSL_SRV_C) )
+
 #if defined(MBEDTLS_SSL_CLI_C)
 /**
  * \brief          Request resumption of session (client-side only)
@@ -3079,6 +3000,10 @@ int mbedtls_ssl_session_save( const mbedtls_ssl_session *session,
  * \return         \c NULL if no session is active.
  */
 const mbedtls_ssl_session *mbedtls_ssl_get_session_pointer( const mbedtls_ssl_context *ssl );
+
+#endif /* MBEDTLS_SSL_PROTO_TLS1_2 || MBEDTLS_SSL_PROTO_TLS1_1 || MBEDTLS_SSL_PROTO_TLS1 ||
+         ( MBEDTLS_SSL_NEW_SESSION_TICKET && MBEDTLS_SSL_SRV_C ) */
+
 
 /**
  * \brief               Set the list of allowed ciphersuites and the preference
@@ -4039,7 +3964,7 @@ void mbedtls_ssl_conf_truncated_hmac( mbedtls_ssl_config *conf, int truncate );
 void mbedtls_ssl_conf_cbc_record_splitting( mbedtls_ssl_config *conf, char split );
 #endif /* MBEDTLS_SSL_CBC_RECORD_SPLITTING */
 
-#if ((defined(MBEDTLS_SSL_SESSION_TICKETS) || (defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && defined (MBEDTLS_SSL_NEW_SESSION_TICKET) )) && defined(MBEDTLS_SSL_CLI_C))
+#if defined(MBEDTLS_SSL_SESSION_TICKETS) || defined (MBEDTLS_SSL_NEW_SESSION_TICKET)
 /**
  * \brief          Enable / Disable session tickets (client only).
  *                 (Default: MBEDTLS_SSL_SESSION_TICKETS_ENABLED.)
@@ -4051,7 +3976,7 @@ void mbedtls_ssl_conf_cbc_record_splitting( mbedtls_ssl_config *conf, char split
  *                                         MBEDTLS_SSL_SESSION_TICKETS_DISABLED)
  */
 void mbedtls_ssl_conf_session_tickets( mbedtls_ssl_config *conf, int use_tickets );
-#endif /* (MBEDTLS_SSL_SESSION_TICKETS || (MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL && MBEDTLS_SSL_NEW_SESSION_TICKET)) && MBEDTLS_SSL_CLI_C */
+#endif /* MBEDTLS_SSL_SESSION_TICKETS || MBEDTLS_SSL_NEW_SESSION_TICKET */
 
 #if defined(MBEDTLS_SSL_RENEGOTIATION)
 /**

--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -1343,7 +1343,7 @@ int mbedtls_ssl_parse_supported_groups_ext(mbedtls_ssl_context* ssl, const unsig
 int mbedtls_ssl_create_binder(mbedtls_ssl_context* ssl, unsigned char* psk, size_t psk_len, const mbedtls_md_info_t* md, const mbedtls_ssl_ciphersuite_t* suite_info, unsigned char* buffer, size_t blen, unsigned char* result);
 #endif /* MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED */
 #if defined(MBEDTLS_SSL_NEW_SESSION_TICKET)
-int mbedtls_ssl_parse_new_session_ticket_server(mbedtls_ssl_context* ssl, unsigned char* buf, size_t len, mbedtls_ssl_ticket* ticket);
+int mbedtls_ssl_parse_psk_identity(mbedtls_ssl_context* ssl, unsigned char* buf, size_t len, uint32_t obfuscated_ticket_age );
 #endif /* MBEDTLS_SSL_NEW_SESSION_TICKET */
 #if defined(MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED)
 int mbedtls_ssl_parse_client_psk_identity_ext(mbedtls_ssl_context* ssl, const unsigned char* buf, size_t len);

--- a/include/mbedtls/ssl_ticket.h
+++ b/include/mbedtls/ssl_ticket.h
@@ -87,13 +87,47 @@ mbedtls_ssl_ticket_context;
  */
 void mbedtls_ssl_ticket_init( mbedtls_ssl_ticket_context *ctx );
 
+
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && defined(MBEDTLS_SSL_NEW_SESSION_TICKET)
-void mbedtls_ssl_del_client_ticket(mbedtls_ssl_ticket* ticket);
-void mbedtls_ssl_init_client_ticket(mbedtls_ssl_ticket* ticket);
-void mbedtls_ssl_conf_client_ticket_disable(mbedtls_ssl_context* ssl);
-void mbedtls_ssl_conf_client_ticket_enable(mbedtls_ssl_context* ssl);
-int mbedtls_ssl_get_client_ticket(const mbedtls_ssl_context* ssl, mbedtls_ssl_ticket* ticket);
-int mbedtls_ssl_conf_client_ticket(const mbedtls_ssl_context* ssl, mbedtls_ssl_ticket* ticket);
+/**
+ * \brief           Allows the caller to set a ticket.
+ * 
+ * \param ssl       SSL context
+ * \param ticket    Content that contains meta-data about the ticket.
+ * \param buf       Buffer containing the ticket.  
+ * \param size      Size of the ticket buffer
+ * \param ke        Key exchange mode (either PSK or PSK-ECDHE)
+ *
+ * \note            Due to the construction of the ticket exchange in TLS/DTLS 1.3
+ *                  this function is merely a wrapper around setting a PSK. 
+ *
+ * \return          0 if successful,
+ *                  or a specific MBEDTLS_ERR_XXX error code
+ */
+int mbedtls_ssl_conf_client_set_ticket( const mbedtls_ssl_context *ssl,
+                                    mbedtls_ssl_ticket *ticket, unsigned char *buf, size_t size, const int ke ); 
+
+/**
+ * \brief           Allows the caller to retrieve a ticket received in the handshake. 
+ *
+ * \param ssl       SSL context
+ * \param metadata  Content that contains meta-data about the ticket.
+ * \param buf       Buffer used to store the opaque part of the ticket.  
+ * \param size      Size of the opaque part of the ticket.
+ *
+ * \note            A ticket contains of two parts, namely (1) a part that is opaque to the 
+ *                  client (which is used as the psk_identity in the handshake), and 
+ *                  (2) metadata about the ticket.
+ *
+ * \note            If the caller sets either the metadata or the buf parameters to NULL 
+ *                  then the function returns the number of bytes needed to store the 
+ *                  opaque part of the ticket. This is allows the caller to adjust the 
+ *                  required buffer size accordingly. 
+ *
+ * \return          0 if successful,
+ *                  or a specific MBEDTLS_ERR_SSL_BAD_INPUT_DATA error code
+ */
+int mbedtls_ssl_get_client_ticket(const mbedtls_ssl_context* ssl, mbedtls_ssl_ticket* metadata, void *buf, size_t *size);
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL && MBEDTLS_SSL_NEW_SESSION_TICKET */
 
 /**
@@ -118,17 +152,10 @@ int mbedtls_ssl_conf_client_ticket(const mbedtls_ssl_context* ssl, mbedtls_ssl_t
  * \return          0 if successful,
  *                  or a specific MBEDTLS_ERR_XXX error code
  */
-#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
-int mbedtls_ssl_ticket_setup( mbedtls_ssl_ticket_context *ctx,
-    int (*f_rng)(void *, unsigned char *, size_t), void *p_rng,
-    mbedtls_cipher_type_t cipher,
-    uint32_t lifetime, mbedtls_ssl_ticket_flags flags);
-#else 
 int mbedtls_ssl_ticket_setup(mbedtls_ssl_ticket_context* ctx,
     int (*f_rng)(void*, unsigned char*, size_t), void* p_rng,
     mbedtls_cipher_type_t cipher,
     uint32_t lifetime);
-#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 
 /**
  * \brief           Implementation of the ticket write callback

--- a/include/mbedtls/ssl_ticket.h
+++ b/include/mbedtls/ssl_ticket.h
@@ -87,49 +87,6 @@ mbedtls_ssl_ticket_context;
  */
 void mbedtls_ssl_ticket_init( mbedtls_ssl_ticket_context *ctx );
 
-
-#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && defined(MBEDTLS_SSL_NEW_SESSION_TICKET)
-/**
- * \brief           Allows the caller to set a ticket.
- * 
- * \param ssl       SSL context
- * \param ticket    Content that contains meta-data about the ticket.
- * \param buf       Buffer containing the ticket.  
- * \param size      Size of the ticket buffer
- * \param ke        Key exchange mode (either PSK or PSK-ECDHE)
- *
- * \note            Due to the construction of the ticket exchange in TLS/DTLS 1.3
- *                  this function is merely a wrapper around setting a PSK. 
- *
- * \return          0 if successful,
- *                  or a specific MBEDTLS_ERR_XXX error code
- */
-int mbedtls_ssl_conf_client_set_ticket( const mbedtls_ssl_context *ssl,
-                                    mbedtls_ssl_ticket *ticket, unsigned char *buf, size_t size, const int ke ); 
-
-/**
- * \brief           Allows the caller to retrieve a ticket received in the handshake. 
- *
- * \param ssl       SSL context
- * \param metadata  Content that contains meta-data about the ticket.
- * \param buf       Buffer used to store the opaque part of the ticket.  
- * \param size      Size of the opaque part of the ticket.
- *
- * \note            A ticket contains of two parts, namely (1) a part that is opaque to the 
- *                  client (which is used as the psk_identity in the handshake), and 
- *                  (2) metadata about the ticket.
- *
- * \note            If the caller sets either the metadata or the buf parameters to NULL 
- *                  then the function returns the number of bytes needed to store the 
- *                  opaque part of the ticket. This is allows the caller to adjust the 
- *                  required buffer size accordingly. 
- *
- * \return          0 if successful,
- *                  or a specific MBEDTLS_ERR_SSL_BAD_INPUT_DATA error code
- */
-int mbedtls_ssl_get_client_ticket(const mbedtls_ssl_context* ssl, mbedtls_ssl_ticket* metadata, void *buf, size_t *size);
-#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL && MBEDTLS_SSL_NEW_SESSION_TICKET */
-
 /**
  * \brief           Prepare context to be actually used
  *

--- a/library/ssl_ciphersuites.c
+++ b/library/ssl_ciphersuites.c
@@ -2344,7 +2344,7 @@ int mbedtls_ssl_get_ciphersuite_id( const char *ciphersuite_name )
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
 unsigned int mbedtls_hash_size_for_ciphersuite(const mbedtls_ssl_ciphersuite_t* ciphersuite)
 {
-    /* We assume that the input parameter, ciphersuite, is not NULL. */
+    /* We assume that the input parameter, ciphersuite, is NOT NULL. */
     switch( ciphersuite->mac )
     {
     case MBEDTLS_MD_SHA256:

--- a/library/ssl_ticket.c
+++ b/library/ssl_ticket.c
@@ -19,7 +19,7 @@
 
 #include "common.h"
 
-#if defined(MBEDTLS_SSL_TICKET_C)
+#if defined(MBEDTLS_SSL_TICKET_C) && defined(MBEDTLS_SSL_SRV_C)
 
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"
@@ -124,17 +124,10 @@ static int ssl_ticket_update_keys( mbedtls_ssl_ticket_context *ctx )
 /*
  * Setup context for actual use
  */
-#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
-int mbedtls_ssl_ticket_setup( mbedtls_ssl_ticket_context* ctx,
-    int (*f_rng)(void *, unsigned char *, size_t), void* p_rng,
-    mbedtls_cipher_type_t cipher,
-    uint32_t lifetime, mbedtls_ssl_ticket_flags flags )
-#else
 int mbedtls_ssl_ticket_setup( mbedtls_ssl_ticket_context *ctx,
     int (*f_rng)(void *, unsigned char *, size_t), void *p_rng,
     mbedtls_cipher_type_t cipher,
     uint32_t lifetime )
-#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     const mbedtls_cipher_info_t *cipher_info;
@@ -143,10 +136,6 @@ int mbedtls_ssl_ticket_setup( mbedtls_ssl_ticket_context *ctx,
     ctx->p_rng = p_rng;
 
     ctx->ticket_lifetime = lifetime;
-
-#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
-    ctx->flags = flags;
-#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 
     cipher_info = mbedtls_cipher_info_from_type( cipher);
     if( cipher_info == NULL )
@@ -192,117 +181,6 @@ int mbedtls_ssl_ticket_setup( mbedtls_ssl_ticket_context *ctx,
     return( 0 );
 }
 
-#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
-
-/*
- * Serialize a session in the following format:
- *  0   .   n-1     session structure, n = sizeof(mbedtls_ssl_session)
- *  n   .   n+2     peer_cert length = m (0 if no certificate)
- *  n+3 .   n+2+m   peer cert ASN.1
- */
-static int ssl_save_session(const mbedtls_ssl_ticket* session,
-    unsigned char* buf, size_t buf_len,
-    size_t* olen)
-{
-    unsigned char* p = buf;
-    size_t left = buf_len;
-#if defined(MBEDTLS_X509_CRT_PARSE_C)
-    size_t cert_len;
-#endif /* MBEDTLS_X509_CRT_PARSE_C */
-
-    if (left < sizeof(mbedtls_ssl_ticket))
-        return(MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL);
-    memcpy(p, session, sizeof(mbedtls_ssl_ticket));
-    p += sizeof(mbedtls_ssl_ticket);
-    left -= sizeof(mbedtls_ssl_ticket);
-
-#if defined(MBEDTLS_X509_CRT_PARSE_C)
-    if (session->peer_cert == NULL)
-        cert_len = 0;
-    else
-        cert_len = session->peer_cert->raw.len;
-
-    if (left < 3 + cert_len)
-        return(MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL);
-
-    *p++ = (unsigned char)(cert_len >> 16 & 0xFF);
-    *p++ = (unsigned char)(cert_len >> 8 & 0xFF);
-    *p++ = (unsigned char)(cert_len & 0xFF);
-
-    if (session->peer_cert != NULL)
-        memcpy(p, session->peer_cert->raw.p, cert_len);
-
-    p += cert_len;
-#endif /* MBEDTLS_X509_CRT_PARSE_C */
-
-    * olen = p - buf;
-
-    return(0);
-}
-
-/*
- * Unserialise session, see ssl_save_session()
- */
-static int ssl_load_session(mbedtls_ssl_ticket* session,
-    const unsigned char* buf, size_t len)
-{
-    const unsigned char* p = buf;
-    const unsigned char* const end = buf + len;
-#if defined(MBEDTLS_X509_CRT_PARSE_C)
-    size_t cert_len;
-#endif /* MBEDTLS_X509_CRT_PARSE_C */
-
-    if (p + sizeof(mbedtls_ssl_ticket) > end)
-        return(MBEDTLS_ERR_SSL_BAD_INPUT_DATA);
-
-    memcpy(session, p, sizeof(mbedtls_ssl_ticket));
-    p += sizeof(mbedtls_ssl_ticket);
-
-#if defined(MBEDTLS_X509_CRT_PARSE_C)
-    if (p + 3 > end)
-        return(MBEDTLS_ERR_SSL_BAD_INPUT_DATA);
-
-    cert_len = (p[0] << 16) | (p[1] << 8) | p[2];
-    p += 3;
-
-    if (cert_len == 0)
-    {
-        session->peer_cert = NULL;
-    }
-    else
-    {
-        int ret;
-
-        if (p + cert_len > end)
-            return(MBEDTLS_ERR_SSL_BAD_INPUT_DATA);
-
-        session->peer_cert = mbedtls_calloc(1, sizeof(mbedtls_x509_crt));
-
-        if (session->peer_cert == NULL)
-            return(MBEDTLS_ERR_SSL_ALLOC_FAILED);
-
-        mbedtls_x509_crt_init(session->peer_cert);
-
-        if ((ret = mbedtls_x509_crt_parse_der(session->peer_cert,
-            p, cert_len)) != 0)
-        {
-            mbedtls_x509_crt_free(session->peer_cert);
-            mbedtls_free(session->peer_cert);
-            session->peer_cert = NULL;
-            return(ret);
-        }
-
-        p += cert_len;
-    }
-#endif /* MBEDTLS_X509_CRT_PARSE_C */
-
-    if (p != end)
-        return(MBEDTLS_ERR_SSL_BAD_INPUT_DATA);
-
-    return(0);
-}
-
-#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 /*
  * Create session ticket, with the following structure:
  *
@@ -316,22 +194,13 @@ static int ssl_load_session(mbedtls_ssl_ticket* session,
  * The key_name, iv, and length of encrypted_state are the additional
  * authenticated data.
  */
-#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
-int mbedtls_ssl_ticket_write(void* p_ticket,
-    const mbedtls_ssl_ticket* session,
-    unsigned char* start,
-    const unsigned char* end,
-    size_t* tlen,
-    uint32_t* ticket_lifetime,
-    mbedtls_ssl_ticket_flags* flags)
-#else
+
 int mbedtls_ssl_ticket_write( void *p_ticket,
                               const mbedtls_ssl_session *session,
                               unsigned char *start,
                               const unsigned char *end,
                               size_t *tlen,
                               uint32_t *ticket_lifetime )
-#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     mbedtls_ssl_ticket_context *ctx = p_ticket;
@@ -363,24 +232,12 @@ int mbedtls_ssl_ticket_write( void *p_ticket,
     key = &ctx->keys[ctx->active];
 
     *ticket_lifetime = ctx->ticket_lifetime;
-#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
-    *flags = ctx->flags;
-#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
-
 
     memcpy( key_name, key->name, TICKET_KEY_NAME_BYTES );
 
     if( ( ret = ctx->f_rng( ctx->p_rng, iv, TICKET_IV_BYTES ) ) != 0 )
         goto cleanup;
 
-#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
-    if ((ret = ssl_save_session(session,
-        state, end - state, &clear_len)) != 0 ||
-        (unsigned long)clear_len > 65535)
-    {
-        goto cleanup;
-    }
-#else
     /* Dump session state */
     if( ( ret = mbedtls_ssl_session_save( session,
                                           state, end - state,
@@ -389,10 +246,6 @@ int mbedtls_ssl_ticket_write( void *p_ticket,
     {
          goto cleanup;
     }
-
-#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
-
-
     state_len_bytes[0] = ( clear_len >> 8 ) & 0xff;
     state_len_bytes[1] = ( clear_len      ) & 0xff;
 
@@ -443,18 +296,10 @@ static mbedtls_ssl_ticket_key *ssl_ticket_select_key(
 /*
  * Load session ticket (see mbedtls_ssl_ticket_write for structure)
  */
-#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
-int mbedtls_ssl_ticket_parse(void* p_ticket,
-    mbedtls_ssl_ticket* session,
-    unsigned char* buf,
-    size_t len)
-#else
 int mbedtls_ssl_ticket_parse( void *p_ticket,
                               mbedtls_ssl_session *session,
                               unsigned char *buf,
                               size_t len )
-#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
-
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     mbedtls_ssl_ticket_context *ctx = p_ticket;
@@ -517,14 +362,10 @@ int mbedtls_ssl_ticket_parse( void *p_ticket,
         ret = MBEDTLS_ERR_SSL_INTERNAL_ERROR;
         goto cleanup;
     }
-#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
-    if ((ret = ssl_load_session(session, ticket, clear_len)) != 0)
-        goto cleanup;
-#else
+
     /* Actually load session */
     if( ( ret = mbedtls_ssl_session_load( session, ticket, clear_len ) ) != 0 )
         goto cleanup;
-#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 
 #if defined(MBEDTLS_HAVE_TIME)
     {
@@ -561,7 +402,7 @@ void mbedtls_ssl_ticket_free( mbedtls_ssl_ticket_context *ctx )
     mbedtls_mutex_free( &ctx->mutex );
 #endif
 
-    mbedtls_platform_zeroize( (void*) ctx, sizeof( mbedtls_ssl_ticket_context ) );
+    mbedtls_platform_zeroize( ctx, sizeof( mbedtls_ssl_ticket_context ) );
 }
 
-#endif /* MBEDTLS_SSL_TICKET_C */
+#endif /* MBEDTLS_SSL_TICKET_C && MBEDTLS_SSL_SRV_C */

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -236,11 +236,19 @@ int mbedtls_ssl_session_copy( mbedtls_ssl_session *dst,
     }
 #endif /* (MBEDTLS_SSL_SESSION_TICKETS || MBEDTLS_SSL_NEW_SESSION_TICKET) && MBEDTLS_SSL_CLI_C */
 
-#if defined(MBEDTLS_SSL_NEW_SESSION_TICKET) && defined(MBEDTLS_SSL_CLI_C)
+#if defined(MBEDTLS_SSL_NEW_SESSION_TICKET)
     /* Resumption Key */
     memcpy( dst->resumption_key, src->resumption_key, src->resumption_key_len );
 
-#endif /* MBEDTLS_SSL_NEW_SESSION_TICKET && MBEDTLS_SSL_CLI_C */
+    if( src->ticket_nonce != NULL )
+    {
+        dst->ticket_nonce = mbedtls_calloc( 1, src->ticket_nonce_len );
+        if( dst->ticket_nonce == NULL )
+            return( MBEDTLS_ERR_SSL_ALLOC_FAILED );
+
+        memcpy( dst->ticket_nonce, src->ticket_nonce, src->ticket_nonce_len );
+    }
+#endif /* MBEDTLS_SSL_NEW_SESSION_TICKET */
 
     return( 0 );
 }

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -6610,7 +6610,8 @@ void mbedtls_ssl_handshake_free( mbedtls_ssl_context *ssl )
         return;
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
-    mbedtls_free( handshake->key_shares_curve_list );
+    if( handshake->key_shares_curve_list != NULL )
+        mbedtls_free( handshake->key_shares_curve_list ); 
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 
 #if defined(MBEDTLS_SSL_ASYNC_PRIVATE)

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -731,9 +731,9 @@ int mbedtls_ssl_create_binder( mbedtls_ssl_context *ssl, unsigned char *psk, siz
 
     hash_length = mbedtls_hash_size_for_ciphersuite( suite_info );
 
-    if( hash_length == -1 )
+    if( hash_length == 0 )
     {
-        MBEDTLS_SSL_DEBUG_MSG( 1, ( "mbedtls_hash_size_for_ciphersuite == -1, mbedtls_ssl_create_binder failed" ) );
+        MBEDTLS_SSL_DEBUG_MSG( 1, ( "mbedtls_hash_size_for_ciphersuite == 0, mbedtls_ssl_create_binder failed" ) );
         return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
     }
 
@@ -1022,9 +1022,9 @@ int mbedtls_ssl_write_pre_shared_key_ext( mbedtls_ssl_context *ssl,
 
         hash_len = mbedtls_hash_size_for_ciphersuite( suite_info );
 
-        if( hash_len == -1 )
+        if( hash_len == 0 )
         {
-            MBEDTLS_SSL_DEBUG_MSG( 1, ( "mbedtls_hash_size_for_ciphersuite == -1, mbedtls_ssl_write_pre_shared_key_ext failed" ) );
+            MBEDTLS_SSL_DEBUG_MSG( 1, ( "mbedtls_hash_size_for_ciphersuite == 0, mbedtls_ssl_write_pre_shared_key_ext failed" ) );
             return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
         }
 
@@ -1042,9 +1042,9 @@ int mbedtls_ssl_write_pre_shared_key_ext( mbedtls_ssl_context *ssl,
 #endif
         break;
     }
-    if( hash_len == -1 )
+    if( hash_len == 0 )
     {
-        MBEDTLS_SSL_DEBUG_MSG( 1, ( "mbedtls_hash_size_for_ciphersuite == -1, mbedtls_ssl_write_pre_shared_key_ext failed" ) );
+        MBEDTLS_SSL_DEBUG_MSG( 1, ( "mbedtls_hash_size_for_ciphersuite == 0, mbedtls_ssl_write_pre_shared_key_ext failed" ) );
         return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
     }
 
@@ -3806,9 +3806,9 @@ static int ssl_hrr_postprocess( mbedtls_ssl_context* ssl,
 
     hash_length = mbedtls_hash_size_for_ciphersuite( ssl->handshake->ciphersuite_info );
 
-    if( hash_length == -1 )
+    if( hash_length == 0 )
     {
-        MBEDTLS_SSL_DEBUG_MSG( 1, ( "mbedtls_hash_size_for_ciphersuite == -1" ) );
+        MBEDTLS_SSL_DEBUG_MSG( 1, ( "mbedtls_hash_size_for_ciphersuite == 0, ssl_hrr_postprocess failed" ) );
         return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
     }
 

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -945,10 +945,14 @@ int mbedtls_ssl_parse_signature_algorithms_ext( mbedtls_ssl_context *ssl,
             num_supported_hashes++;
     }
 
+    /* Clear previously allocated memory */
+    if( ssl->handshake->received_signature_schemes_list != NULL )
+        mbedtls_free( ssl->handshake->received_signature_schemes_list );
+
     /* Store the received and compatible signature algorithms for later use. */
     ssl->handshake->received_signature_schemes_list =
         mbedtls_calloc( num_supported_hashes + 1, sizeof(uint32_t) );
-    /* TODO: Remove heap buffer here */
+
     if( ssl->handshake->received_signature_schemes_list == NULL )
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "malloc failed in ssl_parse_signature_algorithms_ext( )" ) );
@@ -3973,7 +3977,6 @@ void mbedtls_ssl_handshake_wrapup( mbedtls_ssl_context *ssl )
      */
     if( ssl->session )
     {
-
         mbedtls_ssl_session_free( ssl->session );
         mbedtls_free( ssl->session );
     }

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -272,18 +272,15 @@ int mbedtls_ssl_parse_supported_groups_ext(
         return( MBEDTLS_ERR_SSL_BAD_HS_SUPPORTED_GROUPS );
     }
 
-    /* Should never happen unless client duplicates the extension */
-    /*	if( ssl->handshake->curves != NULL )
-	{
-	MBEDTLS_SSL_DEBUG_MSG( 1, ( "bad supported groups extension" ) );
-	return( MBEDTLS_ERR_SSL_BAD_HS_SUPPORTED_GROUPS );
-	}
-    */
     /* Don't allow our peer to make us allocate too much memory,
-     * and leave room for a final 0 */
+     * and leave room for a final 0.
+     */
     our_size = list_size / 2 + 1;
     if( our_size > MBEDTLS_ECP_DP_MAX )
         our_size = MBEDTLS_ECP_DP_MAX;
+
+    if( ssl->handshake->curves != NULL)
+        mbedtls_free( ssl->handshake->curves );
 
     if( ( curves = mbedtls_calloc( our_size, sizeof( *curves ) ) ) == NULL )
     {
@@ -318,7 +315,6 @@ int mbedtls_ssl_parse_supported_groups_ext(
     }
 
     return( 0 );
-
 }
 #endif /* MBEDTLS_ECDH_C || ( MBEDTLS_ECDSA_C */
 

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -3464,56 +3464,54 @@ send_request:
          *
          * For TLS 1.3 this results in a PSK-based exchange.
          */
+        if( opt.reco_mode == 1 )
         {
-            if( opt.reco_mode == 1 )
+            /* free any previously saved data */
+            if( session_data != NULL )
             {
-                /* free any previously saved data */
-                if( session_data != NULL )
-                {
-                    mbedtls_platform_zeroize( session_data, session_data_len );
-                    mbedtls_free( session_data );
-                    session_data = NULL;
-                }
-
-                /* get size of the buffer needed */
-                mbedtls_ssl_session_save( mbedtls_ssl_get_session_pointer( &ssl ),
-                                          NULL, 0, &session_data_len );
-                session_data = mbedtls_calloc( 1, session_data_len );
-                if( session_data == NULL )
-                {
-                    mbedtls_printf( " failed\n  ! alloc %u bytes for session data\n",
-                                    (unsigned) session_data_len );
-                    ret = MBEDTLS_ERR_SSL_ALLOC_FAILED;
-                    goto exit;
-                }
-
-                /* actually save session data */
-                if( ( ret = mbedtls_ssl_session_save( mbedtls_ssl_get_session_pointer( &ssl ),
-                                                      session_data, session_data_len,
-                                                      &session_data_len ) ) != 0 )
-                {
-                    mbedtls_printf( " failed\n  ! mbedtls_ssl_session_saved returned -0x%04x\n\n",
-                                    (unsigned int) -ret );
-                    goto exit;
-                }
-            }
-            else
-            {
-                if( ( ret = mbedtls_ssl_get_session( &ssl, &saved_session ) ) != 0 )
-                {
-                    mbedtls_printf( " failed\n  ! mbedtls_ssl_get_session returned -0x%x\n\n",
-                                    (unsigned int) -ret );
-                    goto exit;
-                }
+                mbedtls_platform_zeroize( session_data, session_data_len );
+                mbedtls_free( session_data );
+                session_data = NULL;
             }
 
-            mbedtls_printf( " ok\n" );
-
-            if( opt.reco_mode == 1 )
+            /* get size of the buffer needed */
+            mbedtls_ssl_session_save( mbedtls_ssl_get_session_pointer( &ssl ),
+                                        NULL, 0, &session_data_len );
+            session_data = mbedtls_calloc( 1, session_data_len );
+            if( session_data == NULL )
             {
-                mbedtls_printf( "    [ Saved %u bytes of session data]\n",
+                mbedtls_printf( " failed\n  ! alloc %u bytes for session data\n",
                                 (unsigned) session_data_len );
+                ret = MBEDTLS_ERR_SSL_ALLOC_FAILED;
+                goto exit;
             }
+
+            /* actually save session data */
+            if( ( ret = mbedtls_ssl_session_save( mbedtls_ssl_get_session_pointer( &ssl ),
+                                                    session_data, session_data_len,
+                                                    &session_data_len ) ) != 0 )
+            {
+                mbedtls_printf( " failed\n  ! mbedtls_ssl_session_saved returned -0x%04x\n\n",
+                                (unsigned int) -ret );
+                goto exit;
+            }
+        }
+        else
+        {
+            if( ( ret = mbedtls_ssl_get_session( &ssl, &saved_session ) ) != 0 )
+            {
+                mbedtls_printf( " failed\n  ! mbedtls_ssl_get_session returned -0x%x\n\n",
+                                (unsigned int) -ret );
+                goto exit;
+            }
+        }
+
+        mbedtls_printf( " ok\n" );
+
+        if( opt.reco_mode == 1 )
+        {
+            mbedtls_printf( "    [ Saved %u bytes of session data]\n",
+                            (unsigned) session_data_len );
         }
     }
 

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -3571,27 +3571,7 @@ int main( int argc, char *argv[] )
                                    mbedtls_ssl_cache_set );
 #endif
 
-#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
-#if defined(MBEDTLS_SSL_NEW_SESSION_TICKET)
-    if( opt.tickets == MBEDTLS_SSL_SESSION_TICKETS_ENABLED )
-    {
-        if( ( ret = mbedtls_ssl_ticket_setup( &ticket_ctx,
-                        mbedtls_ctr_drbg_random, &ctr_drbg,
-                        MBEDTLS_CIPHER_AES_256_GCM,
-                        opt.ticket_timeout, opt.ticket_flags ) ) != 0 )
-        {
-            mbedtls_printf( " failed\n  ! mbedtls_ssl_ticket_setup returned %d\n\n", ret );
-            goto exit;
-        }
-
-        mbedtls_ssl_conf_session_tickets_cb( &conf,
-                mbedtls_ssl_ticket_write,
-                mbedtls_ssl_ticket_parse,
-                &ticket_ctx, opt.tickets );
-    }
-#endif /* MBEDTLS_SSL_NEW_SESSION_TICKET */
-#else
-#if defined(MBEDTLS_SSL_SESSION_TICKETS)
+#if defined(MBEDTLS_SSL_SESSION_TICKETS) || defined(MBEDTLS_SSL_NEW_SESSION_TICKET)
     if( opt.tickets == MBEDTLS_SSL_SESSION_TICKETS_ENABLED )
     {
         if( ( ret = mbedtls_ssl_ticket_setup( &ticket_ctx,
@@ -3607,9 +3587,13 @@ int main( int argc, char *argv[] )
                 mbedtls_ssl_ticket_write,
                 mbedtls_ssl_ticket_parse,
                 &ticket_ctx );
+
+#if defined(MBEDTLS_SSL_NEW_SESSION_TICKET)
+        /* Enable use of tickets */
+        mbedtls_ssl_conf_session_tickets( &conf, opt.tickets );
+#endif /* MBEDTLS_SSL_NEW_SESSION_TICKET */
     }
 #endif /* MBEDTLS_SSL_SESSION_TICKETS */
-#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
 #if defined(MBEDTLS_SSL_COOKIE_C)


### PR DESCRIPTION
# Ticket Handling in TLS 1.3 

The TLS 1.3 specification harmonizes three pre-TLS 1.3 concepts: session resumption, session resumption without server-side state and PSK-based ciphers.
TLS 1.3 instead uses a design that introduces a new, post-handshake message (NewSessionTicket) and combines it with a PSK-based key exchange method. External PSK require a PSK identity and a secret to be configured while the NewSessionTicket message allows the configuration of the PSK identity as well as the secret dynamically following a successful handshake.

The NewSessionTicket message has the following structure: 

~~~
      struct {
          uint32 ticket_lifetime;
          uint32 ticket_age_add;
          opaque ticket_nonce<0..255>;
          opaque ticket<1..2^16-1>;
          Extension extensions<0..2^16-2>;
      } NewSessionTicket;
~~~

In addition to the ticket, which is opaque to the client, the server provides meta-data, which is necessary for proper operation when the client initiates a new handshake using this credential. RFC 8446 does not mandate a structure for the ticket, the Mbed TLS implementation defines one, which can be found in ssl_tls.c - see ssl_session_save(). The server stores the following content inside the ticket before encrypting it with a symmetric key: 

  - ticket creation time
  - ciphersuite
  - ticket lifetime
  - ticket-age-add parameter
  - key length
  - flags
  - resumption key
  - Peer's end-entity certificate
 
Note that the key used to encrypt the ticket by the server is known only to the server and it is rotated on a regular basis. 

The use of tickets is enabled with a compile-time switch (MBEDTLS_SSL_NEW_SESSION_TICKET) and via command line options (tickets) for use with the two example programs, ssl_client2 and ssl_server2. The mbedtls_ssl_ticket_init(), mbedtls_ssl_ticket_setup() and the mbedtls_ssl_conf_session_tickets_cb() API calls initialize data structures, configure crypto algorithms and register callbacks. Example callback functions for writing and parsing tickets are provided in ssl_ticket.h, ssl.h and ssl_ticket.c.

On the server-side the lifetime of tickets can be configured via the command line option ticket_timeout. On the client-side it is necessary to force the example program to run two handshakes via the reconnect options, of which there are several (reconnect, exchanges, reco_delay, reco_mode, and reconnect_hard).

For the server-side the NewSessionTicket message is sent immediately after the handshake. APIs to allow applications to trigger the transmission of NewSessionTicket messages will be added in the future. The ssl_write_new_session_ticket() call triggers the generation of the ticket. To pass the necessary parameters into the mbedtls_ssl_ticket_write() function, which internally calls the mbedtls_ssl_session_save()/ssl_session_save() functions (see ssl_tls.c) the session context contains data items to be included in the ticket itself plus the endpoint and minor_ver information. endpoint is needed to distinguish the client and the server functionality and minor_ver allows to place different information into the ticket depending on whether the handshake negotiated TLS 1.3 or an earlier TLS version. 

Once the client has received the ticket and re-uses it in a subsequent exchange, the server has to decrypt and process the information contained inside the ticket. The exact client-side processing will follow later. The ticket is presented to the server in the pre_shared_key extension as part of the ClientHello message. The pre_shared_key extension has the following structure:

~~~
      struct {
          opaque identity<1..2^16-1>;
          uint32 obfuscated_ticket_age;
      } PskIdentity;

      opaque PskBinderEntry<32..255>;

      struct {
          PskIdentity identities<7..2^16-1>;
          PskBinderEntry binders<33..2^16-1>;
      } OfferedPsks;

      struct {
          select (Handshake.msg_type) {
              case client_hello: OfferedPsks;
              case server_hello: uint16 selected_identity;
          };
      } PreSharedKeyExtension;
~~~

The mbedtls_ssl_parse_client_psk_identity_ext() API is responsbile for parsing the received structure. First, we check whether the identity matches the externally configured PSK value (which is stored in ssl->conf->p_psk). If this lookup was unsuccessful, then we attempt to treat the content of the PSK identity as the ticket and parse it with mbedtls_ssl_parse_psk_identity(). This function calls mbedtls_ssl_ticket_parse() and subsequently mbedtls_ssl_session_load()/ssl_session_load() and, after successful decryption, populates the values into the session structure. Then, various checks are made to determine whether the ticket is still valid (e.g. expired). 

The functionality on the client side is different because tickets are passed through clients as opaque blobs. Ticket support is enabled in ssl_client2 (in addition to the C pre-processor directives in config.h mentioned above) via mbedtls_ssl_conf_session_tickets(). A call to mbedtls_ssl_read() may return a MBEDTLS_ERR_SSL_RECEIVED_NEW_SESSION_TICKET error code, which offers the client an indication that a NewSessionTicket message has been received (instead of the expected application data). Depending on the reconnection mode selected via the command line parameter reco_mode two approaches are possible, namely to copy session, or to serialize a session. Serialization allows storing the ticket on some persistent storage in which case the ticket is first stored in a buffer of type unsigned char using mbedtls_ssl_session_save(). Without serialization, the mbedtls_ssl_get_session() API is used instead, which merely creates a copy of the session structure. The use of the pre-TLS 1.3 mbedtls_ssl_session_xxx APIs allows for better code reuse although more memory is needed using this approach because the TLS 1.3 ticket approach does not require a copy of the session structure. 

When a new handshake is trigger, which uses the previously distributed ticket, the stored information is recovered using mbedtls_ssl_session_load() and mbedtls_ssl_set_session(). mbedtls_ssl_session_load() restores the session state from the ticket buffer and mbedtls_ssl_set_session applies the session state into the ssl content. Finally, it is necessary to change the key exchange method to MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_DHE_KE or MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_KE so that the stack knows to use the PSK-based key exchange mode. 

When the handshake is then executed, the pre_shared_key extension will contain the ticket in the identity field, as described earlier. 


Note: This PR replaces https://github.com/hannestschofenig/mbedtls/pull/27 