### PR TITLE
Use bit or instead of plus to set extensions_present

### DIFF
--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -1911,7 +1911,7 @@ static int ssl_client_hello_write( mbedtls_ssl_context* ssl,
         buf += cur_ext_len;
 
         if( ret == 0 )
-            ssl->handshake->extensions_present += PSK_KEY_EXCHANGE_MODES_EXTENSION;
+            ssl->handshake->extensions_present |= PSK_KEY_EXCHANGE_MODES_EXTENSION;
     }
 #endif /* MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED */
 
@@ -1928,7 +1928,7 @@ static int ssl_client_hello_write( mbedtls_ssl_context* ssl,
         total_ext_len += cur_ext_len;
         buf += cur_ext_len;
 
-        if( ret == 0 ) ssl->handshake->extensions_present += SUPPORTED_GROUPS_EXTENSION;
+        if( ret == 0 ) ssl->handshake->extensions_present |= SUPPORTED_GROUPS_EXTENSION;
     }
 
     /* The supported_signature_algorithms extension is REQUIRED for
@@ -1941,7 +1941,7 @@ static int ssl_client_hello_write( mbedtls_ssl_context* ssl,
         total_ext_len += cur_ext_len;
         buf += cur_ext_len;
 
-        if( ret == 0 ) ssl->handshake->extensions_present += SIGNATURE_ALGORITHM_EXTENSION;
+        if( ret == 0 ) ssl->handshake->extensions_present |= SIGNATURE_ALGORITHM_EXTENSION;
     }
     /* We need to send the key shares under three conditions:
      * 1 ) A certificate-based ciphersuite is being offered. In this case
@@ -1958,7 +1958,7 @@ static int ssl_client_hello_write( mbedtls_ssl_context* ssl,
         total_ext_len += cur_ext_len;
         buf += cur_ext_len;
 
-        if( ret == 0 ) ssl->handshake->extensions_present += KEY_SHARE_EXTENSION;
+        if( ret == 0 ) ssl->handshake->extensions_present |= KEY_SHARE_EXTENSION;
     }
     else if( ssl->handshake->extensions_present & SUPPORTED_GROUPS_EXTENSION && ssl->handshake->extensions_present & SIGNATURE_ALGORITHM_EXTENSION )
     {
@@ -1967,7 +1967,7 @@ static int ssl_client_hello_write( mbedtls_ssl_context* ssl,
         total_ext_len += cur_ext_len;
         buf += cur_ext_len;
 
-        if( ret == 0 ) ssl->handshake->extensions_present += KEY_SHARE_EXTENSION;
+        if( ret == 0 ) ssl->handshake->extensions_present |= KEY_SHARE_EXTENSION;
     }
 #endif /* MBEDTLS_KEY_EXCHANGE_WITH_CERT_ENABLED */
 
@@ -1987,7 +1987,7 @@ static int ssl_client_hello_write( mbedtls_ssl_context* ssl,
         buf += cur_ext_len;
 
         if( ret == 0 )
-            ssl->handshake->extensions_present += PRE_SHARED_KEY_EXTENSION;
+            ssl->handshake->extensions_present |= PRE_SHARED_KEY_EXTENSION;
     }
 #endif /* MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED */
 
@@ -2114,7 +2114,7 @@ static int ssl_parse_server_psk_identity_ext( mbedtls_ssl_context *ssl,
     }
 
 /*	buf += 2; */
-    ssl->handshake->extensions_present += PRE_SHARED_KEY_EXTENSION;
+    ssl->handshake->extensions_present |= PRE_SHARED_KEY_EXTENSION;
     return( 0 );
 }
 
@@ -2212,7 +2212,7 @@ static int ssl_parse_key_shares_ext( mbedtls_ssl_context *ssl,
         return( MBEDTLS_ERR_SSL_BAD_HS_SERVER_KEY_EXCHANGE );
     }
 
-    ssl->handshake->extensions_present += KEY_SHARE_EXTENSION;
+    ssl->handshake->extensions_present |= KEY_SHARE_EXTENSION;
     return( ret );
 }
 #endif /* MBEDTLS_ECDH_C || MBEDTLS_ECDSA_C */

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -2574,7 +2574,7 @@ static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
                     MBEDTLS_SSL_DEBUG_RET( 1, "ssl_parse_servername_ext", ret );
                     return( MBEDTLS_ERR_SSL_BAD_HS_SERVERNAME_EXT );
                 }
-                ssl->handshake->extensions_present += SERVERNAME_EXTENSION;
+                ssl->handshake->extensions_present |= SERVERNAME_EXTENSION;
                 break;
 #endif /* MBEDTLS_SSL_SERVER_NAME_INDICATION */
 
@@ -2591,7 +2591,7 @@ static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
                 }
                 else if( ret == 0 ) /* cid extension present and processed succesfully */
                 {
-                    ssl->handshake->extensions_present += CID_EXTENSION;
+                    ssl->handshake->extensions_present |= CID_EXTENSION;
                 }
                 break;
 #endif /* MBEDTLS_CID */
@@ -2609,7 +2609,7 @@ static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
                 }
                 else if( ret == 0 ) /* cookie extension present and processed succesfully */
                 {
-                    ssl->handshake->extensions_present += COOKIE_EXTENSION;
+                    ssl->handshake->extensions_present |= COOKIE_EXTENSION;
                 }
                 break;
 #endif /* MBEDTLS_SSL_COOKIE_C  */
@@ -2624,7 +2624,7 @@ static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
                 ext_len_psk_ext = ext_size;
                 ext_psk_ptr = ext + 4;
 
-                ssl->handshake->extensions_present += PRE_SHARED_KEY_EXTENSION;
+                ssl->handshake->extensions_present |= PRE_SHARED_KEY_EXTENSION;
                 break;
 #endif /* MBEDTLS_KEY_EXCHANGE_PSK_ENABLED */
 
@@ -2640,7 +2640,7 @@ static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
                    return( MBEDTLS_ERR_SSL_BAD_HS_SUPPORTED_GROUPS );
                    }
                 */
-                ssl->handshake->extensions_present += EARLY_DATA_EXTENSION;
+                ssl->handshake->extensions_present |= EARLY_DATA_EXTENSION;
                 break;
 #endif /* MBEDTLS_ZERO_RTT */
 
@@ -2662,7 +2662,7 @@ static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
                     return( MBEDTLS_ERR_SSL_BAD_HS_SUPPORTED_GROUPS );
                 }
 
-                ssl->handshake->extensions_present += SUPPORTED_GROUPS_EXTENSION;
+                ssl->handshake->extensions_present |= SUPPORTED_GROUPS_EXTENSION;
                 break;
 #endif /* MBEDTLS_ECDH_C || MBEDTLS_ECDSA_C */
 
@@ -2677,7 +2677,7 @@ static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
                     return( MBEDTLS_ERR_SSL_BAD_HS_PSK_KEY_EXCHANGE_MODES_EXT );
                 }
 
-                ssl->handshake->extensions_present += PSK_KEY_EXCHANGE_MODES_EXTENSION;
+                ssl->handshake->extensions_present |= PSK_KEY_EXCHANGE_MODES_EXTENSION;
                 break;
 #endif /* MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED */
 
@@ -2708,10 +2708,10 @@ static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
                      *       the content of it.
                      */
                     final_ret = MBEDTLS_ERR_SSL_BAD_HS_WRONG_KEY_SHARE;
-                    ssl->handshake->extensions_present += KEY_SHARE_EXTENSION;
+                    ssl->handshake->extensions_present |= KEY_SHARE_EXTENSION;
                     break;
                 }
-                ssl->handshake->extensions_present += KEY_SHARE_EXTENSION;
+                ssl->handshake->extensions_present |= KEY_SHARE_EXTENSION;
                 break;
 #endif /* MBEDTLS_ECDH_C || MBEDTLS_ECDSA_C */
 
@@ -2725,7 +2725,7 @@ static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
                     MBEDTLS_SSL_DEBUG_RET( 1, ( "ssl_parse_max_fragment_length_ext" ), ret );
                     return( MBEDTLS_ERR_SSL_BAD_HS_MAX_FRAGMENT_LENGTH_EXT );
                 }
-                ssl->handshake->extensions_present += MAX_FRAGMENT_LENGTH_EXTENSION;
+                ssl->handshake->extensions_present |= MAX_FRAGMENT_LENGTH_EXTENSION;
                 break;
 #endif /* MBEDTLS_SSL_MAX_FRAGMENT_LENGTH */
 
@@ -2738,7 +2738,7 @@ static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
                     MBEDTLS_SSL_DEBUG_RET( 1, ( "ssl_parse_supported_versions_ext" ), ret );
                     return( MBEDTLS_ERR_SSL_BAD_HS_SUPPORTED_VERSIONS_EXT );
                 }
-                ssl->handshake->extensions_present += SUPPORTED_VERSION_EXTENSION;
+                ssl->handshake->extensions_present |= SUPPORTED_VERSION_EXTENSION;
                 break;
 
 #if defined(MBEDTLS_SSL_ALPN)
@@ -2751,7 +2751,7 @@ static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
                     MBEDTLS_SSL_DEBUG_RET( 1, ( "ssl_parse_alpn_ext" ), ret );
                     return( MBEDTLS_ERR_SSL_BAD_HS_ALPN_EXT );
                 }
-                ssl->handshake->extensions_present += ALPN_EXTENSION;
+                ssl->handshake->extensions_present |= ALPN_EXTENSION;
                 break;
 #endif /* MBEDTLS_SSL_ALPN */
 
@@ -2765,7 +2765,7 @@ static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
                     MBEDTLS_SSL_DEBUG_MSG( 1, ( "ssl_parse_supported_signature_algorithms_server_ext ( %d )", ret ) );
                     return( ret );
                 }
-                ssl->handshake->extensions_present += SIGNATURE_ALGORITHM_EXTENSION;
+                ssl->handshake->extensions_present |= SIGNATURE_ALGORITHM_EXTENSION;
                 break;
 #endif /* MBEDTLS_KEY_EXCHANGE_WITH_CERT_ENABLED */
 


### PR DESCRIPTION
Summary:
Set `extensions_present` by `bit or` (`|=`) instead of `plus` (`+=`) for
security reason.
In case there are repeated extensions, current operation (`+=`) may clear the extension present flag,
   and overflow to next one.

Test Plan:
Build and run make test

Reviewers:
hanno.becker@arm.com,hannes.tschofenig@arm.com,junqi.wang@live.com,zhi.han@gmail.com

Subscribers:

Tasks:

Tags: