### PR TITLE
Fix client crash when use early data without psk

### DIFF
--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -3116,7 +3116,7 @@ int mbedtls_ssl_write_early_data_ext( mbedtls_ssl_context *ssl,
 #if defined(MBEDTLS_SSL_CLI_C)
     if( ssl->conf->endpoint == MBEDTLS_SSL_IS_CLIENT )
     {
-        if( ssl->conf->key_exchange_modes == MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_ECDHE_ECDSA ||
+        if( !mbedtls_ssl_conf_tls13_some_psk_enabled( ssl ) ||
             mbedtls_ssl_get_psk( ssl, NULL, NULL ) != 0 ||
             ssl->early_data_enabled == MBEDTLS_SSL_EARLY_DATA_DISABLED )
         {

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -3117,7 +3117,7 @@ int mbedtls_ssl_write_early_data_ext( mbedtls_ssl_context *ssl,
     if( ssl->conf->endpoint == MBEDTLS_SSL_IS_CLIENT )
     {
         if( !mbedtls_ssl_conf_tls13_some_psk_enabled( ssl ) ||
-            mbedtls_ssl_get_psk( ssl, NULL, NULL ) != 0 ||
+            mbedtls_ssl_get_psk_to_offer( ssl, NULL, NULL, NULL, NULL ) != 0 ||
             ssl->early_data_enabled == MBEDTLS_SSL_EARLY_DATA_DISABLED )
         {
             MBEDTLS_SSL_DEBUG_MSG( 2, ( "<= skip write early_data extension" ) );

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -3117,6 +3117,7 @@ int mbedtls_ssl_write_early_data_ext( mbedtls_ssl_context *ssl,
     if( ssl->conf->endpoint == MBEDTLS_SSL_IS_CLIENT )
     {
         if( ssl->conf->key_exchange_modes == MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_ECDHE_ECDSA ||
+            mbedtls_ssl_get_psk( ssl, NULL, NULL ) != 0 ||
             ssl->early_data_enabled == MBEDTLS_SSL_EARLY_DATA_DISABLED )
         {
             MBEDTLS_SSL_DEBUG_MSG( 2, ( "<= skip write early_data extension" ) );

--- a/library/ssl_tls13_keys.c
+++ b/library/ssl_tls13_keys.c
@@ -1220,6 +1220,11 @@ int mbedtls_ssl_tls1_3_key_schedule_stage_early_data(
     mbedtls_ssl_context *ssl )
 {
     int ret = 0;
+    if( ssl->handshake->ciphersuite_info == NULL )
+    {
+        MBEDTLS_SSL_DEBUG_MSG( 1, ( "cipher suite info not found" ) );
+        return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
+    }
     mbedtls_md_type_t const md_type = ssl->handshake->ciphersuite_info->mac;
 
     ret = mbedtls_ssl_tls1_3_evolve_secret( md_type,


### PR DESCRIPTION
Summary:
`ssl->handshake->ciphersuite_info` could be NULL in
[mbedtls_ssl_tls1_3_key_schedule_stage_early_data](https://github.com/hannestschofenig/mbedtls/blob/tls13-prototype/library/ssl_tls13_keys.c#L1223)
```
1223	    mbedtls_md_type_t const md_type = ssl->handshake->ciphersuite_info->mac;
```

Test Plan:
```
../programs/ssl/ssl_server2 server_addr=127.0.0.1 server_port=11252 allow_sha1=1 debug_level=5 force_version=tls1_3
../programs/ssl/ssl_client2 server_addr=127.0.0.1 server_port=11252 allow_sha1=1 debug_level=5 force_version=tls1_3 force_ciphersuite=TLS_AES_128_CCM_SHA256 early_data=1
```

Reviewers:

Subscribers:

Tasks:

Tags: