### PR TITLE
Add opaque context parameter to MPS I/O callbacks

### DIFF
--- a/include/mbedtls/mps/common.h
+++ b/include/mbedtls/mps/common.h
@@ -153,7 +153,7 @@
 #define MBEDTLS_MPS_TRANSFORM_VALIDATION
 
 /*! This flag controls whether tracing for MPS should be enabled. */
-#define MBEDTLS_MPS_TRACE
+//#define MBEDTLS_MPS_TRACE
 
 /*! This internal macro determines whether all Layers of MPS should
  *  be compiled into a single source file.

--- a/include/mbedtls/mps/layer1.h
+++ b/include/mbedtls/mps/layer1.h
@@ -34,8 +34,8 @@
 /*
  * External interface to layer 0
  */
-typedef int mps_l0_recv_t( unsigned char *buf, size_t buflen );
-typedef int mps_l0_send_t( unsigned char const *buf, size_t buflen );
+typedef int mps_l0_recv_t( void* ctx, unsigned char *buf, size_t buflen );
+typedef int mps_l0_send_t( void* ctx, unsigned char const *buf, size_t buflen );
 
 /*
  *
@@ -54,7 +54,10 @@ typedef struct
 {
     mps_alloc     *alloc; /*!< The allocator to use to acquire and release
                            *   the read-buffer used by Layer 1.              */
-    mps_l0_recv_t *recv;  /*!< The Layer 0 receive callback                  */
+
+    void          *recv_ctx; /*!< The opaque context to be passed to the
+                              *   receive callback. This may be \c NULL.     */
+    mps_l0_recv_t *recv;     /*!< The Layer 0 receive callback               */
 
     /* OPTIMIZATION:
      * This buffer is already present in the allocator and
@@ -97,7 +100,10 @@ typedef struct
 {
     mps_alloc     *alloc;  /*!< The allocator to use to acquire and release
                             *   the write-buffer used by Layer 1.            */
-    mps_l0_send_t *send;   /*!< The Layer 0 send callback                    */
+
+    void          *send_ctx; /*!< The opaque context to be passed to the
+                              *   send callback. This may be \c NULL.        */
+    mps_l0_send_t *send;     /*!< The Layer 0 send callback                  */
 
     /* OPTIMIZATION:
      * This buffer is already present in the allocator and
@@ -149,7 +155,10 @@ typedef struct
 {
     mps_alloc     *alloc;   /*!< The allocator to use to acquire and release
                              *   the read-buffer used by Layer 1.             */
-    mps_l0_recv_t *recv;    /*!< The Layer 0 receive callback                 */
+
+    void          *recv_ctx; /*!< The opaque context to be passed to the
+                              *   receive callback. This may be \c NULL.     */
+    mps_l0_recv_t *recv;     /*!< The Layer 0 receive callback               */
 
     /* OPTIMIZATION:
      * This buffer is already present in the allocator and
@@ -178,7 +187,10 @@ typedef struct
 {
     mps_alloc     *alloc;   /*!< The allocator to use to acquire and release
                              *   the write-buffer used by Layer 1.            */
-    mps_l0_send_t *send;    /*!< The Layer 0 receive callback                 */
+
+    void          *send_ctx; /*!< The opaque context to be passed to the
+                              *   send callback. This may be \c NULL.         */
+    mps_l0_send_t *send;     /*!< The Layer 0 receive callback                */
 
     /* OPTIMIZATION:
      * This buffer is already present in the allocator and
@@ -309,7 +321,8 @@ mbedtls_mps_l1_get_mode( mps_l1 *l1 )
  */
 
 MBEDTLS_MPS_PUBLIC int mps_l1_init( mps_l1 *ctx, uint8_t mode, mps_alloc *alloc,
-                            mps_l0_send_t *send, mps_l0_recv_t *recv );
+                                    void* send_ctx, mps_l0_send_t *send,
+                                    void* recv_ctx, mps_l0_recv_t *recv );
 
 /**
  * \brief          Free a Layer 1 context.

--- a/include/mbedtls/mps/transform.h
+++ b/include/mbedtls/mps/transform.h
@@ -30,8 +30,7 @@
 /*
  * \brief   Opaque representation of record protection mechanisms.
  */
-struct mbedtls_mps_transform_t;
-typedef struct mbedtls_mps_transform_t mbedtls_mps_transform_t;
+typedef void mbedtls_mps_transform_t;
 
 /*
  * \brief         Structure representing an inclusion of two buffers.
@@ -64,7 +63,8 @@ typedef struct
                          *   surrounded by a parent buffer. */
 } mps_rec;
 
-extern int transform_free( mbedtls_mps_transform_t *transform );
+typedef int mbedtls_mps_transform_free_t( void *transform );
+extern mbedtls_mps_transform_free_t *mbedtls_mps_transform_free;
 
 /*
  * \brief Encrypt a record using a particular protection mechanism.
@@ -79,9 +79,12 @@ extern int transform_free( mbedtls_mps_transform_t *transform );
  * \return            \c 0 on success.
  * \return            A negative error code on failure.
  */
-extern int transform_encrypt( mbedtls_mps_transform_t *transform, mps_rec *rec,
-                              int (*f_rng)(void *, unsigned char *, size_t),
-                              void *p_rng );
+typedef int mbedtls_mps_transform_encrypt_t(
+    void *transform, mps_rec *rec,
+    int (*f_rng)(void *, unsigned char *, size_t),
+    void *p_rng );
+
+extern mbedtls_mps_transform_encrypt_t *mbedtls_mps_transform_encrypt;
 
 /*
  * \brief Decrypt a record using a particular protection mechanism.
@@ -94,8 +97,10 @@ extern int transform_encrypt( mbedtls_mps_transform_t *transform, mps_rec *rec,
  * \return            \c 0 on success.
  * \return            A negative error code on failure.
  */
-extern int transform_decrypt( mbedtls_mps_transform_t *transform,
-                              mps_rec *rec );
+typedef int mbedtls_mps_transform_decrypt_t( void *transform,
+                                             mps_rec *rec );
+
+extern mbedtls_mps_transform_decrypt_t *mbedtls_mps_transform_decrypt;
 
 /*
  * \brief Obtain the encryption expansion for a record protection mechanism.
@@ -113,7 +118,9 @@ extern int transform_decrypt( mbedtls_mps_transform_t *transform,
  * \return            \c 0 on success.
  * \return            A negative error code on failure.
  */
-extern int transform_get_expansion( mbedtls_mps_transform_t *transform,
-                                    size_t *pre_exp, size_t *post_exp );
+typedef int mbedtls_mps_transform_get_expansion_t( void *transform,
+    size_t *pre_exp, size_t *post_exp );
+
+extern mbedtls_mps_transform_get_expansion_t *mbedtls_mps_transform_get_expansion;
 
 #endif /* MBEDTLS_MPS_TRANSFORM_H */

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -116,6 +116,7 @@ set(src_tls
     mps/mps.c
     mps/reader.c
     mps/writer.c
+    mps/transform.c
 )
 
 if(CMAKE_COMPILER_IS_GNUCC)

--- a/library/Makefile
+++ b/library/Makefile
@@ -172,6 +172,7 @@ OBJS_TLS= \
 	  mps/layer3.o \
 	  mps/mps.o \
 	  mps/allocator.o \
+          mps/transform.o \
           # This line is intentionally left blank
 
 .SILENT:

--- a/library/mps/layer2.c
+++ b/library/mps/layer2.c
@@ -717,9 +717,9 @@ int l2_out_prepare_record( mbedtls_mps_l2 *ctx,
     if( ret != 0 )
         RETURN( ret );
 
-    transform_get_expansion( epoch->transform,
-                             &pre_expansion,
-                             &post_expansion );
+    mbedtls_mps_transform_get_expansion( epoch->transform,
+                                         &pre_expansion,
+                                         &post_expansion );
 
 #if defined(MBEDTLS_MPS_TRANSFORM_VALIDATION)
     {
@@ -873,9 +873,9 @@ int l2_out_dispatch_record( mbedtls_mps_l2 *ctx )
         /* Step 2: Apply record payload protection. */
         TRACE( trace_comment, "Encrypt record. The plaintext offset is %u.",
                (unsigned) rec.buf.data_offset );
-        ret = transform_encrypt( epoch->transform, &rec,
-                                 ctx->conf.f_rng,
-                                 ctx->conf.p_rng );
+        ret = mbedtls_mps_transform_encrypt( epoch->transform, &rec,
+                                             ctx->conf.f_rng,
+                                             ctx->conf.p_rng );
         if( ret != 0 )
         {
             TRACE( trace_comment, "The record encryption failed with %d", ret );
@@ -1944,7 +1944,7 @@ int l2_in_fetch_record( mbedtls_mps_l2 *ctx, mps_rec *rec )
         RETURN( ret );
     }
 
-    ret = transform_decrypt( epoch->transform, rec );
+    ret = mbedtls_mps_transform_decrypt( epoch->transform, rec );
     if( ret != 0 )
     {
         TRACE( trace_comment, "Decryption failed with: %d", (int) ret );
@@ -2709,7 +2709,7 @@ void l2_epoch_free( mbedtls_mps_l2_epoch_t *epoch )
 {
     if( epoch->transform != NULL )
     {
-        transform_free( epoch->transform );
+        mbedtls_mps_transform_free( epoch->transform );
         free( epoch->transform );
     }
 

--- a/library/mps/mps.c
+++ b/library/mps/mps.c
@@ -611,6 +611,10 @@ MBEDTLS_MPS_STATIC int mps_generic_failure_handler( mbedtls_mps *mps, int ret )
     int found = 0;
     const char *error_string = NULL;
 
+#if !defined(MBEDTLS_MPS_TRACE)
+    ((void) error_string);
+#endif
+
     if( ret == 0 )
         return( 0 );
 

--- a/library/mps/transform.c
+++ b/library/mps/transform.c
@@ -1,0 +1,28 @@
+/*
+ *  Message Processing Stack, Record Transformation Mechanisms
+ *
+ *  Copyright (C) 2006-2018, ARM Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of Mbed TLS (https://tls.mbed.org)
+ */
+
+#include "mbedtls/mps/transform.h"
+
+/* TODO: Use dummy default functions. */
+mbedtls_mps_transform_free_t          *mbedtls_mps_transform_free    = NULL;
+mbedtls_mps_transform_decrypt_t       *mbedtls_mps_transform_decrypt = NULL;
+mbedtls_mps_transform_encrypt_t       *mbedtls_mps_transform_encrypt = NULL;
+mbedtls_mps_transform_get_expansion_t *mbedtls_mps_transform_get_expansion = NULL;

--- a/tests/suites/test_suite_mps.function
+++ b/tests/suites/test_suite_mps.function
@@ -469,7 +469,7 @@ typedef struct
  * Transform multiplexing mock record payload protection
  * and real payload protection.
  */
-struct mbedtls_mps_transform_t
+struct mbedtls_mps_transform_wrap_t
 {
     uint8_t type; /* 0: mock, 1: real */
     mbedtls_transform_mock_t mock;
@@ -477,9 +477,10 @@ struct mbedtls_mps_transform_t
     mbedtls_ssl_transform real;
 #endif
 };
+typedef struct mbedtls_mps_transform_wrap_t mbedtls_mps_transform_wrap_t;
 
-static void build_mock_transforms( mbedtls_mps_transform_t *ptr0,
-                                   mbedtls_mps_transform_t *ptr1,
+static void build_mock_transforms( mbedtls_mps_transform_wrap_t *ptr0,
+                                   mbedtls_mps_transform_wrap_t *ptr1,
                                    size_t enabled, size_t pad )
 {
     ptr0->type = 0;
@@ -550,8 +551,8 @@ static void read_version( int *major, int *minor, int transport,
  * TLS version.
  */
 #if !defined(TEST_SUITE_MPS_NO_SSL)
-static int build_real_transforms_worker( mbedtls_mps_transform_t *t_in_,
-                                  mbedtls_mps_transform_t *t_out_,
+static int build_real_transforms_worker( mbedtls_mps_transform_wrap_t *t_in_,
+                                  mbedtls_mps_transform_wrap_t *t_out_,
                                   int cipher_type, int hash_id,
                                   int etm, int tag_mode, int ver,
                                   int (*f_rng)(void *, unsigned char *, size_t),
@@ -741,8 +742,8 @@ static int build_real_transforms_worker( mbedtls_mps_transform_t *t_in_,
     return( 0 );
 }
 
-static int build_real_transforms( mbedtls_mps_transform_t *t_in_,
-                                  mbedtls_mps_transform_t *t_out_ )
+static int build_real_transforms( mbedtls_mps_transform_wrap_t *t_in_,
+                                  mbedtls_mps_transform_wrap_t *t_out_ )
 {
     return( build_real_transforms_worker( t_in_, t_out_,
                            MBEDTLS_CIPHER_AES_256_GCM,
@@ -752,8 +753,9 @@ static int build_real_transforms( mbedtls_mps_transform_t *t_in_,
 }
 #endif /* TEST_SUITE_MPS_NO_SSL */
 
-int transform_free( mbedtls_mps_transform_t *transform_ )
+static int mps_transform_free( void *transform__ )
 {
+    mbedtls_mps_transform_wrap_t *transform_ = (mbedtls_mps_transform_wrap_t*) transform__;
 #if !defined(TEST_SUITE_MPS_NO_SSL)
     if( transform_->type == 1 )
     {
@@ -770,14 +772,16 @@ int transform_free( mbedtls_mps_transform_t *transform_ )
     return( 0 );
 }
 
-int transform_encrypt( mbedtls_mps_transform_t *transform_, mps_rec *rec,
-                       int (*f_rng)(void *, unsigned char *, size_t),
-                       void *p_rng )
+int mps_transform_encrypt( void *transform__,
+                           mps_rec *rec,
+                           int (*f_rng)(void *, unsigned char *, size_t),
+                           void *p_rng )
 {
     size_t idx;
     size_t pre_pad;
     size_t post_pad;
     unsigned char checksum;
+    mbedtls_mps_transform_wrap_t *transform_ = (mbedtls_mps_transform_wrap_t*) transform__;
     mbedtls_transform_mock_t *transform;
 
     /* Distinguish between our test-only mock transforms and
@@ -885,7 +889,7 @@ int transform_encrypt( mbedtls_mps_transform_t *transform_, mps_rec *rec,
     return( 0 );
 }
 
-int transform_decrypt( mbedtls_mps_transform_t *transform_, mps_rec *rec )
+int mps_transform_decrypt( void *transform__, mps_rec *rec )
 {
     size_t idx;
     size_t pre_pad;
@@ -893,6 +897,7 @@ int transform_decrypt( mbedtls_mps_transform_t *transform_, mps_rec *rec )
     uint8_t val;
     uint8_t checksum;
 
+    mbedtls_mps_transform_wrap_t *transform_ = (mbedtls_mps_transform_wrap_t*) transform__;
     mbedtls_transform_mock_t *transform;
     transform = &transform_->mock;
 
@@ -1024,9 +1029,10 @@ int transform_decrypt( mbedtls_mps_transform_t *transform_, mps_rec *rec )
     return( 0 );
 }
 
-int transform_get_expansion( mbedtls_mps_transform_t *transform,
-                             size_t *pre_exp, size_t *post_exp )
+int mps_transform_get_expansion( void *transform_,
+                                 size_t *pre_exp, size_t *post_exp )
 {
+    mbedtls_mps_transform_wrap_t * const transform = (mbedtls_mps_transform_wrap_t*) transform_;
 #if !defined(TEST_SUITE_MPS_NO_SSL)
     if( transform->type == 1 )
     {
@@ -1334,6 +1340,15 @@ static int free_mps_layers()
     }
 
     return( 0 );
+}
+
+__attribute__((constructor))
+static void set_transform_pointers()
+{
+    mbedtls_mps_transform_free = mps_transform_free;
+    mbedtls_mps_transform_encrypt = mps_transform_encrypt;
+    mbedtls_mps_transform_decrypt = mps_transform_decrypt;
+    mbedtls_mps_transform_get_expansion = mps_transform_get_expansion;
 }
 
 /* END_HEADER */
@@ -4068,8 +4083,8 @@ void mbedtls_mps_l2_basic( int mode,
     mps_l2_in in_srv;
 
     /* Dummy record transformations for epoch 0 */
-    mbedtls_mps_transform_t *dummy_c = malloc( sizeof( mbedtls_mps_transform_t ) );
-    mbedtls_mps_transform_t *dummy_s = malloc( sizeof( mbedtls_mps_transform_t ) );
+    mbedtls_mps_transform_wrap_t *dummy_c = malloc( sizeof( mbedtls_mps_transform_wrap_t ) );
+    mbedtls_mps_transform_wrap_t *dummy_s = malloc( sizeof( mbedtls_mps_transform_wrap_t ) );
 
 #if defined(TEST_SUITE_MPS_NO_SSL)
     ((void) real_transforms);
@@ -4219,8 +4234,8 @@ void mbedtls_mps_l2_non_packable_type( int mode,
     mps_l2_in in_srv, in_cli;
 
     /* Dummy record transformations for epoch 0 */
-    mbedtls_mps_transform_t *dummy_c = malloc( sizeof( mbedtls_mps_transform_t ) );
-    mbedtls_mps_transform_t *dummy_s = malloc( sizeof( mbedtls_mps_transform_t ) );
+    mbedtls_mps_transform_wrap_t *dummy_c = malloc( sizeof( mbedtls_mps_transform_wrap_t ) );
+    mbedtls_mps_transform_wrap_t *dummy_s = malloc( sizeof( mbedtls_mps_transform_wrap_t ) );
 
     build_mock_transforms( dummy_s, dummy_c, 1, 5 );
 
@@ -4381,8 +4396,8 @@ void mbedtls_mps_l2_bad_record( int mode,
     mps_l2_in in_srv;
 
     /* Dummy record transformations for epoch 0 */
-    mbedtls_mps_transform_t *dummy_c = malloc( sizeof( mbedtls_mps_transform_t ) );
-    mbedtls_mps_transform_t *dummy_s = malloc( sizeof( mbedtls_mps_transform_t ) );
+    mbedtls_mps_transform_wrap_t *dummy_c = malloc( sizeof( mbedtls_mps_transform_wrap_t ) );
+    mbedtls_mps_transform_wrap_t *dummy_s = malloc( sizeof( mbedtls_mps_transform_wrap_t ) );
 
     build_mock_transforms( dummy_s, dummy_c,
                            /* Use ID transform in case we want to test corrupted content
@@ -4635,8 +4650,8 @@ void mbedtls_mps_l2_anti_replay( int variant )
     mps_l2_in   in_srv;
 
     /* Dummy record transformations for epoch 0 */
-    mbedtls_mps_transform_t *dummy_c = malloc( sizeof( mbedtls_mps_transform_t ) );
-    mbedtls_mps_transform_t *dummy_s = malloc( sizeof( mbedtls_mps_transform_t ) );
+    mbedtls_mps_transform_wrap_t *dummy_c = malloc( sizeof( mbedtls_mps_transform_wrap_t ) );
+    mbedtls_mps_transform_wrap_t *dummy_s = malloc( sizeof( mbedtls_mps_transform_wrap_t ) );
 
     build_mock_transforms( dummy_s, dummy_c, 1, 5 );
 
@@ -4914,8 +4929,8 @@ void mbedtls_mps_l2_pausing( int accumulator_too_small,
     /* The length of the single type B chunk the client sends. */
     mbedtls_mps_size_t const msg_chunk_size_B = 40;
 
-    mbedtls_mps_transform_t *dummy_c = malloc( sizeof( mbedtls_mps_transform_t ) );
-    mbedtls_mps_transform_t *dummy_s = malloc( sizeof( mbedtls_mps_transform_t ) );
+    mbedtls_mps_transform_wrap_t *dummy_c = malloc( sizeof( mbedtls_mps_transform_wrap_t ) );
+    mbedtls_mps_transform_wrap_t *dummy_s = malloc( sizeof( mbedtls_mps_transform_wrap_t ) );
 
     build_mock_transforms( dummy_s, dummy_c, 1, 5 );
 
@@ -5118,10 +5133,10 @@ void mbedtls_mps_l2_switch_epoch( int mode,
     mps_l2_out out_cli;
     mps_l2_in in_srv;
 
-    mbedtls_mps_transform_t *epoch0_c = malloc( sizeof( mbedtls_mps_transform_t ) );
-    mbedtls_mps_transform_t *epoch1_c = malloc( sizeof( mbedtls_mps_transform_t ) );
-    mbedtls_mps_transform_t *epoch0_s = malloc( sizeof( mbedtls_mps_transform_t ) );
-    mbedtls_mps_transform_t *epoch1_s = malloc( sizeof( mbedtls_mps_transform_t ) );
+    mbedtls_mps_transform_wrap_t *epoch0_c = malloc( sizeof( mbedtls_mps_transform_wrap_t ) );
+    mbedtls_mps_transform_wrap_t *epoch1_c = malloc( sizeof( mbedtls_mps_transform_wrap_t ) );
+    mbedtls_mps_transform_wrap_t *epoch0_s = malloc( sizeof( mbedtls_mps_transform_wrap_t ) );
+    mbedtls_mps_transform_wrap_t *epoch1_s = malloc( sizeof( mbedtls_mps_transform_wrap_t ) );
 
 #if !defined(TEST_SUITE_MPS_NO_SSL)
     if( real_transforms == 1 )
@@ -5290,8 +5305,8 @@ void mbedtls_mps_l2_queueing( int allocator_buffer_sz,
     /* Layer 2 objects */
     mps_l2_out out_cli;
     mps_l2_in in_srv;
-    mbedtls_mps_transform_t *dummy_c = malloc( sizeof( mbedtls_mps_transform_t ) );
-    mbedtls_mps_transform_t *dummy_s = malloc( sizeof( mbedtls_mps_transform_t ) );
+    mbedtls_mps_transform_wrap_t *dummy_c = malloc( sizeof( mbedtls_mps_transform_wrap_t ) );
+    mbedtls_mps_transform_wrap_t *dummy_s = malloc( sizeof( mbedtls_mps_transform_wrap_t ) );
 
     build_mock_transforms( dummy_s, dummy_c, 1, 5 );
 
@@ -5396,16 +5411,16 @@ void mbedtls_mps_l2_many_epochs( int mode,
     mbedtls_mps_epoch_id next_cli_epoch;
     mbedtls_mps_epoch_id next_srv_epoch;
 
-    mbedtls_mps_transform_t **epochs_c = malloc( num_rounds *
-                                             sizeof( mbedtls_mps_transform_t ) );
-    mbedtls_mps_transform_t **epochs_s = malloc( num_rounds *
-                                             sizeof( mbedtls_mps_transform_t ) );
+    mbedtls_mps_transform_wrap_t **epochs_c = malloc( num_rounds *
+                                             sizeof( mbedtls_mps_transform_wrap_t ) );
+    mbedtls_mps_transform_wrap_t **epochs_s = malloc( num_rounds *
+                                             sizeof( mbedtls_mps_transform_wrap_t ) );
 
     TEST_ASSERT( epochs_s != NULL && epochs_c != NULL );
     for( size_t id=0; id < (unsigned) num_rounds; id++ )
     {
-        epochs_c[id] = malloc( sizeof( mbedtls_mps_transform_t ) );
-        epochs_s[id] = malloc( sizeof( mbedtls_mps_transform_t ) );
+        epochs_c[id] = malloc( sizeof( mbedtls_mps_transform_wrap_t ) );
+        epochs_s[id] = malloc( sizeof( mbedtls_mps_transform_wrap_t ) );
         TEST_ASSERT( epochs_s[id] != NULL && epochs_c[id] != NULL );
 
 #if defined(TEST_SUITE_MPS_NO_SSL)
@@ -5634,10 +5649,10 @@ void mbedtls_mps_l2_piggyback_data( int mode,
     mps_l2_out out_cli;
     mps_l2_in in_srv;
 
-    mbedtls_mps_transform_t *epoch0_c = malloc( sizeof( mbedtls_mps_transform_t ) );
-    mbedtls_mps_transform_t *epoch1_c = malloc( sizeof( mbedtls_mps_transform_t ) );
-    mbedtls_mps_transform_t *epoch0_s = malloc( sizeof( mbedtls_mps_transform_t ) );
-    mbedtls_mps_transform_t *epoch1_s = malloc( sizeof( mbedtls_mps_transform_t ) );
+    mbedtls_mps_transform_wrap_t *epoch0_c = malloc( sizeof( mbedtls_mps_transform_wrap_t ) );
+    mbedtls_mps_transform_wrap_t *epoch1_c = malloc( sizeof( mbedtls_mps_transform_wrap_t ) );
+    mbedtls_mps_transform_wrap_t *epoch0_s = malloc( sizeof( mbedtls_mps_transform_wrap_t ) );
+    mbedtls_mps_transform_wrap_t *epoch1_s = malloc( sizeof( mbedtls_mps_transform_wrap_t ) );
 
 #if defined(TEST_SUITE_MPS_NO_SSL)
     ((void) real_transforms);
@@ -5758,7 +5773,7 @@ void mbedtls_mps_l2_random( int allocator_buffer_sz,
 
     typed_data_chunk **chunks[2];
     size_t *chunks_per_epoch[2];
-    mbedtls_mps_transform_t **epochs[2];
+    mbedtls_mps_transform_wrap_t **epochs[2];
     mbedtls_mps_epoch_id read_epoch[2];
     mbedtls_mps_epoch_id write_epoch[2];
     size_t read_chunk[2];
@@ -5766,8 +5781,8 @@ void mbedtls_mps_l2_random( int allocator_buffer_sz,
 
     mbedtls_mps_epoch_id latest_epoch[2];
 
-    epochs[0] = malloc( num_epochs * sizeof( mbedtls_mps_transform_t ) );
-    epochs[1] = malloc( num_epochs * sizeof( mbedtls_mps_transform_t ) );
+    epochs[0] = malloc( num_epochs * sizeof( mbedtls_mps_transform_wrap_t ) );
+    epochs[1] = malloc( num_epochs * sizeof( mbedtls_mps_transform_wrap_t ) );
     chunks[0] = malloc( num_epochs * sizeof( typed_data_chunk* ) );
     chunks[1] = malloc( num_epochs * sizeof( typed_data_chunk* ) );
     chunks_per_epoch[0] = malloc( num_epochs * sizeof( size_t ) );
@@ -5781,8 +5796,8 @@ void mbedtls_mps_l2_random( int allocator_buffer_sz,
     {
         size_t chunks_in_epoch;
 
-        epochs[0][id] = malloc( sizeof( mbedtls_mps_transform_t ) );
-        epochs[1][id] = malloc( sizeof( mbedtls_mps_transform_t ) );
+        epochs[0][id] = malloc( sizeof( mbedtls_mps_transform_wrap_t ) );
+        epochs[1][id] = malloc( sizeof( mbedtls_mps_transform_wrap_t ) );
         TEST_ASSERT( epochs[0][id] != NULL && epochs[1][id] != NULL );
 
 #if defined(TEST_SUITE_MPS_NO_SSL)
@@ -6240,8 +6255,8 @@ void mbedtls_mps_l3_basic_handshake(
     size_t additional_fetch = partial_commit ? 10 : 0;
 
     /* Dummy record transformations for epoch 0 */
-    mbedtls_mps_transform_t *dummy_c = malloc( sizeof( mbedtls_mps_transform_t ) );
-    mbedtls_mps_transform_t *dummy_s = malloc( sizeof( mbedtls_mps_transform_t ) );
+    mbedtls_mps_transform_wrap_t *dummy_c = malloc( sizeof( mbedtls_mps_transform_wrap_t ) );
+    mbedtls_mps_transform_wrap_t *dummy_s = malloc( sizeof( mbedtls_mps_transform_wrap_t ) );
 
 #if defined(TEST_SUITE_MPS_NO_SSL)
     ((void) real_transforms);
@@ -6524,8 +6539,8 @@ void mbedtls_mps_l3_bad_msg( int variant )
     mps_l2_out out_cli;
 
     /* Dummy record transformations for epoch 0 */
-    mbedtls_mps_transform_t *dummy_c = malloc( sizeof( mbedtls_mps_transform_t ) );
-    mbedtls_mps_transform_t *dummy_s = malloc( sizeof( mbedtls_mps_transform_t ) );
+    mbedtls_mps_transform_wrap_t *dummy_c = malloc( sizeof( mbedtls_mps_transform_wrap_t ) );
+    mbedtls_mps_transform_wrap_t *dummy_s = malloc( sizeof( mbedtls_mps_transform_wrap_t ) );
 
     build_mock_transforms( dummy_c, dummy_s, 1, 5 );
 
@@ -6686,8 +6701,8 @@ void mbedtls_mps_l3_handshake_gradual( int max_out,
     mps_l3_handshake_in hs_in;
 
     /* Dummy record transformations for epoch 0 */
-    mbedtls_mps_transform_t *dummy_c = malloc( sizeof( mbedtls_mps_transform_t ) );
-    mbedtls_mps_transform_t *dummy_s = malloc( sizeof( mbedtls_mps_transform_t ) );
+    mbedtls_mps_transform_wrap_t *dummy_c = malloc( sizeof( mbedtls_mps_transform_wrap_t ) );
+    mbedtls_mps_transform_wrap_t *dummy_s = malloc( sizeof( mbedtls_mps_transform_wrap_t ) );
 
 #if defined(TEST_SUITE_MPS_NO_SSL)
     ((void) real_transforms);
@@ -7018,8 +7033,8 @@ void mbedtls_mps_l3_basic_application( int mode,
     mps_l3_app_in app_in;
 
     /* Dummy record transformations for epoch 0 */
-    mbedtls_mps_transform_t *dummy_c = malloc( sizeof( mbedtls_mps_transform_t ) );
-    mbedtls_mps_transform_t *dummy_s = malloc( sizeof( mbedtls_mps_transform_t ) );
+    mbedtls_mps_transform_wrap_t *dummy_c = malloc( sizeof( mbedtls_mps_transform_wrap_t ) );
+    mbedtls_mps_transform_wrap_t *dummy_s = malloc( sizeof( mbedtls_mps_transform_wrap_t ) );
 
 #if defined(TEST_SUITE_MPS_NO_SSL)
     ((void) real_transforms);
@@ -7119,8 +7134,8 @@ void mbedtls_mps_l3_basic_alert( int mode,
     mbedtls_mps_epoch_id srv_epoch;
 
     /* Dummy record transformations for epoch 0 */
-    mbedtls_mps_transform_t *dummy_c = malloc( sizeof( mbedtls_mps_transform_t ) );
-    mbedtls_mps_transform_t *dummy_s = malloc( sizeof( mbedtls_mps_transform_t ) );
+    mbedtls_mps_transform_wrap_t *dummy_c = malloc( sizeof( mbedtls_mps_transform_wrap_t ) );
+    mbedtls_mps_transform_wrap_t *dummy_s = malloc( sizeof( mbedtls_mps_transform_wrap_t ) );
 
 #if defined(TEST_SUITE_MPS_NO_SSL)
     ((void) real_transforms);
@@ -7251,8 +7266,8 @@ void mbedtls_mps_l3_basic_ccs( int allocator_buffer_sz,
     mbedtls_mps_epoch_id srv_epoch;
 
     /* Dummy record transformations for epoch 0 */
-    mbedtls_mps_transform_t *dummy_c = malloc( sizeof( mbedtls_mps_transform_t ) );
-    mbedtls_mps_transform_t *dummy_s = malloc( sizeof( mbedtls_mps_transform_t ) );
+    mbedtls_mps_transform_wrap_t *dummy_c = malloc( sizeof( mbedtls_mps_transform_wrap_t ) );
+    mbedtls_mps_transform_wrap_t *dummy_s = malloc( sizeof( mbedtls_mps_transform_wrap_t ) );
 
 #if defined(TEST_SUITE_MPS_NO_SSL)
     ((void) real_transforms);
@@ -7385,8 +7400,8 @@ void mbedtls_mps_l3_handshake_alert_interleaved( int allocator_buffer_sz,
     mbedtls_mps_epoch_id srv_epoch;
 
     /* Dummy record transformations for epoch 0 */
-    mbedtls_mps_transform_t *dummy_c = malloc( sizeof( mbedtls_mps_transform_t ) );
-    mbedtls_mps_transform_t *dummy_s = malloc( sizeof( mbedtls_mps_transform_t ) );
+    mbedtls_mps_transform_wrap_t *dummy_c = malloc( sizeof( mbedtls_mps_transform_wrap_t ) );
+    mbedtls_mps_transform_wrap_t *dummy_s = malloc( sizeof( mbedtls_mps_transform_wrap_t ) );
 
 #if defined(TEST_SUITE_MPS_NO_SSL)
     ((void) real_transforms);
@@ -7750,7 +7765,7 @@ void mbedtls_mps_l3_random( int allocator_buffer_sz,
 
     typed_data_chunk_l3 **chunks[2];
     size_t *chunks_per_epoch[2];
-    mbedtls_mps_transform_t **epochs[2];
+    mbedtls_mps_transform_wrap_t **epochs[2];
     mbedtls_mps_epoch_id read_epoch[2];
     size_t read_chunk[2];
     mbedtls_mps_epoch_id write_epoch[2];
@@ -7760,8 +7775,8 @@ void mbedtls_mps_l3_random( int allocator_buffer_sz,
 
     srand( time( NULL ) );
 
-    epochs[0] = malloc( num_epochs * sizeof( mbedtls_mps_transform_t ) );
-    epochs[1] = malloc( num_epochs * sizeof( mbedtls_mps_transform_t ) );
+    epochs[0] = malloc( num_epochs * sizeof( mbedtls_mps_transform_wrap_t ) );
+    epochs[1] = malloc( num_epochs * sizeof( mbedtls_mps_transform_wrap_t ) );
     chunks[0] = malloc( num_epochs * sizeof( typed_data_chunk* ) );
     chunks[1] = malloc( num_epochs * sizeof( typed_data_chunk* ) );
     chunks_per_epoch[0] = malloc( num_epochs * sizeof( size_t ) );
@@ -7776,8 +7791,8 @@ void mbedtls_mps_l3_random( int allocator_buffer_sz,
         size_t chunks_in_epoch;
         printf( "Initialize epoch %u\n", (unsigned) id );
 
-        epochs[0][id] = malloc( sizeof( mbedtls_mps_transform_t ) );
-        epochs[1][id] = malloc( sizeof( mbedtls_mps_transform_t ) );
+        epochs[0][id] = malloc( sizeof( mbedtls_mps_transform_wrap_t ) );
+        epochs[1][id] = malloc( sizeof( mbedtls_mps_transform_wrap_t ) );
         TEST_ASSERT( epochs[0][id] != NULL && epochs[1][id] != NULL );
 
 #if defined(TEST_SUITE_MPS_NO_SSL)
@@ -8438,8 +8453,8 @@ void mbedtls_mps_l4_basic_handshake(
     size_t additional_fetch = partial_commit ? 10 : 0;
 
     /* Dummy record transformations for epoch 0 */
-    mbedtls_mps_transform_t *dummy_c = malloc( sizeof( mbedtls_mps_transform_t ) );
-    mbedtls_mps_transform_t *dummy_s = malloc( sizeof( mbedtls_mps_transform_t ) );
+    mbedtls_mps_transform_wrap_t *dummy_c = malloc( sizeof( mbedtls_mps_transform_wrap_t ) );
+    mbedtls_mps_transform_wrap_t *dummy_s = malloc( sizeof( mbedtls_mps_transform_wrap_t ) );
 
 #if defined(TEST_SUITE_MPS_NO_SSL)
     ((void) real_transforms);
@@ -8577,15 +8592,15 @@ void mbedtls_mps_l4_warning( int mode,
     mbedtls_mps_epoch_id srv_epoch[2];
 
     /* Dummy record transformations for epoch 0 */
-    mbedtls_mps_transform_t *dummy_c[2];
-    mbedtls_mps_transform_t *dummy_s[2];
+    mbedtls_mps_transform_wrap_t *dummy_c[2];
+    mbedtls_mps_transform_wrap_t *dummy_s[2];
 
     mbedtls_mps_alert_t srv_alert;
 
-    dummy_c[0] = malloc( sizeof( mbedtls_mps_transform_t ) );
-    dummy_c[1] = malloc( sizeof( mbedtls_mps_transform_t ) );
-    dummy_s[0] = malloc( sizeof( mbedtls_mps_transform_t ) );
-    dummy_s[1] = malloc( sizeof( mbedtls_mps_transform_t ) );
+    dummy_c[0] = malloc( sizeof( mbedtls_mps_transform_wrap_t ) );
+    dummy_c[1] = malloc( sizeof( mbedtls_mps_transform_wrap_t ) );
+    dummy_s[0] = malloc( sizeof( mbedtls_mps_transform_wrap_t ) );
+    dummy_s[1] = malloc( sizeof( mbedtls_mps_transform_wrap_t ) );
     TEST_ASSERT( dummy_c[0] != NULL && dummy_c[1] != NULL &&
                  dummy_s[0] != NULL && dummy_s[1] != NULL );
 
@@ -8697,13 +8712,13 @@ void mbedtls_mps_l4_ccs( int mode,
     mbedtls_mps_epoch_id srv_epoch[2];
 
     /* Dummy record transformations for epoch 0 */
-    mbedtls_mps_transform_t *dummy_c[2];
-    mbedtls_mps_transform_t *dummy_s[2];
+    mbedtls_mps_transform_wrap_t *dummy_c[2];
+    mbedtls_mps_transform_wrap_t *dummy_s[2];
 
-    dummy_c[0] = malloc( sizeof( mbedtls_mps_transform_t ) );
-    dummy_c[1] = malloc( sizeof( mbedtls_mps_transform_t ) );
-    dummy_s[0] = malloc( sizeof( mbedtls_mps_transform_t ) );
-    dummy_s[1] = malloc( sizeof( mbedtls_mps_transform_t ) );
+    dummy_c[0] = malloc( sizeof( mbedtls_mps_transform_wrap_t ) );
+    dummy_c[1] = malloc( sizeof( mbedtls_mps_transform_wrap_t ) );
+    dummy_s[0] = malloc( sizeof( mbedtls_mps_transform_wrap_t ) );
+    dummy_s[1] = malloc( sizeof( mbedtls_mps_transform_wrap_t ) );
     TEST_ASSERT( dummy_c[0] != NULL && dummy_c[1] != NULL &&
                  dummy_s[0] != NULL && dummy_s[1] != NULL );
 
@@ -8831,13 +8846,13 @@ void mbedtls_mps_l4_hs_inconsistent_continuation( int variant )
     mbedtls_mps_handshake_in hs_in_srv;
 
     /* Dummy record transformations for epoch 0 */
-    mbedtls_mps_transform_t *dummy_c[2];
-    mbedtls_mps_transform_t *dummy_s[2];
+    mbedtls_mps_transform_wrap_t *dummy_c[2];
+    mbedtls_mps_transform_wrap_t *dummy_s[2];
 
-    dummy_c[0] = malloc( sizeof( mbedtls_mps_transform_t ) );
-    dummy_c[1] = malloc( sizeof( mbedtls_mps_transform_t ) );
-    dummy_s[0] = malloc( sizeof( mbedtls_mps_transform_t ) );
-    dummy_s[1] = malloc( sizeof( mbedtls_mps_transform_t ) );
+    dummy_c[0] = malloc( sizeof( mbedtls_mps_transform_wrap_t ) );
+    dummy_c[1] = malloc( sizeof( mbedtls_mps_transform_wrap_t ) );
+    dummy_s[0] = malloc( sizeof( mbedtls_mps_transform_wrap_t ) );
+    dummy_s[1] = malloc( sizeof( mbedtls_mps_transform_wrap_t ) );
     TEST_ASSERT( dummy_c[0] != NULL && dummy_c[1] != NULL &&
                  dummy_s[0] != NULL && dummy_s[1] != NULL );
 
@@ -9072,8 +9087,8 @@ void mbedtls_mps_l4_disruption( int mode,
     mbedtls_mps_handshake_in hs_in;
 
     /* Dummy record transformations for epoch 0 */
-    mbedtls_mps_transform_t *dummy_c = malloc( sizeof( mbedtls_mps_transform_t ) );
-    mbedtls_mps_transform_t *dummy_s = malloc( sizeof( mbedtls_mps_transform_t ) );
+    mbedtls_mps_transform_wrap_t *dummy_c = malloc( sizeof( mbedtls_mps_transform_wrap_t ) );
+    mbedtls_mps_transform_wrap_t *dummy_s = malloc( sizeof( mbedtls_mps_transform_wrap_t ) );
 
     build_mock_transforms( dummy_c, dummy_s, 1, 5 );
 
@@ -9293,8 +9308,8 @@ void mbedtls_mps_l4_dtls_fragmentation( int allocator_buffer_sz,
     mps_l3_handshake_in hs_in;
 
     /* Dummy record transformations for epoch 0 */
-    mbedtls_mps_transform_t *dummy_c = malloc( sizeof( mbedtls_mps_transform_t ) );
-    mbedtls_mps_transform_t *dummy_s = malloc( sizeof( mbedtls_mps_transform_t ) );
+    mbedtls_mps_transform_wrap_t *dummy_c = malloc( sizeof( mbedtls_mps_transform_wrap_t ) );
+    mbedtls_mps_transform_wrap_t *dummy_s = malloc( sizeof( mbedtls_mps_transform_wrap_t ) );
 
     size_t hs_len = L4_DEFAULT_QUEUE_SIZE;
     size_t hs_offset;
@@ -9439,8 +9454,8 @@ void mbedtls_mps_l4_dtls_reassembly( int allocator_buffer_sz,
     mbedtls_mps_handshake_in  hs_in;
 
     /* Dummy record transformations for epoch 0 */
-    mbedtls_mps_transform_t *dummy_c = malloc( sizeof( mbedtls_mps_transform_t ) );
-    mbedtls_mps_transform_t *dummy_s = malloc( sizeof( mbedtls_mps_transform_t ) );
+    mbedtls_mps_transform_wrap_t *dummy_c = malloc( sizeof( mbedtls_mps_transform_wrap_t ) );
+    mbedtls_mps_transform_wrap_t *dummy_s = malloc( sizeof( mbedtls_mps_transform_wrap_t ) );
 
     size_t hs_len    = 100;
 
@@ -9680,7 +9695,7 @@ void mbedtls_mps_l4_flight_exchange( int mode,
 
     dummy_cb_ctx *cb_ctxs;
 
-    mbedtls_mps_transform_t **epochs[2];
+    mbedtls_mps_transform_wrap_t **epochs[2];
     size_t num_epochs;
 
     mbedtls_mps_epoch_id next_epoch[2];
@@ -9704,14 +9719,14 @@ void mbedtls_mps_l4_flight_exchange( int mode,
             break;
     }
 
-    epochs[0] = malloc( num_epochs * sizeof( mbedtls_mps_transform_t ) );
-    epochs[1] = malloc( num_epochs * sizeof( mbedtls_mps_transform_t ) );
+    epochs[0] = malloc( num_epochs * sizeof( mbedtls_mps_transform_wrap_t ) );
+    epochs[1] = malloc( num_epochs * sizeof( mbedtls_mps_transform_wrap_t ) );
 
     TEST_ASSERT( epochs[1] != NULL && epochs[0] != NULL );
     for( size_t id=0; id < (unsigned) num_epochs; id++ )
     {
-        epochs[0][id] = malloc( sizeof( mbedtls_mps_transform_t ) );
-        epochs[1][id] = malloc( sizeof( mbedtls_mps_transform_t ) );
+        epochs[0][id] = malloc( sizeof( mbedtls_mps_transform_wrap_t ) );
+        epochs[1][id] = malloc( sizeof( mbedtls_mps_transform_wrap_t ) );
         TEST_ASSERT( epochs[1][id] != NULL && epochs[0][id] != NULL );
 
         build_mock_transforms( epochs[0][id], epochs[1][id],
@@ -9998,7 +10013,7 @@ void mbedtls_mps_l4_flight_exchange( int mode,
 
                 /* MPS owns the transform once passed to it, hence will destroy
                  * it when being freed. Set it up again. */
-                epochs[1][0] = malloc( sizeof( mbedtls_mps_transform_t ) );
+                epochs[1][0] = malloc( sizeof( mbedtls_mps_transform_wrap_t ) );
                 epochs[1][0]->type = 0;
                 epochs[1][0]->mock.enabled = 1;
                 epochs[1][0]->mock.pad = 5;

--- a/tests/suites/test_suite_mps.function
+++ b/tests/suites/test_suite_mps.function
@@ -138,10 +138,12 @@ void layer0_free( layer0_mock *mbuf )
 }
 
 /* Read size bytes from mbuf into dst */
-int layer0_read( layer0_mock* const mbuf, unsigned char *dst,
+int layer0_read( void* mbuf_raw,
+                 unsigned char *dst,
                  unsigned long size )
 {
     size_t remaining;
+    layer0_mock* const mbuf = (layer0_mock*) mbuf_raw;
 
     if( mbuf->avail == 0 )
         return( MBEDTLS_ERR_MPS_WANT_READ );
@@ -164,9 +166,11 @@ int layer0_read( layer0_mock* const mbuf, unsigned char *dst,
 }
 
 /* Write size bytes from src into mbuf */
-int layer0_write( layer0_mock* const mbuf, const unsigned char *src,
+int layer0_write( void *mbuf_raw,
+                  const unsigned char *src,
                   size_t size )
 {
+    layer0_mock* const mbuf = (layer0_mock*) mbuf_raw;
     const size_t remaining = mbuf->buflen - mbuf->avail;
 
     if( size == 0 )
@@ -188,30 +192,6 @@ int layer0_write( layer0_mock* const mbuf, const unsigned char *src,
     mbuf->avail += size;
 
     return( size );
-}
-
-/* Write size bytes from src into the server to client buffer */
-int layer0_write_srv( const unsigned char *src, size_t size )
-{
-    return layer0_write( &s2c, src, size );
-}
-
-/* Write size bytes from src into the client to server buffer */
-int layer0_write_cli( const unsigned char *src, size_t size )
-{
-    return layer0_write( &c2s, src, size );
-}
-
-/* Read size bytes from the client to server buffer into dst */
-int layer0_read_srv( unsigned char *dst, unsigned long size )
-{
-    return layer0_read( &c2s, dst, size );
-}
-
-/* Read size bytes from the server to client buffer into dst */
-int layer0_read_cli( unsigned char *dst, unsigned long size )
-{
-    return layer0_read( &s2c, dst, size );
 }
 
 /*
@@ -367,9 +347,10 @@ static size_t layer0_dgram_inc_idx( size_t idx )
         return( idx + 1);
 }
 
-static int layer0_dgram_write( layer0_dgram_mock *ctx,
+static int layer0_dgram_write( void *ctx_raw,
                                const unsigned char *src, size_t size )
 {
+    layer0_dgram_mock* const ctx = (layer0_dgram_mock*) ctx_raw;
     size_t write_pos     = ctx->write_pos;
     size_t read_pos      = ctx->read_pos;
     size_t new_write_pos = layer0_dgram_inc_idx( write_pos );
@@ -384,9 +365,10 @@ static int layer0_dgram_write( layer0_dgram_mock *ctx,
     return( (int) size );
 }
 
-static int layer0_dgram_read( layer0_dgram_mock *ctx,
+static int layer0_dgram_read( void* ctx_raw,
                               unsigned char *dst, unsigned long size )
 {
+    layer0_dgram_mock* const ctx = (layer0_dgram_mock*) ctx_raw;
     size_t write_pos    = ctx->write_pos;
     size_t read_pos     = ctx->read_pos;
     size_t new_read_pos = layer0_dgram_inc_idx( read_pos );
@@ -402,30 +384,6 @@ static int layer0_dgram_read( layer0_dgram_mock *ctx,
 
     ctx->read_pos = new_read_pos;
     return( (int) size );
-}
-
-/* Write size bytes from src into the server to client buffer */
-int layer0_dgram_write_srv( const unsigned char *src, size_t size )
-{
-    return layer0_dgram_write( &s2c_d, src, size );
-}
-
-/* Write size bytes from src into the client to server buffer */
-int layer0_dgram_write_cli( const unsigned char *src, size_t size )
-{
-    return layer0_dgram_write( &c2s_d, src, size );
-}
-
-/* Read size bytes from the client to server buffer into dst */
-int layer0_dgram_read_srv( unsigned char *dst, unsigned long size )
-{
-    return layer0_dgram_read( &c2s_d, dst, size );
-}
-
-/* Read size bytes from the server to client buffer into dst */
-int layer0_dgram_read_cli( unsigned char *dst, unsigned long size )
-{
-    return layer0_dgram_read( &s2c_d, dst, size );
 }
 
 /*
@@ -1228,7 +1186,9 @@ mps_alloc cli_alloc, srv_alloc;
 
 /* Mocks for underlying transport */
 mps_l0_send_t *cli_wr,  *srv_wr;
+void *cli_wr_ctx, *srv_wr_ctx;
 mps_l0_recv_t *cli_rcv, *srv_rcv;
+void *cli_rcv_ctx, *srv_rcv_ctx;
 
 /* MPS Layer instances */
 mps_l1 cli_l1, srv_l1;
@@ -1275,20 +1235,30 @@ static int init_mps_layers()
         CHK( layer0_init( &s2c ) == 0 );
         CHK( layer0_init( &c2s ) == 0 );
 
-        cli_wr  = &layer0_write_cli;
-        cli_rcv = &layer0_read_cli;
-        srv_wr  = &layer0_write_srv;
-        srv_rcv = &layer0_read_srv;
+        cli_wr  = &layer0_write;
+        cli_rcv = &layer0_read;
+        srv_wr  = &layer0_write;
+        srv_rcv = &layer0_read;
+
+        cli_rcv_ctx = &s2c;
+        srv_wr_ctx  = &s2c;
+        cli_wr_ctx  = &c2s;
+        srv_rcv_ctx = &c2s;
     }
     else
     {
         CHK( layer0_dgram_init( &s2c_d ) == 0 );
         CHK( layer0_dgram_init( &c2s_d ) == 0 );
 
-        cli_wr  = &layer0_dgram_write_cli;
-        cli_rcv = &layer0_dgram_read_cli;
-        srv_wr  = &layer0_dgram_write_srv;
-        srv_rcv = &layer0_dgram_read_srv;
+        cli_wr  = &layer0_dgram_write;
+        cli_rcv = &layer0_dgram_read;
+        srv_wr  = &layer0_dgram_write;
+        srv_rcv = &layer0_dgram_read;
+
+        cli_rcv_ctx = &s2c_d;
+        srv_wr_ctx  = &s2c_d;
+        cli_wr_ctx  = &c2s_d;
+        srv_rcv_ctx = &c2s_d;
     }
 
     /* Initialize allocators */
@@ -1297,9 +1267,13 @@ static int init_mps_layers()
 
     /* Initialize Layer 1 */
     CHK( mps_l1_init( &cli_l1, mps_test_config.mode,
-                      &cli_alloc, cli_wr, cli_rcv ) == 0 );
+                      &cli_alloc,
+                      cli_wr_ctx, cli_wr,
+                      cli_rcv_ctx, cli_rcv ) == 0 );
     CHK( mps_l1_init( &srv_l1, mps_test_config.mode,
-                      &srv_alloc, srv_wr, srv_rcv ) == 0 );
+                      &srv_alloc,
+                      srv_wr_ctx, srv_wr,
+                      srv_rcv_ctx, srv_rcv ) == 0 );
 
     /* Initialize Layer 2 */
     CHK( mps_l2_init( &cli_l2, &cli_l1,
@@ -10002,8 +9976,8 @@ void mbedtls_mps_l4_flight_exchange( int mode,
             mps_alloc_init( &srv_alloc, allocator_buffer_sz );
             TEST_ASSERT( mps_l1_init( &srv_l1, MBEDTLS_MPS_MODE_DATAGRAM,
                                       &srv_alloc,
-                                      layer0_dgram_write_srv,
-                                      layer0_dgram_read_srv ) == 0 );
+                                      srv_wr_ctx, srv_wr,
+                                      srv_rcv_ctx, srv_rcv ) == 0 );
             TEST_ASSERT( mps_l2_init( &srv_l2, &srv_l1, MBEDTLS_MPS_MODE_DATAGRAM,
                                       ( 3 * hs_len ) / 2,
                                       ( 3 * hs_len ) / 2,


### PR DESCRIPTION
Previously, the signature of MPS' read/write callbacks was `int recv/send( void *buf, size_t len );` which isn't compatible with the callbacks used by upstream Mbed TLS, which include an opaque context parameter `void *ctx` as the first argument.

This PR changes the signature of MPS' I/O callbacks to match that of upstream Mbed TLS.

Signed-off-by: Hanno Becker <hanno.becker@arm.com>