### PR TITLE
Fix logic error in ssl_server_hello_coordinate about unexpected message

### DIFF
--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -2913,7 +2913,8 @@ static int ssl_server_hello_coordinate( mbedtls_ssl_context* ssl )
      * of ClientHello's we sent, and fail if it
      * exceeds the configured threshold. */
 
-    if( ( ssl->in_msgtype != MBEDTLS_SSL_MSG_HANDSHAKE ) || ( ssl->in_msg[0] != MBEDTLS_SSL_HS_SERVER_HELLO ) )
+    if( ( ssl->in_msgtype != MBEDTLS_SSL_MSG_HANDSHAKE ) || 
+        ( ssl->in_msg[0] != MBEDTLS_SSL_HS_SERVER_HELLO ) )
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "unexpected message" ) );
 

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -2913,7 +2913,7 @@ static int ssl_server_hello_coordinate( mbedtls_ssl_context* ssl )
      * of ClientHello's we sent, and fail if it
      * exceeds the configured threshold. */
 
-    if( ( ssl->in_msgtype != MBEDTLS_SSL_MSG_HANDSHAKE ) && ( ssl->in_msg[0] != MBEDTLS_SSL_HS_SERVER_HELLO ) )
+    if( ( ssl->in_msgtype != MBEDTLS_SSL_MSG_HANDSHAKE ) || ( ssl->in_msg[0] != MBEDTLS_SSL_HS_SERVER_HELLO ) )
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "unexpected message" ) );
 


### PR DESCRIPTION
Summary:
When we check unexpected message in `ssl_server_hello_coordinate`,
     Either invalid msg type or hand shake type should result failure

Test Plan:
Simulator corrupted server hello

Reviewers:hanno.becker@arm.com,hannes.tschofenig@arm.com,junqi.wang@live.com

Subscribers:

Tasks:

Tags: