### PR TITLE
Fix bad hello retry request message

### DIFF
--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -3828,9 +3828,9 @@ static int ssl_write_hello_retry_request( mbedtls_ssl_context *ssl )
         *p++ = ( *curve )->tls_id & 0xFF;
 
         MBEDTLS_SSL_DEBUG_MSG( 3, ( "NamedGroup in HRR: %s", ( *curve )->name ) );
+        total_ext_len += ext_length + 4 /* 2 bytes for extension_type and 2 bytes for length field */;
 
     }
-    total_ext_len += ext_length + 4 /* 2 bytes for extension_type and 2 bytes for length field */;
 #endif /* MBEDTLS_ECDH_C */
 
     *extension_start++ = (unsigned char)( ( total_ext_len >> 8 ) & 0xFF );


### PR DESCRIPTION
Summary:
The updated line should be inside the [if condition](https://github.com/hannestschofenig/mbedtls/blob/tls13-prototype/library/ssl_tls13_server.c#L3797).
Otherwise the extension length would be added into [total extension](https://github.com/hannestschofenig/mbedtls/blob/tls13-prototype/library/ssl_tls13_server.c#L3833) twice, and causes malformed handshake msg.

Test Plan:
```
../programs/ssl/ssl_server2 server_addr=127.0.0.1 server_port=16187 allow_sha1=1 debug_level=5 force_version=tls1_3 key_exchange_modes=ecdhe_ecdsa named_groups=secp256r1
```

```
../programs/ssl/ssl_client2 server_addr=127.0.0.1 server_port=16187 allow_sha1=1 debug_level=5 force_version=tls1_3 server_name=localhost force_ciphersuite=TLS_AES_128_GCM_SHA256 key_exchange_modes=psk_dhe key_share_named_groups=secp521r1
```

Verify that there is no `bad hello retry request message` in client log.
```
ssl_tls13_client.c:3577: |3| hello retry request, chosen ciphersuite: ( 1301 ) - TLS_AES_128_GCM_SHA256
ssl_tls13_client.c:3630: |1| bad hello retry request message
ssl_tls13_client.c:2900: |2| <= parse server hello
ssl_tls13_client.c:4194: |1| ssl_server_hello_process() returned -31617 (-0x7b81)
```

Reviewers:

Subscribers:

Tasks:

Tags: