### PR TITLE
Separate key generation from transform setup

### DIFF
--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -1313,7 +1313,7 @@ int mbedtls_ssl_handshake_key_derivation( mbedtls_ssl_context* ssl,
 int mbedtls_ssl_read_certificate_verify_process(mbedtls_ssl_context* ssl);
 int mbedtls_ssl_certificate_verify_process(mbedtls_ssl_context* ssl);
 
-int mbedtls_set_traffic_key( mbedtls_ssl_context* ssl,
+int mbedtls_ssl_tls13_build_transform( mbedtls_ssl_context* ssl,
                              mbedtls_ssl_key_set* traffic_keys,
                              mbedtls_ssl_transform* transform,
                              int mode );

--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -1306,19 +1306,33 @@ static uint32_t get_varint_value(const uint32_t input);
 #endif /* MBEDTLS_SSL_TLS13_CTLS */
 
 
-int mbedtls_ssl_key_derivation(mbedtls_ssl_context* ssl, mbedtls_ssl_key_set* traffic_keys);
-
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+int mbedtls_ssl_handshake_key_derivation( mbedtls_ssl_context* ssl,
+                                          mbedtls_ssl_key_set* traffic_keys );
 int mbedtls_ssl_read_certificate_verify_process(mbedtls_ssl_context* ssl);
 int mbedtls_ssl_certificate_verify_process(mbedtls_ssl_context* ssl);
 
+int mbedtls_set_traffic_key( mbedtls_ssl_context* ssl,
+                             mbedtls_ssl_key_set* traffic_keys,
+                             mbedtls_ssl_transform* transform,
+                             int mode );
+
+void mbedtls_ssl_set_inbound_transform( mbedtls_ssl_context *ssl,
+                                        mbedtls_ssl_transform *transform );
+void mbedtls_ssl_set_outbound_transform( mbedtls_ssl_context *ssl,
+                                         mbedtls_ssl_transform *transform );
+
 int mbedtls_ssl_tls1_3_derive_master_secret(mbedtls_ssl_context* ssl);
-int mbedtls_set_traffic_key(mbedtls_ssl_context* ssl, mbedtls_ssl_key_set* traffic_keys, mbedtls_ssl_transform* transform, int mode);
-int mbedtls_ssl_generate_application_traffic_keys(mbedtls_ssl_context* ssl, mbedtls_ssl_key_set* traffic_keys);
+
+int mbedtls_ssl_generate_application_traffic_keys( mbedtls_ssl_context* ssl,
+                                                   mbedtls_ssl_key_set* traffic_keys );
+int mbedtls_ssl_generate_handshake_traffic_keys( mbedtls_ssl_context* ssl,
+                                                 mbedtls_ssl_key_set* traffic_keys );
+int mbedtls_ssl_generate_early_data_keys( mbedtls_ssl_context* ssl,
+                                          mbedtls_ssl_key_set* traffic_keys );
 int mbedtls_ssl_generate_resumption_master_secret(mbedtls_ssl_context* ssl);
 int mbedtls_ssl_write_encrypted_extension(mbedtls_ssl_context* ssl);
-int mbedtls_ssl_derive_traffic_keys(mbedtls_ssl_context* ssl, mbedtls_ssl_key_set* traffic_keys);
 int mbedtls_increment_sequence_number(unsigned char* sequenceNumber, unsigned char* nonce, size_t ivlen);
 
 #if defined(MBEDTLS_SSL_TLS13_COMPATIBILITY_MODE)
@@ -1334,7 +1348,6 @@ int mbedtls_ssl_parse_signature_algorithms_ext(mbedtls_ssl_context* ssl, const u
 int mbedtls_ssl_check_signature_scheme(const mbedtls_ssl_context* ssl, int signature_scheme);
 #endif /* MBEDTLS_KEY_EXCHANGE_WITH_CERT_ENABLED */
 #if defined(MBEDTLS_ZERO_RTT)
-int mbedtls_ssl_early_data_key_derivation(mbedtls_ssl_context* ssl, mbedtls_ssl_key_set* traffic_keys);
 int mbedtls_ssl_write_early_data_ext(mbedtls_ssl_context* ssl, unsigned char* buf, size_t buflen, size_t* olen);
 #endif /* MBEDTLS_ZERO_RTT */
 #if (defined(MBEDTLS_ECDH_C) || defined(MBEDTLS_ECDSA_C))

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -167,10 +167,10 @@ static int ssl_write_early_data_prepare( mbedtls_ssl_context* ssl )
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
 
     mbedtls_ssl_transform_free( ssl->transform_negotiate );
-    ret = mbedtls_set_traffic_key( ssl, &traffic_keys, ssl->transform_negotiate, 0 );
+    ret = mbedtls_ssl_tls13_build_transform( ssl, &traffic_keys, ssl->transform_negotiate, 0 );
     if( ret != 0 )
     {
-        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_set_traffic_key", ret );
+        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_tls13_build_transform", ret );
         return( ret );
     }
 
@@ -326,10 +326,10 @@ static int ssl_write_end_of_early_data_prepare( mbedtls_ssl_context* ssl )
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
 
     mbedtls_ssl_transform_free( ssl->transform_negotiate );
-    ret = mbedtls_set_traffic_key( ssl, &traffic_keys, ssl->transform_negotiate, 0 );
+    ret = mbedtls_ssl_tls13_build_transform( ssl, &traffic_keys, ssl->transform_negotiate, 0 );
     if( ret != 0 )
     {
-        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_set_traffic_key", ret );
+        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_tls13_build_transform", ret );
         return( ret );
     }
 
@@ -2664,10 +2664,10 @@ static int ssl_encrypted_extensions_prepare( mbedtls_ssl_context* ssl ) {
         return( ret );
     }
 
-    ret = mbedtls_set_traffic_key( ssl, &traffic_keys, ssl->transform_negotiate, 0 );
+    ret = mbedtls_ssl_tls13_build_transform( ssl, &traffic_keys, ssl->transform_negotiate, 0 );
     if( ret != 0 )
     {
-        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_set_traffic_key", ret );
+        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_tls13_build_transform", ret );
         return( ret );
     }
 

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -155,10 +155,10 @@ static int ssl_write_early_data_prepare( mbedtls_ssl_context* ssl )
     int ret;
     mbedtls_ssl_key_set traffic_keys;
 
-    ret = mbedtls_ssl_early_data_key_derivation( ssl, &traffic_keys );
+    ret = mbedtls_ssl_generate_early_data_keys( ssl, &traffic_keys );
     if( ret != 0 )
     {
-        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_key_derivation", ret );
+        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_generate_early_data_keys", ret );
         return( ret );
     }
 
@@ -173,6 +173,26 @@ static int ssl_write_early_data_prepare( mbedtls_ssl_context* ssl )
         MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_set_traffic_key", ret );
         return( ret );
     }
+
+    /* Activate transform */
+
+#if defined(MBEDTLS_SSL_SRV_C)
+    if( ssl->conf->endpoint == MBEDTLS_SSL_IS_SERVER )
+    {
+        MBEDTLS_SSL_DEBUG_MSG( 3, ( "switching to new transform spec for inbound data" ) );
+        mbedtls_ssl_set_inbound_transform( ssl, ssl->transform_negotiate );
+        ssl->session_in = ssl->session_negotiate;
+    }
+#endif
+
+#if defined(MBEDTLS_SSL_CLI_C)
+    if( ssl->conf->endpoint == MBEDTLS_SSL_IS_CLIENT )
+    {
+        MBEDTLS_SSL_DEBUG_MSG( 3, ( "switching to new transform spec for outbound data" ) );
+        mbedtls_ssl_set_outbound_transform( ssl, ssl->transform_negotiate );
+        ssl->session_out = ssl->session_negotiate;
+    }
+#endif
 
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
     /* epoch value( 1 ) is used for messages protected using keys derived
@@ -294,10 +314,10 @@ static int ssl_write_end_of_early_data_prepare( mbedtls_ssl_context* ssl )
     int ret;
     mbedtls_ssl_key_set traffic_keys;
 
-    ret = mbedtls_ssl_early_data_key_derivation( ssl, &traffic_keys );
+    ret = mbedtls_ssl_generate_early_data_keys( ssl, &traffic_keys );
     if( ret != 0 )
     {
-        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_key_derivation", ret );
+        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_generate_early_data_keys", ret );
         return( ret );
     }
 
@@ -2636,28 +2656,29 @@ static int ssl_encrypted_extensions_prepare( mbedtls_ssl_context* ssl ) {
     int ret;
     mbedtls_ssl_key_set traffic_keys;
 
-    if( ssl->transform_in == NULL )
+    /* Generate handshake keying material */
+    ret = mbedtls_ssl_handshake_key_derivation( ssl, &traffic_keys );
+    if( ret != 0 )
     {
-        ret = mbedtls_ssl_key_derivation( ssl, &traffic_keys );
-        if( ret != 0 )
-        {
-            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_key_derivation", ret );
-            return( ret );
-        }
+        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_handshake_key_derivation", ret );
+        return( ret );
+    }
+
+    ret = mbedtls_set_traffic_key( ssl, &traffic_keys, ssl->transform_negotiate, 0 );
+    if( ret != 0 )
+    {
+        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_set_traffic_key", ret );
+        return( ret );
+    }
+
+    /* Switch to new keys for inbound traffic. */
+    mbedtls_ssl_set_inbound_transform( ssl, ssl->transform_negotiate );
+    ssl->session_in = ssl->session_negotiate;
 
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
-        traffic_keys.epoch = 2;
+    traffic_keys.epoch = 2;
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
 
-        mbedtls_ssl_transform_free( ssl->transform_negotiate );
-        ret = mbedtls_set_traffic_key( ssl, &traffic_keys, ssl->transform_negotiate, 0 );
-        if( ret != 0 )
-        {
-            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_set_traffic_key", ret );
-            return( ret );
-        }
-
-    }
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
     /* epoch value ( 2 ) is used for messages
      * protected using keys derived from the handshake_traffic_secret

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -3411,7 +3411,7 @@ static void ssl_setup_seq_protection_keys( mbedtls_ssl_context *ssl,
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
 
 
-/* mbedtls_set_traffic_key() activates keys and IVs for
+/* mbedtls_ssl_tls13_build_transform() activates keys and IVs for
  * the negotiated ciphersuite for use with encryption/decryption.
  * The sequence numbers are also set to zero.
  *
@@ -3419,7 +3419,7 @@ static void ssl_setup_seq_protection_keys( mbedtls_ssl_context *ssl,
  *   - Do not backup old keys       -- use 1
  *   - Backup old keys in transform -- use 0
  */
-int mbedtls_set_traffic_key( mbedtls_ssl_context *ssl,
+int mbedtls_ssl_tls13_build_transform( mbedtls_ssl_context *ssl,
                              mbedtls_ssl_key_set *traffic_keys,
                              mbedtls_ssl_transform *transform,
                              int remove_old_keys )
@@ -3542,6 +3542,7 @@ int mbedtls_set_traffic_key( mbedtls_ssl_context *ssl,
     transform->maclen      = 0;
     transform->fixed_ivlen = 4;
     transform->minlen      = transform->taglen + 1;
+    transform->minor_ver   = MBEDTLS_SSL_MINOR_VER_4;
 
     /*
      * In case of DTLS, setup sequence number protection keys.
@@ -3918,10 +3919,10 @@ static int ssl_finished_out_prepare( mbedtls_ssl_context* ssl )
 
             /* Setup transform from handshake keying material */
             mbedtls_ssl_transform_free( ssl->transform_out );
-            ret = mbedtls_set_traffic_key( ssl, traffic_keys, ssl->transform_out, 0 );
+            ret = mbedtls_ssl_tls13_build_transform( ssl, traffic_keys, ssl->transform_out, 0 );
             if( ret != 0 )
             {
-                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_set_traffic_key", ret );
+                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_tls13_build_transform", ret );
                 return ( ret );
             }
 
@@ -4029,10 +4030,10 @@ static int ssl_finished_out_postprocess( mbedtls_ssl_context* ssl )
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
 
         mbedtls_ssl_transform_free( ssl->transform_negotiate );
-        ret = mbedtls_set_traffic_key( ssl, traffic_keys, ssl->transform_negotiate, 0 );
+        ret = mbedtls_ssl_tls13_build_transform( ssl, traffic_keys, ssl->transform_negotiate, 0 );
         if( ret != 0 )
         {
-            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_set_traffic_key", ret );
+            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_tls13_build_transform", ret );
             return ( ret );
         }
 

--- a/library/ssl_tls13_messaging.c
+++ b/library/ssl_tls13_messaging.c
@@ -1240,10 +1240,10 @@ static int ssl_prepare_record_content( mbedtls_ssl_context *ssl )
             ( ssl->rec_epoch != ssl->in_epoch ) &&
             ( ssl->transform_in->traffic_keys_previous.epoch == ssl->rec_epoch ) )
         {
-            ret = mbedtls_set_traffic_key( ssl, &ssl->transform_in->traffic_keys_previous, ssl->transform_in,1 );
+            ret = mbedtls_ssl_tls13_build_transform( ssl, &ssl->transform_in->traffic_keys_previous, ssl->transform_in,1 );
             if( ret != 0 )
             {
-                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_set_traffic_key", ret );
+                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_tls13_build_transform", ret );
                 return( ret );
             }
         }
@@ -1277,10 +1277,10 @@ static int ssl_prepare_record_content( mbedtls_ssl_context *ssl )
             ( ssl->rec_epoch != ssl->in_epoch ) &&
             ( ssl->transform_in->traffic_keys_previous.epoch == ssl->rec_epoch ) )
         {
-            ret = mbedtls_set_traffic_key( ssl, &ssl->transform_in->traffic_keys, ssl->transform_in,1 );
+            ret = mbedtls_ssl_tls13_build_transform( ssl, &ssl->transform_in->traffic_keys, ssl->transform_in,1 );
             if( ret != 0 )
             {
-                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_set_traffic_key", ret );
+                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_tls13_build_transform", ret );
                 return( ret );
             }
         }

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -1866,10 +1866,10 @@ static int ssl_read_end_of_early_data_preprocess( mbedtls_ssl_context* ssl )
         goto cleanup;
     }
 
-    ret = mbedtls_set_traffic_key( ssl, &traffic_keys, ssl->transform_negotiate, 0 );
+    ret = mbedtls_ssl_tls13_build_transform( ssl, &traffic_keys, ssl->transform_negotiate, 0 );
     if( ret != 0 )
     {
-        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_set_traffic_key", ret );
+        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_tls13_build_transform", ret );
         goto cleanup;
     }
 
@@ -1973,10 +1973,10 @@ static int ssl_read_early_data_preprocess( mbedtls_ssl_context* ssl )
         goto cleanup;
     }
 
-    ret = mbedtls_set_traffic_key( ssl, &traffic_keys, ssl->transform_negotiate, 0 );
+    ret = mbedtls_ssl_tls13_build_transform( ssl, &traffic_keys, ssl->transform_negotiate, 0 );
     if( ret != 0 )
     {
-        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_set_traffic_key", ret );
+        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_tls13_build_transform", ret );
         goto cleanup;
     }
 
@@ -3482,10 +3482,10 @@ static int ssl_encrypted_extensions_prepare( mbedtls_ssl_context* ssl )
     }
 
     /* Setup transform from handshake key material */
-    ret = mbedtls_set_traffic_key( ssl, &traffic_keys, ssl->transform_negotiate, 0 );
+    ret = mbedtls_ssl_tls13_build_transform( ssl, &traffic_keys, ssl->transform_negotiate, 0 );
     if( ret != 0 )
     {
-        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_set_traffic_key", ret );
+        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_tls13_build_transform", ret );
         return( ret );
     }
 
@@ -4772,10 +4772,10 @@ int mbedtls_ssl_handshake_server_step( mbedtls_ssl_context *ssl )
                     return( ret );
                 }
 
-                ret = mbedtls_set_traffic_key( ssl, &traffic_keys, ssl->transform_negotiate,0 );
+                ret = mbedtls_ssl_tls13_build_transform( ssl, &traffic_keys, ssl->transform_negotiate,0 );
                 if( ret != 0 )
                 {
-                    MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_set_traffic_key", ret );
+                    MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_tls13_build_transform", ret );
                     return( ret );
                 }
 
@@ -4809,10 +4809,10 @@ int mbedtls_ssl_handshake_server_step( mbedtls_ssl_context *ssl )
                 return( ret );
             }
 
-            ret = mbedtls_set_traffic_key( ssl, &traffic_keys, ssl->transform_negotiate, 0 );
+            ret = mbedtls_ssl_tls13_build_transform( ssl, &traffic_keys, ssl->transform_negotiate, 0 );
             if( ret != 0 )
             {
-                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_set_traffic_key", ret );
+                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_tls13_build_transform", ret );
                 return( ret );
             }
 

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -1859,22 +1859,28 @@ static int ssl_read_end_of_early_data_preprocess( mbedtls_ssl_context* ssl )
     int ret;
     mbedtls_ssl_key_set traffic_keys;
 
-    ret = mbedtls_ssl_early_data_key_derivation( ssl, &traffic_keys );
+    ret = mbedtls_ssl_generate_early_data_keys( ssl, &traffic_keys );
     if( ret != 0 )
     {
-        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_early_data_key_derivation", ret );
-        return( ret );
+        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_generate_early_data_keys", ret );
+        goto cleanup;
     }
 
-    mbedtls_ssl_transform_free( ssl->transform_negotiate );
     ret = mbedtls_set_traffic_key( ssl, &traffic_keys, ssl->transform_negotiate, 0 );
     if( ret != 0 )
     {
         MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_set_traffic_key", ret );
-        return ( ret );
+        goto cleanup;
     }
 
-    return( 0 );
+    /* Activate transform */
+    MBEDTLS_SSL_DEBUG_MSG( 3, ( "switching to new transform spec for inbound data" ) );
+    mbedtls_ssl_set_inbound_transform( ssl, ssl->transform_negotiate );
+    ssl->session_in = ssl->session_negotiate;
+
+cleanup:
+    mbedtls_platform_zeroize( &traffic_keys, sizeof( traffic_keys ) );
+    return( ret );
 }
 
 
@@ -1960,20 +1966,24 @@ static int ssl_read_early_data_preprocess( mbedtls_ssl_context* ssl )
     int ret;
     mbedtls_ssl_key_set traffic_keys;
 
-    ret = mbedtls_ssl_early_data_key_derivation( ssl, &traffic_keys );
+    ret = mbedtls_ssl_generate_early_data_keys( ssl, &traffic_keys );
     if( ret != 0 )
     {
-        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_early_data_key_derivation", ret );
-        return( ret );
+        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_generate_early_data_keys", ret );
+        goto cleanup;
     }
 
-    mbedtls_ssl_transform_free( ssl->transform_negotiate );
     ret = mbedtls_set_traffic_key( ssl, &traffic_keys, ssl->transform_negotiate, 0 );
     if( ret != 0 )
     {
         MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_set_traffic_key", ret );
-        return( ret );
+        goto cleanup;
     }
+
+    /* Activate transform */
+    MBEDTLS_SSL_DEBUG_MSG( 3, ( "switching to new transform spec for inbound data" ) );
+    mbedtls_ssl_set_inbound_transform( ssl, ssl->transform_negotiate );
+    ssl->session_in = ssl->session_negotiate;
 
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
     /* epoch value( 1 ) is used for messages protected using keys derived
@@ -1983,7 +1993,9 @@ static int ssl_read_early_data_preprocess( mbedtls_ssl_context* ssl )
     ssl->out_epoch = 1;
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
 
-    return( 0 );
+cleanup:
+    mbedtls_platform_zeroize( &traffic_keys, sizeof( traffic_keys ) );
+    return( ret );
 }
 
 static int ssl_read_early_data_parse( mbedtls_ssl_context* ssl,
@@ -3461,11 +3473,19 @@ static int ssl_encrypted_extensions_prepare( mbedtls_ssl_context* ssl )
     int ret;
     mbedtls_ssl_key_set traffic_keys;
 
-    ret = mbedtls_ssl_key_derivation( ssl, &traffic_keys );
-
+    /* Derive handshake key material */
+    ret = mbedtls_ssl_handshake_key_derivation( ssl, &traffic_keys );
     if( ret != 0 )
     {
-        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_key_derivation", ret );
+        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_handshake_key_derivation", ret );
+        return( ret );
+    }
+
+    /* Setup transform from handshake key material */
+    ret = mbedtls_set_traffic_key( ssl, &traffic_keys, ssl->transform_negotiate, 0 );
+    if( ret != 0 )
+    {
+        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_set_traffic_key", ret );
         return( ret );
     }
 
@@ -3478,23 +3498,11 @@ static int ssl_encrypted_extensions_prepare( mbedtls_ssl_context* ssl )
     }
 #endif
 
-    ssl->transform_out = ssl->transform_negotiate;
-    ssl->session_out = ssl->session_negotiate;
+    mbedtls_ssl_set_outbound_transform( ssl, ssl->transform_negotiate );
+    mbedtls_ssl_set_inbound_transform( ssl, ssl->transform_negotiate );
 
-    mbedtls_ssl_transform_free( ssl->transform_negotiate );
-    ret = mbedtls_set_traffic_key( ssl, &traffic_keys, ssl->transform_negotiate, 0 );
-
-    if( ret != 0 )
-    {
-        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_set_traffic_key", ret );
-        return( ret );
-    }
-
-    /*
-     * Set the out_msg pointer to the correct location based on IV length
-     */
-
-    ssl->out_msg = ssl->out_iv;
+    ssl->session_out   = ssl->session_negotiate;
+    ssl->session_in    = ssl->session_negotiate;
 
     /*
      * Switch to our negotiated transform and session parameters for outbound
@@ -4757,22 +4765,22 @@ int mbedtls_ssl_handshake_server_step( mbedtls_ssl_context *ssl )
 #if defined(MBEDTLS_ZERO_RTT)
             if( ssl->handshake->early_data == MBEDTLS_SSL_EARLY_DATA_ON )
             {
-                ret = mbedtls_ssl_key_derivation( ssl, &traffic_keys );
-
+                ret = mbedtls_ssl_handshake_key_derivation( ssl, &traffic_keys );
                 if( ret != 0 )
                 {
-                    MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_key_derivation", ret );
+                    MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_handshake_key_derivation", ret );
                     return( ret );
                 }
 
-                mbedtls_ssl_transform_free( ssl->transform_negotiate );
                 ret = mbedtls_set_traffic_key( ssl, &traffic_keys, ssl->transform_negotiate,0 );
-
                 if( ret != 0 )
                 {
                     MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_set_traffic_key", ret );
                     return( ret );
                 }
+
+                mbedtls_ssl_set_inbound_transform( ssl, ssl->transform_negotiate );
+                ssl->session_in = ssl->session_negotiate;
             }
 #endif /* MBEDTLS_ZERO_RTT */
 
@@ -4801,9 +4809,7 @@ int mbedtls_ssl_handshake_server_step( mbedtls_ssl_context *ssl )
                 return( ret );
             }
 
-            mbedtls_ssl_transform_free( ssl->transform_negotiate );
             ret = mbedtls_set_traffic_key( ssl, &traffic_keys, ssl->transform_negotiate, 0 );
-
             if( ret != 0 )
             {
                 MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_set_traffic_key", ret );


### PR DESCRIPTION
We should separate the following things clearly:
1) The key schedule during the TLS 1.3 handshake -- as per spec.
2) The derivation of the Mbed TLS - internal transform structure
   from this data.
3) Activation of the generated transform for inbound/outbound
   traffic.

This commit is a major restructuring of the code with the aim
to achive the desired separation.

Signed-off-by: Hanno Becker <hanno.becker@arm.com>