### PR TITLE
Removed ssl_tls13_messaging.c from the mbedTLS VisualStudio Project File

### DIFF
--- a/visualc/VS2010/mbedTLS.vcxproj
+++ b/visualc/VS2010/mbedTLS.vcxproj
@@ -358,7 +358,6 @@
     <ClCompile Include="..\..\3rdparty\everest\library\legacy\Hacl_Curve25519.c" />
     <ClCompile Include="..\..\library\ssl_tls13_client.c" />
     <ClCompile Include="..\..\library\ssl_tls13_generic.c" />
-    <ClCompile Include="..\..\library\ssl_tls13_messaging.c" />
     <ClCompile Include="..\..\library\ssl_tls13_server.c" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />


### PR DESCRIPTION
This file has been removed earlier but is still included in the project file.