### PR TITLE
key_exchange is assigned value from key_exchange_mode

### DIFF
--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -711,15 +711,6 @@ int mbedtls_ssl_write_pre_shared_key_ext( mbedtls_ssl_context *ssl,
         /* In this implementation we only add one pre-shared-key extension. */
         ssl->session_negotiate->ciphersuite = ciphersuites[i];
         ssl->handshake->ciphersuite_info = suite_info;
-#if defined(MBEDTLS_ZERO_RTT)
-        /* Even if we include a key_share extension in the ClientHello
-         * message it will not be used at this stage for the key derivation.
-         */
-        if( ssl->handshake->early_data == MBEDTLS_SSL_EARLY_DATA_ON )
-        {
-            ssl->session_negotiate->key_exchange = MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_KE;
-        }
-#endif
         break;
     }
     if( hash_len == -1 )


### PR DESCRIPTION
Summary:
`MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_KE` is used for
`ssl->conf->key_exchange_modes`. Hower it is assigned to `key_exchange`.
The `key_exchange` assignment in client hello seems incorrect too. It is
typically assigned at server hello. So I suggest to remove such
assignment.

Test Plan:
`ssl-opt.sh`

Reviewers:

Subscribers:

Tasks:

Tags: