### PR TITLE
Fix unused variable when MBEDTLS_DEBUG_C is undefined

### DIFF
--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -3565,7 +3565,6 @@ int mbedtls_ssl_generate_early_data_keys( mbedtls_ssl_context *ssl,
     int ret;
     int hash_length;
     const mbedtls_ssl_ciphersuite_t *ciphersuite_info;
-    mbedtls_ssl_handshake_params *handshake = ssl->handshake;
     const mbedtls_cipher_info_t *cipher_info;
     const mbedtls_md_info_t *md;
     unsigned char padbuf[MBEDTLS_MD_MAX_SIZE];
@@ -3586,7 +3585,7 @@ int mbedtls_ssl_generate_early_data_keys( mbedtls_ssl_context *ssl,
     if( cipher_info == NULL )
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "cipher info for %d not found",
-                                    handshake->ciphersuite_info->cipher ) );
+                                    ssl->handshake->ciphersuite_info->cipher ) );
         return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
     }
 
@@ -3594,7 +3593,7 @@ int mbedtls_ssl_generate_early_data_keys( mbedtls_ssl_context *ssl,
     if( md == NULL )
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "mbedtls_md info for %d not found",
-                                    handshake->ciphersuite_info->mac ) );
+                                    ssl->handshake->ciphersuite_info->mac ) );
         return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
     }
 


### PR DESCRIPTION
Summary:
The variable, `handshake`, in `mbedtls_ssl_generate_early_data_keys` is
unused when MBEDTLS_DEBUG_C is undefined.
Replace it with `ssl->handshake` as `ssl->handshake` has been used in
other places in the function.

Test Plan:
Verify the following compiler error is fixed.
* undefine `MBEDTLS_DEBUG_C` in config.h
* mkdir build && cd build
* CFLAGS="-std=c99 -g -Wunused-variable" cmake ..
* make
```
/home/lhuang04/upstream/library/ssl_tls13_generic.c: In function
‘mbedtls_ssl_generate_early_data_keys’:
/home/lhuang04/upstream/library/ssl_tls13_generic.c:3568:35: error:
unused variable ‘handshake’ [-Werror=unused-variable]
     mbedtls_ssl_handshake_params *handshake = ssl->handshake;
```

Reviewers:
hanno.becker@arm.com,hannes.tschofenig@arm.com,junqi.wang@live.com,zhi.han@gmail.com

Subscribers:

Tasks:

Tags: