### PR TITLE
Use MPS to write EncryptedExtensions, Certificate, CertificateRequest message

### DIFF
--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -1618,6 +1618,14 @@ struct mbedtls_ssl_context
     mbedtls_ssl_transform *transform_handshake;
     mbedtls_ssl_transform *transform_earlydata;
     mbedtls_ssl_transform *transform_application;
+
+#if defined(MBEDTLS_SSL_USE_MPS)
+    /* With MPS, we only remember opaque epoch IDs from the handshake
+     * layer. The transform themselves are managed by MPS. */
+    mbedtls_mps_epoch_id epoch_handshake;
+    mbedtls_mps_epoch_id epoch_earlydata;
+    mbedtls_mps_epoch_id epoch_application;
+#endif /* MBEDTLS_SSL_USE_MPS */
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 
 #if defined(MBEDTLS_SSL_USE_MPS)

--- a/library/mps/layer1.c
+++ b/library/mps/layer1.c
@@ -162,6 +162,9 @@ MBEDTLS_MPS_STATIC void l1_release_if_set( unsigned char **buf_ptr,
                               mps_alloc *ctx,
                               mps_alloc_type purpose )
 {
+    if( *buf_ptr == NULL )
+        return;
+
     *buf_ptr = NULL;
     mps_alloc_release( ctx, purpose );
 }
@@ -171,8 +174,7 @@ MBEDTLS_MPS_STATIC int l1_acquire_if_unset( unsigned char **buf_ptr,
                                             mps_alloc *ctx,
                                             mps_alloc_type purpose )
 {
-    unsigned char *buf = *buf_ptr;
-    if( buf != NULL )
+    if( *buf_ptr != NULL )
         return( 0 );
 
     return( mps_alloc_acquire( ctx, purpose, buf_ptr, buflen ) );

--- a/library/mps/layer2.c
+++ b/library/mps/layer2.c
@@ -719,9 +719,12 @@ int l2_out_prepare_record( mbedtls_mps_l2 *ctx,
     if( ret != 0 )
         RETURN( ret );
 
+    TRACE( trace_comment, "Transform expansion:" );
     mbedtls_mps_transform_get_expansion( epoch->transform,
                                          &pre_expansion,
                                          &post_expansion );
+    TRACE( trace_comment, "* Pre:  %u", (unsigned) pre_expansion  );
+    TRACE( trace_comment, "* Post: %u", (unsigned) post_expansion );
 
 #if defined(MBEDTLS_MPS_TRANSFORM_VALIDATION)
     {
@@ -745,7 +748,9 @@ int l2_out_prepare_record( mbedtls_mps_l2 *ctx,
     {
         mbedtls_mps_size_t bytes_pending;
         TRACE( trace_comment, "Not enough space for to hold a non-empty record." );
-        TRACE( trace_comment, "Need at least %u ( %u header + %u pre-expansion + %u post-expansion + 1 plaintext ) byte, but have only %u bytes available.",
+        TRACE( trace_comment, "Need at least %u ( %u header + %u pre-expansion + "
+                              "%u post-expansion + 1 plaintext ) byte, but have only "
+                              "%u bytes available.",
                (unsigned)( hdr_len + pre_expansion + post_expansion + 1 ),
                (unsigned) hdr_len,
                (unsigned) pre_expansion,
@@ -883,6 +888,8 @@ int l2_out_dispatch_record( mbedtls_mps_l2 *ctx )
             TRACE( trace_comment, "The record encryption failed with %d", ret );
             RETURN( ret );
         }
+        TRACE( trace_comment, "Record type after encryption: %u",
+               (unsigned) rec.type );
 
 #if defined(MBEDTLS_MPS_TRANSFORM_VALIDATION)
         /* Double-check that we have calculated the offset of the
@@ -1031,7 +1038,8 @@ int l2_out_write_protected_record_tls( mbedtls_mps_l2 *ctx, mps_rec *rec )
     /* Write ciphertext length. */
     MPS_WRITE_UINT16_BE( &rec->buf.data_len, hdr + tls_rec_len_offset );
 
-    TRACE( trace_comment, "Write protected record -- DISPATCH" );
+    TRACE( trace_comment, "* Type:    %u", (unsigned) rec->type );
+    TRACE( trace_comment, "* Version: %u", (unsigned) rec->minor_ver );
     RETURN( mps_l1_dispatch( l1, hdr_len + rec->buf.data_len, NULL ) );
 }
 #endif /* MBEDTLS_MPS_PROTO_TLS */

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -624,6 +624,7 @@ int mbedtls_mps_transform_encrypt_default(
 
     rec->buf.data_offset = rec_alt.data_offset;
     rec->buf.data_len = rec_alt.data_len;
+    rec->type = rec_alt.type;
 
     return( 0 );
 }

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -607,14 +607,14 @@ int mbedtls_mps_transform_encrypt_default(
     rec_alt.data_len = rec->buf.data_len;
     rec_alt.data_offset = rec->buf.data_offset;
     rec_alt.type = rec->type;
-    rec_alt.ctr[0] = ( rec->ctr[1] >> 24 ) & 0xFF;
-    rec_alt.ctr[1] = ( rec->ctr[1] >> 16 ) & 0xFF;
-    rec_alt.ctr[2] = ( rec->ctr[1] >>  8 ) & 0xFF;
-    rec_alt.ctr[3] = ( rec->ctr[1] >>  0 ) & 0xFF;
-    rec_alt.ctr[4] = ( rec->ctr[0] >> 24 ) & 0xFF;
-    rec_alt.ctr[5] = ( rec->ctr[0] >> 16 ) & 0xFF;
-    rec_alt.ctr[6] = ( rec->ctr[0] >>  8 ) & 0xFF;
-    rec_alt.ctr[7] = ( rec->ctr[0] >>  0 ) & 0xFF;
+    rec_alt.ctr[0] = ( rec->ctr[0] >> 24 ) & 0xFF;
+    rec_alt.ctr[1] = ( rec->ctr[0] >> 16 ) & 0xFF;
+    rec_alt.ctr[2] = ( rec->ctr[0] >>  8 ) & 0xFF;
+    rec_alt.ctr[3] = ( rec->ctr[0] >>  0 ) & 0xFF;
+    rec_alt.ctr[4] = ( rec->ctr[1] >> 24 ) & 0xFF;
+    rec_alt.ctr[5] = ( rec->ctr[1] >> 16 ) & 0xFF;
+    rec_alt.ctr[6] = ( rec->ctr[1] >>  8 ) & 0xFF;
+    rec_alt.ctr[7] = ( rec->ctr[1] >>  0 ) & 0xFF;
     mbedtls_ssl_write_version( rec->major_ver, rec->minor_ver,
                    MBEDTLS_MPS_MODE_STREAM, &rec_alt.ver[0] );
 
@@ -652,14 +652,14 @@ int mbedtls_mps_transform_decrypt_default( void *transform_, mps_rec *rec )
     rec_alt.data_len = rec->buf.data_len;
     rec_alt.data_offset = rec->buf.data_offset;
     rec_alt.type = rec->type;
-    rec_alt.ctr[0] = ( rec->ctr[1] >> 24 ) & 0xFF;
-    rec_alt.ctr[1] = ( rec->ctr[1] >> 16 ) & 0xFF;
-    rec_alt.ctr[2] = ( rec->ctr[1] >>  8 ) & 0xFF;
-    rec_alt.ctr[3] = ( rec->ctr[1] >>  0 ) & 0xFF;
-    rec_alt.ctr[4] = ( rec->ctr[0] >> 24 ) & 0xFF;
-    rec_alt.ctr[5] = ( rec->ctr[0] >> 16 ) & 0xFF;
-    rec_alt.ctr[6] = ( rec->ctr[0] >>  8 ) & 0xFF;
-    rec_alt.ctr[7] = ( rec->ctr[0] >>  0 ) & 0xFF;
+    rec_alt.ctr[0] = ( rec->ctr[0] >> 24 ) & 0xFF;
+    rec_alt.ctr[1] = ( rec->ctr[0] >> 16 ) & 0xFF;
+    rec_alt.ctr[2] = ( rec->ctr[0] >>  8 ) & 0xFF;
+    rec_alt.ctr[3] = ( rec->ctr[0] >>  0 ) & 0xFF;
+    rec_alt.ctr[4] = ( rec->ctr[1] >> 24 ) & 0xFF;
+    rec_alt.ctr[5] = ( rec->ctr[1] >> 16 ) & 0xFF;
+    rec_alt.ctr[6] = ( rec->ctr[1] >>  8 ) & 0xFF;
+    rec_alt.ctr[7] = ( rec->ctr[1] >>  0 ) & 0xFF;
     mbedtls_ssl_write_version( rec->major_ver, rec->minor_ver,
                                MBEDTLS_MPS_MODE_STREAM, &rec_alt.ver[0] );
 

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -693,6 +693,7 @@ int mbedtls_mps_transform_get_expansion_default( void *transform_,
     {
     case MBEDTLS_MODE_GCM:
     case MBEDTLS_MODE_CCM:
+    case MBEDTLS_MODE_CHACHAPOLY:
         *post_exp = transform->taglen;
         break;
 

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -4628,7 +4628,13 @@ int mbedtls_ssl_session_reset_int( mbedtls_ssl_context *ssl, int partial )
     ssl->transform_handshake   = NULL;
     ssl->transform_earlydata   = NULL;
     ssl->transform_application = NULL;
-#endif
+
+#if defined(MBEDTLS_SSL_USE_MPS)
+    ssl_mps_free( ssl );
+    ssl_mps_init( ssl );
+#endif /* MBEDTLS_SSL_USE_MPS */
+
+#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 
     if( ssl->session )
     {

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -4375,6 +4375,15 @@ exit:
 
     return( ret );
 }
+
+static void ssl_mps_free( mbedtls_ssl_context *ssl )
+{
+    mbedtls_mps_free( &ssl->mps.l4 );
+    mps_l3_free( &ssl->mps.l3 );
+    mps_l2_free( &ssl->mps.l2 );
+    mps_l1_free( &ssl->mps.l1 );
+    mps_alloc_free( &ssl->mps.alloc );
+}
 #endif /* MEDTLS_SSL_USE_MPS */
 
 /*
@@ -7454,6 +7463,10 @@ void mbedtls_ssl_free( mbedtls_ssl_context *ssl )
         return;
 
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> free" ) );
+
+#if defined(MBEDTLS_SSL_USE_MPS)
+    ssl_mps_free( ssl );
+#endif /* MBEDTLS_SSL_USE_MPS */
 
     if( ssl->out_buf != NULL )
     {

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -4171,12 +4171,14 @@ static int ssl_handshake_init( mbedtls_ssl_context *ssl )
 #endif
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+        mbedtls_ssl_transform_free( ssl->transform_handshake   );
+        mbedtls_ssl_transform_free( ssl->transform_earlydata   );
+        mbedtls_ssl_transform_free( ssl->transform_application );
         mbedtls_free( ssl->transform_handshake   );
         mbedtls_free( ssl->transform_earlydata   );
         mbedtls_free( ssl->transform_application );
         ssl->transform_handshake   = NULL;
         ssl->transform_earlydata   = NULL;
-
         ssl->transform_application = NULL;
 #endif
 
@@ -4606,6 +4608,18 @@ int mbedtls_ssl_session_reset_int( mbedtls_ssl_context *ssl, int partial )
         ssl->transform = NULL;
     }
 #endif /* MBEDTLS_SSL_PROTO_TLS1_2_OR_EARLIER */
+
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+    mbedtls_ssl_transform_free( ssl->transform_handshake   );
+    mbedtls_ssl_transform_free( ssl->transform_earlydata   );
+    mbedtls_ssl_transform_free( ssl->transform_application );
+    mbedtls_free( ssl->transform_handshake   );
+    mbedtls_free( ssl->transform_earlydata   );
+    mbedtls_free( ssl->transform_application );
+    ssl->transform_handshake   = NULL;
+    ssl->transform_earlydata   = NULL;
+    ssl->transform_application = NULL;
+#endif
 
     if( ssl->session )
     {
@@ -7483,6 +7497,18 @@ void mbedtls_ssl_free( mbedtls_ssl_context *ssl )
     }
 #endif
 
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+    mbedtls_ssl_transform_free( ssl->transform_handshake   );
+    mbedtls_ssl_transform_free( ssl->transform_earlydata   );
+    mbedtls_ssl_transform_free( ssl->transform_application );
+    mbedtls_free( ssl->transform_handshake   );
+    mbedtls_free( ssl->transform_earlydata   );
+    mbedtls_free( ssl->transform_application );
+    ssl->transform_handshake   = NULL;
+    ssl->transform_earlydata   = NULL;
+    ssl->transform_application = NULL;
+#endif
+
     if( ssl->handshake )
     {
         mbedtls_ssl_handshake_free( ssl );
@@ -7500,6 +7526,9 @@ void mbedtls_ssl_free( mbedtls_ssl_context *ssl )
         mbedtls_free( ssl->transform_handshake   );
         mbedtls_free( ssl->transform_earlydata   );
         mbedtls_free( ssl->transform_application );
+        ssl->transform_handshake   = NULL;
+        ssl->transform_earlydata   = NULL;
+        ssl->transform_application = NULL;
 #endif
 
         mbedtls_ssl_session_free( ssl->session_negotiate );

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -3726,6 +3726,31 @@ static int ssl_server_hello_write( mbedtls_ssl_context* ssl,
         return( MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL );
     }
 
+#if !defined(MBEDTLS_SSL_USE_MPS)
+    /*
+     *  TLS 1.3
+     *     0  .   0   handshake type
+     *     1  .   3   handshake length
+     *
+     *  cTLS
+     *     0  .   0   handshake type
+     *
+     * The header is set by ssl_write_record.
+     * For DTLS 1.3 the other fields are adjusted.
+     */
+#if defined(MBEDTLS_SSL_TLS13_CTLS)
+    if( ssl->handshake->ctls == MBEDTLS_SSL_TLS13_CTLS_USE )
+    {
+        buf++; /* skip handshake type */
+        buflen--;
+    } else
+#endif /* MBEDTLS_SSL_TLS13_CTLS */
+    {
+        buf += 4; /* skip handshake type + length */
+        buflen -=4;
+    }
+#endif /* MBEDTLS_SSL_USE_MPS */
+
     /* Version */
 #if defined(MBEDTLS_SSL_TLS13_CTLS)
     if( ssl->handshake->ctls == MBEDTLS_SSL_TLS13_CTLS_DO_NOT_USE )


### PR DESCRIPTION
__Context:__ This PR continues the gradual progression of the TLS 1.3 prototype to using MPS. The first PR #107 in this series introduces the MPS structures themselves and used them to write the CH and SH on client and sever (unencrypted).

__This PR:__ This PR uses MPS to write the `EncryptedExtensions`, `Certificate` and `CertificateRequest`. This is much more interesting than CH and SH because those messages are actually encrypted message, so the key configuration API of MPS needs to be used.