### PR TITLE
Initialize ret in ssl_finished_out_postprocess

### DIFF
--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -4154,7 +4154,7 @@ static int ssl_finished_out_prepare( mbedtls_ssl_context* ssl )
 
 static int ssl_finished_out_postprocess( mbedtls_ssl_context* ssl )
 {
-    int ret;
+    int ret = 0;
 #if defined(MBEDTLS_SSL_SRV_C)
     const mbedtls_ssl_ciphersuite_t *suite_info =
         mbedtls_ssl_ciphersuite_from_id( ssl->session_negotiate->ciphersuite );


### PR DESCRIPTION
Summary:
The ret is not initialized, and it may not be set before it is returned.
It was caught by -Wsometimes-uninitialized
```
error: variable 'ret' is used uninitialized whenever 'if' condition is
false [-Werror,-Wsometimes-uninitialized]
    if( ssl->conf->endpoint == MBEDTLS_SSL_IS_CLIENT )
```

Test Plan:
Build with -Wsometimes-uninitialized

Reviewers:
hanno.becker@arm.com,hannes.tschofenig@arm.com,junqi.wang@live.com,zhi.han@gmail.com

Subscribers:

Tasks:

Tags: