### PR TITLE
Tls13 prototype ssl opt test error

### DIFF
--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -1313,20 +1313,6 @@ run_test    "TLS 1.3, TLS_AES_128_CCM_SHA256, ECDHE-ECDSA, empty client certific
 	    -c "write empty client certificate"
 
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL
-run_test    "TLS 1.3 TLS_AES_256_GCM_SHA384, ECDHE-ECDSA, SRV auth" \
-            "$P_SRV debug_level=5 force_version=tls1_3 key_exchange_modes=ecdhe_ecdsa ca_file=certs/ca.crt crt_file=certs/server.crt key_file=certs/server.key" \
-            "$P_CLI debug_level=5 force_version=tls1_3 server_name=localhost force_ciphersuite=TLS_AES_256_GCM_SHA384 key_exchange_modes=ecdhe_ecdsa ca_file=certs/ca.crt crt_file=none key_file=none" \
-            0 \
-	    -s "Verifying peer X.509 certificate... failed"                                        \
-	    -s "Certificate verification was skipped"                                              \
-            -c "Protocol is TLSv1.3"                                                               \
-            -c "Ciphersuite is TLS_AES_256_GCM_SHA384"                                             \
-	    -c "Verifying peer X.509 certificate... ok"                                            \
-	    -c "subject name      : C=AU, ST=Some-State, O=Internet Widgits Pty Ltd, CN=localhost" \
-	    -c "signed using      : ECDSA with SHA384"                                             \
-	    -c "EC key size       : 384 bits"
-
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL
 requires_config_enabled MBEDTLS_DEBUG_C
 run_test    "TLS 1.3, TLS_AES_128_CCM_SHA256, ECDHE-ECDSA, CLI+SRV auth, with ticket" \
             "$P_SRV debug_level=5 force_version=tls1_3 auth_mode=required key_exchange_modes=all tickets=1" \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -1387,17 +1387,14 @@ run_test    "TLS 1.3, TLS_AES_256_GCM_SHA384, ECDHE-ECDSA, CLI+SRV auth, with ti
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL
 requires_config_enabled MBEDTLS_DEBUG_C
 run_test    "TLS 1.3, TLS_AES_256_GCM_SHA384 with ECDHE-ECDSA (server auth only) with ticket" \
-            "$P_SRV debug_level=5 force_version=tls1_3 key_exchange_modes=all tickets=1 ca_file=certs/ca.crt crt_file=certs/server.crt key_file=certs/server.key" \
-            "$P_CLI debug_level=5 force_version=tls1_3 server_name=localhost force_ciphersuite=TLS_AES_256_GCM_SHA384 key_exchange_modes=ecdhe_ecdsa ca_file=certs/ca.crt crt_file=none key_file=none reconnect=1 tickets=1" \
+            "$P_SRV debug_level=5 force_version=tls1_3 key_exchange_modes=all tickets=1" \
+            "$P_CLI debug_level=5 force_version=tls1_3 server_name=localhost force_ciphersuite=TLS_AES_256_GCM_SHA384 key_exchange_modes=ecdhe_ecdsa crt_file=none key_file=none reconnect=1 tickets=1" \
             0 \
 	    -s "Verifying peer X.509 certificate... failed"                                        \
 	    -s "Certificate verification was skipped"                                              \
             -c "Protocol is TLSv1.3"                                                               \
             -c "Ciphersuite is TLS_AES_256_GCM_SHA384"                                             \
 	    -c "Verifying peer X.509 certificate... ok"                                            \
-	    -c "subject name      : C=AU, ST=Some-State, O=Internet Widgits Pty Ltd, CN=localhost" \
-	    -c "signed using      : ECDSA with SHA384"                                             \
-	    -c "EC key size       : 384 bits"                                                      \
 	    -c "got ticket"                                                                        \
 	    -c "client hello, adding psk_key_exchange_modes extension"                             \
 	    -c "client hello, adding pre_shared_key extension"                                     \


### PR DESCRIPTION
Fixing two test case failure in `ssl_opt.sh` in `tls13-prototype` branch. Both test suites use non-exist `certs/ca.crt`. The first test case seems a redundant one.

```
21 TLS 1.3 TLS_AES_256_GCM_SHA384, ECDHE-ECDSA, SRV auth ............... SERVER START TIMEOUT
...
26 TLS 1.3, TLS_AES_256_GCM_SHA384 with ECDHE-ECDSA (server auth only) with ticket  SERVER START TIMEOUT

```
```
# TLS 1.3 TLS_AES_256_GCM_SHA384, ECDHE-ECDSA, SRV auth
../programs/ssl/ssl_server2 server_addr=127.0.0.1 server_port=16104 allow_sha1=1 debug_level=5 force_version=tls1_3 key_exchange_modes=ecdhe_ecdsa ca_file=certs/ca.crt crt_file=certs/server.crt key_file=certs/server.key
Number of signature algorithms: 10

  . Seeding the random number generator... ok
  . Loading the CA root certificate ... failed
  !  mbedtls_x509_crt_parse returned -0x3e00

Last error was: -0x3E00 - PK - Read/write of file failed

  . Cleaning up... done.
SERVER START TIMEOUT
```

```
# TLS 1.3, TLS_AES_256_GCM_SHA384 with ECDHE-ECDSA (server auth only) with ticket
../programs/ssl/ssl_server2 server_addr=127.0.0.1 server_port=16104 allow_sha1=1 debug_level=5 force_version=tls1_3 key_exchange_modes=all tickets=1 ca_file=certs/ca.crt crt_file=certs/server.crt key_file=certs/server.key
Number of signature algorithms: 11

  . Seeding the random number generator... ok
  . Loading the CA root certificate ... failed
  !  mbedtls_x509_crt_parse returned -0x3e00

Last error was: -0x3E00 - PK - Read/write of file failed

  . Cleaning up... done.
SERVER START TIMEOUT

```