### PR TITLE
Transition from ee to finished only if server accepts psk

### DIFF
--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -2640,7 +2640,9 @@ static int ssl_encrypted_extensions_postprocess( mbedtls_ssl_context* ssl ) {
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
 
 #if defined(MBEDTLS_ZERO_RTT)
-    if( ssl->handshake->early_data == MBEDTLS_SSL_EARLY_DATA_ON )
+    if( ssl->handshake->early_data == MBEDTLS_SSL_EARLY_DATA_ON &&
+        ( ssl->session_negotiate->key_exchange == MBEDTLS_KEY_EXCHANGE_PSK ||
+                ssl->session_negotiate->key_exchange == MBEDTLS_KEY_EXCHANGE_ECDHE_PSK ) )
     {
         mbedtls_ssl_handshake_set_state( ssl, MBEDTLS_SSL_SERVER_FINISHED );
     }

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -2639,15 +2639,12 @@ static int ssl_encrypted_extensions_postprocess( mbedtls_ssl_context* ssl ) {
         mbedtls_ack_add_record( ssl, MBEDTLS_SSL_HS_ENCRYPTED_EXTENSION, MBEDTLS_SSL_ACK_RECORDS_RECEIVED );
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
 
-#if defined(MBEDTLS_ZERO_RTT)
-    if( ssl->handshake->early_data == MBEDTLS_SSL_EARLY_DATA_ON &&
-        ( ssl->session_negotiate->key_exchange == MBEDTLS_KEY_EXCHANGE_PSK ||
-                ssl->session_negotiate->key_exchange == MBEDTLS_KEY_EXCHANGE_ECDHE_PSK ) )
+    if( ssl->session_negotiate->key_exchange == MBEDTLS_KEY_EXCHANGE_PSK ||
+                ssl->session_negotiate->key_exchange == MBEDTLS_KEY_EXCHANGE_ECDHE_PSK )
     {
         mbedtls_ssl_handshake_set_state( ssl, MBEDTLS_SSL_SERVER_FINISHED );
     }
     else
-#endif /* MBEDTLS_ZERO_RTT */
     {
         mbedtls_ssl_handshake_set_state( ssl, MBEDTLS_SSL_CERTIFICATE_REQUEST );
     }

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -2639,15 +2639,7 @@ static int ssl_encrypted_extensions_postprocess( mbedtls_ssl_context* ssl ) {
         mbedtls_ack_add_record( ssl, MBEDTLS_SSL_HS_ENCRYPTED_EXTENSION, MBEDTLS_SSL_ACK_RECORDS_RECEIVED );
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
 
-    if( ssl->session_negotiate->key_exchange == MBEDTLS_KEY_EXCHANGE_PSK ||
-                ssl->session_negotiate->key_exchange == MBEDTLS_KEY_EXCHANGE_ECDHE_PSK )
-    {
-        mbedtls_ssl_handshake_set_state( ssl, MBEDTLS_SSL_SERVER_FINISHED );
-    }
-    else
-    {
-        mbedtls_ssl_handshake_set_state( ssl, MBEDTLS_SSL_CERTIFICATE_REQUEST );
-    }
+    mbedtls_ssl_handshake_set_state( ssl, MBEDTLS_SSL_CERTIFICATE_REQUEST );
 
     return( 0 );
 }


### PR DESCRIPTION
Summary:

The state machine should be transitioned to `MBEDTLS_SSL_SERVER_FINISHED` based on if server accepts the psk, not by if client sends psk.

We may transition from `MBEDTLS_SSL_ENCRYPTED_EXTENSIONS` to `MBEDTLS_SSL_EARLY_DATA_ON`
when 0RTT is on in client, https://github.com/hannestschofenig/mbedtls/blob/tls13-prototype/library/ssl_tls13_client.c#L2770.
If the server rejects the PSK, we won't able to fall back to full
handshake.

Test Plan:
Test by simulating invalid psk, such as ticket expiration.
Client sends 0RTT, when server rejects the psk by not providing
pre_shared_key extension in server hello, the handshake could fall back
to full handshake and succeed.

Reviewers:
hanno.becker@arm.com,hannes.tschofenig@arm.com,junqi.wang@live.com,zhi.han@gmail.com

Subscribers:

Tasks:

Tags: