### PR TITLE
Improve identifiers and logic around key exchange mode handling

### DIFF
--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -169,16 +169,33 @@
 #define CID_EXTENSION 2048
 
 
-/* Key Exchange Modes
- * MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_ALL refers to
- * the two PSK modes.
+/*
+ * TLS 1.3 Key Exchange Modes
+ *
+ * Mbed TLS internal identifiers for use with the SSL configuration API
+ * mbedtls_ssl_conf_tls13_key_exchange().
  */
-#define MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_KE 0
-#define MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_DHE_KE 1
-#define MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_NONE 252
-#define MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_ECDHE_ECDSA 253
-#define MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_ALL 254
-#define MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_ALL 255
+
+#define MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_NONE                0
+#define MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_KE      ( 1u << 0 )
+#define MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_DHE_KE  ( 1u << 1 )
+#define MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_ECDHE_ECDSA ( 1u << 2 )
+
+/* Convenience macros for sets of key exchanges. */
+#define MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_ALL ( MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_KE     | \
+                                                  MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_DHE_KE | \
+                                                  MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_ECDHE_ECDSA )
+#define MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_ALL ( MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_KE     | \
+                                                      MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_DHE_KE )
+
+/*
+ * Constants from RFC 8446 for TLS 1.3 PSK modes
+ *
+ * Those are used in the Pre-Shared Key Exchange Modes extension.
+ * See Section 4.2.9 in RFC 8446.
+ */
+#define MBEDTLS_SSL_TLS13_PSK_MODE_PURE  0 /* Pure PSK-based exchange  */
+#define MBEDTLS_SSL_TLS13_PSK_MODE_ECDHE 1 /* PSK+ECDHE-based exchange */
 
 /*
  * Various constants

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -3393,7 +3393,7 @@ int mbedtls_ssl_conf_own_cert( mbedtls_ssl_config *conf,
  * \returns A negative error code on failure.
  */
 
-int mbedtls_ssl_conf_ke( mbedtls_ssl_config* conf,
+int mbedtls_ssl_conf_tls13_key_exchange( mbedtls_ssl_config* conf,
                          const int key_exchange_mode );
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 

--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -1309,6 +1309,93 @@ static uint32_t get_varint_value(const uint32_t input);
 
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+
+/*
+ * Helper functions around key exchange modes.
+ */
+static inline unsigned mbedtls_ssl_conf_tls13_get_key_exchange_modes( mbedtls_ssl_context *ssl )
+{
+    return( ssl->conf->key_exchange_modes );
+}
+
+static inline int mbedtls_ssl_conf_tls13_pure_psk_enabled( mbedtls_ssl_context *ssl )
+{
+    if( ( mbedtls_ssl_conf_tls13_get_key_exchange_modes( ssl ) &
+          MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_KE ) != 0 )
+    {
+        return( 1 );
+    }
+
+    return( 0 );
+}
+
+static inline int mbedtls_ssl_conf_tls13_psk_ecdhe_enabled( mbedtls_ssl_context *ssl )
+{
+    if( ( mbedtls_ssl_conf_tls13_get_key_exchange_modes( ssl ) &
+          MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_DHE_KE ) != 0 )
+    {
+        return( 1 );
+    }
+
+    return( 0 );
+}
+
+static inline int mbedtls_ssl_conf_tls13_some_ecdhe_enabled( mbedtls_ssl_context *ssl )
+{
+    if( ( mbedtls_ssl_conf_tls13_get_key_exchange_modes( ssl ) &
+          ( MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_DHE_KE | \
+            MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_ECDHE_ECDSA ) ) != 0 )
+    {
+        return( 1 );
+    }
+
+    return( 0 );
+}
+
+static inline int mbedtls_ssl_conf_tls13_some_psk_enabled( mbedtls_ssl_context *ssl )
+{
+    if( ( mbedtls_ssl_conf_tls13_get_key_exchange_modes( ssl ) &
+          MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_ALL ) != 0 )
+    {
+        return( 1 );
+    }
+
+    return( 0 );
+}
+
+static inline int mbedtls_ssl_conf_tls13_pure_ecdhe_enabled( mbedtls_ssl_context *ssl )
+{
+    if( ( mbedtls_ssl_conf_tls13_get_key_exchange_modes( ssl ) &
+          MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_ECDHE_ECDSA ) != 0 )
+    {
+        return( 1 );
+    }
+
+    return( 0 );
+}
+
+static inline mbedtls_ssl_tls13_key_exchange_with_psk( mbedtls_ssl_context *ssl )
+{
+    if( ssl->session_negotiate->key_exchange == MBEDTLS_KEY_EXCHANGE_PSK ||
+        ssl->session_negotiate->key_exchange == MBEDTLS_KEY_EXCHANGE_ECDHE_PSK )
+    {
+        return( 1 );
+    }
+
+    return( 0 );
+}
+
+/*
+ * Helper functions around EarlyData
+ */
+static inline int mbedtls_ssl_conf_tls13_0rtt_enabled( mbedtls_ssl_context *ssl )
+{
+    if( ssl->conf->early_data == MBEDTLS_SSL_EARLY_DATA_ENABLED )
+        return( 1 );
+
+    return( 0 );
+}
+
 int mbedtls_ssl_handshake_key_derivation( mbedtls_ssl_context* ssl,
                                           mbedtls_ssl_key_set* traffic_keys );
 int mbedtls_ssl_read_certificate_verify_process(mbedtls_ssl_context* ssl);

--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -1374,7 +1374,7 @@ static inline int mbedtls_ssl_conf_tls13_pure_ecdhe_enabled( mbedtls_ssl_context
     return( 0 );
 }
 
-static inline mbedtls_ssl_tls13_key_exchange_with_psk( mbedtls_ssl_context *ssl )
+static inline int mbedtls_ssl_tls13_key_exchange_with_psk( mbedtls_ssl_context *ssl )
 {
     if( ssl->session_negotiate->key_exchange == MBEDTLS_KEY_EXCHANGE_PSK ||
         ssl->session_negotiate->key_exchange == MBEDTLS_KEY_EXCHANGE_ECDHE_PSK )

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -4862,8 +4862,8 @@ int mbedtls_ssl_conf_psk( mbedtls_ssl_config *conf,
 
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
-/* mbedtls_ssl_conf_ke( ) allows to set the key exchange mode. */
-int mbedtls_ssl_conf_ke( mbedtls_ssl_config* conf,
+/* mbedtls_ssl_conf_tls13_key_exchange() allows to set the key exchange mode. */
+int mbedtls_ssl_conf_tls13_key_exchange( mbedtls_ssl_config* conf,
     const int key_exchange_mode )
 {
     conf->key_exchange_modes = key_exchange_mode;

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -983,9 +983,8 @@ int mbedtls_ssl_write_pre_shared_key_ext( mbedtls_ssl_context *ssl,
     /* Check whether we have any PSK credentials configured. */
     if( mbedtls_ssl_get_psk( ssl, NULL, NULL ) != 0 )
     {
-        MBEDTLS_SSL_DEBUG_MSG( 3, ( "No externally configured PSK available." ) );
-
-        return( MBEDTLS_ERR_SSL_PRIVATE_KEY_REQUIRED );
+        MBEDTLS_SSL_DEBUG_MSG( 3, ( "client hello, skip pre_shared_key extensions" ) );
+        return( 0 );
     }
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "client hello, adding pre_shared_key extension" ) );

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -974,12 +974,6 @@ int mbedtls_ssl_write_pre_shared_key_ext( mbedtls_ssl_context *ssl,
 
     *olen = 0;
 
-    if( !( ssl->handshake->extensions_present & PSK_KEY_EXCHANGE_MODES_EXTENSION ) )
-    {
-        MBEDTLS_SSL_DEBUG_MSG( 1, ( "The psk_key_exchange_modes extension has not been added." ) );
-        return( MBEDTLS_ERR_SSL_BAD_HS_PSK_KEY_EXCHANGE_MODES_EXT );
-    }
-
     /* Check whether we have any PSK credentials configured. */
     if( mbedtls_ssl_get_psk( ssl, NULL, NULL ) != 0 )
     {

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -1139,6 +1139,8 @@ int mbedtls_ssl_write_pre_shared_key_ext( mbedtls_ssl_context *ssl,
         }
     }
     *olen = ext_length + 4;
+
+    ssl->handshake->extensions_present |= PRE_SHARED_KEY_EXTENSION;
     return( 0 );
 }
 
@@ -1987,9 +1989,6 @@ static int ssl_client_hello_write( mbedtls_ssl_context* ssl,
         ret = mbedtls_ssl_write_pre_shared_key_ext( ssl, buf, end, &cur_ext_len, 0 );
         total_ext_len += cur_ext_len;
         buf += cur_ext_len;
-
-        if( ret == 0 )
-            ssl->handshake->extensions_present |= PRE_SHARED_KEY_EXTENSION;
     }
 #endif /* MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED */
 

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -395,7 +395,7 @@ static void ssl_write_hostname_ext( mbedtls_ssl_context *ssl,
 
 
 /*
- * ssl_write_supported_versions_ext( ):
+ * ssl_write_supported_versions_ext():
  *
  * struct {
  *      ProtocolVersion versions<2..254>;
@@ -443,7 +443,7 @@ static void ssl_write_supported_versions_ext( mbedtls_ssl_context *ssl,
 #if defined(MBEDTLS_SSL_MAX_FRAGMENT_LENGTH)
 
 /*
- * ssl_write_max_fragment_length_ext( ):
+ * ssl_write_max_fragment_length_ext():
  *
  * enum{
  *    2^9( 1 ), 2^10( 2 ), 2^11( 3 ), 2^12( 4 ), ( 255 )
@@ -490,7 +490,7 @@ static int ssl_write_max_fragment_length_ext( mbedtls_ssl_context *ssl,
 
 #if defined(MBEDTLS_SSL_ALPN)
 /*
- * ssl_write_alpn_ext( ) structure:
+ * ssl_write_alpn_ext() structure:
  *
  * opaque ProtocolName<1..2^8-1>;
  *
@@ -563,7 +563,7 @@ static int ssl_write_alpn_ext( mbedtls_ssl_context *ssl,
 
 #if defined(MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED)
 /*
- * ssl_write_psk_key_exchange_modes_ext( ) structure:
+ * ssl_write_psk_key_exchange_modes_ext() structure:
  *
  * enum { psk_ke( 0 ), psk_dhe_ke( 1 ), ( 255 ) } PskKeyExchangeMode;
  *
@@ -573,11 +573,11 @@ static int ssl_write_alpn_ext( mbedtls_ssl_context *ssl,
  */
 
 static int ssl_write_psk_key_exchange_modes_ext( mbedtls_ssl_context *ssl,
-                                                unsigned char* buf,
-                                                unsigned char* end,
-                                                size_t* olen )
+                                                 unsigned char* buf,
+                                                 unsigned char* end,
+                                                 size_t* olen )
 {
-    unsigned char *p = ( unsigned char * ) buf;
+    unsigned char *p = (unsigned char *) buf;
     *olen = 0;
 
     /* Check whether we have any PSK credentials configured. */
@@ -589,7 +589,7 @@ static int ssl_write_psk_key_exchange_modes_ext( mbedtls_ssl_context *ssl,
     /*} */
 
     /* max length of this extension is 7 bytes */
-    if( (size_t)( end - p ) < ( 7 ) )
+    if( (size_t)( end - p ) < 7 )
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "Not enough buffer" ) );
         return( MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL );
@@ -599,11 +599,13 @@ static int ssl_write_psk_key_exchange_modes_ext( mbedtls_ssl_context *ssl,
 
     /* Extension Type */
     *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_PSK_KEY_EXCHANGE_MODES >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_PSK_KEY_EXCHANGE_MODES ) & 0xFF );
+    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_PSK_KEY_EXCHANGE_MODES >> 0 ) & 0xFF );
 
-    if( ssl->conf->key_exchange_modes == MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_ALL ||
-        ssl->conf->key_exchange_modes == MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_ALL ) {
-
+    if( ssl->conf->key_exchange_modes ==
+          MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_ALL ||
+        ssl->conf->key_exchange_modes ==
+          MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_ALL )
+    {
         /* Extension Length */
         *p++ = 0;
         *p++ = 3;
@@ -614,7 +616,9 @@ static int ssl_write_psk_key_exchange_modes_ext( mbedtls_ssl_context *ssl,
         *p++ = MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_DHE_KE;
         *olen = 7;
 
-        MBEDTLS_SSL_DEBUG_MSG( 5, ( "Adding %d and %d psk_key_exchange_modes", MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_KE, MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_DHE_KE ) );
+        MBEDTLS_SSL_DEBUG_MSG( 5, ( "Adding %d and %d psk_key_exchange_modes",
+                                    MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_KE,
+                                    MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_DHE_KE ) );
     }
     else
     {
@@ -627,7 +631,8 @@ static int ssl_write_psk_key_exchange_modes_ext( mbedtls_ssl_context *ssl,
         *p++= ssl->conf->key_exchange_modes;
         *olen = 6;
 
-        MBEDTLS_SSL_DEBUG_MSG( 5, ( "Adding %d psk_key_exchange_mode", ssl->conf->key_exchange_modes ) );
+        MBEDTLS_SSL_DEBUG_MSG( 5, ( "Adding %d psk_key_exchange_mode",
+                                    ssl->conf->key_exchange_modes ) );
     }
 
     return ( 0 );
@@ -636,7 +641,7 @@ static int ssl_write_psk_key_exchange_modes_ext( mbedtls_ssl_context *ssl,
 
 
 /*
- * mbedtls_ssl_write_pre_shared_key_ext( ) structure:
+ * mbedtls_ssl_write_pre_shared_key_ext() structure:
  *
  * struct {
  *   opaque identity<1..2^16-1>;
@@ -664,7 +669,7 @@ static int ssl_write_psk_key_exchange_modes_ext( mbedtls_ssl_context *ssl,
  */
 
 #if defined(MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED)
-/* mbedtls_ssl_create_binder( ):
+/* mbedtls_ssl_create_binder():
 
    0
    |
@@ -686,7 +691,13 @@ static int ssl_write_psk_key_exchange_modes_ext( mbedtls_ssl_context *ssl,
    |                     = client_early_traffic_secret
 */
 
-int mbedtls_ssl_create_binder( mbedtls_ssl_context *ssl, unsigned char *psk, size_t psk_len, const mbedtls_md_info_t *md, const mbedtls_ssl_ciphersuite_t *suite_info, unsigned char *buffer, size_t blen, unsigned char *result ) {
+int mbedtls_ssl_create_binder( mbedtls_ssl_context *ssl,
+                               unsigned char *psk, size_t psk_len,
+                               const mbedtls_md_info_t *md,
+                               const mbedtls_ssl_ciphersuite_t *suite_info,
+                               unsigned char *buffer, size_t blen,
+                               unsigned char *result )
+{
     int ret = 0;
     int hash_length;
     unsigned char salt[MBEDTLS_MD_MAX_SIZE];
@@ -721,7 +732,7 @@ int mbedtls_ssl_create_binder( mbedtls_ssl_context *ssl, unsigned char *psk, siz
 
     if( ret != 0 )
     {
-        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_hkdf_extract( ) with early_secret", ret );
+        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_hkdf_extract() with early_secret", ret );
         return( ret );
     }
 
@@ -786,7 +797,7 @@ int mbedtls_ssl_create_binder( mbedtls_ssl_context *ssl, unsigned char *psk, siz
 
     if( ret != 0 )
     {
-        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_tls1_3_derive_secret( ) with binder_key: Error", ret );
+        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_tls1_3_derive_secret() with binder_key: Error", ret );
         return( ret );
     }
 
@@ -952,9 +963,13 @@ exit:
 
 
 int mbedtls_ssl_write_pre_shared_key_ext( mbedtls_ssl_context *ssl,
-                                 unsigned char* buf, unsigned char* end, size_t* olen, int dummy_run )
+                                          unsigned char* buf, unsigned char* end,
+                                          size_t* olen,
+                                          int dummy_run )
 {
-    unsigned char *p = ( unsigned char * ) buf, *truncated_clienthello_end, *truncated_clienthello_start = ssl->out_msg;
+    unsigned char *p = (unsigned char *) buf;
+    unsigned char *truncated_clienthello_end;
+    unsigned char *truncated_clienthello_start = ssl->out_msg;
     size_t ext_length = 0;
     uint32_t obfuscated_ticket_age=0;
     const mbedtls_ssl_ciphersuite_t *suite_info;
@@ -997,10 +1012,7 @@ int mbedtls_ssl_write_pre_shared_key_ext( mbedtls_ssl_context *ssl,
         hash_len = mbedtls_hash_size_for_ciphersuite( suite_info );
 
         if( hash_len == -1 )
-        {
-            MBEDTLS_SSL_DEBUG_MSG( 1, ( "mbedtls_hash_size_for_ciphersuite == -1, mbedtls_ssl_write_pre_shared_key_ext failed" ) );
             return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
-        }
 
         /* In this implementation we only add one pre-shared-key extension. */
         ssl->session_negotiate->ciphersuite = ciphersuites[i];
@@ -1018,7 +1030,8 @@ int mbedtls_ssl_write_pre_shared_key_ext( mbedtls_ssl_context *ssl,
     }
     if( hash_len == -1 )
     {
-        MBEDTLS_SSL_DEBUG_MSG( 1, ( "mbedtls_hash_size_for_ciphersuite == -1, mbedtls_ssl_write_pre_shared_key_ext failed" ) );
+        MBEDTLS_SSL_DEBUG_MSG( 1, ( "mbedtls_hash_size_for_ciphersuite == -1, "\
+                                    "mbedtls_ssl_write_pre_shared_key_ext failed" ) );
         return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
     }
 
@@ -1080,15 +1093,20 @@ int mbedtls_ssl_write_pre_shared_key_ext( mbedtls_ssl_context *ssl,
 #if defined(MBEDTLS_HAVE_TIME)
             now = time( NULL );
 
-            if( !( ssl->conf->ticket_received <= now && now - ssl->conf->ticket_received < 7 * 86400 * 1000 ) )
+            if( !( ssl->conf->ticket_received <= now &&
+                   now - ssl->conf->ticket_received < 7 * 86400 * 1000 ) )
             {
                 MBEDTLS_SSL_DEBUG_MSG( 3, ( "ticket expired" ) );
                 /* TBD: We would have to fall back to another PSK */
                 return( MBEDTLS_ERR_SSL_SESSION_TICKET_EXPIRED );
             }
 
-            obfuscated_ticket_age = ( uint32_t )( now - ssl->conf->ticket_received ) + ssl->conf->ticket_age_add;
-            MBEDTLS_SSL_DEBUG_MSG( 5, ( "obfuscated_ticket_age: %u", obfuscated_ticket_age ) );
+            obfuscated_ticket_age =
+                (uint32_t)( now - ssl->conf->ticket_received ) +
+                ssl->conf->ticket_age_add;
+
+            MBEDTLS_SSL_DEBUG_MSG( 5, ( "obfuscated_ticket_age: %u",
+                                        obfuscated_ticket_age ) );
 #endif /* MBEDTLS_HAVE_TIME */
         }
 
@@ -1111,15 +1129,19 @@ int mbedtls_ssl_write_pre_shared_key_ext( mbedtls_ssl_context *ssl,
         /* 1 bytes length field for next psk binder */
         *p++ = (unsigned char)( ( hash_len ) & 0xFF );
 
-        MBEDTLS_SSL_DEBUG_BUF( 3, "ssl_calc_binder computed over ", truncated_clienthello_start, truncated_clienthello_end - truncated_clienthello_start );
+        MBEDTLS_SSL_DEBUG_BUF( 3, "ssl_calc_binder computed over ",
+                      truncated_clienthello_start,
+                      truncated_clienthello_end - truncated_clienthello_start );
 
-        ret = mbedtls_ssl_create_binder( ssl, ssl->conf->psk, ssl->conf->psk_len, mbedtls_md_info_from_type( suite_info->mac ),
-                                suite_info, truncated_clienthello_start, truncated_clienthello_end - truncated_clienthello_start, p );
-
+        ret = mbedtls_ssl_create_binder( ssl, ssl->conf->psk,
+                  ssl->conf->psk_len,
+                  mbedtls_md_info_from_type( suite_info->mac ),
+                  suite_info, truncated_clienthello_start,
+                  truncated_clienthello_end - truncated_clienthello_start, p );
 
         if( ret != 0 )
         {
-            MBEDTLS_SSL_DEBUG_RET( 1, "create_binder in mbedtls_ssl_write_pre_shared_key_ext failed: %d", ret );
+            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_write_pre_shared_key_ext()", ret );
             return( MBEDTLS_ERR_SSL_BAD_HS_CLIENT_HELLO );
         }
     }
@@ -1210,7 +1232,7 @@ static int ssl_write_supported_groups_ext( mbedtls_ssl_context *ssl,
     {
 /*		info = mbedtls_ecp_curve_info_from_grp_id( *grp_id ); */
 #else
-    for ( info = mbedtls_ecp_curve_list( ); info->grp_id != MBEDTLS_ECP_DP_NONE; info++ )
+    for ( info = mbedtls_ecp_curve_list(); info->grp_id != MBEDTLS_ECP_DP_NONE; info++ )
     {
 #endif
         elliptic_curve_len += 2;
@@ -1241,7 +1263,7 @@ static int ssl_write_supported_groups_ext( mbedtls_ssl_context *ssl,
         if( info == NULL )
             return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
 #else
-    for ( info = mbedtls_ecp_curve_list( ); info->grp_id != MBEDTLS_ECP_DP_NONE; info++ )
+    for ( info = mbedtls_ecp_curve_list(); info->grp_id != MBEDTLS_ECP_DP_NONE; info++ )
     {
 #endif
         elliptic_curve_list[elliptic_curve_len++] = info->tls_id >> 8;
@@ -1610,7 +1632,7 @@ static int ssl_client_hello_write( mbedtls_ssl_context* ssl,
     /* NOTE:
      * Even for DTLS 1.3, we are writing a TLS handshake header here.
      * The actual DTLS 1.3 handshake header is inserted in
-     * the record writing routine mbedtls_ssl_write_record( ).
+     * the record writing routine mbedtls_ssl_write_record().
      *
      * For cTLS the length, and the version field
      * are elided. The random bytes are shorter.
@@ -1639,7 +1661,7 @@ static int ssl_client_hello_write( mbedtls_ssl_context* ssl,
     if( ssl->conf->max_major_ver == 0 )
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "configured max major version is invalid, "
-                                    "consider using mbedtls_ssl_config_defaults( )" ) );
+                                    "consider using mbedtls_ssl_config_defaults()" ) );
         return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
     }
 
@@ -1959,7 +1981,8 @@ static int ssl_client_hello_write( mbedtls_ssl_context* ssl,
 
         if( ret == 0 ) ssl->handshake->extensions_present |= KEY_SHARE_EXTENSION;
     }
-    else if( ssl->handshake->extensions_present & SUPPORTED_GROUPS_EXTENSION && ssl->handshake->extensions_present & SIGNATURE_ALGORITHM_EXTENSION )
+    else if( ssl->handshake->extensions_present & SUPPORTED_GROUPS_EXTENSION &&
+             ssl->handshake->extensions_present & SIGNATURE_ALGORITHM_EXTENSION )
     {
         /* We are using a certificate-based key exchange */
         ret = ssl_write_key_shares_ext( ssl, buf, end, &cur_ext_len );
@@ -1981,7 +2004,7 @@ static int ssl_client_hello_write( mbedtls_ssl_context* ssl,
          * because it has to be updated later.
          */
         ssl->handshake->ptr_to_psk_ext = buf;
-        ret = mbedtls_ssl_write_pre_shared_key_ext( ssl, buf, end, &cur_ext_len,0 );
+        ret = mbedtls_ssl_write_pre_shared_key_ext( ssl, buf, end, &cur_ext_len, 0 );
         total_ext_len += cur_ext_len;
         buf += cur_ext_len;
 
@@ -2023,8 +2046,8 @@ static int ssl_parse_supported_version_ext( mbedtls_ssl_context* ssl,
     else
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
     {
-        if( len != 2 || 
-            buf[0] != MBEDTLS_SSL_MAJOR_VERSION_3 || 
+        if( len != 2 ||
+            buf[0] != MBEDTLS_SSL_MAJOR_VERSION_3 ||
             buf[1] != MBEDTLS_SSL_MINOR_VERSION_4 )
         {
             MBEDTLS_SSL_DEBUG_MSG( 1, ( "unexpected version" ) );
@@ -2176,12 +2199,12 @@ int mbedtls_ssl_get_early_data_status( mbedtls_ssl_context *ssl )
 /* TODO: Code for MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED missing */
 /*
 
-  ssl_parse_key_shares_ext( ) verifies whether the information in the extension
+  ssl_parse_key_shares_ext() verifies whether the information in the extension
   is correct and stores the provided key shares.
 
 */
 
-/* The ssl_parse_key_shares_ext( ) function is used
+/* The ssl_parse_key_shares_ext() function is used
  *  by the client to parse a KeyShare extension in
  *  a ServerHello message.
  *
@@ -2259,7 +2282,7 @@ static int ssl_parse_key_shares_ext( mbedtls_ssl_context *ssl,
 
     if( check_ecdh_params( ssl ) != 0 )
     {
-        MBEDTLS_SSL_DEBUG_MSG( 1, ( "check_ecdh_params( ) failed!" ) );
+        MBEDTLS_SSL_DEBUG_MSG( 1, ( "check_ecdh_params() failed!" ) );
         return( MBEDTLS_ERR_SSL_BAD_HS_SERVER_KEY_EXCHANGE );
     }
 

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -1934,20 +1934,17 @@ static int ssl_client_hello_write( mbedtls_ssl_context* ssl,
         total_ext_len += cur_ext_len;
         buf += cur_ext_len;
 
-        if( ret == 0 ) ssl->handshake->extensions_present |= SUPPORTED_GROUPS_EXTENSION;
-    }
+        if( ret == 0 )
+            ssl->handshake->extensions_present |= SUPPORTED_GROUPS_EXTENSION;
 
-    /* The supported_signature_algorithms extension is REQUIRED for
-     * certificate authenticated ciphersuites.
-     */
-
-    if( mbedtls_ssl_conf_tls13_pure_psk_enabled( ssl ) )
-    {
+        /* The supported_signature_algorithms extension is REQUIRED for
+         * certificate authenticated ciphersuites. */
         ret = mbedtls_ssl_write_signature_algorithms_ext( ssl, buf, end, &cur_ext_len );
         total_ext_len += cur_ext_len;
         buf += cur_ext_len;
 
-        if( ret == 0 ) ssl->handshake->extensions_present |= SIGNATURE_ALGORITHM_EXTENSION;
+        if( ret == 0 )
+            ssl->handshake->extensions_present |= SIGNATURE_ALGORITHM_EXTENSION;
     }
     /* We need to send the key shares under three conditions:
      * 1 ) A certificate-based ciphersuite is being offered. In this case

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -1893,8 +1893,8 @@ static int ssl_client_hello_write( mbedtls_ssl_context* ssl,
 
 #if defined(MBEDTLS_SSL_SERVER_NAME_INDICATION)
     /* For PSK-based ciphersuites we don't really need the SNI extension */
-    if( ssl->conf->key_exchange_modes == MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_ECDHE_ECDSA ||
-        ssl->conf->key_exchange_modes == MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_ALL ) {
+    if( mbedtls_ssl_conf_tls13_pure_ecdhe_enabled( ssl ) )
+    {
         ssl_write_hostname_ext( ssl, buf, end, &cur_ext_len );
         total_ext_len += cur_ext_len;
         buf += cur_ext_len;
@@ -1927,11 +1927,8 @@ static int ssl_client_hello_write( mbedtls_ssl_context* ssl,
     /* The supported_groups and the key_share extensions are
      * REQUIRED for ECDHE ciphersuites.
      */
-    if( ssl->conf->key_exchange_modes == MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_ECDHE_ECDSA ||
-        ssl->conf->key_exchange_modes == MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_DHE_KE ||
-        ssl->conf->key_exchange_modes == MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_ALL ||
-        ssl->conf->key_exchange_modes == MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_ALL ) {
-
+    if( mbedtls_ssl_conf_tls13_some_ecdhe_enabled( ssl ) )
+    {
         ret = ssl_write_supported_groups_ext( ssl, buf, end, &cur_ext_len );
         total_ext_len += cur_ext_len;
         buf += cur_ext_len;
@@ -1943,8 +1940,8 @@ static int ssl_client_hello_write( mbedtls_ssl_context* ssl,
      * certificate authenticated ciphersuites.
      */
 
-    if( ssl->conf->key_exchange_modes == MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_ECDHE_ECDSA ||
-        ssl->conf->key_exchange_modes == MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_ALL ) {
+    if( mbedtls_ssl_conf_tls13_pure_psk_enabled( ssl ) )
+    {
         ret = mbedtls_ssl_write_signature_algorithms_ext( ssl, buf, end, &cur_ext_len );
         total_ext_len += cur_ext_len;
         buf += cur_ext_len;
@@ -1958,9 +1955,8 @@ static int ssl_client_hello_write( mbedtls_ssl_context* ssl,
      *    psk_key_exchange_modes has been added as the last extension.
      * 3 ) Or, in case all ciphers are supported ( which includes #1 and #2 from above )
      */
-    if( ssl->conf->key_exchange_modes == MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_DHE_KE ||
-        ssl->conf->key_exchange_modes == MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_ALL ||
-        ssl->conf->key_exchange_modes == MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_ALL ) {
+    if( mbedtls_ssl_conf_tls13_some_ecdhe_enabled( ssl ) )
+    {
         /* We are using a PSK-based key exchange with DHE */
         ret = ssl_write_key_shares_ext( ssl, buf, end, &cur_ext_len );
         total_ext_len += cur_ext_len;
@@ -1982,11 +1978,8 @@ static int ssl_client_hello_write( mbedtls_ssl_context* ssl,
 
 #if defined(MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED)
 
-    if( ssl->conf->key_exchange_modes == MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_ALL ||
-        ssl->conf->key_exchange_modes == MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_KE ||
-        ssl->conf->key_exchange_modes == MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_DHE_KE ||
-        ssl->conf->key_exchange_modes == MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_ALL ) {
-
+    if( mbedtls_ssl_conf_tls13_some_psk_enabled( ssl ) )
+    {
         /* We need to save the pointer to the pre-shared key extension
          * because it has to be updated later.
          */

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -4837,7 +4837,7 @@ int mbedtls_ssl_conf_client_ticket( const mbedtls_ssl_context *ssl,
      * TBD: Ideally, the application developer should have the option
      * to decide between plain PSK-KE and PSK-KE-DH
      */
-    ret = mbedtls_ssl_conf_ke( conf, 0 );
+    ret = mbedtls_ssl_conf_tls13_key_exchange( conf, 0 );
     if( ret != 0 )
         return( ret );
 

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -4833,14 +4833,6 @@ int mbedtls_ssl_conf_client_ticket( const mbedtls_ssl_context *ssl,
     if( ret != 0 )
         return( ret );
 
-    /* Set the key exchange mode to PSK
-     * TBD: Ideally, the application developer should have the option
-     * to decide between plain PSK-KE and PSK-KE-DH
-     */
-    ret = mbedtls_ssl_conf_tls13_key_exchange( conf, 0 );
-    if( ret != 0 )
-        return( ret );
-
     /* We set the ticket_age_add and the time we received the ticket */
 #if defined(MBEDTLS_HAVE_TIME)
     ret = mbedtls_ssl_conf_ticket_meta( conf,

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -4828,7 +4828,7 @@ int mbedtls_ssl_conf_client_ticket( const mbedtls_ssl_context *ssl,
 
     /* Set the psk and psk_identity */
     ret = mbedtls_ssl_conf_psk( conf, ticket->key, ticket->key_len,
-                                ( const unsigned char * )ticket->ticket,
+                                (const unsigned char *)ticket->ticket,
                                 ticket->ticket_len );
     if( ret != 0 )
         return( ret );
@@ -4843,7 +4843,9 @@ int mbedtls_ssl_conf_client_ticket( const mbedtls_ssl_context *ssl,
 
     /* We set the ticket_age_add and the time we received the ticket */
 #if defined(MBEDTLS_HAVE_TIME)
-    ret = mbedtls_ssl_conf_ticket_meta( conf, ticket->ticket_age_add, ticket->start );
+    ret = mbedtls_ssl_conf_ticket_meta( conf,
+                                        ticket->ticket_age_add,
+                                        ticket->start );
 #else
     ret = mbedtls_ssl_conf_ticket_meta( conf, ticket->ticket_age_add );
 #endif /* MBEDTLS_HAVE_TIME */

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -1395,13 +1395,13 @@ static int ssl_parse_max_fragment_length_ext( mbedtls_ssl_context *ssl,
  */
 
 static int ssl_parse_key_exchange_modes_ext( mbedtls_ssl_context *ssl,
-                                            const unsigned char *buf,
-                                            size_t len )
+                                             const unsigned char *buf,
+                                             size_t len )
 {
     int ret = 0;
 
     /* Length has to be either 1 or 2 based on the currently defined psk key exchange modes */
-    if( len < 2 || len >3 )
+    if( len < 2 || len > 3 )
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "bad psk key exchange modes extension in client hello message" ) );
         return( MBEDTLS_ERR_SSL_BAD_HS_CLIENT_HELLO );
@@ -1410,27 +1410,39 @@ static int ssl_parse_key_exchange_modes_ext( mbedtls_ssl_context *ssl,
     /* We check for the allowed combinations and set the key_exchange_modes variable accordingly */
     if( buf[0] == 2 )
     {
-        if( ( buf[1] == MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_KE || buf[1] == MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_DHE_KE ) &&
-            ( buf[2] == MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_KE || buf[2] == MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_DHE_KE ) ) {
-            ssl->session_negotiate->key_exchange_modes = MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_ALL;
+        if( ( buf[1] == MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_KE ||
+              buf[1] == MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_DHE_KE ) &&
+            ( buf[2] == MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_KE ||
+              buf[2] == MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_DHE_KE ) )
+        {
+            ssl->session_negotiate->key_exchange_modes =
+                MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_ALL;
         }
-        else ret = MBEDTLS_ERR_SSL_BAD_HS_CLIENT_HELLO;
+        else
+        {
+            ret = MBEDTLS_ERR_SSL_BAD_HS_CLIENT_HELLO;
+        }
     }
     else if( buf[0] == 1 )
     {
         switch ( buf[1] )
         {
             case 0:
-                ssl->session_negotiate->key_exchange_modes = MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_KE;
+                ssl->session_negotiate->key_exchange_modes =
+                    MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_KE;
                 break;
             case 1:
-                ssl->session_negotiate->key_exchange_modes = MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_DHE_KE;
+                ssl->session_negotiate->key_exchange_modes =
+                    MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_DHE_KE;
                 break;
             default:
                 ret = MBEDTLS_ERR_SSL_BAD_HS_CLIENT_HELLO;
         }
     }
-    else ret = MBEDTLS_ERR_SSL_BAD_HS_CLIENT_HELLO;
+    else
+    {
+        ret = MBEDTLS_ERR_SSL_BAD_HS_CLIENT_HELLO;
+    }
 
     if( ret != 0 )
     {
@@ -2849,34 +2861,58 @@ static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
     /* List all the extensions we have received */
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "Supported Extensions:" ) );
-    MBEDTLS_SSL_DEBUG_MSG( 3, ( "- KEY_SHARE_EXTENSION ( %s )", ( ( ssl->handshake->extensions_present & KEY_SHARE_EXTENSION ) > 0 ) ? "TRUE" : "FALSE" ) );
-    MBEDTLS_SSL_DEBUG_MSG( 3, ( "- PSK_KEY_EXCHANGE_MODES_EXTENSION ( %s )", ( ( ssl->handshake->extensions_present & PSK_KEY_EXCHANGE_MODES_EXTENSION ) > 0 ) ? "TRUE" : "FALSE" ) );
-    MBEDTLS_SSL_DEBUG_MSG( 3, ( "- PRE_SHARED_KEY_EXTENSION ( %s )", ( ( ssl->handshake->extensions_present & PRE_SHARED_KEY_EXTENSION ) > 0 ) ? "TRUE" : "FALSE" ) );
-    MBEDTLS_SSL_DEBUG_MSG( 3, ( "- SIGNATURE_ALGORITHM_EXTENSION ( %s )", ( ( ssl->handshake->extensions_present & SIGNATURE_ALGORITHM_EXTENSION ) >0 ) ? "TRUE" : "FALSE" ) );
-    MBEDTLS_SSL_DEBUG_MSG( 3, ( "- SUPPORTED_GROUPS_EXTENSION ( %s )", ( ( ssl->handshake->extensions_present & SUPPORTED_GROUPS_EXTENSION ) >0 ) ? "TRUE" : "FALSE" ) );
-    MBEDTLS_SSL_DEBUG_MSG( 3, ( "- SUPPORTED_VERSION_EXTENSION ( %s )", ( ( ssl->handshake->extensions_present & SUPPORTED_VERSION_EXTENSION ) > 0 ) ? "TRUE" : "FALSE" ) );
+    MBEDTLS_SSL_DEBUG_MSG( 3, ( "- KEY_SHARE_EXTENSION ( %s )",
+                                ( ( ssl->handshake->extensions_present & KEY_SHARE_EXTENSION ) > 0 ) ?
+                                "TRUE" : "FALSE" ) );
+    MBEDTLS_SSL_DEBUG_MSG( 3, ( "- PSK_KEY_EXCHANGE_MODES_EXTENSION ( %s )",
+                                ( ( ssl->handshake->extensions_present & PSK_KEY_EXCHANGE_MODES_EXTENSION ) > 0 ) ?
+                                "TRUE" : "FALSE" ) );
+    MBEDTLS_SSL_DEBUG_MSG( 3, ( "- PRE_SHARED_KEY_EXTENSION ( %s )",
+                                ( ( ssl->handshake->extensions_present & PRE_SHARED_KEY_EXTENSION ) > 0 ) ?
+                                "TRUE" : "FALSE" ) );
+    MBEDTLS_SSL_DEBUG_MSG( 3, ( "- SIGNATURE_ALGORITHM_EXTENSION ( %s )",
+                                ( ( ssl->handshake->extensions_present & SIGNATURE_ALGORITHM_EXTENSION ) > 0 ) ?
+                                "TRUE" : "FALSE" ) );
+    MBEDTLS_SSL_DEBUG_MSG( 3, ( "- SUPPORTED_GROUPS_EXTENSION ( %s )",
+                                ( ( ssl->handshake->extensions_present & SUPPORTED_GROUPS_EXTENSION ) >0 ) ?
+                                "TRUE" : "FALSE" ) );
+    MBEDTLS_SSL_DEBUG_MSG( 3, ( "- SUPPORTED_VERSION_EXTENSION ( %s )",
+                                ( ( ssl->handshake->extensions_present & SUPPORTED_VERSION_EXTENSION ) > 0 ) ?
+                                "TRUE" : "FALSE" ) );
 #if defined(MBEDTLS_CID)
-    MBEDTLS_SSL_DEBUG_MSG( 3, ( "- CID_EXTENSION  ( %s )", ( ( ssl->handshake->extensions_present & CID_EXTENSION ) > 0 ) ? "TRUE" : "FALSE" ) );
+    MBEDTLS_SSL_DEBUG_MSG( 3, ( "- CID_EXTENSION  ( %s )",
+                                ( ( ssl->handshake->extensions_present & CID_EXTENSION ) > 0 ) ?
+                                "TRUE" : "FALSE" ) );
 #endif /* MBEDTLS_CID */
 #if defined ( MBEDTLS_SSL_SERVER_NAME_INDICATION )
-    MBEDTLS_SSL_DEBUG_MSG( 3, ( "- SERVERNAME_EXTENSION    ( %s )", ( ( ssl->handshake->extensions_present & SERVERNAME_EXTENSION ) > 0 ) ? "TRUE" : "FALSE" ) );
+    MBEDTLS_SSL_DEBUG_MSG( 3, ( "- SERVERNAME_EXTENSION    ( %s )",
+                                ( ( ssl->handshake->extensions_present & SERVERNAME_EXTENSION ) > 0 ) ?
+                                "TRUE" : "FALSE" ) );
 #endif /* MBEDTLS_SSL_SERVER_NAME_INDICATION */
 #if defined ( MBEDTLS_SSL_ALPN )
-    MBEDTLS_SSL_DEBUG_MSG( 3, ( "- ALPN_EXTENSION   ( %s )", ( ( ssl->handshake->extensions_present & ALPN_EXTENSION ) > 0 ) ? "TRUE" : "FALSE" ) );
+    MBEDTLS_SSL_DEBUG_MSG( 3, ( "- ALPN_EXTENSION   ( %s )",
+                                ( ( ssl->handshake->extensions_present & ALPN_EXTENSION ) > 0 ) ?
+                                "TRUE" : "FALSE" ) );
 #endif /* MBEDTLS_SSL_ALPN */
 #if defined ( MBEDTLS_SSL_MAX_FRAGMENT_LENGTH )
-    MBEDTLS_SSL_DEBUG_MSG( 3, ( "- MAX_FRAGMENT_LENGTH_EXTENSION  ( %s )", ( ( ssl->handshake->extensions_present & MAX_FRAGMENT_LENGTH_EXTENSION ) > 0 ) ? "TRUE" : "FALSE" ) );
+    MBEDTLS_SSL_DEBUG_MSG( 3, ( "- MAX_FRAGMENT_LENGTH_EXTENSION  ( %s )",
+                                ( ( ssl->handshake->extensions_present & MAX_FRAGMENT_LENGTH_EXTENSION ) > 0 ) ?
+                                "TRUE" : "FALSE" ) );
 #endif /* MBEDTLS_SSL_MAX_FRAGMENT_LENGTH */
 #if defined ( MBEDTLS_SSL_COOKIE_C )
-    MBEDTLS_SSL_DEBUG_MSG( 3, ( "- COOKIE_EXTENSION ( %s )", ( ( ssl->handshake->extensions_present & COOKIE_EXTENSION ) >0 ) ? "TRUE" : "FALSE" ) );
+    MBEDTLS_SSL_DEBUG_MSG( 3, ( "- COOKIE_EXTENSION ( %s )",
+                                ( ( ssl->handshake->extensions_present & COOKIE_EXTENSION ) >0 ) ?
+                                "TRUE" : "FALSE" ) );
 #endif /* MBEDTLS_SSL_COOKIE_C */
 #if defined(MBEDTLS_ZERO_RTT)
-    MBEDTLS_SSL_DEBUG_MSG( 3, ( "- EARLY_DATA_EXTENSION ( %s )", ( ( ssl->handshake->extensions_present & EARLY_DATA_EXTENSION ) >0 ) ? "TRUE" : "FALSE" ) );
+    MBEDTLS_SSL_DEBUG_MSG( 3, ( "- EARLY_DATA_EXTENSION ( %s )",
+                                ( ( ssl->handshake->extensions_present & EARLY_DATA_EXTENSION ) > 0 ) ?
+                                "TRUE" : "FALSE" ) );
 #endif /* MBEDTLS_ZERO_RTT*/
 
 /* Determine key exchange algorithm to use. There are three types of key exchanges
- * supported in TLS 1.3, namely ( EC )DH with ECDSA, ( EC )DH with PSK, and plain PSK.
- * Additionally, we need to consider the ZeroRTT exchange as well.
+ * supported in TLS 1.3, namely (EC)DH with ECDSA, (EC)DH with PSK, and plain PSK.
+ * Additionally, we need to consider the 0-RTT exchange as well.
  */
 
 #if defined(MBEDTLS_ZERO_RTT)
@@ -3096,7 +3132,8 @@ static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
     }
 #endif /* MBEDTLS_SSL_COOKIE_C */
 
-    if( final_ret == MBEDTLS_ERR_SSL_BAD_HS_WRONG_KEY_SHARE || final_ret == MBEDTLS_ERR_SSL_BAD_HS_MISSING_COOKIE_EXT )
+    if( final_ret == MBEDTLS_ERR_SSL_BAD_HS_WRONG_KEY_SHARE ||
+        final_ret == MBEDTLS_ERR_SSL_BAD_HS_MISSING_COOKIE_EXT )
     {
         /* create stateless transcript hash for HRR */
 

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -2284,6 +2284,59 @@ read_record_header:
     return( 0 );
 }
 
+static void ssl_debug_print_client_hello_exts( mbedtls_ssl_context *ssl )
+{
+    MBEDTLS_SSL_DEBUG_MSG( 3, ( "Supported Extensions:" ) );
+    MBEDTLS_SSL_DEBUG_MSG( 3, ( "- KEY_SHARE_EXTENSION ( %s )",
+                                ( ( ssl->handshake->extensions_present & KEY_SHARE_EXTENSION ) > 0 ) ?
+                                "TRUE" : "FALSE" ) );
+    MBEDTLS_SSL_DEBUG_MSG( 3, ( "- PSK_KEY_EXCHANGE_MODES_EXTENSION ( %s )",
+                                ( ( ssl->handshake->extensions_present & PSK_KEY_EXCHANGE_MODES_EXTENSION ) > 0 ) ?
+                                "TRUE" : "FALSE" ) );
+    MBEDTLS_SSL_DEBUG_MSG( 3, ( "- PRE_SHARED_KEY_EXTENSION ( %s )",
+                                ( ( ssl->handshake->extensions_present & PRE_SHARED_KEY_EXTENSION ) > 0 ) ?
+                                "TRUE" : "FALSE" ) );
+    MBEDTLS_SSL_DEBUG_MSG( 3, ( "- SIGNATURE_ALGORITHM_EXTENSION ( %s )",
+                                ( ( ssl->handshake->extensions_present & SIGNATURE_ALGORITHM_EXTENSION ) > 0 ) ?
+                                "TRUE" : "FALSE" ) );
+    MBEDTLS_SSL_DEBUG_MSG( 3, ( "- SUPPORTED_GROUPS_EXTENSION ( %s )",
+                                ( ( ssl->handshake->extensions_present & SUPPORTED_GROUPS_EXTENSION ) >0 ) ?
+                                "TRUE" : "FALSE" ) );
+    MBEDTLS_SSL_DEBUG_MSG( 3, ( "- SUPPORTED_VERSION_EXTENSION ( %s )",
+                                ( ( ssl->handshake->extensions_present & SUPPORTED_VERSION_EXTENSION ) > 0 ) ?
+                                "TRUE" : "FALSE" ) );
+#if defined(MBEDTLS_CID)
+    MBEDTLS_SSL_DEBUG_MSG( 3, ( "- CID_EXTENSION  ( %s )",
+                                ( ( ssl->handshake->extensions_present & CID_EXTENSION ) > 0 ) ?
+                                "TRUE" : "FALSE" ) );
+#endif /* MBEDTLS_CID */
+#if defined ( MBEDTLS_SSL_SERVER_NAME_INDICATION )
+    MBEDTLS_SSL_DEBUG_MSG( 3, ( "- SERVERNAME_EXTENSION    ( %s )",
+                                ( ( ssl->handshake->extensions_present & SERVERNAME_EXTENSION ) > 0 ) ?
+                                "TRUE" : "FALSE" ) );
+#endif /* MBEDTLS_SSL_SERVER_NAME_INDICATION */
+#if defined ( MBEDTLS_SSL_ALPN )
+    MBEDTLS_SSL_DEBUG_MSG( 3, ( "- ALPN_EXTENSION   ( %s )",
+                                ( ( ssl->handshake->extensions_present & ALPN_EXTENSION ) > 0 ) ?
+                                "TRUE" : "FALSE" ) );
+#endif /* MBEDTLS_SSL_ALPN */
+#if defined ( MBEDTLS_SSL_MAX_FRAGMENT_LENGTH )
+    MBEDTLS_SSL_DEBUG_MSG( 3, ( "- MAX_FRAGMENT_LENGTH_EXTENSION  ( %s )",
+                                ( ( ssl->handshake->extensions_present & MAX_FRAGMENT_LENGTH_EXTENSION ) > 0 ) ?
+                                "TRUE" : "FALSE" ) );
+#endif /* MBEDTLS_SSL_MAX_FRAGMENT_LENGTH */
+#if defined ( MBEDTLS_SSL_COOKIE_C )
+    MBEDTLS_SSL_DEBUG_MSG( 3, ( "- COOKIE_EXTENSION ( %s )",
+                                ( ( ssl->handshake->extensions_present & COOKIE_EXTENSION ) >0 ) ?
+                                "TRUE" : "FALSE" ) );
+#endif /* MBEDTLS_SSL_COOKIE_C */
+#if defined(MBEDTLS_ZERO_RTT)
+    MBEDTLS_SSL_DEBUG_MSG( 3, ( "- EARLY_DATA_EXTENSION ( %s )",
+                                ( ( ssl->handshake->extensions_present & EARLY_DATA_EXTENSION ) > 0 ) ?
+                                "TRUE" : "FALSE" ) );
+#endif /* MBEDTLS_ZERO_RTT*/
+}
+
 static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
                                   unsigned char* buf,
                                   size_t buflen )
@@ -2840,56 +2893,7 @@ static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
     ssl->handshake->ciphersuite_info = ciphersuite_info;
 
     /* List all the extensions we have received */
-
-    MBEDTLS_SSL_DEBUG_MSG( 3, ( "Supported Extensions:" ) );
-    MBEDTLS_SSL_DEBUG_MSG( 3, ( "- KEY_SHARE_EXTENSION ( %s )",
-                                ( ( ssl->handshake->extensions_present & KEY_SHARE_EXTENSION ) > 0 ) ?
-                                "TRUE" : "FALSE" ) );
-    MBEDTLS_SSL_DEBUG_MSG( 3, ( "- PSK_KEY_EXCHANGE_MODES_EXTENSION ( %s )",
-                                ( ( ssl->handshake->extensions_present & PSK_KEY_EXCHANGE_MODES_EXTENSION ) > 0 ) ?
-                                "TRUE" : "FALSE" ) );
-    MBEDTLS_SSL_DEBUG_MSG( 3, ( "- PRE_SHARED_KEY_EXTENSION ( %s )",
-                                ( ( ssl->handshake->extensions_present & PRE_SHARED_KEY_EXTENSION ) > 0 ) ?
-                                "TRUE" : "FALSE" ) );
-    MBEDTLS_SSL_DEBUG_MSG( 3, ( "- SIGNATURE_ALGORITHM_EXTENSION ( %s )",
-                                ( ( ssl->handshake->extensions_present & SIGNATURE_ALGORITHM_EXTENSION ) > 0 ) ?
-                                "TRUE" : "FALSE" ) );
-    MBEDTLS_SSL_DEBUG_MSG( 3, ( "- SUPPORTED_GROUPS_EXTENSION ( %s )",
-                                ( ( ssl->handshake->extensions_present & SUPPORTED_GROUPS_EXTENSION ) >0 ) ?
-                                "TRUE" : "FALSE" ) );
-    MBEDTLS_SSL_DEBUG_MSG( 3, ( "- SUPPORTED_VERSION_EXTENSION ( %s )",
-                                ( ( ssl->handshake->extensions_present & SUPPORTED_VERSION_EXTENSION ) > 0 ) ?
-                                "TRUE" : "FALSE" ) );
-#if defined(MBEDTLS_CID)
-    MBEDTLS_SSL_DEBUG_MSG( 3, ( "- CID_EXTENSION  ( %s )",
-                                ( ( ssl->handshake->extensions_present & CID_EXTENSION ) > 0 ) ?
-                                "TRUE" : "FALSE" ) );
-#endif /* MBEDTLS_CID */
-#if defined ( MBEDTLS_SSL_SERVER_NAME_INDICATION )
-    MBEDTLS_SSL_DEBUG_MSG( 3, ( "- SERVERNAME_EXTENSION    ( %s )",
-                                ( ( ssl->handshake->extensions_present & SERVERNAME_EXTENSION ) > 0 ) ?
-                                "TRUE" : "FALSE" ) );
-#endif /* MBEDTLS_SSL_SERVER_NAME_INDICATION */
-#if defined ( MBEDTLS_SSL_ALPN )
-    MBEDTLS_SSL_DEBUG_MSG( 3, ( "- ALPN_EXTENSION   ( %s )",
-                                ( ( ssl->handshake->extensions_present & ALPN_EXTENSION ) > 0 ) ?
-                                "TRUE" : "FALSE" ) );
-#endif /* MBEDTLS_SSL_ALPN */
-#if defined ( MBEDTLS_SSL_MAX_FRAGMENT_LENGTH )
-    MBEDTLS_SSL_DEBUG_MSG( 3, ( "- MAX_FRAGMENT_LENGTH_EXTENSION  ( %s )",
-                                ( ( ssl->handshake->extensions_present & MAX_FRAGMENT_LENGTH_EXTENSION ) > 0 ) ?
-                                "TRUE" : "FALSE" ) );
-#endif /* MBEDTLS_SSL_MAX_FRAGMENT_LENGTH */
-#if defined ( MBEDTLS_SSL_COOKIE_C )
-    MBEDTLS_SSL_DEBUG_MSG( 3, ( "- COOKIE_EXTENSION ( %s )",
-                                ( ( ssl->handshake->extensions_present & COOKIE_EXTENSION ) >0 ) ?
-                                "TRUE" : "FALSE" ) );
-#endif /* MBEDTLS_SSL_COOKIE_C */
-#if defined(MBEDTLS_ZERO_RTT)
-    MBEDTLS_SSL_DEBUG_MSG( 3, ( "- EARLY_DATA_EXTENSION ( %s )",
-                                ( ( ssl->handshake->extensions_present & EARLY_DATA_EXTENSION ) > 0 ) ?
-                                "TRUE" : "FALSE" ) );
-#endif /* MBEDTLS_ZERO_RTT*/
+    ssl_debug_print_client_hello_exts( ssl );
 
 /* Determine key exchange algorithm to use. There are three types of key exchanges
  * supported in TLS 1.3, namely (EC)DH with ECDSA, (EC)DH with PSK, and plain PSK.

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -2935,7 +2935,7 @@ static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
                     MBEDTLS_SSL_DEBUG_MSG( 3, ( "Using a PSK key exchange" ) );
                     ssl->session_negotiate->key_exchange = MBEDTLS_KEY_EXCHANGE_PSK;
                     ssl->handshake->early_data = MBEDTLS_SSL_EARLY_DATA_ON;
-                    goto end_client_hello;
+                    goto have_key_exchange;
                 }
             }
         }
@@ -2967,7 +2967,7 @@ static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
                     MBEDTLS_SSL_DEBUG_MSG( 3, ( "Using a ECDHE-PSK key exchange" ) );
                     ssl->session_negotiate->key_exchange = MBEDTLS_KEY_EXCHANGE_ECDHE_PSK;
                     ssl->handshake->early_data = MBEDTLS_SSL_EARLY_DATA_ON;
-                    goto end_client_hello;
+                    goto have_key_exchange;
                 }
             }
         }
@@ -3007,7 +3007,7 @@ static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
                 }
                 MBEDTLS_SSL_DEBUG_MSG( 3, ( "Using a PSK key exchange" ) );
                 ssl->session_negotiate->key_exchange = MBEDTLS_KEY_EXCHANGE_PSK;
-                goto end_client_hello;
+                goto have_key_exchange;
             }
         }
     }
@@ -3040,7 +3040,7 @@ static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
 
                 MBEDTLS_SSL_DEBUG_MSG( 3, ( "Using a ECDHE-PSK key exchange" ) );
                 ssl->session_negotiate->key_exchange = MBEDTLS_KEY_EXCHANGE_ECDHE_PSK;
-                goto end_client_hello;
+                goto have_key_exchange;
             }
         }
     }
@@ -3062,7 +3062,7 @@ static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
         {
             MBEDTLS_SSL_DEBUG_MSG( 3, ( "Using a ECDSA-ECDHE key exchange" ) );
             ssl->session_negotiate->key_exchange = MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA;
-            goto end_client_hello;
+            goto have_key_exchange;
         }
     }
 
@@ -3077,7 +3077,7 @@ static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
     if( final_ret == MBEDTLS_ERR_SSL_BAD_HS_WRONG_KEY_SHARE )
         return( MBEDTLS_ERR_SSL_BAD_HS_WRONG_KEY_SHARE );
 
-    end_client_hello:
+    have_key_exchange:
 
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
     if( ssl->conf->transport == MBEDTLS_SSL_TRANSPORT_DATAGRAM )

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -2911,12 +2911,7 @@ static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
             ( ssl->handshake->extensions_present & PSK_KEY_EXCHANGE_MODES_EXTENSION ) )
         {
             /* Test whether we are allowed to use this mode ( server-side check ) */
-            if( ( ssl->conf->key_exchange_modes ==
-                    MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_KE )  ||
-                ( ssl->conf->key_exchange_modes ==
-                    MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_ALL ) ||
-                ( ssl->conf->key_exchange_modes ==
-                    MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_ALL ) )
+            if( mbedtls_ssl_conf_tls13_pure_psk_enabled( ssl ) )
             {
                 /* Test whether we are allowed to use this mode ( client-side check ) */
                 if( ( ssl->session_negotiate->key_exchange_modes ==
@@ -2947,12 +2942,7 @@ static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
             ( ssl->handshake->extensions_present & PSK_KEY_EXCHANGE_MODES_EXTENSION ) )
         {
             /* Test whether we are allowed to use this mode ( server-side check ) */
-            if( ssl->conf->key_exchange_modes ==
-                  MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_DHE_KE ||
-                ssl->conf->key_exchange_modes ==
-                  MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_ALL ||
-                ssl->conf->key_exchange_modes ==
-                MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_ALL )
+            if( mbedtls_ssl_conf_tls13_psk_ecdhe_enabled( ssl ) )
             {
                 /* Test whether we are allowed to use this mode ( client-side check ) */
                 if( ssl->session_negotiate->key_exchange_modes ==
@@ -2996,12 +2986,7 @@ static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
         ( ssl->handshake->extensions_present & PSK_KEY_EXCHANGE_MODES_EXTENSION ) )
     {
         /* Test whether we are allowed to use this mode ( server-side check ) */
-        if( ssl->conf->key_exchange_modes ==
-              MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_KE ||
-            ssl->conf->key_exchange_modes ==
-              MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_ALL ||
-            ssl->conf->key_exchange_modes ==
-              MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_ALL )
+        if( mbedtls_ssl_conf_tls13_pure_psk_enabled( ssl ) )
         {
             /* Test whether we are allowed to use this mode ( client-side check ) */
             if( ssl->session_negotiate->key_exchange_modes ==
@@ -3033,12 +3018,7 @@ static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
         ( ssl->handshake->extensions_present & PSK_KEY_EXCHANGE_MODES_EXTENSION ) )
     {
         /* Test whether we are allowed to use this mode ( server-side check ) */
-        if( ssl->conf->key_exchange_modes ==
-              MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_DHE_KE ||
-            ssl->conf->key_exchange_modes ==
-              MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_ALL    ||
-            ssl->conf->key_exchange_modes ==
-              MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_ALL )
+        if( mbedtls_ssl_conf_tls13_psk_ecdhe_enabled( ssl ) )
         {
             /* Test whether we are allowed to use this mode ( client-side check ) */
             if( ssl->session_negotiate->key_exchange_modes ==

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -2337,6 +2337,118 @@ static void ssl_debug_print_client_hello_exts( mbedtls_ssl_context *ssl )
 #endif /* MBEDTLS_ZERO_RTT*/
 }
 
+static int ssl_client_hello_has_psk_extensions( mbedtls_ssl_context *ssl )
+{
+    if( ( ssl->handshake->extensions_present & PRE_SHARED_KEY_EXTENSION ) &&
+        ( ssl->handshake->extensions_present & PSK_KEY_EXCHANGE_MODES_EXTENSION ) )
+    {
+        return( 1 );
+    }
+
+    return( 0 );
+}
+
+static int ssl_client_hello_has_cert_extensions( mbedtls_ssl_context *ssl )
+{
+    if( ( ssl->handshake->extensions_present & SUPPORTED_GROUPS_EXTENSION )    &&
+        ( ssl->handshake->extensions_present & SIGNATURE_ALGORITHM_EXTENSION ) &&
+        ( ssl->handshake->extensions_present & KEY_SHARE_EXTENSION ) )
+    {
+        return( 1 );
+    }
+
+    return( 0 );
+}
+
+static int ssl_client_hello_allows_psk_mode( mbedtls_ssl_context *ssl,
+                                             unsigned psk_mode )
+{
+    if( ( ssl->session_negotiate->key_exchange_modes & psk_mode ) != 0 )
+    {
+        return( 1 );
+    }
+
+    return( 0 );
+}
+
+static int ssl_client_hello_allows_pure_psk( mbedtls_ssl_context *ssl )
+{
+    return( ssl_client_hello_allows_psk_mode( ssl,
+                           MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_KE ) );
+}
+
+static int ssl_client_hello_allows_psk_ecdhe( mbedtls_ssl_context *ssl )
+{
+    return( ssl_client_hello_allows_psk_mode( ssl,
+                           MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_DHE_KE ) );
+}
+
+static int ssl_check_psk_key_exchange( mbedtls_ssl_context *ssl )
+{
+    if( !ssl_client_hello_has_psk_extensions( ssl ) )
+        return( 0 );
+
+    /* Test whether pure PSK is offered by client and supported by us. */
+    if( mbedtls_ssl_conf_tls13_pure_psk_enabled( ssl ) &&
+        ssl_client_hello_allows_pure_psk( ssl ) )
+    {
+        MBEDTLS_SSL_DEBUG_MSG( 3, ( "Using a PSK key exchange" ) );
+        ssl->session_negotiate->key_exchange = MBEDTLS_KEY_EXCHANGE_PSK;
+        return( 1 );
+    }
+
+    /* Test whether PSK-ECDHE is offered by client and supported by us. */
+    if( mbedtls_ssl_conf_tls13_psk_ecdhe_enabled( ssl ) &&
+        ssl_client_hello_allows_psk_ecdhe( ssl ) )
+    {
+        MBEDTLS_SSL_DEBUG_MSG( 3, ( "Using a ECDHE-PSK key exchange" ) );
+        ssl->session_negotiate->key_exchange = MBEDTLS_KEY_EXCHANGE_ECDHE_PSK;
+        return( 1 );
+    }
+
+    /* Can't use PSK */
+    return( 0 );
+}
+
+static int ssl_check_certificate_key_exchange( mbedtls_ssl_context *ssl )
+{
+    if( !mbedtls_ssl_conf_tls13_pure_ecdhe_enabled( ssl ) )
+        return( 0 );
+
+    if( !ssl_client_hello_has_cert_extensions( ssl ) )
+        return( 0 );
+
+    ssl->session_negotiate->key_exchange = MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA;
+    return( 1 );
+}
+
+#if defined(MBEDTLS_ZERO_RTT)
+static int ssl_check_use_0rtt_handshake( mbedtls_ssl_context *ssl )
+{
+    /* Check if the user has enabled 0-RTT in the config */
+    if( !mbedtls_ssl_conf_tls13_0rtt_enabled( ssl ) )
+        return( 0 );
+
+    /* Check if the client has indicated the use of 0-RTT */
+    if( ( ssl->handshake->extensions_present & EARLY_DATA_EXTENSION ) == 0 )
+        return( 0 );
+
+    /* If the client has indicated the use of 0-RTT but not sent
+     * the PSK extensions, that's not conformant (and there's no
+     * way to continue from here). */
+    if( !ssl_client_hello_has_psk_extensions( ssl ) )
+    {
+        MBEDTLS_SSL_DEBUG_MSG( 1,
+            ( "Client indicated 0-RTT without offering PSK extensions" ) );
+        return( MBEDTLS_ERR_SSL_BAD_HS_CLIENT_HELLO );
+    }
+
+    /* Accept 0-RTT */
+    ssl->handshake->early_data = MBEDTLS_SSL_EARLY_DATA_ON;
+    return( 0 );
+}
+#endif /* MBEDTLS_ZERO_RTT*/
+
 static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
                                   unsigned char* buf,
                                   size_t buflen )
@@ -2895,189 +3007,49 @@ static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
     /* List all the extensions we have received */
     ssl_debug_print_client_hello_exts( ssl );
 
-/* Determine key exchange algorithm to use. There are three types of key exchanges
- * supported in TLS 1.3, namely (EC)DH with ECDSA, (EC)DH with PSK, and plain PSK.
- * Additionally, we need to consider the 0-RTT exchange as well.
- */
+    /*
+     * Determine the key exchange algorithm to use.
+     * There are three types of key exchanges supported in TLS 1.3:
+     * - (EC)DH with ECDSA,
+     * - (EC)DH with PSK,
+     * - plain PSK.
+     *
+     * The PSK-based key exchanges may additionally be used with 0-RTT.
+     *
+     * Our built-in order of preference is
+     *  1 ) Plain PSK Mode
+     *  2 ) (EC)DHE-PSK Mode
+     *  3 ) Certificate Mode
+     */
+
+    ssl->session_negotiate->key_exchange = 0;
+
+    if( !ssl_check_psk_key_exchange( ssl ) &&
+        !ssl_check_certificate_key_exchange( ssl ) )
+    {
+        MBEDTLS_SSL_DEBUG_MSG( 1, ( "ClientHello message misses mandatory extensions." ) );
+        return( MBEDTLS_ERR_SSL_BAD_HS_MISSING_EXTENSION_EXT );
+    }
 
 #if defined(MBEDTLS_ZERO_RTT)
-    /*
-     * 0 ) Zero-RTT Exchange / Early Data
-     *    It requires early_data extension, at least key_exchange_modes and
-     *    the pre_shared_key extension. It may additionally provide key share
-     *    and supported_groups.
-     */
-    if( ssl->handshake->extensions_present & EARLY_DATA_EXTENSION )
+    ret = ssl_check_use_0rtt_handshake( ssl );
+    if( ret != 0 )
+        return( ret );
+#endif /* MBEDTLS_ZERO_RTT */
+
+    /* If we've settled on a PSK-based exchange, parse PSK identity ext */
+    if( mbedtls_ssl_tls13_key_exchange_with_psk( ssl ) )
     {
-        /* Pure PSK mode */
-        if( ( ssl->conf->early_data == MBEDTLS_SSL_EARLY_DATA_ENABLED ) &&
-            ( ssl->handshake->extensions_present & PRE_SHARED_KEY_EXTENSION ) &&
-            ( ssl->handshake->extensions_present & PSK_KEY_EXCHANGE_MODES_EXTENSION ) )
+        ret = mbedtls_ssl_parse_client_psk_identity_ext( ssl,
+                                                         ext_psk_ptr,
+                                                         ext_len_psk_ext );
+        if( ret != 0 )
         {
-            /* Test whether we are allowed to use this mode ( server-side check ) */
-            if( mbedtls_ssl_conf_tls13_pure_psk_enabled( ssl ) )
-            {
-                /* Test whether we are allowed to use this mode ( client-side check ) */
-                if( ( ssl->session_negotiate->key_exchange_modes ==
-                        MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_KE ) ||
-                    ( ssl->session_negotiate->key_exchange_modes ==
-                        MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_ALL ) )
-                {
-                    ret = mbedtls_ssl_parse_client_psk_identity_ext( ssl,
-                            ext_psk_ptr,
-                            ext_len_psk_ext );
-                    if( ret != 0 )
-                    {
-                        MBEDTLS_SSL_DEBUG_RET( 1, ( "ssl_parse_client_psk_identity" ),
-                                               ret );
-                        return( ret );
-                    }
-                    MBEDTLS_SSL_DEBUG_MSG( 3, ( "Using a PSK key exchange" ) );
-                    ssl->session_negotiate->key_exchange = MBEDTLS_KEY_EXCHANGE_PSK;
-                    ssl->handshake->early_data = MBEDTLS_SSL_EARLY_DATA_ON;
-                    goto have_key_exchange;
-                }
-            }
-        }
-        /* ECDHE-PSK mode */
-        if( ( ssl->conf->early_data == MBEDTLS_SSL_EARLY_DATA_ENABLED )       &&
-            ( ssl->handshake->extensions_present & PRE_SHARED_KEY_EXTENSION ) &&
-            ( ssl->handshake->extensions_present & KEY_SHARE_EXTENSION )      &&
-            ( ssl->handshake->extensions_present & PSK_KEY_EXCHANGE_MODES_EXTENSION ) )
-        {
-            /* Test whether we are allowed to use this mode ( server-side check ) */
-            if( mbedtls_ssl_conf_tls13_psk_ecdhe_enabled( ssl ) )
-            {
-                /* Test whether we are allowed to use this mode ( client-side check ) */
-                if( ssl->session_negotiate->key_exchange_modes ==
-                      MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_DHE_KE ||
-                    ssl->session_negotiate->key_exchange_modes ==
-                      MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_ALL )
-                {
-                    ret = mbedtls_ssl_parse_client_psk_identity_ext( ssl,
-                            ext_psk_ptr,
-                            ext_len_psk_ext );
-                    if( ret != 0 )
-                    {
-                        MBEDTLS_SSL_DEBUG_RET( 1, ( "ssl_parse_client_psk_identity" ),
-                                               ret );
-                        return( ret );
-                    }
-
-                    MBEDTLS_SSL_DEBUG_MSG( 3, ( "Using a ECDHE-PSK key exchange" ) );
-                    ssl->session_negotiate->key_exchange = MBEDTLS_KEY_EXCHANGE_ECDHE_PSK;
-                    ssl->handshake->early_data = MBEDTLS_SSL_EARLY_DATA_ON;
-                    goto have_key_exchange;
-                }
-            }
+            MBEDTLS_SSL_DEBUG_RET( 1, ( "ssl_parse_client_psk_identity" ),
+                                   ret );
+            return( ret );
         }
     }
-#endif /* MBEDTLS_ZERO_RTT*/
-
-    /* The order of preference is
-     *  1 ) Plain PSK Mode
-     *  2 ) ( EC )DHE-PSK Mode
-     *  3 ) Certificate Mode
-     *
-     * Currently, the preference order is hard-coded - not configurable.
-     */
-    /*
-     * 1 ) Plain PSK-based key exchange
-     *    Requires key_exchange_modes and the pre_shared_key extension
-     *
-     */
-    if( ( ssl->handshake->extensions_present & PRE_SHARED_KEY_EXTENSION ) &&
-        ( ssl->handshake->extensions_present & PSK_KEY_EXCHANGE_MODES_EXTENSION ) )
-    {
-        /* Test whether we are allowed to use this mode ( server-side check ) */
-        if( mbedtls_ssl_conf_tls13_pure_psk_enabled( ssl ) )
-        {
-            /* Test whether we are allowed to use this mode ( client-side check ) */
-            if( ssl->session_negotiate->key_exchange_modes ==
-                  MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_KE   ||
-                ssl->session_negotiate->key_exchange_modes ==
-                  MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_ALL )
-            {
-                if( ( ret = mbedtls_ssl_parse_client_psk_identity_ext( ssl,
-                                ext_psk_ptr,
-                                ext_len_psk_ext ) ) != 0 )
-                {
-                    MBEDTLS_SSL_DEBUG_RET( 1, ( "ssl_parse_client_psk_identity" ), ret );
-                    return( ret );
-                }
-                MBEDTLS_SSL_DEBUG_MSG( 3, ( "Using a PSK key exchange" ) );
-                ssl->session_negotiate->key_exchange = MBEDTLS_KEY_EXCHANGE_PSK;
-                goto have_key_exchange;
-            }
-        }
-    }
-
-    /*
-     * 2 ) ( EC )DHE-PSK-based key exchange
-     *    Requires key share, supported_groups, key_exchange_modes and
-     *    the pre_shared_key extension.
-     */
-    if( ( ssl->handshake->extensions_present & PRE_SHARED_KEY_EXTENSION ) &&
-        ( ssl->handshake->extensions_present & KEY_SHARE_EXTENSION )      &&
-        ( ssl->handshake->extensions_present & PSK_KEY_EXCHANGE_MODES_EXTENSION ) )
-    {
-        /* Test whether we are allowed to use this mode ( server-side check ) */
-        if( mbedtls_ssl_conf_tls13_psk_ecdhe_enabled( ssl ) )
-        {
-            /* Test whether we are allowed to use this mode ( client-side check ) */
-            if( ssl->session_negotiate->key_exchange_modes ==
-                  MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_DHE_KE ||
-                ssl->session_negotiate->key_exchange_modes ==
-                  MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_ALL )
-            {
-                if( ( ret = mbedtls_ssl_parse_client_psk_identity_ext( ssl,
-                                ext_psk_ptr,
-                                ext_len_psk_ext ) ) != 0 )
-                {
-                    MBEDTLS_SSL_DEBUG_RET( 1, ( "ssl_parse_client_psk_identity" ), ret );
-                    return( ret );
-                }
-
-                MBEDTLS_SSL_DEBUG_MSG( 3, ( "Using a ECDHE-PSK key exchange" ) );
-                ssl->session_negotiate->key_exchange = MBEDTLS_KEY_EXCHANGE_ECDHE_PSK;
-                goto have_key_exchange;
-            }
-        }
-    }
-
-    /*
-     * 3 ) Certificate-based key exchange
-     *    It requires supported_groups, supported_signature extensions, and key share
-     *
-     */
-    if( ( ssl->handshake->extensions_present & SUPPORTED_GROUPS_EXTENSION )    &&
-        ( ssl->handshake->extensions_present & SIGNATURE_ALGORITHM_EXTENSION ) &&
-        ( ssl->handshake->extensions_present & KEY_SHARE_EXTENSION ) )
-    {
-        /* Test whether we are allowed to use this mode ( server-side check ) */
-        if( ssl->conf->key_exchange_modes ==
-              MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_ECDHE_ECDSA ||
-            ssl->conf->key_exchange_modes ==
-              MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_ALL )
-        {
-            MBEDTLS_SSL_DEBUG_MSG( 3, ( "Using a ECDSA-ECDHE key exchange" ) );
-            ssl->session_negotiate->key_exchange = MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA;
-            goto have_key_exchange;
-        }
-    }
-
-    if( ssl->session_negotiate->key_exchange == 0 ) {
-      MBEDTLS_SSL_DEBUG_MSG( 1, ( "ClientHello message misses mandatory extensions." ) );
-      return( MBEDTLS_ERR_SSL_BAD_HS_MISSING_EXTENSION_EXT );
-    }
-
-    /* If we previously determined that an HRR is needed then
-     * we will send it now.
-     */
-    if( final_ret == MBEDTLS_ERR_SSL_BAD_HS_WRONG_KEY_SHARE )
-        return( MBEDTLS_ERR_SSL_BAD_HS_WRONG_KEY_SHARE );
-
-    have_key_exchange:
 
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
     if( ssl->conf->transport == MBEDTLS_SSL_TRANSPORT_DATAGRAM )

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -2750,7 +2750,7 @@ int main( int argc, char *argv[] )
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
     // Configure key exchange mode
-    mbedtls_ssl_conf_ke( &conf, opt.key_exchange_modes );
+    mbedtls_ssl_conf_tls13_key_exchange( &conf, opt.key_exchange_modes );
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 
 #if defined(MBEDTLS_DHM_C)

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -3929,7 +3929,7 @@ int main( int argc, char *argv[] )
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
     /* Configure supported TLS 1.3 key exchange modes. */
-    mbedtls_ssl_conf_ke(&conf, opt.key_exchange_modes);
+    mbedtls_ssl_conf_tls13_key_exchange(&conf, opt.key_exchange_modes);
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 
 #if defined(MBEDTLS_DHM_C)

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -1328,7 +1328,7 @@ requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL
 requires_config_enabled MBEDTLS_DEBUG_C
 run_test    "TLS 1.3, TLS_AES_128_CCM_SHA256, ECDHE-ECDSA, CLI+SRV auth, with ticket" \
             "$P_SRV debug_level=5 force_version=tls1_3 auth_mode=required key_exchange_modes=all tickets=1" \
-            "$P_CLI debug_level=5 force_version=tls1_3 server_name=localhost force_ciphersuite=TLS_AES_128_CCM_SHA256 key_exchange_modes=ecdhe_ecdsa reconnect=1 tickets=1" \
+            "$P_CLI debug_level=5 force_version=tls1_3 server_name=localhost force_ciphersuite=TLS_AES_128_CCM_SHA256 key_exchange_modes=all reconnect=1 tickets=1" \
             0 \
 	    -s "Verifying peer X.509 certificate... ok"                          \
 	    -s "subject name      : C=NL, O=PolarSSL, CN=PolarSSL Test Client 2" \
@@ -1346,7 +1346,7 @@ requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL
 requires_config_enabled MBEDTLS_DEBUG_C
 run_test    "TLS 1.3, TLS_AES_128_GCM_SHA256, ECDHE-ECDSA, CLI+SRV auth, with ticket" \
             "$P_SRV debug_level=5 force_version=tls1_3 auth_mode=required key_exchange_modes=all tickets=1" \
-            "$P_CLI debug_level=5 force_version=tls1_3 server_name=localhost force_ciphersuite=TLS_AES_128_GCM_SHA256 key_exchange_modes=ecdhe_ecdsa reconnect=1 tickets=1" \
+            "$P_CLI debug_level=5 force_version=tls1_3 server_name=localhost force_ciphersuite=TLS_AES_128_GCM_SHA256 key_exchange_modes=all reconnect=1 tickets=1" \
             0 \
 	    -s "Verifying peer X.509 certificate... ok"                          \
 	    -s "subject name      : C=NL, O=PolarSSL, CN=PolarSSL Test Client 2" \
@@ -1364,7 +1364,7 @@ requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL
 requires_config_enabled MBEDTLS_DEBUG_C
 run_test    "TLS 1.3, TLS_AES_128_CCM_8_SHA256, ECDHE-ECDSA, CLI+SRV auth, with ticket" \
             "$P_SRV debug_level=5 force_version=tls1_3 auth_mode=required key_exchange_modes=all tickets=1" \
-            "$P_CLI debug_level=5 force_version=tls1_3 server_name=localhost force_ciphersuite=TLS_AES_128_CCM_8_SHA256 key_exchange_modes=ecdhe_ecdsa reconnect=1 tickets=1" \
+            "$P_CLI debug_level=5 force_version=tls1_3 server_name=localhost force_ciphersuite=TLS_AES_128_CCM_8_SHA256 key_exchange_modes=all reconnect=1 tickets=1" \
             0 \
 	    -s "Verifying peer X.509 certificate... ok"                          \
 	    -s "subject name      : C=NL, O=PolarSSL, CN=PolarSSL Test Client 2" \
@@ -1382,7 +1382,7 @@ requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL
 requires_config_enabled MBEDTLS_DEBUG_C
 run_test    "TLS 1.3, TLS_AES_256_GCM_SHA384, ECDHE-ECDSA, CLI+SRV auth, with ticket" \
             "$P_SRV debug_level=5 force_version=tls1_3 auth_mode=required key_exchange_modes=all tickets=1" \
-            "$P_CLI debug_level=5 force_version=tls1_3 server_name=localhost force_ciphersuite=TLS_AES_256_GCM_SHA384 key_exchange_modes=ecdhe_ecdsa reconnect=1 tickets=1" \
+            "$P_CLI debug_level=5 force_version=tls1_3 server_name=localhost force_ciphersuite=TLS_AES_256_GCM_SHA384 key_exchange_modes=all reconnect=1 tickets=1" \
             0 \
 	    -s "Verifying peer X.509 certificate... ok"                          \
 	    -s "subject name      : C=NL, O=PolarSSL, CN=PolarSSL Test Client 2" \
@@ -1400,7 +1400,7 @@ requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL
 requires_config_enabled MBEDTLS_DEBUG_C
 run_test    "TLS 1.3, TLS_AES_256_GCM_SHA384 with ECDHE-ECDSA (server auth only) with ticket" \
             "$P_SRV debug_level=5 force_version=tls1_3 key_exchange_modes=all tickets=1" \
-            "$P_CLI debug_level=5 force_version=tls1_3 server_name=localhost force_ciphersuite=TLS_AES_256_GCM_SHA384 key_exchange_modes=ecdhe_ecdsa reconnect=1 tickets=1" \
+            "$P_CLI debug_level=5 force_version=tls1_3 server_name=localhost force_ciphersuite=TLS_AES_256_GCM_SHA384 key_exchange_modes=all reconnect=1 tickets=1" \
             0 \
 	    -s "Verifying peer X.509 certificate... failed"                                        \
 	    -s "Certificate verification was skipped"                                              \
@@ -1533,8 +1533,8 @@ run_test    "TLS 1.3, TLS_AES_256_GCM_SHA384, ext PSK, early data status - accep
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL
 requires_config_enabled MBEDTLS_DEBUG_C
 run_test    "TLS 1.3, TLS_AES_128_CCM_8_SHA256, ClientHello message misses mandatory extensions" \
-            "$P_SRV debug_level=5 force_version=tls1_3 key_exchange_modes=ecdhe_ecdsa named_groups=secp256r1" \
-            "$P_CLI debug_level=5 force_version=tls1_3 server_name=localhost force_ciphersuite=TLS_AES_128_CCM_8_SHA256 key_exchange_modes=psk_dhe  key_share_named_groups=secp521r1" \
+            "$P_SRV debug_level=5 force_version=tls1_3 key_exchange_modes=psk" \
+            "$P_CLI debug_level=5 force_version=tls1_3 server_name=localhost force_ciphersuite=TLS_AES_128_CCM_8_SHA256 key_exchange_modes=psk" \
             1 \
 	    -s "ClientHello message misses mandatory extensions."                 \
 	    -s "send alert message"                                               \


### PR DESCRIPTION
This PR makes various changes to the way the TLS 1.3 prototype deals with key exchange mode identifiers:
* It separates Mbed TLS - internal key exchange mode identifers from those used by the standard, as explained in #111.
* It introduces various helper functions for checking whether a certain key exchange is supported in the current context, removing lengthy branch conditions which are error-prone and harden readability. Another rationale to have such stub functions is that it will ease moving around the respective structure fields, or even completely removing them if their value shall be known at compile-time -- the latter is a simple way of saving quite some code on highly constrained environments where a static TLS configuration shall be used. This fixes #110.
* It streamlines the server-side logic of determining which key exchange mode to use, which previously had a number of repetitions of code and was quite monolithic. There are now two three helper functions to check for suitability of (a) PSK-based exchanges, (b) certificate-based exchanges, (c) 0-RTT based exchanges.
* Various readability and style improvements were made along the way.
* The key exchange configuration API `mbedtls_ssl_conf_ke()` was renamed to `mbedtls_ssl_conf_tls13_key_exchange_modes()`.
* The semantics of `mbedtls_ssl_conf_ke()` was changed in the following way: Enabling a PSK based exchange doesn't force the client-side user to actually register a PSK. It only means that PSK based exchanges are supported in principle. Concretely, within the code this means that the PSK related extensions will be silently skipped if no PSK is available, instead of leading to a fatal failure as before. This make the common use and test case of an ECDHE-handshake followed by a resumption-PSK-based handshake easier, because it doesn't require manipulating the SSL configuration in between, which is strictly speaking an API violation. This fixes #128.
