### PR TITLE
Send pending alert after ssl_server_hello_process

### DIFF
--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -3824,7 +3824,7 @@ int mbedtls_ssl_handshake_client_step( mbedtls_ssl_context *ssl )
             if( ret != 0 )
             {
                 MBEDTLS_SSL_DEBUG_RET( 1, "ssl_write_client_hello", ret );
-                return( ret );
+                break;
             }
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
             if( ssl->conf->transport == MBEDTLS_SSL_TRANSPORT_DATAGRAM )
@@ -3864,7 +3864,7 @@ int mbedtls_ssl_handshake_client_step( mbedtls_ssl_context *ssl )
             if( ret != 0 )
             {
                 MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_write_change_cipher_spec_process", ret );
-                return( ret );
+                break;
             }
 
             break;
@@ -3879,7 +3879,7 @@ int mbedtls_ssl_handshake_client_step( mbedtls_ssl_context *ssl )
             if( ret != 0 )
             {
                 MBEDTLS_SSL_DEBUG_RET( 1, "ssl_write_early_data_process", ret );
-                return( ret );
+                break;
             }
 
             break;
@@ -3949,7 +3949,7 @@ int mbedtls_ssl_handshake_client_step( mbedtls_ssl_context *ssl )
             if( ret != 0 )
             {
                 MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_write_change_cipher_spec_process", ret );
-                return( ret );
+                break;
             }
 
             break;
@@ -3962,7 +3962,7 @@ int mbedtls_ssl_handshake_client_step( mbedtls_ssl_context *ssl )
             if( ret != 0 )
             {
                 MBEDTLS_SSL_DEBUG_RET( 1, "ssl_write_client_hello", ret );
-                return( ret );
+                break;
             }
             mbedtls_ssl_handshake_set_state( ssl, MBEDTLS_SSL_SECOND_SERVER_HELLO );
 
@@ -4018,7 +4018,7 @@ int mbedtls_ssl_handshake_client_step( mbedtls_ssl_context *ssl )
             if( ret != 0 )
             {
                 MBEDTLS_SSL_DEBUG_RET( 1, "ssl_encrypted_extensions_process", ret );
-                return( ret );
+                break;
             }
 
             break;
@@ -4031,7 +4031,7 @@ int mbedtls_ssl_handshake_client_step( mbedtls_ssl_context *ssl )
             if( ret != 0 )
             {
                 MBEDTLS_SSL_DEBUG_RET( 1, "ssl_certificate_request_process", ret );
-                return( ret );
+                break;
             }
 
             break;
@@ -4044,7 +4044,7 @@ int mbedtls_ssl_handshake_client_step( mbedtls_ssl_context *ssl )
             if( ret != 0 )
             {
                 MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_read_certificate_process", ret );
-                return( ret );
+                break;
             }
             break;
 
@@ -4056,7 +4056,7 @@ int mbedtls_ssl_handshake_client_step( mbedtls_ssl_context *ssl )
             if( ret != 0 )
             {
                 MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_read_certificate_verify_process", ret );
-                return( ret );
+                break;
             }
 
             break;
@@ -4070,7 +4070,7 @@ int mbedtls_ssl_handshake_client_step( mbedtls_ssl_context *ssl )
             if( ret != 0 )
             {
                 MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_finished_in_process", ret );
-                return( ret );
+                break;
             }
 #if	defined(MBEDTLS_SSL_PROTO_DTLS)
             if( ssl->conf->transport == MBEDTLS_SSL_TRANSPORT_DATAGRAM )
@@ -4105,7 +4105,7 @@ int mbedtls_ssl_handshake_client_step( mbedtls_ssl_context *ssl )
             if( ret != 0 )
             {
                 MBEDTLS_SSL_DEBUG_RET( 1, "ssl_write_end_of_early_data_process", ret );
-                return( ret );
+                break;
             }
 
             break;
@@ -4121,7 +4121,7 @@ int mbedtls_ssl_handshake_client_step( mbedtls_ssl_context *ssl )
             if( ret != 0 )
             {
                 MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_write_change_cipher_spec_process", ret );
-                return( ret );
+                break;
             }
 
             break;
@@ -4137,7 +4137,7 @@ int mbedtls_ssl_handshake_client_step( mbedtls_ssl_context *ssl )
             if( ret != 0 )
             {
                 MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_write_certificate_process", ret );
-                return( ret );
+                break;
             }
             break;
 
@@ -4149,7 +4149,7 @@ int mbedtls_ssl_handshake_client_step( mbedtls_ssl_context *ssl )
             if( ret != 0 )
             {
                 MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_certificate_verify_process", ret );
-                return( ret );
+                break;
             }
             break;
 
@@ -4161,7 +4161,7 @@ int mbedtls_ssl_handshake_client_step( mbedtls_ssl_context *ssl )
             if( ret != 0 )
             {
                 MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_finished_out_process", ret );
-                return( ret );
+                break;
             }
             break;
 

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -3900,7 +3900,7 @@ int mbedtls_ssl_handshake_client_step( mbedtls_ssl_context *ssl )
             if( ret != 0 )
             {
                 MBEDTLS_SSL_DEBUG_RET( 1, "ssl_server_hello_process", ret );
-                return( ret );
+                break;
             }
 
 #if	defined(MBEDTLS_SSL_PROTO_DTLS)
@@ -3990,7 +3990,7 @@ int mbedtls_ssl_handshake_client_step( mbedtls_ssl_context *ssl )
             if( ret != 0 )
             {
                 MBEDTLS_SSL_DEBUG_RET( 1, "ssl_parse_server_hello", ret );
-                return( ret );
+                break;
             }
 
 #if	defined(MBEDTLS_SSL_PROTO_DTLS)


### PR DESCRIPTION
Summary:
`ssl_server_hello_process` may call `ssl_server_hello_coordinate`, and
other subroutines, they may setup pending alerts by
SSL_PEND_FATAL_ALERT.
These pending alerts may not be fired as we return early before we call
[mbedtls_ssl_handle_pending_alert](https://github.com/hannestschofenig/mbedtls/blob/tls13-prototype/library/ssl_tls13_client.c#L4477)

Change`return` to `break` for some subroutines in `mbedtls_ssl_handshake_client_step` so that the pending alert will be sent out.

Test Plan:
Send corrupted server hello, verify the unexpected message alert is
fired.

Test Plan:
Send corrupted server hello, verify the unexpected message alert is
fired.

Reviewers:
hanno.becker@arm.com,hannes.tschofenig@arm.com,junqi.wang@live.com,zhi.han@gmail.com

Subscribers:

Tasks:

Tags: