### PR TITLE
Set call back to delegate entire certificate validation process

### DIFF
--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -1221,6 +1221,10 @@ struct mbedtls_ssl_config
     /** Callback to customize X.509 certificate chain verification          */
     int (*f_vrfy)(void *, mbedtls_x509_crt *, int, uint32_t *);
     void *p_vrfy;                   /*!< context for X.509 verify calllback */
+#if defined(MBEDTLS_SSL_SERVER_NAME_INDICATION) && defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+    int (*f_verify_callback)(void *, const mbedtls_x509_crt *, const char *);
+    void *p_verify_callback;
+#endif /* MBEDTLS_SSL_SERVER_NAME_INDICATION && MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 #endif /* MBEDTLS_X509_CRT_PARSE_C */
 
 #if defined(MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED)
@@ -1953,6 +1957,25 @@ void mbedtls_ssl_conf_early_data(mbedtls_ssl_config* conf, int early_data, char*
 void mbedtls_ssl_conf_verify( mbedtls_ssl_config *conf,
                      int (*f_vrfy)(void *, mbedtls_x509_crt *, int, uint32_t *),
                      void *p_vrfy );
+#if defined(MBEDTLS_SSL_SERVER_NAME_INDICATION) && defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+/**
+ * \brief          Set the verification callback (Optional).
+ *
+ *                 If the application does not explicitly specify a
+ *                 verification callback function, the built-in verification
+ *                 function is used. If a verification callback is specified via
+ *                 mbedtls_ssl_conf_set_verify_callback(), the supplied callback
+ *                 function is called instead. By setting callback to NULL, the
+ *                 default behaviour is restored.
+ *
+ * \param conf              SSL configuration
+ * \param f_verify_callback verification function
+ * \param p_verify_callback verification parameter
+ */
+void mbedtls_ssl_conf_set_verify_callback( mbedtls_ssl_config *conf,
+                     int (*f_verify_callback)(void *, const mbedtls_x509_crt *, const char *),
+                     void *p_verify_callback );
+#endif /* MBEDTLS_SSL_SERVER_NAME_INDICATION && MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 #endif /* MBEDTLS_X509_CRT_PARSE_C */
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && defined(MBEDTLS_X509_CRT_PARSE_C)

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -4514,6 +4514,16 @@ void mbedtls_ssl_conf_verify( mbedtls_ssl_config *conf,
     conf->f_vrfy      = f_vrfy;
     conf->p_vrfy      = p_vrfy;
 }
+
+#if defined(MBEDTLS_SSL_SERVER_NAME_INDICATION) && defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+void mbedtls_ssl_conf_set_verify_callback( mbedtls_ssl_config *conf,
+                     int (*f_verify_callback)(void *, const mbedtls_x509_crt *, const char *),
+                     void *p_verify_callback ) {
+    conf->f_verify_callback = f_verify_callback;
+    conf->p_verify_callback = p_verify_callback;
+}
+#endif /* MBEDTLS_SSL_SERVER_NAME_INDICATION && MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
+
 #endif /* MBEDTLS_X509_CRT_PARSE_C */
 
 void mbedtls_ssl_conf_rng( mbedtls_ssl_config *conf,


### PR DESCRIPTION
Summary:
Set call back, `f_verify_callback`, to delegate the entire certificate
validation process to application.
The application has additional validation logic which is not supported
in default mbedtls implementation, such as cert pinning. It may also
delegate some validation process to OS.

Test Plan:
Build and make test

Reviewers:
hanno.becker@arm.com,hannes.tschofenig@arm.com,junqi.wang@live.com,zhi.han@gmail.com

Subscribers:

Tasks:

Tags: