### PR TITLE
Improve structure and reduce code-duplication around HS transcripts and PSK binders

### DIFF
--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -1414,9 +1414,16 @@ int mbedtls_ssl_create_binder( mbedtls_ssl_context *ssl,
                                unsigned char *psk, size_t psk_len,
                                const mbedtls_md_info_t *md,
                                const mbedtls_ssl_ciphersuite_t *suite_info,
-                               unsigned char *buffer, size_t blen,
                                unsigned char *result );
 #endif /* MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED */
+
+int mbedtls_ssl_get_handshake_transcript( mbedtls_ssl_context *ssl,
+                                          const mbedtls_md_type_t md,
+                                          unsigned char *dst,
+                                          size_t dst_len,
+                                          size_t *olen );
+
+int mbedtls_ssl_hash_transcript( mbedtls_ssl_context *ssl );
 
 void mbedtls_ssl_set_inbound_transform( mbedtls_ssl_context *ssl,
                                         mbedtls_ssl_transform *transform );
@@ -1440,7 +1447,11 @@ int mbedtls_ssl_write_change_cipher_spec(mbedtls_ssl_context* ssl);
 #endif /* MBEDTLS_SSL_TLS13_COMPATIBILITY_MODE */
 
 #if defined(MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED)
-int mbedtls_ssl_write_pre_shared_key_ext(mbedtls_ssl_context* ssl, unsigned char* buf, unsigned char* end, size_t* olen, int dummy_run);
+int mbedtls_ssl_write_pre_shared_key_ext(mbedtls_ssl_context* ssl,
+                                         unsigned char* buf, unsigned char* end,
+                                         size_t* olen,
+                                         size_t* binder_list_length,
+                                         int part );
 #endif /* MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED */
 #if defined(MBEDTLS_KEY_EXCHANGE_WITH_CERT_ENABLED)
 int mbedtls_ssl_write_signature_algorithms_ext(mbedtls_ssl_context* ssl, unsigned char* buf, unsigned char* end, size_t* olen);

--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -1182,6 +1182,8 @@ void mbedtls_ssl_handshake_wrapup(mbedtls_ssl_context* ssl);
 
 int mbedtls_ssl_send_fatal_handshake_failure(mbedtls_ssl_context* ssl);
 int mbedtls_ssl_write_handshake_msg( mbedtls_ssl_context *ssl );
+int mbedtls_ssl_write_handshake_msg_ext( mbedtls_ssl_context *ssl,
+                                         int update_checksum );
 
 /**
  * \brief       Update record layer

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -2692,28 +2692,6 @@ int mbedtls_ssl_write_handshake_msg_ext( mbedtls_ssl_context *ssl,
         }
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
 
-#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
-#if defined(MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED) && defined(MBEDTLS_SSL_CLI_C)
-        /* We need to patch the psk binder by
-         * re-running the function to get the correct length information for the extension.
-         * But: we only do that when in ClientHello state and when using a PSK mode
-         */
-        if( ( ssl->conf->endpoint == MBEDTLS_SSL_IS_CLIENT )                  &&
-            ( ssl->state == MBEDTLS_SSL_CLIENT_HELLO )                        &&
-            ( ssl->handshake->extensions_present & PRE_SHARED_KEY_EXTENSION ) &&
-            ( ssl->conf->key_exchange_modes == MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_ALL ||
-              ssl->conf->key_exchange_modes == MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_ALL     ||
-              ssl->conf->key_exchange_modes == MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_KE  ||
-              ssl->conf->key_exchange_modes == MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_DHE_KE ) )
-        {
-            size_t len = ssl->out_msglen;
-            size_t dummy_length;
-            mbedtls_ssl_write_pre_shared_key_ext( ssl, ssl->handshake->ptr_to_psk_ext,
-                                                  &ssl->out_msg[len], &dummy_length, 1 );
-        }
-#endif /* MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED && MBEDTLS_SSL_CLI_C */
-#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
-
         /* Update running hashes of handshake messages seen */
         if( hs_type != MBEDTLS_SSL_HS_HELLO_REQUEST &&
             update_checksum )

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -2573,6 +2573,12 @@ void mbedtls_ssl_send_flight_completed( mbedtls_ssl_context *ssl )
  */
 int mbedtls_ssl_write_handshake_msg( mbedtls_ssl_context *ssl )
 {
+    return( mbedtls_ssl_write_handshake_msg_ext( ssl, 1 /* update checksum */ ) );
+}
+
+int mbedtls_ssl_write_handshake_msg_ext( mbedtls_ssl_context *ssl,
+                                         int update_checksum )
+{
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     const size_t hs_len = ssl->out_msglen - 4;
     const unsigned char hs_type = ssl->out_msg[0];
@@ -2709,8 +2715,11 @@ int mbedtls_ssl_write_handshake_msg( mbedtls_ssl_context *ssl )
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 
         /* Update running hashes of handshake messages seen */
-        if( hs_type != MBEDTLS_SSL_HS_HELLO_REQUEST )
+        if( hs_type != MBEDTLS_SSL_HS_HELLO_REQUEST &&
+            update_checksum )
+        {
             ssl->handshake->update_checksum( ssl, ssl->out_msg, ssl->out_msglen );
+        }
     }
 
     /* Either send now, or just save to be sent (and resent) later */

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -709,6 +709,7 @@ static void ssl_update_checksum_sha256( mbedtls_ssl_context *, const unsigned ch
 static void ssl_update_checksum_sha384( mbedtls_ssl_context *, const unsigned char *, size_t );
 #endif
 
+#if defined(MBEDTLS_SHA256_C)
 static int ssl_get_handshake_transcript_sha256( mbedtls_ssl_context *ssl,
                                                 unsigned char *dst,
                                                 size_t dst_len,
@@ -736,7 +737,9 @@ exit:
     mbedtls_sha256_free( &sha256 );
     return( ret );
 }
+#endif /* MBEDTLS_SHA256_C */
 
+#if defined(MBEDTLS_SHA512_C)
 static int ssl_get_handshake_transcript_sha384( mbedtls_ssl_context *ssl,
                                                 unsigned char *dst,
                                                 size_t dst_len,
@@ -764,6 +767,7 @@ exit:
     mbedtls_sha512_free( &sha512 );
     return( ret );
 }
+#endif /* MBEDTLS_SHA512_C */
 
 static int ssl_hash_transcript_core( mbedtls_ssl_context *ssl,
                                      mbedtls_md_type_t md,

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -700,6 +700,7 @@ static void ssl_calc_finished_tls_sha384( mbedtls_ssl_context *, unsigned char *
 #endif /* MBEDTLS_SSL_PROTO_TLS1_2 */
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+
 #if defined(MBEDTLS_SHA256_C)
 static void ssl_update_checksum_sha256( mbedtls_ssl_context *, const unsigned char *, size_t );
 #endif
@@ -707,6 +708,193 @@ static void ssl_update_checksum_sha256( mbedtls_ssl_context *, const unsigned ch
 #if defined(MBEDTLS_SHA512_C)
 static void ssl_update_checksum_sha384( mbedtls_ssl_context *, const unsigned char *, size_t );
 #endif
+
+static int ssl_get_handshake_transcript_sha256( mbedtls_ssl_context *ssl,
+                                                unsigned char *dst,
+                                                size_t dst_len,
+                                                size_t *olen )
+{
+    int ret;
+    mbedtls_sha256_context sha256;
+
+    if( dst_len < 32 )
+        return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
+
+    mbedtls_sha256_init( &sha256 );
+    mbedtls_sha256_clone( &sha256, &ssl->handshake->fin_sha256 );
+
+    if( ( ret = mbedtls_sha256_finish_ret( &sha256, dst ) ) != 0 )
+    {
+        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha256_finish_ret", ret );
+        goto exit;
+    }
+
+    *olen = 32;
+
+exit:
+
+    mbedtls_sha256_free( &sha256 );
+    return( ret );
+}
+
+static int ssl_get_handshake_transcript_sha384( mbedtls_ssl_context *ssl,
+                                                unsigned char *dst,
+                                                size_t dst_len,
+                                                size_t *olen )
+{
+    int ret;
+    mbedtls_sha512_context sha512;
+
+    if( dst_len < 48 )
+        return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
+
+    mbedtls_sha512_init( &sha512 );
+    mbedtls_sha512_clone( &sha512, &ssl->handshake->fin_sha512 );
+
+    if( ( ret = mbedtls_sha512_finish_ret( &sha512, dst ) ) != 0 )
+    {
+        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha512_finish_ret", ret );
+        goto exit;
+    }
+
+    *olen = 48;
+
+exit:
+
+    mbedtls_sha512_free( &sha512 );
+    return( ret );
+}
+
+static int ssl_hash_transcript_core( mbedtls_ssl_context *ssl,
+                                     mbedtls_md_type_t md,
+                                     unsigned char *transcript,
+                                     size_t len,
+                                     size_t *olen )
+{
+    int ret;
+    size_t hash_size;
+
+    if( len < 4 )
+        return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
+
+    ret = mbedtls_ssl_get_handshake_transcript( ssl, md,
+                                          transcript + 4,
+                                          len - 4,
+                                          &hash_size );
+    if( ret != 0 )
+    {
+        MBEDTLS_SSL_DEBUG_RET( 4, "mbedtls_ssl_get_handshake_transcript", ret );
+        return( ret );
+    }
+
+    transcript[0] = MBEDTLS_SSL_HS_MESSAGE_HASH;
+    transcript[1] = 0;
+    transcript[2] = 0;
+    transcript[3] = hash_size;
+
+    *olen = 4 + hash_size;
+    return( 0 );
+}
+
+#if defined(MBEDTLS_SHA256_C)
+static int ssl_hash_transcript_sha256( mbedtls_ssl_context *ssl )
+{
+    int ret;
+    unsigned char transcript[ 32 + 4 ];
+    size_t olen;
+
+    ret = ssl_hash_transcript_core( ssl, MBEDTLS_MD_SHA256,
+                                    transcript,
+                                    sizeof( transcript ),
+                                    &olen );
+    if( ret != 0 )
+    {
+        MBEDTLS_SSL_DEBUG_RET( 4, "ssl_hash_transcript_core", ret );
+        return( ret );
+    }
+
+    MBEDTLS_SSL_DEBUG_BUF( 4, "Truncated SHA-256 handshake transcript",
+                           transcript, olen );
+
+    mbedtls_sha256_starts_ret( &ssl->handshake->fin_sha256, 0 );
+    ssl_update_checksum_sha256( ssl, transcript, olen );
+
+    return( 0 );
+}
+#endif /* MBEDTLS_SHA256_C */
+
+#if defined(MBEDTLS_SHA512_C)
+static int ssl_hash_transcript_sha384( mbedtls_ssl_context *ssl )
+{
+    int ret;
+    unsigned char transcript[ 48 + 4 ];
+    size_t olen;
+
+    ret = ssl_hash_transcript_core( ssl, MBEDTLS_MD_SHA384,
+                                    transcript,
+                                    sizeof( transcript ),
+                                    &olen );
+    if( ret != 0 )
+        return( ret );
+
+    MBEDTLS_SSL_DEBUG_BUF( 4, "Truncated SHA-384 handshake transcript",
+                           transcript, olen );
+
+    mbedtls_sha512_starts_ret( &ssl->handshake->fin_sha512, 1 );
+    ssl_update_checksum_sha384( ssl, transcript, olen );
+
+    return( 0 );
+}
+#endif /* MBEDTLS_SHA512_C */
+
+/* Replace Transcript-Hash(X) by
+ * Transcript-Hash( message_hash     ||
+ *                 00 00 Hash.length ||
+ *                 X )
+ */
+int mbedtls_ssl_hash_transcript( mbedtls_ssl_context *ssl )
+{
+    int ret = 0;
+
+#if defined(MBEDTLS_SHA256_C)
+    ret = ssl_hash_transcript_sha256( ssl );
+    if( ret != 0 )
+        goto exit;
+#endif /* MBEDTLS_SHA256_C */
+
+#if defined(MBEDTLS_SHA512_C)
+    ret = ssl_hash_transcript_sha384( ssl );
+    if( ret != 0 )
+        goto exit;
+#endif /* MBEDTLS_SHA512_C */
+
+exit:
+    return( 0 );
+}
+
+int mbedtls_ssl_get_handshake_transcript( mbedtls_ssl_context *ssl,
+                                          const mbedtls_md_type_t md,
+                                          unsigned char *dst,
+                                          size_t dst_len,
+                                          size_t *olen )
+{
+#if defined(MBEDTLS_SHA512_C)
+    if( md == MBEDTLS_MD_SHA384 )
+    {
+        return( ssl_get_handshake_transcript_sha384( ssl, dst, dst_len, olen ) );
+    }
+    else
+#endif /* MBEDTLS_SHA512_C */
+#if defined(MBEDTLS_SHA256_C)
+    if( md == MBEDTLS_MD_SHA256 )
+    {
+        return( ssl_get_handshake_transcript_sha256( ssl, dst, dst_len, olen ) );
+    }
+    else
+#endif /* MBEDTLS_SHA256_C */
+    return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
+}
+
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 
 #if defined(MBEDTLS_KEY_EXCHANGE_PSK_ENABLED) && \
@@ -2936,184 +3124,52 @@ void mbedtls_ssl_reset_checksum( mbedtls_ssl_context *ssl )
 static void ssl_update_checksum_start( mbedtls_ssl_context *ssl,
                                        const unsigned char *buf, size_t len )
 {
-    int ret = 0;
-
+#if defined(MBEDTLS_SSL_DEBUG_HANDSHAKE_HASHES)
 #if defined(MBEDTLS_SHA256_C)
-#if defined(MBEDTLS_SSL_DEBUG_HANDSHAKE_HASHES)
     mbedtls_sha256_context sha256_debug;
-#endif // MBEDTLS_SSL_DEBUG_HANDSHAKE_HASHES
 #endif // MBEDTLS_SHA256_C
-
 #if defined(MBEDTLS_SHA512_C)
-#if defined(MBEDTLS_SSL_DEBUG_HANDSHAKE_HASHES)
     mbedtls_sha512_context sha512_debug;
-#endif // MBEDTLS_SSL_DEBUG_HANDSHAKE_HASHES
 #endif // MBEDTLS_SHA512_C
-
-#if defined(MBEDTLS_SSL_DEBUG_HANDSHAKE_HASHES)
     unsigned char padbuf[MBEDTLS_MD_MAX_SIZE];
 #endif /* MBEDTLS_SSL_DEBUG_HANDSHAKE_HASHES */
-    const mbedtls_ssl_ciphersuite_t* suite_info;
-
-    suite_info = mbedtls_ssl_ciphersuite_from_id( ssl->session_negotiate->ciphersuite );
-
-    /* Check whether cipher has already been set. If it hasn't
-     * then we have to compute a hash with all available algorithms.
-     */
-    if( suite_info != NULL ) {
-
-        if( suite_info->mac == MBEDTLS_MD_SHA256 ) {
-#if defined(MBEDTLS_SHA256_C)
-            MBEDTLS_SSL_DEBUG_BUF( 4, "Transcript state ( before )", ( unsigned char* )
-                ssl->handshake->fin_sha256.state, 32 );
-            if( ( ret = mbedtls_sha256_update_ret( &ssl->handshake->fin_sha256,
-                                                   buf,
-                                                   len ) ) != 0 )
-            {
-                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha256_update_ret", ret );
-                goto exit;
-            }
-            MBEDTLS_SSL_DEBUG_BUF( 4, "Input to handshake hash", buf, len );
-            MBEDTLS_SSL_DEBUG_BUF( 4, "Transcript state ( after )", ( unsigned char* )
-                ssl->handshake->fin_sha256.state, 32 );
-#if defined(MBEDTLS_SSL_DEBUG_HANDSHAKE_HASHES)
-            mbedtls_sha256_init( &sha256_debug );
-            mbedtls_sha256_clone( &sha256_debug, &ssl->handshake->fin_sha256 );
-
-            if( ( ret = mbedtls_sha256_finish_ret( &sha256_debug,
-                                                   padbuf ) ) != 0 )
-            {
-                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha256_finish_ret", ret );
-                goto exit;
-            }
-            MBEDTLS_SSL_DEBUG_BUF( 4, "Handshake hash", ( unsigned char* )
-                padbuf, 32 );
-#endif // MBEDTLS_SSL_DEBUG_HANDSHAKE_HASHES
-#else
-            MBEDTLS_SSL_DEBUG_MSG( 1, ( "ssl_update_checksum_start: Unknow hash function." ) );
-            return;
-#endif /* MBEDTLS_SHA256_C */
-        }
-        else if( suite_info->mac == MBEDTLS_MD_SHA384 ) {
-#if defined(MBEDTLS_SHA512_C)
-            MBEDTLS_SSL_DEBUG_BUF( 4, "Transcript state ( before )", ( unsigned char* )
-                ssl->handshake->fin_sha512.state, 48 );
-            if( ( ret = mbedtls_sha512_update_ret( &ssl->handshake->fin_sha512,
-                                                   buf,
-                                                   len ) ) != 0 )
-            {
-                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha512_update_ret", ret );
-                goto exit;
-            }
-            MBEDTLS_SSL_DEBUG_BUF( 4, "Input to handshake hash", buf, len );
-            MBEDTLS_SSL_DEBUG_BUF( 4, "Transcript state ( after )", ( unsigned char* )
-                ssl->handshake->fin_sha512.state, 48 );
-
-#if defined(MBEDTLS_SSL_DEBUG_HANDSHAKE_HASHES)
-            mbedtls_sha512_init( &sha512_debug );
-
-            if( ( ret = mbedtls_sha512_starts_ret( &sha512_debug,
-                                                   1 ) ) != 0 )
-            {
-                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha512_starts_ret", ret );
-                goto exit;
-            }
-
-            mbedtls_sha512_clone( &sha512_debug, &ssl->handshake->fin_sha512 );
-
-            if( ( ret = mbedtls_sha512_finish_ret( &sha512_debug,
-                                                   padbuf ) ) != 0 )
-            {
-                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha512_finish_ret", ret );
-                goto exit;
-            }
-            MBEDTLS_SSL_DEBUG_BUF( 4, "Handshake hash", ( unsigned char* )
-                padbuf, 48 );
-#endif // MBEDTLS_SSL_DEBUG_HANDSHAKE_HASHES
-#else
-            MBEDTLS_SSL_DEBUG_MSG( 1, ( "ssl_update_checksum_start: Unknow hash function." ) );
-            return;
-#endif /* MBEDTLS_SHA512_C */
-        }
-        else {
-            MBEDTLS_SSL_DEBUG_MSG( 1, ( "ssl_update_checksum_start: Unknow hash function." ) );
-            return;
-        }
-    } // suite_info != NULL
-    else {
 
 #if defined(MBEDTLS_SHA256_C)
-        MBEDTLS_SSL_DEBUG_BUF( 4, "Transcript state ( before )", ( unsigned char* )
-            ssl->handshake->fin_sha256.state, 32 );
-        if( ( ret = mbedtls_sha256_update_ret( &ssl->handshake->fin_sha256,
-                                               buf,
-                                               len ) ) != 0 )
-        {
-            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha256_update_ret", ret );
-            goto exit;
-        }
-        MBEDTLS_SSL_DEBUG_BUF( 4, "Input to handshake hash", buf, len );
-        MBEDTLS_SSL_DEBUG_BUF( 4, "Transcript state ( after )", ( unsigned char* )
-            ssl->handshake->fin_sha256.state, 32 );
+    MBEDTLS_SSL_DEBUG_BUF( 4, "Transcript state (before)",
+          (unsigned char*) ssl->handshake->fin_sha256.state, 32 );
+    mbedtls_sha256_update_ret( &ssl->handshake->fin_sha256, buf, len );
+    MBEDTLS_SSL_DEBUG_BUF( 4, "Input to handshake hash", buf, len );
+    MBEDTLS_SSL_DEBUG_BUF( 4, "Transcript state (after)", ( unsigned char* )
+                           ssl->handshake->fin_sha256.state, 32 );
 
 #if defined(MBEDTLS_SSL_DEBUG_HANDSHAKE_HASHES)
-        mbedtls_sha256_init( &sha256_debug );
-        mbedtls_sha256_clone( &sha256_debug, &ssl->handshake->fin_sha256 );
-
-        if( ( ret = mbedtls_sha256_finish_ret( &sha256_debug,
-                                               padbuf ) ) != 0 )
-        {
-            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha256_finish_ret", ret );
-            goto exit;
-        }
-        MBEDTLS_SSL_DEBUG_BUF( 4, "Handshake hash", ( unsigned char* )
-            padbuf, 32 );
-
-        mbedtls_sha256_free( &sha256_debug );
+    mbedtls_sha256_init( &sha256_debug );
+    mbedtls_sha256_clone( &sha256_debug, &ssl->handshake->fin_sha256 );
+    mbedtls_sha256_finish_ret( &sha256_debug, padbuf );
+    mbedtls_sha256_free( &sha256_debug );
+    MBEDTLS_SSL_DEBUG_BUF( 4, "SHA-256 handshake hash", (unsigned char*)
+                           padbuf, 32 );
 #endif // MBEDTLS_SSL_DEBUG_HANDSHAKE_HASHES
 #endif /* MBEDTLS_SHA256_C */
 
 #if defined(MBEDTLS_SHA512_C)
-        MBEDTLS_SSL_DEBUG_BUF( 4, "Transcript state ( before )", ( unsigned char* )
-            ssl->handshake->fin_sha512.state, 48 );
-        if( ( ret = mbedtls_sha512_update_ret( &ssl->handshake->fin_sha512,
-                                               buf,
-                                               len ) ) != 0 )
-        {
-            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha512_update_ret", ret );
-            goto exit;
-        }
-        MBEDTLS_SSL_DEBUG_BUF( 4, "Input to handshake hash", buf, len );
-        MBEDTLS_SSL_DEBUG_BUF( 4, "Transcript state ( after )", ( unsigned char* )
-            ssl->handshake->fin_sha512.state, 48 );
+    MBEDTLS_SSL_DEBUG_BUF( 4, "Transcript state (before)", (unsigned char*)
+                           ssl->handshake->fin_sha512.state, 48 );
+    mbedtls_sha512_update_ret( &ssl->handshake->fin_sha512, buf, len );
+    MBEDTLS_SSL_DEBUG_BUF( 4, "Input to handshake hash", buf, len );
+    MBEDTLS_SSL_DEBUG_BUF( 4, "Transcript state (after)", ( unsigned char* )
+                           ssl->handshake->fin_sha512.state, 48 );
 
 #if defined(MBEDTLS_SSL_DEBUG_HANDSHAKE_HASHES)
-        mbedtls_sha512_init( &sha512_debug );
-
-        if( ( ret = mbedtls_sha512_starts_ret( &sha512_debug,
-                                               1 ) ) != 0 )
-        {
-            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha512_starts_ret", ret );
-            goto exit;
-        }
-
-        mbedtls_sha512_clone( &sha512_debug, &ssl->handshake->fin_sha512 );
-
-        if( ( ret = mbedtls_sha512_finish_ret( &sha512_debug,
-                                               padbuf ) ) != 0 )
-        {
-            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha512_finish_ret", ret );
-            goto exit;
-        }
-        MBEDTLS_SSL_DEBUG_BUF( 4, "Handshake hash", ( unsigned char* )
-            padbuf, 48 );
-
-        mbedtls_sha512_free( &sha512_debug );
+    mbedtls_sha512_init( &sha512_debug );
+    mbedtls_sha512_starts_ret( &sha512_debug, 1 );
+    mbedtls_sha512_clone( &sha512_debug, &ssl->handshake->fin_sha512 );
+    mbedtls_sha512_finish_ret( &sha512_debug, padbuf );
+    mbedtls_sha512_free( &sha512_debug );
+    MBEDTLS_SSL_DEBUG_BUF( 4, "SHA-384 handshake hash", ( unsigned char* )
+                           padbuf, 48 );
 #endif // MBEDTLS_SSL_DEBUG_HANDSHAKE_HASHES
 #endif /* MBEDTLS_SHA512_C */
-    }
-
-exit:;
 }
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 
@@ -7426,7 +7482,7 @@ static int ssl_preset_suiteb_signature_algorithms_tls13[] = {
 //    SIGNATURE_ECDSA_SECP521r1_SHA512,
 #endif /* MBEDTLS_SHA512_C && MBEDTLS_ECP_DP_SECP521R1_ENABLED */
     SIGNATURE_NONE
-}; 
+};
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 
 #endif /* MBEDTLS_KEY_EXCHANGE_WITH_CERT_ENABLED */
@@ -7855,10 +7911,10 @@ int mbedtls_ssl_check_curve( const mbedtls_ssl_context *ssl, mbedtls_ecp_group_i
 /*
  * Check if a hash proposed by the peer is in our list.
  * Return 0 if we're willing to use it, -1 otherwise.
- * 
- * Assumption: sig_hashes is terminated either with 
- * SIGNATURE_NONE or with MBEDTLS_MD_NONE and both 
- * equal 0x0. 
+ *
+ * Assumption: sig_hashes is terminated either with
+ * SIGNATURE_NONE or with MBEDTLS_MD_NONE and both
+ * equal 0x0.
  */
 int mbedtls_ssl_check_sig_hash( const mbedtls_ssl_context *ssl,
                                 mbedtls_md_type_t md )

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -665,30 +665,30 @@ static int ssl_write_psk_key_exchange_modes_ext( mbedtls_ssl_context *ssl,
  * } PreSharedKeyExtension;
  *
  *
- * dummy_run = 0 --> initial run
- * dummy_run == 1 --> second run
+ * part = 0 ==> everything up to the PSK binder list,
+ *              returning the binder list length in `binder_list_length`.
+ * part = 1 ==> the PSK binder list
  */
 
 #if defined(MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED)
 
+#define SSL_WRITE_PSK_EXT_PARTIAL           0
+#define SSL_WRITE_PSK_EXT_ADD_PSK_BINDERS   1
+
 int mbedtls_ssl_write_pre_shared_key_ext( mbedtls_ssl_context *ssl,
                                           unsigned char* buf, unsigned char* end,
-                                          size_t* olen,
-                                          int dummy_run )
+                                          size_t *bytes_written,
+                                          size_t *total_ext_len,
+                                          int part )
 {
+    int ret;
     unsigned char *p = (unsigned char *) buf;
-    unsigned char *truncated_clienthello_end;
-    unsigned char *truncated_clienthello_start = ssl->out_msg;
-    size_t ext_length = 0;
-    uint32_t obfuscated_ticket_age=0;
     const mbedtls_ssl_ciphersuite_t *suite_info;
-    int hash_len=-1, ret;
     const int *ciphersuites;
-#if defined(MBEDTLS_HAVE_TIME)
-    time_t now;
-#endif
+    int hash_len;
 
-    *olen = 0;
+    *total_ext_len = 0;
+    *bytes_written = 0;
 
     if( !mbedtls_ssl_conf_tls13_some_psk_enabled( ssl ) )
         return( 0 );
@@ -699,8 +699,6 @@ int mbedtls_ssl_write_pre_shared_key_ext( mbedtls_ssl_context *ssl,
         MBEDTLS_SSL_DEBUG_MSG( 3, ( "client hello, skip pre_shared_key extensions" ) );
         return( 0 );
     }
-
-    MBEDTLS_SSL_DEBUG_MSG( 3, ( "client hello, adding pre_shared_key extension" ) );
 
     /*
      * Ciphersuite list
@@ -713,11 +711,6 @@ int mbedtls_ssl_write_pre_shared_key_ext( mbedtls_ssl_context *ssl,
 
         if( suite_info == NULL )
             continue;
-
-        hash_len = mbedtls_hash_size_for_ciphersuite( suite_info );
-
-        if( hash_len == -1 )
-            return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
 
         /* In this implementation we only add one pre-shared-key extension. */
         ssl->session_negotiate->ciphersuite = ciphersuites[i];
@@ -733,72 +726,96 @@ int mbedtls_ssl_write_pre_shared_key_ext( mbedtls_ssl_context *ssl,
 #endif
         break;
     }
+
+    hash_len = mbedtls_hash_size_for_ciphersuite( suite_info );
     if( hash_len == -1 )
-    {
-        MBEDTLS_SSL_DEBUG_MSG( 1, ( "mbedtls_hash_size_for_ciphersuite == -1, "\
-                                    "mbedtls_ssl_write_pre_shared_key_ext failed" ) );
         return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
-    }
 
-    /*
-     * The length ( excluding the extension header ) includes:
-     *
-     *  - 2 bytes for total length of identities
-     *     - 2 bytes for length of first identity value
-     *     - identity value ( of length len; min( len )>=1 )
-     *     - 4 bytes for obfuscated_ticket_age
-     *                ...
-     *  - 2 bytes for total length of psk binders
-     *      - 1 byte for length of first psk binder value
-     *      - 32 bytes ( with SHA256 ), or 48 bytes ( with SHA384 ) for psk binder value
-     *                ...
-     *
-     * Note: Currently we assume we have only one PSK credential configured per server.
-     */
-    ext_length = 2 + 2 + ssl->conf->psk_identity_len + 4 + 2 + 1 + hash_len;
 
-    /* ext_length + Extension Type ( 2 bytes ) + Extension Length ( 2 bytes ) */
-    if( end < p || (size_t)( end - p ) < ( ext_length + 4 ) )
-    {
-        MBEDTLS_SSL_DEBUG_MSG( 1, ( "buffer too short" ) );
-        return( MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL );
-    }
+    size_t const ext_type_bytes           = 2;
+    size_t const ext_len_bytes            = 2;
+    size_t const psk_identities_len_bytes = 2;
+    size_t const psk_identity_len_bytes   = 2;
+    size_t const psk_identity_bytes       = ssl->conf->psk_identity_len;
+    size_t const obfuscated_ticket_bytes  = 4;
+    size_t const psk_binders_len_bytes    = 2;
+    size_t const psk_binder_len_bytes     = 1;
+    size_t const psk_binder_bytes         = hash_len;
 
-    if( dummy_run == 0 )
+    size_t const psk_binder_list_bytes = psk_binders_len_bytes  +
+                                           psk_binder_len_bytes +
+                                           psk_binder_bytes;
+
+    size_t const ext_len = psk_identities_len_bytes     +
+                              psk_identity_len_bytes    +
+                              psk_identity_bytes        +
+                              obfuscated_ticket_bytes   +
+                           psk_binder_list_bytes;
+
+    size_t const ext_len_total = ext_type_bytes +
+                                 ext_len_bytes  +
+                                   ext_len;
+
+    if( part == SSL_WRITE_PSK_EXT_PARTIAL )
     {
-        memset( p, 0, ext_length );
-    }
-    else
-    {
-        int external_psk;
+        uint32_t obfuscated_ticket_age = 0;
+
+        MBEDTLS_SSL_DEBUG_MSG( 3,
+                     ( "client hello, adding pre_shared_key extension, "
+                       "omitting PSK binder list" ) );
+
+        /* Write extension up to but excluding the PSK binders list
+
+         * The length (excluding the extension header) includes:
+         *
+         *  - 2 bytes for total length of identities
+         *     - 2 bytes for length of first identity value
+         *     - identity value ( of length len; min( len )>=1 )
+         *     - 4 bytes for obfuscated_ticket_age
+         *                ...
+         *  - 2 bytes for total length of psk binders
+         *      - 1 byte for length of first psk binder value
+         *      - 32 or 48 bytes (for SHA256/384) for PSK binder value
+         *                ...
+         *
+         * Note: Currently we assume we have only one PSK credential
+         * configured per server.
+         */
+
+        /* ext_length + Extension Type ( 2 bytes ) + Extension Length ( 2 bytes ) */
+        if( end < p || (size_t)( end - p ) < ext_len_total )
+        {
+            MBEDTLS_SSL_DEBUG_MSG( 1, ( "buffer too short" ) );
+            return( MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL );
+        }
 
         /* Extension Type */
         *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_PRE_SHARED_KEY >> 8 ) & 0xFF );
-        *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_PRE_SHARED_KEY ) & 0xFF );
+        *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_PRE_SHARED_KEY >> 0 ) & 0xFF );
 
         /* Extension Length */
-        *p++ = (unsigned char)( ( ext_length >> 8 ) & 0xFF );
-        *p++ = (unsigned char)( ext_length & 0xFF );
+        *p++ = (unsigned char)( ( ext_len >> 8 ) & 0xFF );
+        *p++ = (unsigned char)( ( ext_len >> 0 ) & 0xFF );
 
         /* 2 bytes length field for array of PskIdentity */
         *p++ = (unsigned char)( ( ( ssl->conf->psk_identity_len + 4 + 2 ) >> 8 ) & 0xFF );
-        *p++ = (unsigned char)( ( ssl->conf->psk_identity_len + 4 + 2 ) & 0xFF );
+        *p++ = (unsigned char)( ( ( ssl->conf->psk_identity_len + 4 + 2 ) >> 0 ) & 0xFF );
 
         /* 2 bytes length field for psk_identity */
         *p++ = (unsigned char)( ( ( ssl->conf->psk_identity_len ) >> 8 ) & 0xFF );
-        *p++ = (unsigned char)( ( ssl->conf->psk_identity_len ) & 0xFF );
+        *p++ = (unsigned char)( ( ( ssl->conf->psk_identity_len ) >> 0 ) & 0xFF );
 
         /* actual psk_identity */
         memcpy( p, ssl->conf->psk_identity, ssl->conf->psk_identity_len );
-
         p += ssl->conf->psk_identity_len;
 
-        /* Calculate obfuscated_ticket_age */
-        /* ( but not for externally configured PSKs ) */
+        /* Calculate obfuscated_ticket_age (omitted for external PSKs). */
         if( ssl->conf->ticket_age_add > 0 )
         {
+            /* TODO: Should we somehow fail if TIME is disabled here?
+             * TODO: Use Mbed TLS' time abstraction? */
 #if defined(MBEDTLS_HAVE_TIME)
-            now = time( NULL );
+            time_t now = time( NULL );
 
             if( !( ssl->conf->ticket_received <= now &&
                    now - ssl->conf->ticket_received < 7 * 86400 * 1000 ) )
@@ -820,25 +837,25 @@ int mbedtls_ssl_write_pre_shared_key_ext( mbedtls_ssl_context *ssl,
         /* add obfuscated ticket age */
         *p++ = ( obfuscated_ticket_age >> 24 ) & 0xFF;
         *p++ = ( obfuscated_ticket_age >> 16 ) & 0xFF;
-        *p++ = ( obfuscated_ticket_age >> 8 ) & 0xFF;
-        *p++ = ( obfuscated_ticket_age ) & 0xFF;
-/*		p += 4; */
+        *p++ = ( obfuscated_ticket_age >> 8  ) & 0xFF;
+        *p++ = ( obfuscated_ticket_age >> 0  ) & 0xFF;
 
-        /* Store this pointer since we need it to compute the psk binder */
-        truncated_clienthello_end = p;
+        *bytes_written = ext_len_total - psk_binder_list_bytes;
+        *total_ext_len = ext_len_total;
 
-        /* Add PSK binder for included identity */
+        ssl->handshake->extensions_present |= PRE_SHARED_KEY_EXTENSION;
+    }
+    else if( part == SSL_WRITE_PSK_EXT_ADD_PSK_BINDERS )
+    {
+        int external_psk;
+        MBEDTLS_SSL_DEBUG_MSG( 3, ( "client hello, adding PSK binder list" ) );
 
         /* 2 bytes length field for array of psk binders */
         *p++ = (unsigned char)( ( ( hash_len + 1 ) >> 8 ) & 0xFF );
-        *p++ = (unsigned char)( ( hash_len + 1 ) & 0xFF );
+        *p++ = (unsigned char)( ( ( hash_len + 1 ) >> 0 ) & 0xFF );
 
         /* 1 bytes length field for next psk binder */
         *p++ = (unsigned char)( ( hash_len ) & 0xFF );
-
-        MBEDTLS_SSL_DEBUG_BUF( 3, "ssl_calc_binder computed over ",
-                      truncated_clienthello_start,
-                      truncated_clienthello_end - truncated_clienthello_start );
 
         if( ssl->conf->resumption_mode )
             external_psk = 0;
@@ -849,18 +866,17 @@ int mbedtls_ssl_write_pre_shared_key_ext( mbedtls_ssl_context *ssl,
                   external_psk,
                   ssl->conf->psk, ssl->conf->psk_len,
                   mbedtls_md_info_from_type( suite_info->mac ),
-                  suite_info, truncated_clienthello_start,
-                  truncated_clienthello_end - truncated_clienthello_start, p );
+                  suite_info, p );
 
         if( ret != 0 )
         {
             MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_write_pre_shared_key_ext()", ret );
             return( MBEDTLS_ERR_SSL_BAD_HS_CLIENT_HELLO );
         }
-    }
-    *olen = ext_length + 4;
 
-    ssl->handshake->extensions_present |= PRE_SHARED_KEY_EXTENSION;
+        *bytes_written = psk_binder_list_bytes;
+    }
+
     return( 0 );
 }
 
@@ -1209,14 +1225,17 @@ static int ssl_write_key_shares_ext( mbedtls_ssl_context *ssl,
 static int ssl_client_hello_process( mbedtls_ssl_context* ssl );
 
 static int ssl_client_hello_prepare( mbedtls_ssl_context* ssl );
-static int ssl_client_hello_write( mbedtls_ssl_context* ssl,
-                                   unsigned char* buf,
-                                   size_t buflen,
-                                   size_t* olen );
+static int ssl_client_hello_write_partial( mbedtls_ssl_context* ssl,
+                                           unsigned char* buf, size_t buflen,
+                                           size_t* len_without_binders,
+                                           size_t* len_with_binders );
 
 static int ssl_client_hello_process( mbedtls_ssl_context* ssl )
 {
     int ret = 0;
+    size_t msg_len, len_without_binders;
+    unsigned char *buf;
+    size_t len;
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> write client hello" ) );
 
     if( ssl->handshake->state_local.cli_hello_out.preparation_done == 0 )
@@ -1228,14 +1247,24 @@ static int ssl_client_hello_process( mbedtls_ssl_context* ssl )
     /* Make sure we can write a new message. */
     MBEDTLS_SSL_PROC_CHK( mbedtls_ssl_flush_output( ssl ) );
 
-    /* Prepare ClientHello message in output buffer. */
-    MBEDTLS_SSL_PROC_CHK( ssl_client_hello_write( ssl, ssl->out_msg,
-                                                  MBEDTLS_SSL_MAX_CONTENT_LEN,
-                                                  &ssl->out_msglen ) );
+    /* Prepare ClientHello message in output buffer, up to
+     * but excluding the PSK binder list (if present).
+     *
+     * In contrast to other handshake writing functions, this
+     * function returns two length values: Firstly, the length
+     * of the message up to the binder's list. And secondly,
+     * the total length of the message including the binders
+     * list. */
+    buf = ssl->out_msg;
+    len = MBEDTLS_SSL_MAX_CONTENT_LEN;
+    MBEDTLS_SSL_PROC_CHK( ssl_client_hello_write_partial( ssl, buf, len,
+                                                  &len_without_binders,
+                                                  &msg_len ) );
+    ssl->out_msglen = msg_len;
 
     {
         unsigned char hs_hdr[4];
-        size_t const hs_len = ssl->out_msglen - 4;
+        size_t const hs_len = msg_len - 4;
 
         /* Build HS header for checksum update. */
         hs_hdr[0] = MBEDTLS_SSL_HS_CLIENT_HELLO;
@@ -1246,17 +1275,24 @@ static int ssl_client_hello_process( mbedtls_ssl_context* ssl )
         ssl->handshake->update_checksum( ssl, hs_hdr, sizeof( hs_hdr ) );
 
         /* Manually update the checksum with ClientHello using dummy PSK binders. */
-        ssl->handshake->update_checksum( ssl, ssl->out_msg + 4, hs_len );
+        ssl->handshake->update_checksum( ssl, buf + 4, len_without_binders - 4 );
     }
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && \
     defined(MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED)
     /* Patch the PSK binder after updating the HS checksum. */
     {
-        size_t len = ssl->out_msglen;
-        size_t dummy_length;
-        mbedtls_ssl_write_pre_shared_key_ext( ssl, ssl->handshake->ptr_to_psk_ext,
-                                              &ssl->out_msg[len], &dummy_length, 1 );
+
+        size_t dummy0, dummy1;
+        mbedtls_ssl_write_pre_shared_key_ext( ssl,
+                                              buf + len_without_binders,
+                                              buf + len,
+                                              &dummy0, &dummy1,
+                                              SSL_WRITE_PSK_EXT_ADD_PSK_BINDERS );
+
+        /* Manually update the checksum with ClientHello using dummy PSK binders. */
+        ssl->handshake->update_checksum( ssl, buf + len_without_binders,
+                                         msg_len - len_without_binders );
     }
 #endif /* MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED &&
           MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
@@ -1342,10 +1378,10 @@ static int ssl_client_hello_prepare( mbedtls_ssl_context* ssl )
     return( 0 );
 }
 
-static int ssl_client_hello_write( mbedtls_ssl_context* ssl,
-                                   unsigned char* buf,
-                                   size_t buflen,
-                                   size_t* olen )
+static int ssl_client_hello_write_partial( mbedtls_ssl_context* ssl,
+                                           unsigned char* buf, size_t buflen,
+                                           size_t* len_without_binders,
+                                           size_t* len_with_binders )
 {
     int ret;
 
@@ -1725,16 +1761,20 @@ static int ssl_client_hello_write( mbedtls_ssl_context* ssl,
 #endif /* MBEDTLS_KEY_EXCHANGE_WITH_CERT_ENABLED */
 
 #if defined(MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED)
-    /* We need to save the pointer to the pre-shared key extension
-     * because it has to be updated later.
-     */
-    ssl->handshake->ptr_to_psk_ext = buf;
-    ret = mbedtls_ssl_write_pre_shared_key_ext( ssl, buf, end, &cur_ext_len, 0 );
-    if( ret != 0 )
-        return( ret );
+    {
+        size_t bytes_written;
+        /* We need to save the pointer to the pre-shared key extension
+         * because it has to be updated later. */
+        ret = mbedtls_ssl_write_pre_shared_key_ext( ssl, buf, end,
+                                                    &bytes_written,
+                                                    &cur_ext_len,
+                                                    SSL_WRITE_PSK_EXT_PARTIAL );
+        if( ret != 0 )
+            return( ret );
 
-    total_ext_len += cur_ext_len;
-    buf += cur_ext_len;
+        total_ext_len += cur_ext_len;
+        buf += bytes_written;
+    }
 #endif /* MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED */
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "client hello, total extension length: %d",
@@ -1745,9 +1785,9 @@ static int ssl_client_hello_write( mbedtls_ssl_context* ssl,
     /* Write extension length */
     *extension_start++ = (unsigned char)( ( total_ext_len >> 8 ) & 0xFF );
     *extension_start++ = (unsigned char)( ( total_ext_len ) & 0xFF );
-    buflen -= 2 + total_ext_len;
 
-    *olen = buf - start;
+    *len_without_binders = buf - start;
+    *len_with_binders = ( extension_start + total_ext_len ) - start;
     return( 0 );
 }
 
@@ -3565,134 +3605,17 @@ static int ssl_hrr_postprocess( mbedtls_ssl_context* ssl,
                                 size_t orig_msg_len )
 {
     int ret = 0;
-    unsigned char transcript[MBEDTLS_MD_MAX_SIZE + 4]; /* used to store the ClientHello1 msg */
-    int hash_length;
 
     ssl->handshake->hello_retry_requests_received++;
 
-    MBEDTLS_SSL_DEBUG_MSG( 5, ( "--- Update Checksum ( ssl_prepare_handshake_record, stateless transcript hash for HRR )" ) );
-
-    /* A special handling of the transcript hash is needed. We skipped
-     * updating the transcript hash when the HRR message was received.
-     *
-     * 1. The current transcript hash was computed over the first ClientHello.
-     * We need to compute a final hash of ClientHello1 and then put it
-     * into the following structure:
-     *
-     *  Transcript-Hash( ClientHello1, HelloRetryRequest, ... MN ) =
-     *     Hash( message_hash         ||
-     *           00 00 Hash.length    ||
-     *	         Hash( ClientHello1 ) ||
-     *           HelloRetryRequest ... MN )
-     *
-     * 2. Then, we need to reset the transcript and put the hash of the above-
-     *    computed value.
-     *
-     */
-
-    transcript[0] = MBEDTLS_SSL_HS_MESSAGE_HASH;
-    transcript[1] = 0;
-    transcript[2] = 0;
-
-    hash_length = mbedtls_hash_size_for_ciphersuite( ssl->handshake->ciphersuite_info );
-
-    if( hash_length == -1 )
+    MBEDTLS_SSL_DEBUG_MSG( 4, ( "Compress transcript hash for stateless HRR" ) );
+    ret = mbedtls_ssl_hash_transcript( ssl );
+    if( ret != 0 )
     {
-        MBEDTLS_SSL_DEBUG_MSG( 1, ( "mbedtls_hash_size_for_ciphersuite == -1" ) );
-        return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
+        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_hash_transcript", ret );
+        return( ret );
     }
 
-    transcript[3] = ( uint8_t )hash_length;
-
-    /* #if defined(MBEDTLS_SHA256_C)
-       mbedtls_sha256_context sha256;
-       #endif
-
-       #if defined(MBEDTLS_SHA512_C)
-       mbedtls_sha512_context sha512;
-       #endif
-    */
-    if( ssl->handshake->ciphersuite_info->mac == MBEDTLS_MD_SHA256 )
-    {
-#if defined(MBEDTLS_SHA256_C)
-        if( ( ret = mbedtls_sha256_finish_ret( &ssl->handshake->fin_sha256,
-                                               &transcript[4]) ) != 0 )
-        {
-            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha256_finish_ret", ret );
-            goto exit;
-        }
-        MBEDTLS_SSL_DEBUG_BUF( 5, "Transcript-Hash( ClientHello1, HelloRetryRequest, ... MN )", &transcript[0], 32 + 4 );
-
-        /* reset transcript */
-        mbedtls_sha256_init( &ssl->handshake->fin_sha256 );
-        if( ( ret = mbedtls_sha256_starts_ret( &ssl->handshake->fin_sha256,
-                                               0 ) ) != 0 )
-        {
-            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha256_starts_ret", ret );
-            goto exit;
-        }
-        /*mbedtls_sha256_update( &ssl->handshake->fin_sha256, &transcript[0], hash_length + 4 ); */
-#else
-        MBEDTLS_SSL_DEBUG_MSG( 1, ( "mbedtls_ssl_tls1_3_derive_master_secret: Unknow hash function." ) );
-        return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
-#endif /* MBEDTLS_SHA256_C */
-    }
-    else if( ssl->handshake->ciphersuite_info->mac == MBEDTLS_MD_SHA384 )
-    {
-#if defined(MBEDTLS_SHA512_C)
-        if( ( ret = mbedtls_sha512_finish_ret( &ssl->handshake->fin_sha512,
-                                               &transcript[4]) ) != 0 )
-        {
-            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha512_finish_ret", ret );
-            goto exit;
-        }
-        MBEDTLS_SSL_DEBUG_BUF( 5, "Transcript-Hash( ClientHello1, HelloRetryRequest, ... MN )", &transcript[0], 48 + 4 );
-
-        /* reset transcript */
-        mbedtls_sha512_init( &ssl->handshake->fin_sha512 );
-        if( ( ret = mbedtls_sha512_starts_ret( &ssl->handshake->fin_sha512,
-                                               1 ) ) != 0 )
-        {
-            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha512_starts_ret", ret );
-            goto exit;
-        }
-        /*mbedtls_sha256_update( &ssl->handshake->fin_sha512, &transcript[0], hash_length + 4 ); */
-#else
-        MBEDTLS_SSL_DEBUG_MSG( 1, ( "mbedtls_ssl_tls1_3_derive_master_secret: Unknow hash function." ) );
-        return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
-#endif /* MBEDTLS_SHA512_C */
-    }
-    else if( ssl->handshake->ciphersuite_info->mac == MBEDTLS_MD_SHA512 )
-    {
-#if defined(MBEDTLS_SHA512_C)
-        if( ( ret = mbedtls_sha512_finish_ret( &ssl->handshake->fin_sha512,
-                                               &transcript[4]) ) != 0 )
-        {
-            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha512_finish_ret", ret );
-            goto exit;
-        }
-        MBEDTLS_SSL_DEBUG_BUF( 5, "Transcript-Hash( ClientHello1, HelloRetryRequest, ... MN )", &transcript[0], 64 + 4 );
-
-        /* reset transcript */
-        mbedtls_sha512_init( &ssl->handshake->fin_sha512 );
-        if( ( ret = mbedtls_sha512_starts_ret( &ssl->handshake->fin_sha512,
-                                               0 ) ) != 0 )
-        {
-            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha512_starts_ret", ret );
-            goto exit;
-        }
-        /*mbedtls_sha256_update( &ssl->handshake->fin_sha512, &transcript[0], hash_length + 4 ); */
-    }
-    else
-    {
-#else
-        MBEDTLS_SSL_DEBUG_MSG( 1, ( "mbedtls_ssl_tls1_3_derive_master_secret: Unknow hash function." ) );
-        return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
-#endif /* MBEDTLS_SHA512_C */
-    }
-
-    /* hash modified transcript for ClientHello1 */
-    ssl->handshake->update_checksum( ssl, &transcript[0], hash_length + 4 );
     /* Add transcript for HRR */
     ssl->handshake->update_checksum( ssl, orig_buf, orig_msg_len );
 
@@ -3700,13 +3623,8 @@ static int ssl_hrr_postprocess( mbedtls_ssl_context* ssl,
     mbedtls_ssl_recv_flight_completed( ssl );
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
 
-exit:
-    return( ret );
+    return( 0 );
 }
-
-
-
-
 
 #if !defined(foobar)
 static void mbedtls_patch_pointers( mbedtls_ssl_context* ssl )

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -1652,6 +1652,9 @@ static int ssl_client_hello_write( mbedtls_ssl_context* ssl,
     /* Add the psk_key_exchange_modes extension.
      */
     ret = ssl_write_psk_key_exchange_modes_ext( ssl, buf, end, &cur_ext_len );
+    if( ret != 0 )
+        return( ret );
+
     total_ext_len += cur_ext_len;
     buf += cur_ext_len;
 #endif /* MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED */
@@ -1661,12 +1664,18 @@ static int ssl_client_hello_write( mbedtls_ssl_context* ssl,
      * REQUIRED for ECDHE ciphersuites.
      */
     ret = ssl_write_supported_groups_ext( ssl, buf, end, &cur_ext_len );
+    if( ret != 0 )
+        return( ret );
+
     total_ext_len += cur_ext_len;
     buf += cur_ext_len;
 
     /* The supported_signature_algorithms extension is REQUIRED for
      * certificate authenticated ciphersuites. */
     ret = mbedtls_ssl_write_signature_algorithms_ext( ssl, buf, end, &cur_ext_len );
+    if( ret != 0 )
+        return( ret );
+
     total_ext_len += cur_ext_len;
     buf += cur_ext_len;
 
@@ -1679,6 +1688,9 @@ static int ssl_client_hello_write( mbedtls_ssl_context* ssl,
      */
 
     ret = ssl_write_key_shares_ext( ssl, buf, end, &cur_ext_len );
+    if( ret != 0 )
+        return( ret );
+
     total_ext_len += cur_ext_len;
     buf += cur_ext_len;
 #endif /* MBEDTLS_KEY_EXCHANGE_WITH_CERT_ENABLED */
@@ -1689,6 +1701,9 @@ static int ssl_client_hello_write( mbedtls_ssl_context* ssl,
      */
     ssl->handshake->ptr_to_psk_ext = buf;
     ret = mbedtls_ssl_write_pre_shared_key_ext( ssl, buf, end, &cur_ext_len, 0 );
+    if( ret != 0 )
+        return( ret );
+
     total_ext_len += cur_ext_len;
     buf += cur_ext_len;
 #endif /* MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED */

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -934,17 +934,21 @@ static int ssl_write_supported_groups_ext( mbedtls_ssl_context *ssl,
 #if defined(MBEDTLS_ECP_C)
     const mbedtls_ecp_group_id *grp_id;
 #else
-    ( ( void )ssl );
+    ((void) ssl);
 #endif
 
     *olen = 0;
 
 #if defined(MBEDTLS_ECP_C)
-    for ( grp_id = ssl->conf->curve_list; *grp_id != MBEDTLS_ECP_DP_NONE; grp_id++ )
+    for ( grp_id = ssl->conf->curve_list;
+          *grp_id != MBEDTLS_ECP_DP_NONE;
+          grp_id++ )
     {
 /*		info = mbedtls_ecp_curve_info_from_grp_id( *grp_id ); */
 #else
-    for ( info = mbedtls_ecp_curve_list(); info->grp_id != MBEDTLS_ECP_DP_NONE; info++ )
+    for ( info = mbedtls_ecp_curve_list();
+          info->grp_id != MBEDTLS_ECP_DP_NONE;
+          info++ )
     {
 #endif
         elliptic_curve_len += 2;
@@ -968,19 +972,25 @@ static int ssl_write_supported_groups_ext( mbedtls_ssl_context *ssl,
     elliptic_curve_len = 0;
 
 #if defined(MBEDTLS_ECP_C)
-    for ( grp_id = ssl->conf->curve_list; *grp_id != MBEDTLS_ECP_DP_NONE; grp_id++ )
+    for ( grp_id = ssl->conf->curve_list;
+          *grp_id != MBEDTLS_ECP_DP_NONE;
+          grp_id++ )
     {
         info = mbedtls_ecp_curve_info_from_grp_id( *grp_id );
 
         if( info == NULL )
             return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
 #else
-    for ( info = mbedtls_ecp_curve_list(); info->grp_id != MBEDTLS_ECP_DP_NONE; info++ )
+    for ( info = mbedtls_ecp_curve_list();
+          info->grp_id != MBEDTLS_ECP_DP_NONE;
+          info++ )
     {
 #endif
         elliptic_curve_list[elliptic_curve_len++] = info->tls_id >> 8;
         elliptic_curve_list[elliptic_curve_len++] = info->tls_id & 0xFF;
-        MBEDTLS_SSL_DEBUG_MSG( 5, ( "Named Curve: %s ( %x )", mbedtls_ecp_curve_info_from_tls_id( info->tls_id )->name, info->tls_id ) );
+        MBEDTLS_SSL_DEBUG_MSG( 5, ( "Named Curve: %s ( %x )",
+                  mbedtls_ecp_curve_info_from_tls_id( info->tls_id )->name,
+                  info->tls_id ) );
     }
 
     *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_SUPPORTED_GROUPS >> 8 ) & 0xFF );
@@ -996,7 +1006,7 @@ static int ssl_write_supported_groups_ext( mbedtls_ssl_context *ssl,
 
     *olen = 6 + elliptic_curve_len;
     return( 0 );
-    }
+}
 #endif /* defined(MBEDTLS_ECDH_C) */
 
 /*

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -1005,6 +1005,8 @@ static int ssl_write_supported_groups_ext( mbedtls_ssl_context *ssl,
     MBEDTLS_SSL_DEBUG_BUF( 3, "Supported groups extension", buf + 4, elliptic_curve_len + 2 );
 
     *olen = 6 + elliptic_curve_len;
+
+    ssl->handshake->extensions_present |= SUPPORTED_GROUPS_EXTENSION;
     return( 0 );
 }
 #endif /* defined(MBEDTLS_ECDH_C) */
@@ -1650,12 +1652,9 @@ static int ssl_client_hello_write( mbedtls_ssl_context* ssl,
      */
     if( mbedtls_ssl_conf_tls13_some_ecdhe_enabled( ssl ) )
     {
-        ret = ssl_write_supported_groups_ext( ssl, buf, end, &cur_ext_len );
-        total_ext_len += cur_ext_len;
-        buf += cur_ext_len;
-
-        if( ret == 0 )
-            ssl->handshake->extensions_present |= SUPPORTED_GROUPS_EXTENSION;
+    ret = ssl_write_supported_groups_ext( ssl, buf, end, &cur_ext_len );
+    total_ext_len += cur_ext_len;
+    buf += cur_ext_len;
 
         /* The supported_signature_algorithms extension is REQUIRED for
          * certificate authenticated ciphersuites. */

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -1153,8 +1153,8 @@ int mbedtls_ssl_write_signature_algorithms_ext( mbedtls_ssl_context *ssl,
 
     if( sig_alg_len == 0 )
     {
-            MBEDTLS_SSL_DEBUG_MSG( 1, ( "No signature algorithms defined." ) );
-            return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
+        MBEDTLS_SSL_DEBUG_MSG( 1, ( "No signature algorithms defined." ) );
+        return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
     }
 
     if( end < p || (size_t)( end - p ) < sig_alg_len + 6 )

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -1141,6 +1141,16 @@ int mbedtls_ssl_write_signature_algorithms_ext( mbedtls_ssl_context *ssl,
 
     *olen = 0;
 
+    /* Skip the extension on the client if all allowed key exchanges
+     * are PSK-based. */
+#if defined(MBEDTLS_SSL_CLI_C)
+    if( ssl->conf->endpoint == MBEDTLS_SSL_IS_CLIENT &&
+        !mbedtls_ssl_conf_tls13_some_ecdhe_enabled( ssl ) )
+    {
+        return( 0 );
+    }
+#endif /* MBEDTLS_SSL_CLI_C */
+
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "adding signature_algorithms extension" ) );
 
     /*
@@ -1189,6 +1199,7 @@ int mbedtls_ssl_write_signature_algorithms_ext( mbedtls_ssl_context *ssl,
 
     *olen = 6 + sig_alg_len;
 
+    ssl->handshake->extensions_present |= SIGNATURE_ALGORITHM_EXTENSION;
     return( 0 );
 }
 

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -176,14 +176,13 @@ int mbedtls_ssl_create_binder( mbedtls_ssl_context *ssl,
                                unsigned char *psk, size_t psk_len,
                                const mbedtls_md_info_t *md,
                                const mbedtls_ssl_ciphersuite_t *suite_info,
-                               unsigned char *buffer, size_t blen,
                                unsigned char *result )
 {
     int ret = 0;
     int hash_length;
     unsigned char salt[MBEDTLS_MD_MAX_SIZE];
-    unsigned char padbuf[MBEDTLS_MD_MAX_SIZE];
-    unsigned char hash[MBEDTLS_MD_MAX_SIZE];
+    unsigned char transcript[MBEDTLS_MD_MAX_SIZE];
+    size_t transcript_len;
     unsigned char binder_key[MBEDTLS_MD_MAX_SIZE];
     unsigned char finished_key[MBEDTLS_MD_MAX_SIZE];
 
@@ -219,36 +218,6 @@ int mbedtls_ssl_create_binder( mbedtls_ssl_context *ssl,
      *    Derive-Secret( early_secret, "ext binder" | "res binder", "" )
      */
 
-    /* Create hash of empty message first.
-     * TBD: replace by constant.
-     *
-     * For SHA256 the constant is
-     * e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-     *
-     * For SHA384 the constant is
-     * 38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b
-     */
-
-#if defined(MBEDTLS_SHA256_C)
-    if( suite_info->mac == MBEDTLS_MD_SHA256 )
-    {
-        mbedtls_sha256( (const unsigned char *) "", 0, hash, 0 );
-    }
-    else
-#endif /* MBEDTLS_SHA256_C */
-#if defined(MBEDTLS_SHA512_C)
-    if( suite_info->mac == MBEDTLS_MD_SHA384 )
-    {
-        mbedtls_sha512( (const unsigned char *) "", 0,
-                        hash, 1 /* for SHA384 */ );
-    }
-    else
-#endif /* MBEDTLS_SHA512_C */
-    {
-        MBEDTLS_SSL_DEBUG_MSG( 1, ( "mbedtls_ssl_create_binder: Unknow hash function." ) );
-        return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
-    }
-
     if( !is_external )
     {
         ret = mbedtls_ssl_tls1_3_derive_secret( mbedtls_md_get_type( md ),
@@ -274,114 +243,12 @@ int mbedtls_ssl_create_binder( mbedtls_ssl_context *ssl,
         return( ret );
     }
 
-#if defined(MBEDTLS_SHA256_C)
-    if( suite_info->mac == MBEDTLS_MD_SHA256 )
-    {
-        mbedtls_sha256_context sha256;
-        mbedtls_sha256_init( &sha256 );
-
-        if( ( ret = mbedtls_sha256_starts_ret( &sha256, 0 ) ) != 0 )
-        {
-            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha256_starts_ret", ret );
-            goto sha256_done;
-        }
-
-        MBEDTLS_SSL_DEBUG_BUF( 5, "input buffer for psk binder", buffer, blen );
-        if( ( ret = mbedtls_sha256_update_ret( &sha256, buffer, blen ) ) != 0 )
-        {
-            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha256_update_ret", ret );
-            goto sha256_done;
-        }
-
-        if( ( ret = mbedtls_sha256_finish_ret( &sha256, padbuf ) ) != 0 )
-        {
-            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha256_finish_ret", ret );
-            goto sha256_done;
-        }
-        MBEDTLS_SSL_DEBUG_BUF( 5, "handshake hash for psk binder", padbuf, 32 );
-
-    sha256_done:
-
-        mbedtls_sha256_free( &sha256 );
-        if( ret != 0 )
-            goto exit;
-    }
-    else
-#endif /* MBEDTLS_SHA256_C */
-#if defined(MBEDTLS_SHA512_C)
-    if( suite_info->mac == MBEDTLS_MD_SHA384 )
-    {
-        mbedtls_sha512_context sha512;
-        mbedtls_sha512_init( &sha512 );
-
-        if( ( ret = mbedtls_sha512_starts_ret( &sha512, 1 ) ) != 0 )
-        {
-            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha512_starts_ret", ret );
-            goto sha384_done;
-        }
-        mbedtls_sha512_clone( &sha512, &ssl->handshake->fin_sha512 );
-
-        MBEDTLS_SSL_DEBUG_BUF( 5, "input buffer for psk binder", buffer, blen );
-        if( ( ret = mbedtls_sha512_update_ret( &sha512, buffer, blen ) ) != 0 )
-        {
-            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha512_update_ret", ret );
-            mbedtls_sha512_free( &sha512 );
-            goto sha384_done;
-        }
-
-        if( ( ret = mbedtls_sha512_finish_ret( &sha512, padbuf ) ) != 0 )
-        {
-            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha512_finish_ret", ret );
-            goto sha384_done;
-        }
-        MBEDTLS_SSL_DEBUG_BUF( 5, "handshake hash for psk binder", padbuf, 48 );
-
-    sha384_done:
-
-        mbedtls_sha512_free( &sha512 );
-        if( ret != 0 )
-            goto exit;
-
-    }
-    else if( suite_info->mac == MBEDTLS_MD_SHA512 )
-    {
-        mbedtls_sha512_context sha512;
-        mbedtls_sha512_init( &sha512 );
-
-        if( ( ret = mbedtls_sha512_starts_ret( &sha512, 0 ) ) != 0 )
-        {
-            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha512_starts_ret", ret );
-            goto sha512_done;
-        }
-
-        mbedtls_sha512_clone( &sha512, &ssl->handshake->fin_sha512 );
-
-        MBEDTLS_SSL_DEBUG_BUF( 5, "input buffer for psk binder", buffer, blen );
-        if( ( ret = mbedtls_sha512_update_ret( &sha512, buffer, blen ) ) != 0 )
-        {
-            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha512_update_ret", ret );
-            goto sha512_done;
-        }
-
-        if( ( ret = mbedtls_sha512_finish_ret( &sha512, padbuf ) ) != 0 )
-        {
-            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha512_finish_ret", ret );
-            goto sha512_done;
-        }
-        MBEDTLS_SSL_DEBUG_BUF( 5, "handshake hash for psk binder", padbuf, 64 );
-
-    sha512_done:
-
-        mbedtls_sha512_free( &sha512 );
-        if( ret != 0 )
-            goto exit;
-    }
-    else
-#endif /* MBEDTLS_SHA512_C */
-    {
-        MBEDTLS_SSL_DEBUG_MSG( 1, ( "should never happen" ) );
-        return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
-    }
+    /* Get current state of handshake transcript. */
+    ret = mbedtls_ssl_get_handshake_transcript( ssl, suite_info->mac,
+                                                transcript, sizeof( transcript ),
+                                                &transcript_len );
+    if( ret != 0 )
+        return( ret );
 
     /*
      * finished_key =
@@ -406,7 +273,9 @@ int mbedtls_ssl_create_binder( mbedtls_ssl_context *ssl,
     MBEDTLS_SSL_DEBUG_BUF( 3, "finished_key", finished_key, hash_length );
 
     /* compute mac and write it into the buffer */
-    ret = mbedtls_md_hmac( md, finished_key, hash_length, padbuf, hash_length, result );
+    ret = mbedtls_md_hmac( md, finished_key, hash_length,
+                           transcript, transcript_len,
+                           result );
 
     if( ret != 0 )
     {
@@ -415,13 +284,14 @@ int mbedtls_ssl_create_binder( mbedtls_ssl_context *ssl,
     }
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "verify_data of psk binder" ) );
-    MBEDTLS_SSL_DEBUG_BUF( 3, "Input", padbuf, hash_length );
+    MBEDTLS_SSL_DEBUG_BUF( 3, "Input", transcript, hash_length );
     MBEDTLS_SSL_DEBUG_BUF( 3, "Key", finished_key, hash_length );
     MBEDTLS_SSL_DEBUG_BUF( 3, "Output", result, hash_length );
 
 exit:
 
-    mbedtls_platform_zeroize( finished_key, hash_length );
+    mbedtls_platform_zeroize( finished_key, sizeof( finished_key ) );
+    mbedtls_platform_zeroize( binder_key,   sizeof( binder_key ) );
     return( ret );
 }
 #endif /* MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED */
@@ -432,7 +302,7 @@ static int ssl_calc_finished_tls_sha256(
 {
     int ret;
     mbedtls_sha256_context sha256;
-    unsigned char padbuf[32];
+    unsigned char transcript[32];
     unsigned char* finished_key;
     const mbedtls_md_info_t* md;
 
@@ -457,13 +327,13 @@ static int ssl_calc_finished_tls_sha256(
       #endif
     */
 
-    if( ( ret = mbedtls_sha256_finish_ret( &sha256, padbuf ) ) != 0 )
+    if( ( ret = mbedtls_sha256_finish_ret( &sha256, transcript ) ) != 0 )
     {
         MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha256_finish_ret", ret );
         goto exit;
     }
 
-    MBEDTLS_SSL_DEBUG_BUF( 5, "handshake hash", padbuf, 32 );
+    MBEDTLS_SSL_DEBUG_BUF( 5, "handshake hash", transcript, 32 );
 
     /* TLS 1.3 Finished message
      *
@@ -538,7 +408,7 @@ static int ssl_calc_finished_tls_sha256(
     }
 
     /* compute mac and write it into the buffer */
-    ret = mbedtls_md_hmac( md, finished_key, 32, padbuf, 32, buf );
+    ret = mbedtls_md_hmac( md, finished_key, 32, transcript, 32, buf );
 
     ssl->handshake->state_local.finished_out.digest_len = 32;
 
@@ -549,13 +419,13 @@ static int ssl_calc_finished_tls_sha256(
     }
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "verify_data of Finished message" ) );
-    MBEDTLS_SSL_DEBUG_BUF( 3, "Input", padbuf, 32 );
+    MBEDTLS_SSL_DEBUG_BUF( 3, "Input", transcript, 32 );
     MBEDTLS_SSL_DEBUG_BUF( 3, "Key", finished_key, 32 );
     MBEDTLS_SSL_DEBUG_BUF( 3, "Output", buf, 32 );
 
 exit:
     mbedtls_sha256_free( &sha256 );
-    mbedtls_platform_zeroize( padbuf, sizeof( padbuf ) );
+    mbedtls_platform_zeroize( transcript, sizeof( transcript ) );
 
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "<= calc  finished" ) );
     return ( ret );

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -543,37 +543,38 @@ int mbedtls_ssl_parse_new_session_ticket_server(
 #endif /* MBEDTLS_SSL_NEW_SESSION_TICKET */
 
 #if defined(MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED)
-int mbedtls_ssl_parse_client_psk_identity_ext( mbedtls_ssl_context *ssl,
-                                               const unsigned char *buf,
-                                               size_t len )
+int mbedtls_ssl_parse_client_psk_identity_ext(
+    mbedtls_ssl_context *ssl,
+    const unsigned char *buf,
+    size_t len )
 {
     int ret = 0;
-    unsigned char *truncated_clienthello_end;
-    unsigned char  *truncated_clienthello_start = ssl->in_msg;
     unsigned int item_array_length, item_length, sum, length_so_far;
     unsigned char server_computed_binder[MBEDTLS_MD_MAX_SIZE];
     uint32_t obfuscated_ticket_age;
     mbedtls_ssl_ticket ticket;
     const unsigned char *psk = NULL;
+    unsigned char const * const start = buf;
     size_t psk_len = 0;
 #if defined(MBEDTLS_HAVE_TIME)
     time_t now;
     int64_t diff;
 #endif /* MBEDTLS_HAVE_TIME */
+    unsigned char const *end_of_psk_identities;
 
     /* Read length of array of identities */
     item_array_length = ( buf[0] << 8 ) | buf[1];
-
     length_so_far = item_array_length + 2;
-    buf += 2;
     if( length_so_far > len )
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "bad psk_identity extension in client hello message" ) );
         return( MBEDTLS_ERR_SSL_BAD_HS_CLIENT_HELLO );
     }
+    end_of_psk_identities = buf + length_so_far;
+    buf += 2;
     sum = 2;
-    while ( sum < item_array_length+2 ) {
-
+    while( sum < item_array_length + 2 )
+    {
         /* Read to psk identity length */
         item_length = ( buf[0] << 8 ) | buf[1];
         sum = sum + 2 + item_length;
@@ -610,7 +611,8 @@ int mbedtls_ssl_parse_client_psk_identity_ext( mbedtls_ssl_context *ssl,
             {
                 ret = MBEDTLS_ERR_SSL_UNKNOWN_IDENTITY;
             }
-            else {
+            else
+            {
                 /* skip obfuscated ticket age */
                 /* TBD: Process obfuscated ticket age ( zero for externally configured PSKs?! ) */
                 buf = buf + item_length + 4; /* 4 for obfuscated ticket age */;
@@ -797,10 +799,12 @@ int mbedtls_ssl_parse_client_psk_identity_ext( mbedtls_ssl_context *ssl,
 
 psk_parsing_successful:
 
-    /* Store this pointer since we need it to compute
-     *  the psk binder.
-     */
-    truncated_clienthello_end = (unsigned char*) buf;
+    /* Update the handshake transcript with the CH content up to
+     * but excluding the PSK binder list. */
+    ssl->handshake->update_checksum( ssl, start,
+                                     (size_t)( end_of_psk_identities - start ) );
+
+    buf = end_of_psk_identities;
 
     /* read length of psk binder array */
     item_array_length = ( buf[0] << 8 ) | buf[1];
@@ -808,8 +812,8 @@ psk_parsing_successful:
     buf += 2;
 
     sum = 0;
-    while ( sum < item_array_length ) {
-
+    while( sum < item_array_length )
+    {
         /* Read to psk binder length */
         item_length = buf[0];
         sum = sum + 1 + item_length;
@@ -825,10 +829,6 @@ psk_parsing_successful:
             return( MBEDTLS_ERR_SSL_BAD_HS_CLIENT_HELLO );
         }
 
-        MBEDTLS_SSL_DEBUG_BUF( 3, "ssl_calc_binder computed over ",
-             truncated_clienthello_start,
-             truncated_clienthello_end - truncated_clienthello_start );
-
         if( ssl->handshake->resume == 1 )
         {
             /* Case 1: We are using the PSK from a ticket */
@@ -839,8 +839,6 @@ psk_parsing_successful:
                         mbedtls_md_info_from_type(
                             ssl->handshake->ciphersuite_info->mac ),
                         ssl->handshake->ciphersuite_info,
-                        truncated_clienthello_start,
-                        truncated_clienthello_end - truncated_clienthello_start,
                         server_computed_binder );
         }
         else
@@ -855,15 +853,13 @@ psk_parsing_successful:
                      mbedtls_md_info_from_type(
                          ssl->handshake->ciphersuite_info->mac ),
                      ssl->handshake->ciphersuite_info,
-                     truncated_clienthello_start,
-                     truncated_clienthello_end - truncated_clienthello_start,
                      server_computed_binder );
         }
 
         /* We do not check for multiple binders */
         if( ret != 0 )
         {
-            MBEDTLS_SSL_DEBUG_MSG( 1, ( "Psk binder calculation failed." ) );
+            MBEDTLS_SSL_DEBUG_MSG( 1, ( "PSK binder calculation failed." ) );
             return( MBEDTLS_ERR_SSL_BAD_HS_CLIENT_HELLO );
         }
 
@@ -885,11 +881,23 @@ psk_parsing_successful:
         }
 
         buf += item_length;
-        return( 0 );
+
+        ret = 0;
+        goto done;
     }
 
     /* No valid PSK binder value found */
-    return( MBEDTLS_ERR_SSL_BAD_HS_CLIENT_HELLO );
+    /* TODO: Shouldn't we just fall back to a full handshake in this case? */
+    ret = MBEDTLS_ERR_SSL_BAD_HS_CLIENT_HELLO;
+
+done:
+
+    /* Update the handshake transcript with the binder list. */
+    ssl->handshake->update_checksum( ssl,
+                                     end_of_psk_identities,
+                                     (size_t)( buf - end_of_psk_identities ) );
+
+    return( ret );
 }
 #endif /* MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED*/
 
@@ -2217,21 +2225,16 @@ static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
 {
     int ret, final_ret = 0, got_common_suite;
     size_t i, j;
-    size_t  comp_len, sess_len;
-    size_t orig_msg_len, ciph_len, ext_len, ext_len_psk_ext = 0;
+    size_t comp_len, sess_len;
+    size_t ciph_len, ext_len, ext_len_psk_ext = 0;
     unsigned char *orig_buf, *end = buf + buflen;
     unsigned char *ciph_offset;
 #if defined(MBEDTLS_SSL_COOKIE_C) && defined(MBEDTLS_SSL_PROTO_DTLS)
     size_t cookie_offset, cookie_len;
 #endif /* MBEDTLS_SSL_COOKIE_C && MBEDTLS_SSL_PROTO_DTLS */
-    unsigned char* p, * ext, * ext_psk_ptr = NULL;
-#if defined(MBEDTLS_SHA256_C)
-    mbedtls_sha256_context sha256;
-#endif /* MBEDTLS_SHA256_C */
-
-#if defined(MBEDTLS_SHA512_C)
-    mbedtls_sha512_context sha512;
-#endif /* MBEDTLS_SHA512_C */
+    unsigned char *p = NULL;
+    unsigned char *ext = NULL;
+    unsigned char *ext_psk_ptr = NULL;
 
     const int* ciphersuites;
     const mbedtls_ssl_ciphersuite_t* ciphersuite_info;
@@ -2241,7 +2244,6 @@ static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
 
     /* TBD: Refactor */
     orig_buf = buf;
-    orig_msg_len = mbedtls_ssl_hs_hdr_len( ssl ) + ( ( ssl->in_msg[2] << 8 ) | ssl->in_msg[3] );
 
     /*
      * ClientHello layer:
@@ -2471,12 +2473,15 @@ static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
     ext = buf;
     MBEDTLS_SSL_DEBUG_BUF( 3, "client hello extensions", ext, ext_len );
 
-    while ( ext_len != 0 )
+    while( ext_len != 0 )
     {
-        unsigned int ext_id = ( ( ext[0] << 8 )
-                               | ( ext[1] ) );
-        unsigned int ext_size = ( ( ext[2] << 8 )
-                                 | ( ext[3] ) );
+        unsigned int ext_id, ext_size;
+
+        if( ext_len < 4 )
+        {
+            MBEDTLS_SSL_DEBUG_MSG( 1, ( "bad client hello message" ) );
+            return( MBEDTLS_ERR_SSL_BAD_HS_CLIENT_HELLO );
+        }
 
         /* The PSK extension must be the last in the ClientHello.
          * Fail if we've found it already but haven't yet reached
@@ -2487,11 +2492,15 @@ static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
             return( MBEDTLS_ERR_SSL_BAD_HS_CLIENT_HELLO );
         }
 
+        ext_id   = ( ( (size_t) ext[0] << 8 ) | ( (size_t) ext[1] << 0 ) );
+        ext_size = ( ( (size_t) ext[2] << 8 ) | ( (size_t) ext[3] << 0 ) );
+
         if( ext_size + 4 > ext_len )
         {
             MBEDTLS_SSL_DEBUG_MSG( 1, ( "bad client hello message" ) );
             return( MBEDTLS_ERR_SSL_BAD_HS_CLIENT_HELLO );
         }
+
         switch ( ext_id )
         {
 #if defined(MBEDTLS_SSL_SERVER_NAME_INDICATION)
@@ -2703,13 +2712,23 @@ static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
         }
 
         ext_len -= 4 + ext_size;
-        ext += 4 + ext_size;
+        ext     += 4 + ext_size;
+    }
 
-        if( ext_len > 0 && ext_len < 4 )
-        {
-            MBEDTLS_SSL_DEBUG_MSG( 1, ( "bad client hello message" ) );
-            return( MBEDTLS_ERR_SSL_BAD_HS_CLIENT_HELLO );
-        }
+    /* Update checksum with either
+     * - The entire content of the CH message, if no PSK extension is present
+     * - The content up to but excluding the PSK extension, if present.
+     */
+    {
+        unsigned char *ch_without_psk;
+        if( ext_psk_ptr == NULL )
+            ch_without_psk = ext;
+        else
+            ch_without_psk = ext_psk_ptr;
+
+        ssl->handshake->update_checksum( ssl,
+                                         orig_buf,
+                                         ch_without_psk - orig_buf );
     }
 
     /*
@@ -2843,170 +2862,16 @@ static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
     if( final_ret == MBEDTLS_ERR_SSL_BAD_HS_WRONG_KEY_SHARE ||
         final_ret == MBEDTLS_ERR_SSL_BAD_HS_MISSING_COOKIE_EXT )
     {
-        /* create stateless transcript hash for HRR */
-
-        unsigned char transcript[MBEDTLS_MD_MAX_SIZE + 4]; /* used to store the ClientHello1 msg */
-        int hash_length;
-
-        MBEDTLS_SSL_DEBUG_MSG( 5, ( "--- Checksum ( ssl_parse_client_hello, stateless transcript hash for HRR )" ) );
-
         /*
-         *  Transcript-Hash( ClientHello1, HelloRetryRequest, ... MN ) =
-         *     Hash( message_hash         ||
-         *           00 00 Hash.length    ||
-         *	         Hash( ClientHello1 ) ||
-         *           HelloRetryRequest ... MN )
-         *
+         * Create stateless transcript hash for HRR
          */
-        transcript[0] = MBEDTLS_SSL_HS_MESSAGE_HASH;
-        transcript[1] = 0;
-        transcript[2] = 0;
-
-        hash_length = mbedtls_hash_size_for_ciphersuite( ssl->handshake->ciphersuite_info );
-
-        if( hash_length == -1 )
+        MBEDTLS_SSL_DEBUG_MSG( 4, ( "Compress transcript hash for stateless HRR" ) );
+        ret = mbedtls_ssl_hash_transcript( ssl );
+        if( ret != 0 )
         {
-            MBEDTLS_SSL_DEBUG_MSG( 1, ( "mbedtls_hash_size_for_ciphersuite == -1" ) );
-            return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
+            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_hash_transcript", ret );
+            return( ret );
         }
-
-        transcript[3] = ( uint8_t )hash_length;
-
-
-        if( ssl->handshake->ciphersuite_info->mac == MBEDTLS_MD_SHA256 )
-        {
-#if defined(MBEDTLS_SHA256_C)
-            mbedtls_sha256_init( &sha256 );
-
-            if( ( ret = mbedtls_sha256_starts_ret( &sha256, 0 ) ) != 0 )
-            {
-                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha256_starts_ret", ret );
-                final_ret = ret;
-                goto cleanup;
-            }
-
-            /* Hash ClientHello message */
-            if( ( ret = mbedtls_sha256_update_ret( &sha256,
-                                                   orig_buf,
-                                                   orig_msg_len ) ) != 0 )
-            {
-                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha256_update_ret", ret );
-                final_ret = ret;
-                goto cleanup;
-            }
-
-            if( ( ret = mbedtls_sha256_finish_ret( &sha256,
-                                                   &transcript[4]) ) != 0 )
-            {
-                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha256_finish_ret", ret );
-                final_ret = ret;
-                goto cleanup;
-            }
-            MBEDTLS_SSL_DEBUG_BUF( 5, "Transcript-Hash( ClientHello1, HelloRetryRequest, ... MN )", &transcript[0], 32+4 );
-#else
-            MBEDTLS_SSL_DEBUG_MSG( 1, ( "mbedtls_ssl_tls1_3_derive_master_secret: Unknow hash function." ) );
-            return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
-#endif /* MBEDTLS_SHA256_C */
-        }
-        else if( ssl->handshake->ciphersuite_info->mac == MBEDTLS_MD_SHA384 )
-        {
-#if defined(MBEDTLS_SHA512_C)
-            mbedtls_sha512_init( &sha512 );
-
-            if( ( ret = mbedtls_sha512_starts_ret( &sha512, 1 ) ) != 0 )
-            {
-                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha512_starts_ret", ret );
-                final_ret = ret;
-                goto cleanup;
-            }
-
-            /* Hash ClientHello message */
-            if( ( ret = mbedtls_sha512_update_ret( &sha512,
-                                                   orig_buf,
-                                                   orig_msg_len ) ) != 0 )
-            {
-                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha512_update_ret", ret );
-                final_ret = ret;
-                goto cleanup;
-            }
-
-            if( ( ret = mbedtls_sha512_finish_ret( &sha512,
-                                                   &transcript[4] ) ) != 0 )
-            {
-                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha512_finish_ret", ret );
-                goto cleanup;
-            }
-            MBEDTLS_SSL_DEBUG_BUF( 5, "Transcript-Hash( ClientHello1, HelloRetryRequest, ... MN )", &transcript[0], 48+4 );
-#else
-            MBEDTLS_SSL_DEBUG_MSG( 1, ( "mbedtls_ssl_tls1_3_derive_master_secret: Unknow hash function." ) );
-            return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
-#endif /* MBEDTLS_SHA512_C */
-        }
-        else if( ssl->handshake->ciphersuite_info->mac == MBEDTLS_MD_SHA512 )
-        {
-#if defined(MBEDTLS_SHA512_C)
-            mbedtls_sha512_init( &sha512 );
-
-            if( ( ret = mbedtls_sha512_starts_ret( &sha512, 0 ) ) != 0 )
-            {
-                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha512_starts_ret", ret );
-                final_ret = ret;
-                goto cleanup;
-            }
-
-            /* Hash ClientHello message */
-            if( ( ret = mbedtls_sha512_update_ret( &sha512,
-                                                   orig_buf,
-                                                   orig_msg_len ) ) != 0 )
-            {
-                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha512_update_ret", ret );
-                final_ret = ret;
-                goto cleanup;
-            }
-
-            if( ( ret = mbedtls_sha512_finish_ret( &sha512,
-                                                   &transcript[4] ) ) != 0 )
-            {
-                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha512_finish_ret", ret );
-                final_ret = ret;
-                goto cleanup;
-            }
-            MBEDTLS_SSL_DEBUG_BUF( 5, "ClientHello hash", &transcript[4], 64 );
-        }
-        else {
-#else
-            MBEDTLS_SSL_DEBUG_MSG( 1, ( "mbedtls_ssl_tls1_3_derive_master_secret: Unknow hash function." ) );
-            return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
-#endif  /* MBEDTLS_SHA512_C */
-        }
-        ssl->handshake->update_checksum( ssl, &transcript[0], hash_length + 4 );
-    }
-    else {
-        /* create normal transcript hash */
-        MBEDTLS_SSL_DEBUG_MSG( 5, ( "--- Checksum ( ssl_parse_client_hello, normal transcript hash )" ) );
-        ssl->handshake->update_checksum( ssl, orig_buf, orig_msg_len );
-    }
-    mbedtls_ssl_optimize_checksum( ssl, ssl->handshake->ciphersuite_info );
-
-cleanup:
-#if defined(MBEDTLS_SHA256_C)
-    if( ssl->handshake->ciphersuite_info->mac == MBEDTLS_MD_SHA256 )
-    {
-        mbedtls_sha256_free( &sha256 );
-    }
-    else
-#endif
-#if defined(MBEDTLS_SHA512_C)
-    if( ssl->handshake->ciphersuite_info->mac == MBEDTLS_MD_SHA384 ||
-        ssl->handshake->ciphersuite_info->mac == MBEDTLS_MD_SHA512 )
-    {
-        mbedtls_sha512_free( &sha512 );
-    }
-    else
-#endif
-    {
-        MBEDTLS_SSL_DEBUG_MSG( 1, ( "mbedtls_ssl_tls1_3_derive_master_secret: Unknow hash function." ) );
-        return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
     }
 
     return( final_ret );

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -2478,6 +2478,15 @@ static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
         unsigned int ext_size = ( ( ext[2] << 8 )
                                  | ( ext[3] ) );
 
+        /* The PSK extension must be the last in the ClientHello.
+         * Fail if we've found it already but haven't yet reached
+         * the end of the extension block. */
+        if( ext_psk_ptr != NULL )
+        {
+            MBEDTLS_SSL_DEBUG_MSG( 1, ( "bad client hello message" ) );
+            return( MBEDTLS_ERR_SSL_BAD_HS_CLIENT_HELLO );
+        }
+
         if( ext_size + 4 > ext_len )
         {
             MBEDTLS_SSL_DEBUG_MSG( 1, ( "bad client hello message" ) );


### PR DESCRIPTION
This PR improves structure and reduces code-duplication around the calculation of handshake transcripts and the (related) calculation and verification of PSK binders in the ClientHello PSK extension.

This also fixes #133 and #113.