### PR TITLE
Fix logic error in ssl_parse_supported_version_ext

### DIFF
--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -2024,8 +2024,7 @@ static int ssl_parse_supported_version_ext( mbedtls_ssl_context* ssl,
     else
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
     {
-        /* TODO: Remove magic numbers */
-        if( len != 2 && buf[0] != 0x3 && buf[1] != 0x3 )
+        if( len != 2 || buf[0] != MBEDTLS_SSL_MAJOR_VERSION_3 || buf[1] != MBEDTLS_SSL_MINOR_VERSION_4 )
         {
             MBEDTLS_SSL_DEBUG_MSG( 1, ( "unexpected version" ) );
             return( MBEDTLS_ERR_SSL_BAD_HS_SERVER_HELLO );

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -2024,7 +2024,9 @@ static int ssl_parse_supported_version_ext( mbedtls_ssl_context* ssl,
     else
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
     {
-        if( len != 2 || buf[0] != MBEDTLS_SSL_MAJOR_VERSION_3 || buf[1] != MBEDTLS_SSL_MINOR_VERSION_4 )
+        if( len != 2 || 
+            buf[0] != MBEDTLS_SSL_MAJOR_VERSION_3 || 
+            buf[1] != MBEDTLS_SSL_MINOR_VERSION_4 )
         {
             MBEDTLS_SSL_DEBUG_MSG( 1, ( "unexpected version" ) );
             return( MBEDTLS_ERR_SSL_BAD_HS_SERVER_HELLO );


### PR DESCRIPTION
Summary:
When we check the [supported version
extension](https://github.com/hannestschofenig/mbedtls/blob/tls13-prototype/library/ssl_tls13_client.c#L2028-L2032),
the following logic is incorrect.
```
if( len != 2 && buf[0] != 0x3 && buf[1] != 0x3 )
{
  MBEDTLS_SSL_DEBUG_MSG( 1, ( "unexpected version") );
  return( MBEDTLS_ERR_SSL_BAD_HS_SERVER_HELLO);
}
```

We should change the logic `and` to logic `or`

```
if( len != 2 || buf[0] != 0x3 || buf[1] != 0x3 )
{
  MBEDTLS_SSL_DEBUG_MSG( 1, ( "unexpected version") );
  return( MBEDTLS_ERR_SSL_BAD_HS_SERVER_HELLO);
}
```

The only legit input is len ==  2, buf[0] == 3
(MBEDTLS_SSL_MAJOR_VERSION_3) and buf[1] == 4
(MBEDTLS_SSL_MINOR_VERSION_4). In the origial logic, typical invalid
input, such as len == 0, would return 0 from
`ssl_parse_supported_version_ext`.

Other notes:
* Also removed the comments about magic number, and replace it with macros
* The check for
* [DTLS](https://github.com/hannestschofenig/mbedtls/blob/tls13-prototype/library/ssl_tls13_client.c#L2018) seem incorrect too, I will leave it for now.

Test Plan:
Build and test.
Run gdb to validate the invalid input is flaged.
```
Thread 1 "tests" hit Breakpoint 1, ssl_parse_supported_version_ext
(ssl=0x615000002120, buf=0x62900000a23d "\003\004", len=2)
    at library/ssl_tls13_client.c:2148
2148          if( len != 2 || buf[0] != MBEDTLS_SSL_MAJOR_VERSION_3 ||
    buf[1] != MBEDTLS_SSL_MINOR_VERSION_4 )
(gdb) p buf[1]
$4 = 4 '\004'
(gdb) set buf[1] = 3
(gdb) p buf[1]
$5 = 3 '\003'
(gdb) p buf[0]
$6 = 3 '\003'
(gdb) n
2150              MBEDTLS_SSL_DEBUG_MSG( 1, ( "unexpected version" ) );
(gdb) n
mbedDBG[1]:
xplat/mobilenetwork/third-party/mbedtls/library/ssl_tls13_client.c:2150
unexpected version

2151              return( MBEDTLS_ERR_SSL_BAD_HS_SERVER_HELLO );
(gdb) n
```

Reviewers:
hanno.becker@arm.com,hannes.tschofenig@arm.com,junqi.wang@live.com,zhi.han@gmail.com

Subscribers:

Tasks:

Tags: