### PR TITLE
Fix calculation of handshake message length in Ticket-fetch routine

### DIFF
--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -4701,7 +4701,7 @@ static int mbedtls_ssl_new_session_ticket_fetch( mbedtls_ssl_context* ssl,
                                   size_t* dstlen )
 {
     *dst = ssl->in_msg + mbedtls_ssl_hs_hdr_len( ssl );
-    *dstlen = ssl->in_msglen - mbedtls_ssl_hs_hdr_len( ssl );
+    *dstlen = ssl->in_hslen - mbedtls_ssl_hs_hdr_len( ssl );
 
     return( 0 );
 }


### PR DESCRIPTION
`ssl->in_msglen` is the total record length, while `ssl->in_hslen` is the handshake content length, including the handshake header.
