### PR TITLE
Fix server crash because memset on ptr of ptr of mbedtls_ssl_ticket

### DIFF
--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -521,7 +521,7 @@ int mbedtls_ssl_parse_new_session_ticket_server(
     if( ( ret = ssl->conf->f_ticket_parse( ssl->conf->p_ticket, ticket,
                                          ticket_buffer, len ) ) != 0 )
     {
-        mbedtls_platform_zeroize( &ticket, sizeof( mbedtls_ssl_ticket ) );
+        mbedtls_platform_zeroize( ticket, sizeof( mbedtls_ssl_ticket ) );
         mbedtls_free( ticket_buffer );
         if( ret == MBEDTLS_ERR_SSL_INVALID_MAC )
             MBEDTLS_SSL_DEBUG_MSG( 3, ( "ticket is not authentic" ) );


### PR DESCRIPTION
Summary:
This [memset](https://github.com/hannestschofenig/mbedtls/blob/tls13-prototype/library/ssl_tls13_server.c#L524) is problematic, as the `ticket` is declared as [mbedtls_ssl_ticket*](https://github.com/hannestschofenig/mbedtls/blob/tls13-prototype/library/ssl_tls13_server.c#L492).

```
mbedtls_platform_zeroize( &ticket, sizeof( mbedtls_ssl_ticket ) );
```
Fix it by not using `&`.

Test Plan:
```
../programs/ssl/ssl_server2 server_addr=127.0.0.1 server_port=11252
allow_sha1=1 debug_level=5 force_version=tls1_3
../programs/ssl/ssl_client2 server_addr=127.0.0.1 server_port=11252
allow_sha1=1 debug_level=5 force_version=tls1_3
force_ciphersuite=TLS_AES_128_CCM_SHA256 psk=010203 psk_identity=0a0b0c
key_exchange_modes=psk early_data=1
```

Reviewers:

Subscribers:

Tasks:

Tags: