### PR TITLE
Update ssl_internal.h

### DIFF
--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -1176,6 +1176,13 @@ int mbedtls_ssl_handle_message_type( mbedtls_ssl_context *ssl );
 int mbedtls_ssl_prepare_handshake_record( mbedtls_ssl_context *ssl );
 void mbedtls_ssl_update_handshake_status( mbedtls_ssl_context *ssl );
 
+int mbedtls_ssl_handshake_client_step(mbedtls_ssl_context* ssl);
+int mbedtls_ssl_handshake_server_step(mbedtls_ssl_context* ssl);
+void mbedtls_ssl_handshake_wrapup(mbedtls_ssl_context* ssl);
+
+int mbedtls_ssl_send_fatal_handshake_failure(mbedtls_ssl_context* ssl);
+int mbedtls_ssl_write_handshake_msg( mbedtls_ssl_context *ssl );
+
 /**
  * \brief       Update record layer
  *
@@ -1252,14 +1259,6 @@ void mbedtls_ssl_update_handshake_status( mbedtls_ssl_context *ssl );
  *              following the above definition.
  *
  */
-
-int mbedtls_ssl_handshake_client_step(mbedtls_ssl_context* ssl);
-int mbedtls_ssl_handshake_server_step(mbedtls_ssl_context* ssl);
-void mbedtls_ssl_handshake_wrapup(mbedtls_ssl_context* ssl);
-
-int mbedtls_ssl_send_fatal_handshake_failure(mbedtls_ssl_context* ssl);
-int mbedtls_ssl_write_handshake_msg( mbedtls_ssl_context *ssl );
-
 int mbedtls_ssl_read_record( mbedtls_ssl_context *ssl,
                              unsigned update_hs_digest );
 


### PR DESCRIPTION
The documentation of  mbedtls_ssl_read_record is out of place. This is found on mac while trying to compile.