### PR TITLE
Set key_exchange to its own enum value

### DIFF
--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -1011,7 +1011,7 @@ int mbedtls_ssl_write_pre_shared_key_ext( mbedtls_ssl_context *ssl,
          */
         if( ssl->handshake->early_data == MBEDTLS_SSL_EARLY_DATA_ON )
         {
-            ssl->session_negotiate->key_exchange = MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_KE;
+            ssl->session_negotiate->key_exchange = MBEDTLS_KEY_EXCHANGE_NONE;
         }
 #endif
         break;


### PR DESCRIPTION
Summary:
This technically is no-op change. MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_KE is for `key_exchange_modes`, not for `key_exchnage`.
Fix it by using corresponding `key_exchange` enum of `MBEDTLS_KEY_EXCHANGE_NONE`.

Test Plan:
make test and ssl-opt.sh

Reviewers:

Subscribers:

Tasks:

Tags: