### PR TITLE
server aborts hs if client misses manadatory extensions

### DIFF
--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -3065,16 +3065,16 @@ static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
         }
     }
 
+    if( ssl->session_negotiate->key_exchange == 0 ) {
+      MBEDTLS_SSL_DEBUG_MSG( 1, ( "ClientHello message misses mandatory extensions." ) );
+      return( MBEDTLS_ERR_SSL_BAD_HS_MISSING_EXTENSION_EXT );
+    }
+
     /* If we previously determined that an HRR is needed then
      * we will send it now.
      */
     if( final_ret == MBEDTLS_ERR_SSL_BAD_HS_WRONG_KEY_SHARE )
         return( MBEDTLS_ERR_SSL_BAD_HS_WRONG_KEY_SHARE );
-
-/*	if( ssl->session_negotiate->key_exchange == 0 ) { */
-    MBEDTLS_SSL_DEBUG_MSG( 1, ( "ClientHello message misses mandatory extensions." ) );
-    return( MBEDTLS_ERR_SSL_BAD_HS_MISSING_EXTENSION_EXT );
-/*	} */
 
     end_client_hello:
 

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -1530,6 +1530,17 @@ run_test    "TLS 1.3, TLS_AES_256_GCM_SHA384, ext PSK, early data status - accep
             0 \
 	    -c "early data status = 2"  \
 
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL
+requires_config_enabled MBEDTLS_DEBUG_C
+run_test    "TLS 1.3, TLS_AES_128_CCM_8_SHA256, ClientHello message misses mandatory extensions" \
+            "$P_SRV debug_level=5 force_version=tls1_3 key_exchange_modes=ecdhe_ecdsa named_groups=secp256r1" \
+            "$P_CLI debug_level=5 force_version=tls1_3 server_name=localhost force_ciphersuite=TLS_AES_128_CCM_8_SHA256 key_exchange_modes=psk_dhe  key_share_named_groups=secp521r1" \
+            1 \
+	    -s "ClientHello message misses mandatory extensions."                 \
+	    -s "send alert message"                                               \
+	    -C "received HelloRetryRequest message"                               \
+      -c "got an alert message, type: \\[2:109]"
+
 #
 # TLS 1.2 specific tests
 #


### PR DESCRIPTION
Summary:
Server may send hello retry just because of [mismatch key share extension](https://github.com/hannestschofenig/mbedtls/blob/tls13-prototype/library/ssl_tls13_server.c#L3072). It should do that only when there is no [missed manadatory extension](https://github.com/hannestschofenig/mbedtls/blob/tls13-prototype/library/ssl_tls13_server.c#L3074).

Test Plan:
```
../programs/ssl/ssl_server2 server_addr=127.0.0.1 server_port=16187 allow_sha1=1 debug_level=5 force_version=tls1_3 key_exchange_modes=ecdhe_ecdsa named_groups=secp256r1
```

```
../programs/ssl/ssl_client2 server_addr=127.0.0.1 server_port=16187 allow_sha1=1 debug_level=5 force_version=tls1_3 server_name=localhost force_ciphersuite=TLS_AES_128_GCM_SHA256 key_exchange_modes=psk_dhe key_share_named_groups=secp521r1
```

Added new test case for this issue into ssl-opt.sh

Reviewers:

Subscribers:

Tasks:

Tags: