### PR TITLE
Fix compiler error when MBEDTLS_SHA512_C is not defined

### DIFF
--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -229,14 +229,24 @@ int mbedtls_ssl_create_binder( mbedtls_ssl_context *ssl,
      * 38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b
      */
 
+#if defined(MBEDTLS_SHA256_C)
     if( suite_info->mac == MBEDTLS_MD_SHA256 )
     {
         mbedtls_sha256( (const unsigned char *) "", 0, hash, 0 );
     }
-    else if( suite_info->mac == MBEDTLS_MD_SHA384 )
+    else
+#endif /* MBEDTLS_SHA256_C */
+#if defined(MBEDTLS_SHA512_C)
+    if( suite_info->mac == MBEDTLS_MD_SHA384 )
     {
         mbedtls_sha512( (const unsigned char *) "", 0,
                         hash, 1 /* for SHA384 */ );
+    }
+    else
+#endif /* MBEDTLS_SHA512_C */
+    {
+        MBEDTLS_SSL_DEBUG_MSG( 1, ( "mbedtls_ssl_create_binder: Unknow hash function." ) );
+        return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
     }
 
     if( !is_external )


### PR DESCRIPTION
Summary:
It is a follow up fix for PR[132](https://github.com/hannestschofenig/mbedtls/pull/132).
If `MBEDTLS_SHA512_C` is not defined as following, there will be compiler error as below.
```
diff --git a/include/mbedtls/config.h b/include/mbedtls/config.h
index e65e1109b..80ff8c3f5 100644
--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -3317,7 +3317,7 @@
  *
  * This module adds support for SHA-384 and SHA-512.
  */
-#define MBEDTLS_SHA512_C
+//#define MBEDTLS_SHA512_C

 /**
  * \def MBEDTLS_SSL_CACHE_C

```

```
library/ssl_tls13_generic.c: In function ‘mbedtls_ssl_create_binder’:
library/ssl_tls13_generic.c:238:9: error: implicit declaration of function ‘mbedtls_sha512’ [-Werror=implicit-function-declaration]
         mbedtls_sha512( (const unsigned char *) "", 0,
         ^
cc1: all warnings being treated as errors
make[2]: *** [library/CMakeFiles/mbedtls.dir/ssl_tls13_generic.c.o] Error 1
make[2]: *** Waiting for unfinished jobs....
[ 34%] Built target cert_req
[ 34%] Built target cert_write
make[1]: *** [library/CMakeFiles/mbedtls.dir/all] Error 2
make: *** [all] Error 2

```

Test Plan:
make
Reviewers:

Subscribers:

Tasks:

Tags: