### PR TITLE
Move mbedtls_ssl_handshake_key_derivation from ee prepare to sh post

### DIFF
--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -2605,28 +2605,7 @@ cleanup:
 }
 
 static int ssl_encrypted_extensions_prepare( mbedtls_ssl_context* ssl ) {
-
-    int ret;
-    mbedtls_ssl_key_set traffic_keys;
-
-    /* Generate handshake keying material */
-    ret = mbedtls_ssl_handshake_key_derivation( ssl, &traffic_keys );
-    if( ret != 0 )
-    {
-        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_handshake_key_derivation", ret );
-        return( ret );
-    }
-
-    ret = mbedtls_ssl_tls13_build_transform( ssl, &traffic_keys, ssl->transform_handshake, 0 );
-    if( ret != 0 )
-    {
-        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_tls13_build_transform", ret );
-        return( ret );
-    }
-
-    /* Switch to new keys for inbound traffic. */
-    mbedtls_ssl_set_inbound_transform( ssl, ssl->transform_handshake );
-    ssl->session_in = ssl->session_negotiate;
+    ( ( void )ssl );
 
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
     traffic_keys.epoch = 2;
@@ -3267,6 +3246,7 @@ static int ssl_server_hello_parse( mbedtls_ssl_context* ssl,
 
 static int ssl_server_hello_postprocess( mbedtls_ssl_context* ssl )
 {
+    int ret;
     /* We need to set the key exchange algorithm based on the
      * following rules:
      *
@@ -3303,6 +3283,26 @@ static int ssl_server_hello_postprocess( mbedtls_ssl_context* ssl )
     }
 #endif /* MBEDTLS_CID */
 
+    mbedtls_ssl_key_set traffic_keys;
+
+    /* Generate handshake keying material */
+    ret = mbedtls_ssl_handshake_key_derivation( ssl, &traffic_keys );
+    if( ret != 0 )
+    {
+        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_handshake_key_derivation", ret );
+        return( ret );
+    }
+
+    ret = mbedtls_ssl_tls13_build_transform( ssl, &traffic_keys, ssl->transform_handshake, 0 );
+    if( ret != 0 )
+    {
+        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_tls13_build_transform", ret );
+        return( ret );
+    }
+
+    /* Switch to new keys for inbound traffic. */
+    mbedtls_ssl_set_inbound_transform( ssl, ssl->transform_handshake );
+    ssl->session_in = ssl->session_negotiate;
     return( 0 );
 }
 

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -3234,6 +3234,7 @@ static int ssl_server_hello_parse( mbedtls_ssl_context* ssl,
 static int ssl_server_hello_postprocess( mbedtls_ssl_context* ssl )
 {
     int ret;
+    mbedtls_ssl_key_set traffic_keys;
     /* We need to set the key exchange algorithm based on the
      * following rules:
      *
@@ -3269,8 +3270,6 @@ static int ssl_server_hello_postprocess( mbedtls_ssl_context* ssl )
         ssl->in_cid_len = 0;
     }
 #endif /* MBEDTLS_CID */
-
-    mbedtls_ssl_key_set traffic_keys;
 
     /* Generate handshake keying material */
     ret = mbedtls_ssl_handshake_key_derivation( ssl, &traffic_keys );

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -2606,19 +2606,6 @@ cleanup:
 
 static int ssl_encrypted_extensions_prepare( mbedtls_ssl_context* ssl ) {
     ( ( void )ssl );
-
-#if defined(MBEDTLS_SSL_PROTO_DTLS)
-    traffic_keys.epoch = 2;
-#endif /* MBEDTLS_SSL_PROTO_DTLS */
-
-#if defined(MBEDTLS_SSL_PROTO_DTLS)
-    /* epoch value ( 2 ) is used for messages
-     * protected using keys derived from the handshake_traffic_secret
-     */
-    ssl->in_epoch = 2;
-    ssl->out_epoch = 2;
-#endif /* MBEDTLS_SSL_PROTO_DTLS */
-
     return( 0 );
 }
 
@@ -3303,6 +3290,21 @@ static int ssl_server_hello_postprocess( mbedtls_ssl_context* ssl )
     /* Switch to new keys for inbound traffic. */
     mbedtls_ssl_set_inbound_transform( ssl, ssl->transform_handshake );
     ssl->session_in = ssl->session_negotiate;
+
+#if defined(MBEDTLS_SSL_PROTO_DTLS)
+    traffic_keys.epoch = 2;
+#endif /* MBEDTLS_SSL_PROTO_DTLS */
+
+#if defined(MBEDTLS_SSL_PROTO_DTLS)
+    /* epoch value ( 2 ) is used for messages
+     * protected using keys derived from the handshake_traffic_secret
+     */
+    ssl->in_epoch = 2;
+    ssl->out_epoch = 2;
+#endif /* MBEDTLS_SSL_PROTO_DTLS */
+
+    mbedtls_platform_zeroize( &traffic_keys, sizeof( traffic_keys ) );
+
     return( 0 );
 }
 


### PR DESCRIPTION
Summary:
According to https://tools.ietf.org/html/rfc8446#appendix-A.1, handshake
secret could be set after client receives server hello. Although it
sounds not much different between `ssl_encrypted_extensions_prepare` and
`ssl_server_hello_postprocess`. In some transport, such as QUIC, we
won't able to receive Encrypted Extension msg without handshake secret.
We suggest to move the `mbedtls_ssl_handshake_key_derivation` from
`ssl_encrypted_extensions_prepare` to `ssl_server_hello_postprocess`.

Test Plan:
`ssl-opt.sh`

Reviewers:

Subscribers:

Tasks:

Tags: