### PR TITLE
Tls13 prototype compile out srv

### DIFF
--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -922,6 +922,14 @@ int mbedtls_ssl_parse_signature_algorithms_ext( mbedtls_ssl_context *ssl,
                                         size_t len )
 {
     size_t sig_alg_list_size; /* size of receive signature algorithms list */
+    sig_alg_list_size = ( ( buf[0] << 8 ) | ( buf[1] ) );
+    if( sig_alg_list_size + 2 != len ||
+        sig_alg_list_size % 2 != 0 )
+    {
+        MBEDTLS_SSL_DEBUG_MSG( 1, ( "bad signature_algorithms extension" ) );
+        return( MBEDTLS_ERR_SSL_BAD_HS_CLIENT_HELLO );
+    }
+#if defined(MBEDTLS_SSL_SRV_C)
     const unsigned char *p; /* pointer to individual signature algorithm */
     const unsigned char *end = buf + len; /* end of buffer */
     const int *md_cur; /* iterate through configured signature schemes */
@@ -930,13 +938,6 @@ int mbedtls_ssl_parse_signature_algorithms_ext( mbedtls_ssl_context *ssl,
     size_t num_supported_hashes;
     uint32_t i; /* iterature through received_signature_schemes_list */
 
-    sig_alg_list_size = ( ( buf[0] << 8 ) | ( buf[1] ) );
-    if( sig_alg_list_size + 2 != len ||
-        sig_alg_list_size % 2 != 0 )
-    {
-        MBEDTLS_SSL_DEBUG_MSG( 1, ( "bad signature_algorithms extension" ) );
-        return( MBEDTLS_ERR_SSL_BAD_HS_CLIENT_HELLO );
-    }
 
     /* Determine the number of signature algorithms we support. */
     num_supported_hashes = 0;
@@ -983,6 +984,7 @@ int mbedtls_ssl_parse_signature_algorithms_ext( mbedtls_ssl_context *ssl,
     }
 
     ssl->handshake->received_signature_schemes_list[i] = SIGNATURE_NONE;
+#endif /* MBEDTLS_SSL_SRV_C */
 
     return( 0 );
 }

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -1794,7 +1794,6 @@ static int ssl_certificate_verify_write( mbedtls_ssl_context* ssl,
     int ret;
     size_t n = 0, offset = 0;
     unsigned char verify_buffer[ MBEDTLS_SSL_VERIFY_STRUCT_MAX_SIZE ];
-    const int *sig_scheme; /* iterate through configured signature schemes */
     size_t verify_buffer_len;
     mbedtls_pk_context *own_key;
     size_t own_key_size;
@@ -1855,8 +1854,10 @@ static int ssl_certificate_verify_write( mbedtls_ssl_context* ssl,
     /* Verify whether we can use signature algorithm */
     ssl->handshake->signature_scheme_client = SIGNATURE_NONE;
 
+#if defined(MBEDTLS_SSL_SRV_C)
     if( ssl->handshake->received_signature_schemes_list != NULL )
     {
+        const int *sig_scheme; /* iterate through configured signature schemes */
         for( sig_scheme = ssl->handshake->received_signature_schemes_list; *sig_scheme != SIGNATURE_NONE; sig_scheme++ )
         {
             if( *sig_scheme == sig_alg )
@@ -1866,6 +1867,7 @@ static int ssl_certificate_verify_write( mbedtls_ssl_context* ssl,
             }
         }
     }
+#endif /* MBEDTLS_SSL_SRV_C */
 
     if( ssl->handshake->signature_scheme_client == SIGNATURE_NONE )
     {


### PR DESCRIPTION
Fix compiler error when `MBEDTLS_SSL_SRV_C` is not defined. see summary in commits for details.