### PR TITLE
Add separate transforms for {EarlyData,Handshake,AppData} in TLS 1.3

### DIFF
--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -597,6 +597,7 @@ extern "C" {
         MBEDTLS_SSL_CERTIFICATE_VERIFY,
         MBEDTLS_SSL_SERVER_FINISHED,
         MBEDTLS_SSL_EARLY_DATA,
+        MBEDTLS_SSL_END_OF_EARLY_DATA,
         MBEDTLS_SSL_CLIENT_CERTIFICATE,
         MBEDTLS_SSL_CLIENT_CERTIFICATE_VERIFY,
         MBEDTLS_SSL_CLIENT_FINISHED,
@@ -1550,8 +1551,17 @@ struct mbedtls_ssl_context
      */
     mbedtls_ssl_transform *transform_in;        /*!<  current transform params (in)   */
     mbedtls_ssl_transform *transform_out;       /*!<  current transform params (in)   */
+
+#if defined(MBEDTLS_SSL_PROTO_TLS1_2_OR_EARLIER)
     mbedtls_ssl_transform *transform;           /*!<  negotiated transform params     */
     mbedtls_ssl_transform *transform_negotiate; /*!<  transform params in negotiation */
+#endif /* MBEDTLS_SSL_PROTO_TLS1_2_OR_EARLIER */
+
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+    mbedtls_ssl_transform *transform_handshake;
+    mbedtls_ssl_transform *transform_earlydata;
+    mbedtls_ssl_transform *transform_application;
+#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 
     /*
      * Timers

--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -169,6 +169,7 @@ enum varint_length_enum { VARINT_LENGTH_FAILURE = 0, VARINT_LENGTH_1_BYTE = 1, V
     defined(MBEDTLS_SSL_PROTO_TLS1)   ||                              \
     defined(MBEDTLS_SSL_PROTO_TLS1_1) ||                              \
     defined(MBEDTLS_SSL_PROTO_TLS1_2)
+#define MBEDTLS_SSL_PROTO_TLS1_2_OR_EARLIER
 
 /* This macro determines whether CBC is supported. */
 #if defined(MBEDTLS_CIPHER_MODE_CBC) &&                               \

--- a/library/ssl_tls13_messaging.c
+++ b/library/ssl_tls13_messaging.c
@@ -69,7 +69,7 @@ static int ssl_encrypt_buf( mbedtls_ssl_context *ssl )
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "=> encrypt buf" ) );
 
-    if( ssl->session_out == NULL || ssl->transform_out == NULL )
+    if( ssl->transform_out == NULL )
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "should never happen" ) );
         return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
@@ -256,7 +256,7 @@ static int ssl_decrypt_buf( mbedtls_ssl_context *ssl )
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "=> decrypt buf" ) );
 
-    if( ssl->session_in == NULL || ssl->transform_in == NULL )
+    if( ssl->transform_in == NULL )
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "should never happen" ) );
         return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
@@ -1530,7 +1530,7 @@ read_record_header:
                     break;
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
                 default:
-                    MBEDTLS_SSL_DEBUG_MSG( 1, ( "unknown message" ) );
+                    MBEDTLS_SSL_DEBUG_MSG( 1, ( "unknown message type %u", ssl->in_msg[i-1] ) );
 
                     mbedtls_ssl_send_alert_message( ssl,
                                                     MBEDTLS_SSL_ALERT_LEVEL_FATAL,


### PR DESCRIPTION
Fixes #81 and #82 