### PR TITLE
Remove traffic_key from finished_out

### DIFF
--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -694,7 +694,6 @@ struct mbedtls_ssl_handshake_params
              * but excluding the outgoing finished message. */
             unsigned char digest[MBEDTLS_MD_MAX_SIZE];
             size_t digest_len;
-            mbedtls_ssl_key_set* traffic_keys;
         } finished_out;
 
         /* Incoming Finished message */

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -4132,13 +4132,8 @@ static int ssl_finished_out_postprocess( mbedtls_ssl_context* ssl );
 int mbedtls_ssl_finished_out_process( mbedtls_ssl_context* ssl )
 {
     int ret;
-    mbedtls_ssl_key_set traffic_keys;
 
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> write finished" ) );
-
-    memset( ( void* )&traffic_keys, 0, sizeof( mbedtls_ssl_key_set ) );
-
-    ssl->handshake->state_local.finished_out.traffic_keys = &traffic_keys;
 
     if( !ssl->handshake->state_local.finished_out.preparation_done )
     {


### PR DESCRIPTION
Summary:
The `traffic_key` field is not used in the `finished_out` structure.

Test Plan:
ssl-opt.sh

Reviewers:

Subscribers:

Tasks:

Tags: