### PR TITLE
Implement early data status

### DIFF
--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -796,16 +796,16 @@ typedef struct mbedtls_ssl_flight_item mbedtls_ssl_flight_item;
 /**
  * \brief Get information about the use of 0-RTT in a TLS 1.3 handshake
  *
- * \param ssl        SSL context.
+ * \param ssl      The SSL context to query
  *
- *
- * \return         The early data status.
- *
- * \note           The status is initially set as not sent (MBEDTLS_SSL_EARLY_DATA_NOT_SENT).
- *                 If the early data extension is sent by client, it will be set to
- *                 rejected (MBEDTLS_SSL_EARLY_DATA_REJECTED).
- *                 Once client receives early data extension from corresponding server response,
- *                 the status will be set to accepted (MBEDTLS_SSL_EARLY_DATA_ACCEPTED)
+ * \returns        #MBEDTLS_SSL_EARLY_DATA_NOT_SENT if the client has not indicated
+ *                 the use of 0-RTT.
+ * \returns        #MBEDTLS_SSL_EARLY_DATA_REJECTED if the client has indicated the use
+ *                 of 0-RTT but the server has not accepted it.
+ *                 In this situation, the client may want to re-send the 0-RTT data
+ *                 as ordinary post-handshake application data via mbedtls_ssl_write().
+ * \returns        #MBEDTLS_SSL_EARLY_DATA_ACCEPTED if the client has indicated the use
+ *                 of 0-RTT and the server has accepted it.
  */
 int mbedtls_ssl_get_early_data_status( mbedtls_ssl_context *ssl );
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL && MBEDTLS_ZERO_RTT && MBEDTLS_SSL_CLI_C */

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -787,18 +787,27 @@ typedef struct mbedtls_ssl_key_cert mbedtls_ssl_key_cert;
 typedef struct mbedtls_ssl_flight_item mbedtls_ssl_flight_item;
 #endif
 
-#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && defined(MBEDTLS_ZERO_RTT) && defined(MBEDTLS_SSL_CLI_C)
 #define MBEDTLS_SSL_EARLY_DATA_NOT_SENT       0
 #define MBEDTLS_SSL_EARLY_DATA_REJECTED       1
 #define MBEDTLS_SSL_EARLY_DATA_ACCEPTED       2
 
 /**
- * \brief get client early data state. This can only be called after handshake is completed
+ * \brief get client early data status.
  *
  * \param ssl        SSL context.
+ *
+ *
+ * \return         The early data status.
+ *
+ * \note           The status is initially set as not sent (MBEDTLS_SSL_EARLY_DATA_NOT_SENT).
+ *                 If the early data extension is sent by client, it will be set to
+ *                 rejected (MBEDTLS_SSL_EARLY_DATA_REJECTED).
+ *                 Once client receives early data extension from corresponding server response,
+ *                 the status will be set to accepted (MBEDTLS_SSL_EARLY_DATA_ACCEPTED)
  */
-int mbedtls_ssl_get_early_data_status(mbedtls_ssl_context *ssl);
-#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
+int mbedtls_ssl_get_early_data_status( mbedtls_ssl_context *ssl );
+#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL && MBEDTLS_ZERO_RTT && MBEDTLS_SSL_CLI_C */
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && defined(MBEDTLS_SSL_NEW_SESSION_TICKET)
 
@@ -1749,12 +1758,12 @@ struct mbedtls_ssl_context
                             *   and #MBEDTLS_SSL_CID_DISABLED. */
 #endif /* MBEDTLS_SSL_DTLS_CONNECTION_ID */
 
-#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && defined(MBEDTLS_ZERO_RTT) && defined(MBEDTLS_SSL_CLI_C)
     /*
      * early data request state
      */
     int early_data_status;
-#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
+#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL && MBEDTLS_ZERO_RTT && MBEDTLS_SSL_CLI_C */
 
 };
 

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -787,13 +787,14 @@ typedef struct mbedtls_ssl_key_cert mbedtls_ssl_key_cert;
 typedef struct mbedtls_ssl_flight_item mbedtls_ssl_flight_item;
 #endif
 
-#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && defined(MBEDTLS_ZERO_RTT) && defined(MBEDTLS_SSL_CLI_C)
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && \
+    defined(MBEDTLS_ZERO_RTT) && defined(MBEDTLS_SSL_CLI_C)
 #define MBEDTLS_SSL_EARLY_DATA_NOT_SENT       0
 #define MBEDTLS_SSL_EARLY_DATA_REJECTED       1
 #define MBEDTLS_SSL_EARLY_DATA_ACCEPTED       2
 
 /**
- * \brief get client early data status.
+ * \brief Get information about the use of 0-RTT in a TLS 1.3 handshake
  *
  * \param ssl        SSL context.
  *
@@ -1758,7 +1759,8 @@ struct mbedtls_ssl_context
                             *   and #MBEDTLS_SSL_CID_DISABLED. */
 #endif /* MBEDTLS_SSL_DTLS_CONNECTION_ID */
 
-#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && defined(MBEDTLS_ZERO_RTT) && defined(MBEDTLS_SSL_CLI_C)
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && \
+    defined(MBEDTLS_ZERO_RTT) && defined(MBEDTLS_SSL_CLI_C)
     /*
      * early data request state
      */

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -787,6 +787,19 @@ typedef struct mbedtls_ssl_key_cert mbedtls_ssl_key_cert;
 typedef struct mbedtls_ssl_flight_item mbedtls_ssl_flight_item;
 #endif
 
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+#define MBEDTLS_SSL_EARLY_DATA_NOT_SENT       0
+#define MBEDTLS_SSL_EARLY_DATA_REJECTED       1
+#define MBEDTLS_SSL_EARLY_DATA_ACCEPTED       2
+
+/**
+ * \brief get client early data state. This can only be called after handshake is completed
+ *
+ * \param ssl        SSL context.
+ */
+int mbedtls_ssl_get_early_data_status(mbedtls_ssl_context *ssl);
+#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
+
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && defined(MBEDTLS_SSL_NEW_SESSION_TICKET)
 
 typedef enum
@@ -1735,6 +1748,14 @@ struct mbedtls_ssl_context
                             *   Possible values are #MBEDTLS_SSL_CID_ENABLED
                             *   and #MBEDTLS_SSL_CID_DISABLED. */
 #endif /* MBEDTLS_SSL_DTLS_CONNECTION_ID */
+
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+    /*
+     * early data request state
+     */
+    int early_data_status;
+#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
+
 };
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -796,8 +796,12 @@ typedef struct mbedtls_ssl_flight_item mbedtls_ssl_flight_item;
 /**
  * \brief Get information about the use of 0-RTT in a TLS 1.3 handshake
  *
- * \param ssl      The SSL context to query
+ * \param ssl      The SSL context to query.
  *
+ * \returns        #MBEDTLS_ERR_SSL_BAD_INPUT_DATA if this function is called
+ *                 from the server-side.
+ * \returns        #MBEDTLS_ERR_SSL_BAD_INPUT_DATA if this function is called
+ *                 prior to completion of the handshake.
  * \returns        #MBEDTLS_SSL_EARLY_DATA_NOT_SENT if the client has not indicated
  *                 the use of 0-RTT.
  * \returns        #MBEDTLS_SSL_EARLY_DATA_REJECTED if the client has indicated the use

--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -1293,7 +1293,8 @@ int mbedtls_ssl_write_finished( mbedtls_ssl_context *ssl );
 int mbedtls_ssl_new_session_ticket_process(mbedtls_ssl_context* ssl);
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 
-#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && defined(MBEDTLS_ZERO_RTT) && defined(MBEDTLS_SSL_CLI_C)
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && \
+    defined(MBEDTLS_ZERO_RTT) \&& defined(MBEDTLS_SSL_CLI_C)
 /* parse early data extension */
 int ssl_parse_early_data_ext( mbedtls_ssl_context *ssl,
     const unsigned char *buf, size_t len );

--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -1293,6 +1293,11 @@ int mbedtls_ssl_write_finished( mbedtls_ssl_context *ssl );
 int mbedtls_ssl_new_session_ticket_process(mbedtls_ssl_context* ssl);
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+/* parse early data extension */
+int ssl_parse_early_data_ext(mbedtls_ssl_context *ssl,
+    const unsigned char *buf, size_t len);
+#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 
 #if defined(MBEDTLS_SSL_TLS13_CTLS)
 static enum varint_length_enum set_varint_length(uint32_t input, uint32_t* output);

--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -1293,11 +1293,11 @@ int mbedtls_ssl_write_finished( mbedtls_ssl_context *ssl );
 int mbedtls_ssl_new_session_ticket_process(mbedtls_ssl_context* ssl);
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 
-#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && defined(MBEDTLS_ZERO_RTT) && defined(MBEDTLS_SSL_CLI_C)
 /* parse early data extension */
-int ssl_parse_early_data_ext(mbedtls_ssl_context *ssl,
-    const unsigned char *buf, size_t len);
-#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
+int ssl_parse_early_data_ext( mbedtls_ssl_context *ssl,
+    const unsigned char *buf, size_t len );
+#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL && MBEDTLS_ZERO_RTT && MBEDTLS_SSL_CLI_C */
 
 #if defined(MBEDTLS_SSL_TLS13_CTLS)
 static enum varint_length_enum set_varint_length(uint32_t input, uint32_t* output);

--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -1294,7 +1294,7 @@ int mbedtls_ssl_new_session_ticket_process(mbedtls_ssl_context* ssl);
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && \
-    defined(MBEDTLS_ZERO_RTT) \&& defined(MBEDTLS_SSL_CLI_C)
+    defined(MBEDTLS_ZERO_RTT) && defined(MBEDTLS_SSL_CLI_C)
 /* parse early data extension */
 int ssl_parse_encrypted_extensions_early_data_ext( mbedtls_ssl_context *ssl,
     const unsigned char *buf, size_t len );

--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -1296,7 +1296,7 @@ int mbedtls_ssl_new_session_ticket_process(mbedtls_ssl_context* ssl);
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && \
     defined(MBEDTLS_ZERO_RTT) \&& defined(MBEDTLS_SSL_CLI_C)
 /* parse early data extension */
-int ssl_parse_early_data_ext( mbedtls_ssl_context *ssl,
+int ssl_parse_encrypted_extensions_early_data_ext( mbedtls_ssl_context *ssl,
     const unsigned char *buf, size_t len );
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL && MBEDTLS_ZERO_RTT && MBEDTLS_SSL_CLI_C */
 

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -2139,15 +2139,24 @@ int ssl_parse_encrypted_extensions_early_data_ext( mbedtls_ssl_context *ssl,
                                                    const unsigned char *buf,
                                                    size_t len )
 {
-  ( ( void )buf );
-  if ( ssl->state == MBEDTLS_SSL_ENCRYPTED_EXTENSIONS &&
-      ssl->handshake->early_data == MBEDTLS_SSL_EARLY_DATA_ON &&
-      len == 0 )
-  {
+    if( ssl->handshake->early_data != MBEDTLS_SSL_EARLY_DATA_ON )
+    {
+        /* The server must not send the EarlyDataIndication if the
+         * client hasn't indicated the use of 0-RTT. */
+        return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
+    }
+
+    if( len != 0 )
+    {
+        /* The message must be empty. */
+        return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
+    }
+
+    /* Nothing to parse */
+    ((void) buf);
+
     ssl->early_data_status = MBEDTLS_SSL_EARLY_DATA_ACCEPTED;
-    return 0;
-  }
-  return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
+    return( 0 );
 }
 
 int mbedtls_ssl_get_early_data_status( mbedtls_ssl_context *ssl )

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -2161,6 +2161,12 @@ int ssl_parse_encrypted_extensions_early_data_ext( mbedtls_ssl_context *ssl,
 
 int mbedtls_ssl_get_early_data_status( mbedtls_ssl_context *ssl )
 {
+    if( ssl->state != MBEDTLS_SSL_HANDSHAKE_OVER )
+        return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
+
+    if( ssl->conf->endpoint == MBEDTLS_SSL_IS_SERVER )
+        return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
+
     return( ssl->early_data_status );
 }
 #endif /* MBEDTLS_ZERO_RTT */

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -2161,7 +2161,7 @@ int ssl_parse_encrypted_extensions_early_data_ext( mbedtls_ssl_context *ssl,
 
 int mbedtls_ssl_get_early_data_status( mbedtls_ssl_context *ssl )
 {
-  return ssl->early_data_status;
+    return( ssl->early_data_status );
 }
 #endif /* MBEDTLS_ZERO_RTT */
 

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -2120,6 +2120,7 @@ static int ssl_parse_server_psk_identity_ext( mbedtls_ssl_context *ssl,
 
 #endif
 
+#if defined(MBEDTLS_ZERO_RTT)
 /* Early Data Extension
 *
 * struct {} Empty;
@@ -2132,22 +2133,26 @@ static int ssl_parse_server_psk_identity_ext( mbedtls_ssl_context *ssl,
 *   };
 * } EarlyDataIndication;
 */
-int ssl_parse_early_data_ext(mbedtls_ssl_context *ssl,
-    const unsigned char *buf, size_t len) {
+int ssl_parse_early_data_ext( mbedtls_ssl_context *ssl,
+    const unsigned char *buf, size_t len )
+{
   ( ( void )buf );
-  if (ssl->state == MBEDTLS_SSL_ENCRYPTED_EXTENSIONS
-      && ssl->handshake->early_data == MBEDTLS_SSL_EARLY_DATA_ON
-      && len == 0) {
+  if ( ssl->state == MBEDTLS_SSL_ENCRYPTED_EXTENSIONS &&
+      ssl->handshake->early_data == MBEDTLS_SSL_EARLY_DATA_ON &&
+      len == 0 )
+  {
     ssl->early_data_status = MBEDTLS_SSL_EARLY_DATA_ACCEPTED;
     return 0;
   }
-  return MBEDTLS_ERR_SSL_INTERNAL_ERROR;
+  return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
 }
 
-int mbedtls_ssl_get_early_data_status(mbedtls_ssl_context *ssl)
+int mbedtls_ssl_get_early_data_status( mbedtls_ssl_context *ssl )
 {
   return ssl->early_data_status;
 }
+#endif /* MBEDTLS_ZERO_RTT */
+
 #if ( defined(MBEDTLS_ECDH_C) || defined(MBEDTLS_ECDSA_C) )
 
 /* TODO: Code for MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED missing */
@@ -2766,6 +2771,7 @@ static int ssl_encrypted_extensions_parse( mbedtls_ssl_context* ssl,
                 break;
 #endif /* MBEDTLS_SSL_SERVER_NAME_INDICATION */
 
+#if defined(MBEDTLS_ZERO_RTT)
             case MBEDTLS_TLS_EXT_EARLY_DATA:
               MBEDTLS_SSL_DEBUG_MSG(3, ("found early data extension"));
 
@@ -2775,6 +2781,7 @@ static int ssl_encrypted_extensions_parse( mbedtls_ssl_context* ssl,
                 return(ret);
               }
               break;
+#endif /* MBEDTLS_ZERO_RTT */
             default:
                 MBEDTLS_SSL_DEBUG_MSG( 3, ( "unknown extension found: %d ( ignoring )", ext_id ) );
         }

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -2132,9 +2132,12 @@ static int ssl_parse_server_psk_identity_ext( mbedtls_ssl_context *ssl,
 *     case encrypted_extensions: Empty;
 *   };
 * } EarlyDataIndication;
+*
+* This function only handles the case of the EncryptedExtensions message.
 */
-int ssl_parse_early_data_ext( mbedtls_ssl_context *ssl,
-    const unsigned char *buf, size_t len )
+int ssl_parse_encrypted_extensions_early_data_ext( mbedtls_ssl_context *ssl,
+                                                   const unsigned char *buf,
+                                                   size_t len )
 {
   ( ( void )buf );
   if ( ssl->state == MBEDTLS_SSL_ENCRYPTED_EXTENSIONS &&
@@ -2773,15 +2776,18 @@ static int ssl_encrypted_extensions_parse( mbedtls_ssl_context* ssl,
 
 #if defined(MBEDTLS_ZERO_RTT)
             case MBEDTLS_TLS_EXT_EARLY_DATA:
-              MBEDTLS_SSL_DEBUG_MSG(3, ("found early data extension"));
+                MBEDTLS_SSL_DEBUG_MSG(3, ("found early data extension"));
 
-              if ((ret =  ssl_parse_early_data_ext(ssl, ext + 4, (size_t)ext_size)) != 0)
-              {
-                MBEDTLS_SSL_DEBUG_RET(1, "ssl_parse_early_data_ext", ret);
-                return(ret);
-              }
-              break;
+                ret = ssl_parse_encrypted_extensions_early_data_ext(
+                    ssl, ext + 4, (size_t) ext_size );
+                if( ret != 0 )
+                {
+                    MBEDTLS_SSL_DEBUG_RET( 1, "ssl_parse_early_data_ext", ret );
+                    return( ret );
+                }
+                break;
 #endif /* MBEDTLS_ZERO_RTT */
+
             default:
                 MBEDTLS_SSL_DEBUG_MSG( 3, ( "unknown extension found: %d ( ignoring )", ext_id ) );
         }

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -4999,7 +4999,6 @@ int mbedtls_ssl_write_early_data_ext( mbedtls_ssl_context *ssl,
 #if defined(MBEDTLS_SSL_CLI_C)
     if( ssl->conf->endpoint == MBEDTLS_SSL_IS_CLIENT )
     {
-        ssl->early_data_status = MBEDTLS_SSL_EARLY_DATA_NOT_SENT;
         if( ssl->conf->key_exchange_modes == MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_ECDHE_ECDSA ||
             ssl->conf->early_data == MBEDTLS_SSL_EARLY_DATA_DISABLED ) {
 
@@ -5021,6 +5020,8 @@ int mbedtls_ssl_write_early_data_ext( mbedtls_ssl_context *ssl,
     if( ssl->conf->endpoint == MBEDTLS_SSL_IS_CLIENT )
     {
         MBEDTLS_SSL_DEBUG_MSG( 3, ( "client hello, adding early_data extension" ) );
+        // We're using rejected once we sent the EarlyData extension,
+        // and change it to accepted upon receipt of the server extension.
         ssl->early_data_status = MBEDTLS_SSL_EARLY_DATA_REJECTED;
     }
 #endif /* MBEDTLS_SSL_CLI_C */

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -4999,6 +4999,7 @@ int mbedtls_ssl_write_early_data_ext( mbedtls_ssl_context *ssl,
 #if defined(MBEDTLS_SSL_CLI_C)
     if( ssl->conf->endpoint == MBEDTLS_SSL_IS_CLIENT )
     {
+        ssl->early_data_status = MBEDTLS_SSL_EARLY_DATA_NOT_SENT;
         if( ssl->conf->key_exchange_modes == MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_ECDHE_ECDSA ||
             ssl->conf->early_data == MBEDTLS_SSL_EARLY_DATA_DISABLED ) {
 
@@ -5020,6 +5021,7 @@ int mbedtls_ssl_write_early_data_ext( mbedtls_ssl_context *ssl,
     if( ssl->conf->endpoint == MBEDTLS_SSL_IS_CLIENT )
     {
         MBEDTLS_SSL_DEBUG_MSG( 3, ( "client hello, adding early_data extension" ) );
+        ssl->early_data_status = MBEDTLS_SSL_EARLY_DATA_REJECTED;
     }
 #endif /* MBEDTLS_SSL_CLI_C */
 

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -5020,8 +5020,8 @@ int mbedtls_ssl_write_early_data_ext( mbedtls_ssl_context *ssl,
     if( ssl->conf->endpoint == MBEDTLS_SSL_IS_CLIENT )
     {
         MBEDTLS_SSL_DEBUG_MSG( 3, ( "client hello, adding early_data extension" ) );
-        // We're using rejected once we sent the EarlyData extension,
-        // and change it to accepted upon receipt of the server extension.
+        /* We're using rejected once we sent the EarlyData extension,
+           and change it to accepted upon receipt of the server extension. */
         ssl->early_data_status = MBEDTLS_SSL_EARLY_DATA_REJECTED;
     }
 #endif /* MBEDTLS_SSL_CLI_C */

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -3101,7 +3101,8 @@ int main( int argc, char *argv[] )
           MBEDTLS_SSL_PROTO_TLS1_2 */
 #endif /* MBEDTLS_SSL_EXPORT_KEYS */
 
-#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && defined(MBEDTLS_ZERO_RTT) && defined(MBEDTLS_SSL_CLI_C)
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && \
+    defined(MBEDTLS_ZERO_RTT) && defined(MBEDTLS_SSL_CLI_C)
     mbedtls_printf( "early data status = %d\n", mbedtls_ssl_get_early_data_status( &ssl ) );
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL && MBEDTLS_ZERO_RTT && MBEDTLS_SSL_CLI_C */
 

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -3101,6 +3101,10 @@ int main( int argc, char *argv[] )
           MBEDTLS_SSL_PROTO_TLS1_2 */
 #endif /* MBEDTLS_SSL_EXPORT_KEYS */
 
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && defined(MBEDTLS_ZERO_RTT) && defined(MBEDTLS_SSL_CLI_C)
+    mbedtls_printf( "early data status = %d\n", mbedtls_ssl_get_early_data_status( &ssl ) );
+#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL && MBEDTLS_ZERO_RTT && MBEDTLS_SSL_CLI_C */
+
 #if defined(MBEDTLS_X509_CRT_PARSE_C)
     /*
      * 5. Verify the server certificate

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -1512,6 +1512,24 @@ run_test    "TLS 1.3, TLS_AES_128_CCM_SHA256 with ECDHE-ECDSA, SRV auth, HRR enf
             -c "Verifying peer X.509 certificate... ok" \
             -c "Key Exchange Mode is ECDHE-ECDSA"
 
+# test early data status - not sent
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL
+requires_config_enabled MBEDTLS_DEBUG_C
+run_test    "TLS 1.3, TLS_AES_256_GCM_SHA384, ext PSK, early data status - not sent" \
+            "$P_SRV debug_level=5 force_version=tls1_3 psk=010203 psk_identity=0a0b0c" \
+            "$P_CLI debug_level=5 force_version=tls1_3 force_ciphersuite=TLS_AES_256_GCM_SHA384 psk=010203 psk_identity=0a0b0c" \
+            0 \
+	    -c "early data status = 0"  \
+
+# test early data status - accepted
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL
+requires_config_enabled MBEDTLS_DEBUG_C
+run_test    "TLS 1.3, TLS_AES_256_GCM_SHA384, ext PSK, early data status - accepted" \
+            "$P_SRV debug_level=5 force_version=tls1_3 early_data=1 key_exchange_modes=psk psk=010203 psk_identity=0a0b0c" \
+            "$P_CLI debug_level=5 force_version=tls1_3 force_ciphersuite=TLS_AES_256_GCM_SHA384 key_exchange_modes=psk early_data=1 psk=010203 psk_identity=0a0b0c" \
+            0 \
+	    -c "early data status = 2"  \
+
 #
 # TLS 1.2 specific tests
 #


### PR DESCRIPTION
Summary:
* Add `early_data_status` in `mbedtls_ssl_context` to book keep the status of early data
* The status includes: NOT_SENT, ACCEPT, and REJECT.
* Parsing the early data status from the early data extension of `encrypted_extensions`

Knowing early data status, such as rejection, will be useful for
applications to decide if they could send early data or not.

Test Plan:
Build and make test

Reviewers:
hanno.becker@arm.com,hannes.tschofenig@arm.com,junqi.wang@live.com,zhi.han@gmail.com

Subscribers:

Tasks:

Tags: