### PR TITLE
Only allocate buf for ticket_nonce if length is larger than zero

### DIFF
--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -6545,7 +6545,7 @@ void mbedtls_ssl_session_free( mbedtls_ssl_session *session )
 
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
-    if( session->ticket_nonce_len > 0 ) mbedtls_free( session->ticket_nonce );
+    mbedtls_free( session->ticket_nonce );
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 
 #endif

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -4780,13 +4780,16 @@ static int mbedtls_ssl_new_session_ticket_parse( mbedtls_ssl_context* ssl,
         ssl->session->ticket_nonce_len = 0;
     }
 
-    if( ( ssl->session->ticket_nonce = mbedtls_calloc( 1, ticket_nonce_len ) ) == NULL )
+    if( ticket_nonce_len > 0 )
     {
-        MBEDTLS_SSL_DEBUG_MSG( 1, ( "ticket_nonce alloc failed" ) );
-        return( MBEDTLS_ERR_SSL_ALLOC_FAILED );
-    }
+        if( ( ssl->session->ticket_nonce = mbedtls_calloc( 1, ticket_nonce_len ) ) == NULL )
+        {
+            MBEDTLS_SSL_DEBUG_MSG( 1, ( "ticket_nonce alloc failed" ) );
+            return( MBEDTLS_ERR_SSL_ALLOC_FAILED );
+        }
 
-    memcpy( ssl->session->ticket_nonce, &buf[9], ticket_nonce_len );
+        memcpy( ssl->session->ticket_nonce, &buf[9], ticket_nonce_len );
+    }
 
     ssl->session->ticket_nonce_len = ticket_nonce_len;
 


### PR DESCRIPTION
calloc may return NULL if size of 0, depending on implementations.