### PR TITLE
Use conf instead of ssl context for mbedtls_ssl_conf_client_ticket_en…

### DIFF
--- a/include/mbedtls/ssl_ticket.h
+++ b/include/mbedtls/ssl_ticket.h
@@ -90,8 +90,8 @@ void mbedtls_ssl_ticket_init( mbedtls_ssl_ticket_context *ctx );
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && defined(MBEDTLS_SSL_NEW_SESSION_TICKET)
 void mbedtls_ssl_del_client_ticket(mbedtls_ssl_ticket* ticket);
 void mbedtls_ssl_init_client_ticket(mbedtls_ssl_ticket* ticket);
-void mbedtls_ssl_conf_client_ticket_disable(mbedtls_ssl_context* ssl);
-void mbedtls_ssl_conf_client_ticket_enable(mbedtls_ssl_context* ssl);
+void mbedtls_ssl_conf_client_ticket_disable(mbedtls_ssl_config *conf);
+void mbedtls_ssl_conf_client_ticket_enable(mbedtls_ssl_config *conf);
 int mbedtls_ssl_get_client_ticket(const mbedtls_ssl_context* ssl, mbedtls_ssl_ticket* ticket);
 int mbedtls_ssl_conf_client_ticket(const mbedtls_ssl_context* ssl, mbedtls_ssl_ticket* ticket);
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL && MBEDTLS_SSL_NEW_SESSION_TICKET */

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -4932,22 +4932,13 @@ int mbedtls_ssl_get_client_ticket( const mbedtls_ssl_context *ssl, mbedtls_ssl_t
 }
 #endif /* MBEDTLS_SSL_NEW_SESSION_TICKET && MBEDTLS_SSL_CLI_C */
 
-void mbedtls_ssl_conf_client_ticket_enable( mbedtls_ssl_context *ssl )
+void mbedtls_ssl_conf_client_ticket_enable( mbedtls_ssl_config *conf )
 {
-    mbedtls_ssl_config *conf;
-    if( ssl == NULL ) return;
-    conf = ( mbedtls_ssl_config * ) ssl->conf;
-    if( conf == NULL ) return;
     conf->resumption_mode = 1; /* enable resumption mode */
 }
 
-void mbedtls_ssl_conf_client_ticket_disable( mbedtls_ssl_context *ssl )
+void mbedtls_ssl_conf_client_ticket_disable( mbedtls_ssl_config *conf )
 {
-    mbedtls_ssl_config *conf;
-
-    if( ssl == NULL ) return;
-    conf = ( mbedtls_ssl_config * ) ssl->conf;
-    if( conf == NULL ) return;
     conf->resumption_mode = 0; /* set full exchange */
 }
 

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -3815,7 +3815,7 @@ reconnect:
             goto exit;
         }
         // enable resumption
-        mbedtls_ssl_conf_client_ticket_enable( &ssl );
+        mbedtls_ssl_conf_client_ticket_enable( ( mbedtls_ssl_config * ) ssl.conf );
 #else
 
         if( opt.reco_mode == 1 )


### PR DESCRIPTION
…able[disable]

Summary:
Since the `resumption_mode` is set on the configure level, use it as
input directly instead of passing `mbedtls_ssl_context`.

Test Plan:
Build and make test

Reviewers:
hanno.becker@arm.com,hannes.tschofenig@arm.com,junqi.wang@live.com,zhi.han@gmail.com

Subscribers:

Tasks:

Tags: