### PR TITLE
Add guards to MPS functions only used for tracing

### DIFF
--- a/library/mps/layer2.c
+++ b/library/mps/layer2.c
@@ -135,6 +135,7 @@ MBEDTLS_MPS_STATIC int l2_type_empty_allowed( mbedtls_mps_l2 *ctx,
  * Epoch handling
  */
 
+#if defined(MBEDTLS_MPS_TRACE)
 static inline const char * l2_epoch_usage_to_string(
     mbedtls_mps_epoch_usage usage )
 {
@@ -150,6 +151,7 @@ static inline const char * l2_epoch_usage_to_string(
 
     return( "NONE" );
 }
+#endif /* MBEDTLS_MPS_TRACE */
 
 /* Internal macro used to indicate internal usage
  * of an epoch, e.g. because data it still pending

--- a/library/mps/mps.c
+++ b/library/mps/mps.c
@@ -2974,6 +2974,7 @@ MBEDTLS_MPS_STATIC int mps_request_resend( mbedtls_mps *mps )
                                      MPS_RETRANSMIT_ONLY_EMPTY_FRAGMENTS ) );
 }
 
+#if defined(MBEDTLS_MPS_TRACE)
 static inline const char * mps_flight_state_to_string(
     mbedtls_mps_flight_state_t state )
 {
@@ -2997,6 +2998,7 @@ static inline const char * mps_flight_state_to_string(
             return( "UNKNOWN" );
     }
 }
+#endif /* MBEDTLS_MPS_TRACE */
 
 MBEDTLS_MPS_INLINE
 /* Perform a retransmisison state machine transition and


### PR DESCRIPTION
MPS Layer 2 and Layer 4 contain functions which are unused when MPS tracing is disabled (`MBEDTLS_MPS_TRACE` isn't set). Guard them by `MBEDTLS_MPS_TRACE` to avoid unused function warnings.

Signed-off-by: Hanno Becker <hanno.becker@arm.com>