### PR TITLE
Store `flags` into ticket in mbedtls_ssl_get_client_ticket

### DIFF
--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -5087,6 +5087,7 @@ int mbedtls_ssl_get_client_ticket( const mbedtls_ssl_context *ssl, mbedtls_ssl_t
         /* store time we received the ticket */
         ticket->start = ssl->session->ticket_received;
 #endif /* MBEDTLS_HAVE_TIME */
+        ticket->flags = ssl->session->flags;
 
         return( 0 );
     }


### PR DESCRIPTION
Summary:
`flags` is a field defined in both
[`mbedtls_ssl_ticket`](https://github.com/hannestschofenig/mbedtls/blob/tls13-prototype/include/mbedtls/ssl.h#L835), and
[`mbedtls_ssl_session`](https://github.com/hannestschofenig/mbedtls/blob/tls13-prototype/include/mbedtls/ssl.h#L1130).
When the data is transform from `mbedtls_ssl_session` to `mbedtls_ssl_ticket` in `mbedtls_ssl_get_client_ticket`, `flags` should be stored as other fields, such as `ticket_age_add`, and `ticket_lifetime`.

Test Plan:
Build
Reviewers:
hanno.becker@arm.com,hannes.tschofenig@arm.com,junqi.wang@live.com,zhi.han@gmail.com

Subscribers:

Tasks:

Tags: