### PR TITLE
Simplify state machine evolution around 0-RTT

### DIFF
--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -174,6 +174,7 @@ static int ssl_write_early_data_prepare( mbedtls_ssl_context* ssl )
     }
 
     /* Activate transform */
+    MBEDTLS_SSL_DEBUG_MSG( 1, ( "Switch to 0-RTT keys for outbound traffic" ) );
     mbedtls_ssl_set_outbound_transform( ssl, ssl->transform_earlydata );
 
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
@@ -4221,6 +4222,7 @@ int mbedtls_ssl_handshake_client_step( mbedtls_ssl_context *ssl )
         case MBEDTLS_SSL_HANDSHAKE_WRAPUP:
 
             mbedtls_ssl_set_inbound_transform ( ssl, ssl->transform_application );
+            MBEDTLS_SSL_DEBUG_MSG( 1, ( "Switch to application keys for all traffic" ) );
             mbedtls_ssl_set_outbound_transform( ssl, ssl->transform_application );
 
             mbedtls_ssl_handshake_wrapup( ssl );

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -124,25 +124,21 @@ int ssl_write_early_data_process( mbedtls_ssl_context* ssl )
 
     MBEDTLS_SSL_PROC_CHK( ssl_write_early_data_prepare( ssl ) );
 
-    if ( ret == 0 )
-    {
-        /* Make sure we can write a new message. */
-        MBEDTLS_SSL_PROC_CHK( mbedtls_ssl_flush_output( ssl ) );
+    /* Make sure we can write a new message. */
+    MBEDTLS_SSL_PROC_CHK( mbedtls_ssl_flush_output( ssl ) );
 
-        /* Write early-data to message buffer. */
-        MBEDTLS_SSL_PROC_CHK( ssl_write_early_data_write( ssl, ssl->out_msg,
-            MBEDTLS_SSL_MAX_CONTENT_LEN,
-            &ssl->out_msglen ) );
+    /* Write early-data to message buffer. */
+    MBEDTLS_SSL_PROC_CHK( ssl_write_early_data_write( ssl, ssl->out_msg,
+                                                      MBEDTLS_SSL_MAX_CONTENT_LEN,
+                                                      &ssl->out_msglen ) );
 
-        ssl->out_msgtype = MBEDTLS_SSL_MSG_APPLICATION_DATA;
+    ssl->out_msgtype = MBEDTLS_SSL_MSG_APPLICATION_DATA;
 
-        /* Dispatch message */
-        MBEDTLS_SSL_PROC_CHK( mbedtls_ssl_write_record( ssl, SSL_FORCE_FLUSH ) );
+    /* Dispatch message */
+    MBEDTLS_SSL_PROC_CHK( mbedtls_ssl_write_record( ssl, SSL_FORCE_FLUSH ) );
 
-        /* Update state */
-        MBEDTLS_SSL_PROC_CHK( ssl_write_early_data_postprocess( ssl ) );
-
-    }
+    /* Update state */
+    MBEDTLS_SSL_PROC_CHK( ssl_write_early_data_postprocess( ssl ) );
 
 cleanup:
 
@@ -265,26 +261,22 @@ int ssl_write_end_of_early_data_process( mbedtls_ssl_context* ssl )
 
     MBEDTLS_SSL_PROC_CHK( ssl_write_end_of_early_data_prepare( ssl ) );
 
-    if ( ret == 0 )
-    {
-        /* Make sure we can write a new message. */
-        MBEDTLS_SSL_PROC_CHK( mbedtls_ssl_flush_output( ssl ) );
+    /* Make sure we can write a new message. */
+    MBEDTLS_SSL_PROC_CHK( mbedtls_ssl_flush_output( ssl ) );
 
-        /* Write end-of-early-data to message buffer. */
-        MBEDTLS_SSL_PROC_CHK( ssl_write_end_of_early_data_write( ssl, ssl->out_msg,
-            MBEDTLS_SSL_MAX_CONTENT_LEN,
-            &ssl->out_msglen ) );
+    /* Write end-of-early-data to message buffer. */
+    MBEDTLS_SSL_PROC_CHK( ssl_write_end_of_early_data_write( ssl, ssl->out_msg,
+                                                             MBEDTLS_SSL_MAX_CONTENT_LEN,
+                                                             &ssl->out_msglen ) );
 
-        ssl->out_msgtype = MBEDTLS_SSL_MSG_HANDSHAKE;
-        ssl->out_msg[0] = MBEDTLS_SSL_HS_END_OF_EARLY_DATA;
+    ssl->out_msgtype = MBEDTLS_SSL_MSG_HANDSHAKE;
+    ssl->out_msg[0] = MBEDTLS_SSL_HS_END_OF_EARLY_DATA;
 
-        /* Dispatch message */
-        MBEDTLS_SSL_PROC_CHK( mbedtls_ssl_write_handshake_msg( ssl ) );
+    /* Dispatch message */
+    MBEDTLS_SSL_PROC_CHK( mbedtls_ssl_write_handshake_msg( ssl ) );
 
-        /* Update state */
-        MBEDTLS_SSL_PROC_CHK( ssl_write_end_of_early_data_postprocess( ssl ) );
-
-    }
+    /* Update state */
+    MBEDTLS_SSL_PROC_CHK( ssl_write_end_of_early_data_postprocess( ssl ) );
 
 cleanup:
 

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -4108,7 +4108,7 @@ int mbedtls_ssl_handshake_client_step( mbedtls_ssl_context *ssl )
 #if defined(MBEDTLS_ZERO_RTT)
             if( ssl->handshake->early_data == MBEDTLS_SSL_EARLY_DATA_ON )
             {
-                mbedtls_ssl_handshake_set_state( ssl, MBEDTLS_SSL_EARLY_DATA );
+                mbedtls_ssl_handshake_set_state( ssl, MBEDTLS_SSL_END_OF_EARLY_DATA );
             }
             else
 #endif /* MBEDTLS_ZERO_RTT */
@@ -4126,7 +4126,7 @@ int mbedtls_ssl_handshake_client_step( mbedtls_ssl_context *ssl )
 
             /* ----- WRITE END-OF-EARLY-DATA ----*/
 
-        case MBEDTLS_SSL_EARLY_DATA:
+        case MBEDTLS_SSL_END_OF_EARLY_DATA:
 
             ret = ssl_write_end_of_early_data_process( ssl );
 

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -97,11 +97,12 @@ static int check_ecdh_params( const mbedtls_ssl_context *ssl )
   * Overview
   */
 
-#if defined(MBEDTLS_ZERO_RTT)
-
   /* Main state-handling entry point; orchestrates the other functions. */
 int ssl_write_early_data_process( mbedtls_ssl_context* ssl );
 
+#define SSL_EARLY_DATA_WRITE 0
+#define SSL_EARLY_DATA_SKIP  1
+static int ssl_write_early_data_coordinate( mbedtls_ssl_context* ssl );
 static int ssl_write_early_data_prepare( mbedtls_ssl_context* ssl );
 
 /* Write early-data message */
@@ -122,20 +123,24 @@ int ssl_write_early_data_process( mbedtls_ssl_context* ssl )
     int ret;
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> write early data" ) );
 
-    MBEDTLS_SSL_PROC_CHK( ssl_write_early_data_prepare( ssl ) );
+    MBEDTLS_SSL_PROC_CHK( ssl_write_early_data_coordinate( ssl ) );
+    if( ret == SSL_EARLY_DATA_WRITE )
+    {
+        MBEDTLS_SSL_PROC_CHK( ssl_write_early_data_prepare( ssl ) );
 
-    /* Make sure we can write a new message. */
-    MBEDTLS_SSL_PROC_CHK( mbedtls_ssl_flush_output( ssl ) );
+        /* Make sure we can write a new message. */
+        MBEDTLS_SSL_PROC_CHK( mbedtls_ssl_flush_output( ssl ) );
 
-    /* Write early-data to message buffer. */
-    MBEDTLS_SSL_PROC_CHK( ssl_write_early_data_write( ssl, ssl->out_msg,
-                                                      MBEDTLS_SSL_MAX_CONTENT_LEN,
-                                                      &ssl->out_msglen ) );
+        /* Write early-data to message buffer. */
+        MBEDTLS_SSL_PROC_CHK( ssl_write_early_data_write( ssl, ssl->out_msg,
+                                                          MBEDTLS_SSL_MAX_CONTENT_LEN,
+                                                          &ssl->out_msglen ) );
 
-    ssl->out_msgtype = MBEDTLS_SSL_MSG_APPLICATION_DATA;
+        ssl->out_msgtype = MBEDTLS_SSL_MSG_APPLICATION_DATA;
 
-    /* Dispatch message */
-    MBEDTLS_SSL_PROC_CHK( mbedtls_ssl_write_record( ssl, SSL_FORCE_FLUSH ) );
+        /* Dispatch message */
+        MBEDTLS_SSL_PROC_CHK( mbedtls_ssl_write_record( ssl, SSL_FORCE_FLUSH ) );
+    }
 
     /* Update state */
     MBEDTLS_SSL_PROC_CHK( ssl_write_early_data_postprocess( ssl ) );
@@ -145,6 +150,21 @@ cleanup:
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "<= write early data" ) );
     return( ret );
 }
+
+#if defined(MBEDTLS_ZERO_RTT)
+static int ssl_write_early_data_coordinate( mbedtls_ssl_context* ssl )
+{
+    if( ssl->handshake->early_data != MBEDTLS_SSL_EARLY_DATA_ON )
+        return( SSL_EARLY_DATA_SKIP );
+
+    return( SSL_EARLY_DATA_WRITE );
+}
+#else /* MBEDTLS_ZERO_RTT */
+static int ssl_write_early_data_coordinate( mbedtls_ssl_context* ssl )
+{
+    return( SSL_EARLY_DATA_SKIP );
+}
+#endif /* MBEDTLS_ZERO_RTT */
 
 static int ssl_write_early_data_prepare( mbedtls_ssl_context* ssl )
 {
@@ -221,8 +241,6 @@ static int ssl_write_early_data_postprocess( mbedtls_ssl_context* ssl )
     return ( 0 );
 }
 
-#endif /* MBEDTLS_ZERO_RTT */
-
 
 /*
  *
@@ -234,12 +252,12 @@ static int ssl_write_early_data_postprocess( mbedtls_ssl_context* ssl )
   * Overview
   */
 
-#if defined(MBEDTLS_ZERO_RTT)
-
   /* Main state-handling entry point; orchestrates the other functions. */
 int ssl_write_end_of_early_data_process( mbedtls_ssl_context* ssl );
 
-static int ssl_write_end_of_early_data_prepare( mbedtls_ssl_context* ssl );
+#define SSL_END_OF_EARLY_DATA_WRITE 0
+#define SSL_END_OF_EARLY_DATA_SKIP  1
+static int ssl_write_end_of_early_data_coordinate( mbedtls_ssl_context* ssl );
 
 /* Write nd-of-early-data message */
 static int ssl_write_end_of_early_data_write( mbedtls_ssl_context* ssl,
@@ -259,21 +277,25 @@ int ssl_write_end_of_early_data_process( mbedtls_ssl_context* ssl )
     int ret;
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> write EndOfEarlyData" ) );
 
-    MBEDTLS_SSL_PROC_CHK( ssl_write_end_of_early_data_prepare( ssl ) );
+    MBEDTLS_SSL_PROC_CHK( ssl_write_end_of_early_data_coordinate( ssl ) );
 
-    /* Make sure we can write a new message. */
-    MBEDTLS_SSL_PROC_CHK( mbedtls_ssl_flush_output( ssl ) );
+    if( ret == SSL_END_OF_EARLY_DATA_WRITE )
+    {
+        /* Make sure we can write a new message. */
+        MBEDTLS_SSL_PROC_CHK( mbedtls_ssl_flush_output( ssl ) );
 
-    /* Write end-of-early-data to message buffer. */
-    MBEDTLS_SSL_PROC_CHK( ssl_write_end_of_early_data_write( ssl, ssl->out_msg,
-                                                             MBEDTLS_SSL_MAX_CONTENT_LEN,
-                                                             &ssl->out_msglen ) );
+        /* Write end-of-early-data to message buffer. */
+        MBEDTLS_SSL_PROC_CHK( ssl_write_end_of_early_data_write(
+                                  ssl, ssl->out_msg,
+                                  MBEDTLS_SSL_MAX_CONTENT_LEN,
+                                  &ssl->out_msglen ) );
 
-    ssl->out_msgtype = MBEDTLS_SSL_MSG_HANDSHAKE;
-    ssl->out_msg[0] = MBEDTLS_SSL_HS_END_OF_EARLY_DATA;
+        ssl->out_msgtype = MBEDTLS_SSL_MSG_HANDSHAKE;
+        ssl->out_msg[0] = MBEDTLS_SSL_HS_END_OF_EARLY_DATA;
 
-    /* Dispatch message */
-    MBEDTLS_SSL_PROC_CHK( mbedtls_ssl_write_handshake_msg( ssl ) );
+        /* Dispatch message */
+        MBEDTLS_SSL_PROC_CHK( mbedtls_ssl_write_handshake_msg( ssl ) );
+    }
 
     /* Update state */
     MBEDTLS_SSL_PROC_CHK( ssl_write_end_of_early_data_postprocess( ssl ) );
@@ -284,10 +306,16 @@ cleanup:
     return( ret );
 }
 
-static int ssl_write_end_of_early_data_prepare( mbedtls_ssl_context* ssl )
+static int ssl_write_end_of_early_data_coordinate( mbedtls_ssl_context* ssl )
 {
     ((void) ssl);
-    return( 0 );
+
+#if defined(MBEDTLS_ZERO_RTT)
+    if( ssl->handshake->early_data == MBEDTLS_SSL_EARLY_DATA_ON )
+        return( SSL_END_OF_EARLY_DATA_WRITE );
+#endif /* MBEDTLS_ZERO_RTT */
+
+    return( SSL_END_OF_EARLY_DATA_SKIP );
 }
 
 static int ssl_write_end_of_early_data_write( mbedtls_ssl_context* ssl,
@@ -310,18 +338,21 @@ static int ssl_write_end_of_early_data_write( mbedtls_ssl_context* ssl,
     return( 0 );
 }
 
-
-
 static int ssl_write_end_of_early_data_postprocess( mbedtls_ssl_context* ssl )
 {
+#if defined(MBEDTLS_SSL_TLS13_COMPATIBILITY_MODE)
+#if defined(MBEDTLS_ZERO_RTT)
+    if( ssl->handshake->early_data != MBEDTLS_SSL_EARLY_DATA_ON )
+#endif /* MBEDTLS_ZERO_RTT */
+    {
+        mbedtls_ssl_handshake_set_state( ssl, MBEDTLS_SSL_CLIENT_CCS_AFTER_SERVER_FINISHED );
+        return( 0 );
+    }
+#endif /* MBEDTLS_SSL_TLS13_COMPATIBILITY_MODE */
 
-    mbedtls_ssl_handshake_set_state( ssl, MBEDTLS_SSL_CLIENT_FINISHED );
-
+    mbedtls_ssl_handshake_set_state( ssl, MBEDTLS_SSL_CLIENT_CERTIFICATE );
     return ( 0 );
 }
-
-
-#endif /* MBEDTLS_ZERO_RTT */
 
 
 #if defined(MBEDTLS_SSL_SERVER_NAME_INDICATION)
@@ -3851,20 +3882,11 @@ int mbedtls_ssl_handshake_client_step( mbedtls_ssl_context *ssl )
                 mbedtls_ack_add_record( ssl, MBEDTLS_SSL_HS_CLIENT_HELLO, MBEDTLS_SSL_ACK_RECORDS_SENT );
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
 
-#if defined(MBEDTLS_ZERO_RTT)
-            if( ssl->handshake->early_data == MBEDTLS_SSL_EARLY_DATA_ON )
-            {
 #if defined(MBEDTLS_SSL_TLS13_COMPATIBILITY_MODE)
-                mbedtls_ssl_handshake_set_state( ssl, MBEDTLS_SSL_CLIENT_CCS_AFTER_CLIENT_HELLO );
+            mbedtls_ssl_handshake_set_state( ssl, MBEDTLS_SSL_CLIENT_CCS_AFTER_CLIENT_HELLO );
 #else
-                mbedtls_ssl_handshake_set_state( ssl, MBEDTLS_SSL_EARLY_APP_DATA );
+            mbedtls_ssl_handshake_set_state( ssl, MBEDTLS_SSL_EARLY_APP_DATA );
 #endif /* MBEDTLS_SSL_TLS13_COMPATIBILITY_MODE */
-            }
-            else
-#endif /* MBEDTLS_ZERO_RTT */
-            {
-                mbedtls_ssl_handshake_set_state( ssl, MBEDTLS_SSL_SERVER_HELLO );
-            }
 
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
             if( ssl->conf->transport == MBEDTLS_SSL_TRANSPORT_DATAGRAM )
@@ -3880,7 +3902,6 @@ int mbedtls_ssl_handshake_client_step( mbedtls_ssl_context *ssl )
         case MBEDTLS_SSL_CLIENT_CCS_AFTER_CLIENT_HELLO:
 
             ret = mbedtls_ssl_write_change_cipher_spec_process( ssl );
-
             if( ret != 0 )
             {
                 MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_write_change_cipher_spec_process", ret );
@@ -4097,22 +4118,7 @@ int mbedtls_ssl_handshake_client_step( mbedtls_ssl_context *ssl )
                 mbedtls_ack_add_record( ssl, MBEDTLS_SSL_HS_FINISHED, MBEDTLS_SSL_ACK_RECORDS_RECEIVED );
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
 
-#if defined(MBEDTLS_ZERO_RTT)
-            if( ssl->handshake->early_data == MBEDTLS_SSL_EARLY_DATA_ON )
-            {
-                mbedtls_ssl_handshake_set_state( ssl, MBEDTLS_SSL_END_OF_EARLY_DATA );
-            }
-            else
-#endif /* MBEDTLS_ZERO_RTT */
-            {
-#if defined(MBEDTLS_SSL_TLS13_COMPATIBILITY_MODE)
-                mbedtls_ssl_handshake_set_state( ssl, MBEDTLS_SSL_CLIENT_CCS_AFTER_SERVER_FINISHED );
-#else
-                mbedtls_ssl_handshake_set_state( ssl, MBEDTLS_SSL_CLIENT_CERTIFICATE );
-#endif /* MBEDTLS_SSL_TLS13_COMPATIBILITY_MODE */
-
-            }
-            break;
+            mbedtls_ssl_handshake_set_state( ssl, MBEDTLS_SSL_END_OF_EARLY_DATA );
 
 #if defined(MBEDTLS_ZERO_RTT)
 

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -4458,13 +4458,15 @@ static int ssl_finished_in_parse( mbedtls_ssl_context* ssl,
     MBEDTLS_SSL_DEBUG_MSG( 5, ( "Verify finished message" ) );
 
     MBEDTLS_SSL_DEBUG_BUF( 5, "Hash ( self-computed ):",
-                           ssl->handshake->state_local.finished_in.digest, ssl->handshake->state_local.finished_in.digest_len );
-    MBEDTLS_SSL_DEBUG_BUF( 5, "Hash ( received message ):", buf, ssl->handshake->state_local.finished_in.digest_len );
+                           ssl->handshake->state_local.finished_in.digest,
+                           ssl->handshake->state_local.finished_in.digest_len );
+    MBEDTLS_SSL_DEBUG_BUF( 5, "Hash ( received message ):", buf,
+                           ssl->handshake->state_local.finished_in.digest_len );
 
     /* Semantic validation */
     if( mbedtls_ssl_safer_memcmp( buf,
-                                  ssl->handshake->state_local.finished_in.digest,
-                                  ssl->handshake->state_local.finished_in.digest_len ) != 0 )
+                   ssl->handshake->state_local.finished_in.digest,
+                   ssl->handshake->state_local.finished_in.digest_len ) != 0 )
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "bad finished message" ) );
 

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -4256,21 +4256,6 @@ static int ssl_finished_out_postprocess( mbedtls_ssl_context* ssl )
     {
         size_t transcript_len;
 
-#if defined(MBEDTLS_ZERO_RTT)
-        if( ssl->handshake->early_data == MBEDTLS_SSL_EARLY_DATA_ON )
-        {
-            /* Activate early data transform */
-            MBEDTLS_SSL_DEBUG_MSG( 3, ( "switching to new transform spec for inbound 0-RTT data" ) );
-            MBEDTLS_SSL_DEBUG_MSG( 1, ( "Switch to 0-RTT keys for inbound traffic" ) );
-            mbedtls_ssl_set_inbound_transform( ssl, ssl->transform_earlydata );
-            mbedtls_ssl_handshake_set_state( ssl, MBEDTLS_SSL_EARLY_APP_DATA );
-        }
-        else
-#endif /* MBEDTLS_ZERO_RTT */
-        {
-            mbedtls_ssl_handshake_set_state( ssl, MBEDTLS_SSL_CLIENT_CERTIFICATE );
-        }
-
         ret = mbedtls_ssl_get_handshake_transcript( ssl,
                               ssl->handshake->ciphersuite_info->mac,
                               ssl->handshake->server_finished_digest,
@@ -4307,6 +4292,8 @@ static int ssl_finished_out_postprocess( mbedtls_ssl_context* ssl )
             MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_tls13_build_transform", ret );
             return( ret );
         }
+
+        mbedtls_ssl_handshake_set_state( ssl, MBEDTLS_SSL_EARLY_APP_DATA );
     }
     else
 #endif /* MBEDTLS_SSL_SRV_C */

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -1171,6 +1171,9 @@ int mbedtls_ssl_parse_signature_algorithms_ext( mbedtls_ssl_context *ssl,
 void mbedtls_ssl_set_inbound_transform( mbedtls_ssl_context *ssl,
                                        mbedtls_ssl_transform *transform )
 {
+    if( ssl->transform_in == transform )
+        return;
+
     ssl->transform_in = transform;
     memset( ssl->in_ctr, 0, 8 );
 

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -2668,6 +2668,7 @@ static int ssl_write_certificate_coordinate( mbedtls_ssl_context* ssl )
 #if defined(MBEDTLS_SSL_CLI_C)
     if( ssl->conf->endpoint == MBEDTLS_SSL_IS_CLIENT )
     {
+        MBEDTLS_SSL_DEBUG_MSG( 1, ( "Switch to handshake keys for outbound traffic" ) );
         mbedtls_ssl_set_outbound_transform( ssl, ssl->transform_handshake );
 
 #if defined(MBEDTLS_SSL_USE_MPS)
@@ -2986,6 +2987,7 @@ static int ssl_read_certificate_coordinate( mbedtls_ssl_context* ssl )
 #if defined(MBEDTLS_SSL_SRV_C)
     if( ssl->conf->endpoint == MBEDTLS_SSL_IS_SERVER )
     {
+        MBEDTLS_SSL_DEBUG_MSG( 1, ( "Switch to handshake keys for inbound traffic" ) );
         mbedtls_ssl_set_inbound_transform( ssl, ssl->transform_handshake );
     }
 #endif /* MBEDTLS_SSL_SRV_C */
@@ -4256,6 +4258,7 @@ static int ssl_finished_out_postprocess( mbedtls_ssl_context* ssl )
         {
             /* Activate early data transform */
             MBEDTLS_SSL_DEBUG_MSG( 3, ( "switching to new transform spec for inbound 0-RTT data" ) );
+            MBEDTLS_SSL_DEBUG_MSG( 1, ( "Switch to 0-RTT keys for inbound traffic" ) );
             mbedtls_ssl_set_inbound_transform( ssl, ssl->transform_earlydata );
             mbedtls_ssl_handshake_set_state( ssl, MBEDTLS_SSL_EARLY_APP_DATA );
         }

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -1571,7 +1571,10 @@ cleanup:
   /* Main state-handling entry point; orchestrates the other functions. */
 int ssl_read_end_of_early_data_process( mbedtls_ssl_context* ssl );
 
-static int ssl_read_end_of_early_data_preprocess( mbedtls_ssl_context* ssl );
+#define SSL_END_OF_EARLY_DATA_SKIP   0
+#define SSL_END_OF_EARLY_DATA_EXPECT 1
+
+static int ssl_read_end_of_early_data_coordinate( mbedtls_ssl_context* ssl );
 
 /* There is no parse function for the end_of_early_data message. */
 
@@ -1587,21 +1590,23 @@ int ssl_read_end_of_early_data_process( mbedtls_ssl_context* ssl )
     int ret;
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> parse end_of_early_data" ) );
 
-    MBEDTLS_SSL_PROC_CHK( ssl_read_end_of_early_data_preprocess( ssl ) );
-
-    /* Fetching step */
-    if ( (ret = mbedtls_ssl_read_record( ssl, 0 ) ) != 0 )
+    MBEDTLS_SSL_PROC_CHK( ssl_read_end_of_early_data_coordinate( ssl ) );
+    if( ret == SSL_END_OF_EARLY_DATA_EXPECT )
     {
-        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_read_record", ret );
-        goto cleanup;
-    }
+        /* Fetching step */
+        if ( ( ret = mbedtls_ssl_read_record( ssl, 0 ) ) != 0 )
+        {
+            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_read_record", ret );
+            goto cleanup;
+        }
 
-    if ( ssl->in_msgtype != MBEDTLS_SSL_MSG_HANDSHAKE ||
-        ssl->in_msg[0] != MBEDTLS_SSL_HS_END_OF_EARLY_DATA )
-    {
-        MBEDTLS_SSL_DEBUG_MSG( 1, ( "bad end_of_early_data message" ) );
-        ret = MBEDTLS_ERR_SSL_UNEXPECTED_MESSAGE;
-        goto cleanup;
+        if ( ssl->in_msgtype != MBEDTLS_SSL_MSG_HANDSHAKE ||
+             ssl->in_msg[0] != MBEDTLS_SSL_HS_END_OF_EARLY_DATA )
+        {
+            MBEDTLS_SSL_DEBUG_MSG( 1, ( "bad end_of_early_data message" ) );
+            ret = MBEDTLS_ERR_SSL_UNEXPECTED_MESSAGE;
+            goto cleanup;
+        }
     }
 
     /* Postprocessing step: Update state machine */
@@ -1614,16 +1619,24 @@ cleanup:
 
 }
 
-static int ssl_read_end_of_early_data_preprocess( mbedtls_ssl_context* ssl )
+#if !defined(MBEDTLS_ZERO_RTT)
+static int ssl_read_end_of_early_data_coordinate( mbedtls_ssl_context* ssl )
 {
-    ((void) ssl);
-    return( 0 );
+    return( SSL_END_OF_EARLY_DATA_SKIP );
 }
+#else /* MBEDTLS_ZERO_RTT */
+static int ssl_read_end_of_early_data_coordinate( mbedtls_ssl_context* ssl )
+{
+    if( ssl->handshake->early_data != MBEDTLS_SSL_EARLY_DATA_ON )
+        return( SSL_END_OF_EARLY_DATA_SKIP );
 
+    return( SSL_END_OF_EARLY_DATA_EXPECT );
+}
+#endif /* MBEDTLS_ZERO_RTT */
 
 static int ssl_read_end_of_early_data_postprocess( mbedtls_ssl_context* ssl )
 {
-    mbedtls_ssl_handshake_set_state( ssl, MBEDTLS_SSL_CLIENT_FINISHED );
+    mbedtls_ssl_handshake_set_state( ssl, MBEDTLS_SSL_CLIENT_CERTIFICATE );
     return ( 0 );
 }
 #endif /* MBEDTLS_ZERO_RTT */
@@ -1638,12 +1651,13 @@ static int ssl_read_end_of_early_data_postprocess( mbedtls_ssl_context* ssl )
   * Overview
   */
 
-#if defined(MBEDTLS_ZERO_RTT)
-
   /* Main state-handling entry point; orchestrates the other functions. */
 int ssl_read_early_data_process( mbedtls_ssl_context* ssl );
 
-static int ssl_read_early_data_preprocess( mbedtls_ssl_context* ssl );
+#define SSL_EARLY_DATA_SKIP   0
+#define SSL_EARLY_DATA_EXPECT 1
+
+static int ssl_read_early_data_coordinate( mbedtls_ssl_context* ssl );
 
 /* Parse early data send by the peer. */
 static int ssl_read_early_data_parse( mbedtls_ssl_context* ssl,
@@ -1662,53 +1676,80 @@ int ssl_read_early_data_process( mbedtls_ssl_context* ssl )
     int ret;
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> parse early data" ) );
 
-    MBEDTLS_SSL_PROC_CHK( ssl_read_early_data_preprocess( ssl ) );
+    MBEDTLS_SSL_PROC_CHK( ssl_read_early_data_coordinate( ssl ) );
 
-    /* Fetching step */
-    if ( ( ret = mbedtls_ssl_read_record( ssl, 0 ) ) != 0 )
+    if( ret == SSL_EARLY_DATA_EXPECT )
     {
-        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_read_record", ret );
-        goto cleanup;
+        /* Fetching step */
+        if ( ( ret = mbedtls_ssl_read_record( ssl, 0 ) ) != 0 )
+        {
+            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_read_record", ret );
+            goto cleanup;
+        }
+
+        if( ssl->in_msgtype != MBEDTLS_SSL_MSG_APPLICATION_DATA )
+        {
+            ret = MBEDTLS_ERR_SSL_UNEXPECTED_MESSAGE;
+            goto cleanup;
+        }
+
+        /* Parsing step */
+        MBEDTLS_SSL_PROC_CHK( ssl_read_early_data_parse( ssl,
+                                      ssl->in_msg, ssl->in_msglen ) );
+
+        /* No state machine update at this point -- we might receive
+         * multiple 0-RTT messages. */
     }
-
-    /* Check for EndOfEarlyData */
-    if( ssl->in_msgtype == MBEDTLS_SSL_MSG_HANDSHAKE )
+    else
     {
-        ssl->keep_current_message = 1;
-        /* Postprocessing step: Update state machine */
         MBEDTLS_SSL_PROC_CHK( ssl_read_early_data_postprocess( ssl ) );
-        return( 0 );
     }
-
-    if( ssl->in_msgtype != MBEDTLS_SSL_MSG_APPLICATION_DATA )
-    {
-        ret = MBEDTLS_ERR_SSL_UNEXPECTED_MESSAGE;
-        goto cleanup;
-    }
-
-    /* Parsing step */
-    MBEDTLS_SSL_PROC_CHK( ssl_read_early_data_parse( ssl,
-                                ssl->in_msg, ssl->in_msglen ) );
-
-    /* No state machine update at this point -- we might receive
-     * multiple 0-RTT messages. */
 
 cleanup:
 
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "<= parse early data" ) );
     return( ret );
-
 }
 
-static int ssl_read_early_data_preprocess( mbedtls_ssl_context* ssl )
+#if !defined(MBEDTLS_ZERO_RTT)
+static int ssl_read_early_data_coordinate( mbedtls_ssl_context* ssl )
 {
-    ((void) ssl);
-    return( 0 );
+    return( SSL_EARLY_DATA_SKIP );
 }
+#else /* MBEDTLS_ZERO_RTT */
+static int ssl_read_early_data_coordinate( mbedtls_ssl_context* ssl )
+{
+    int ret;
+
+    if( ssl->handshake->early_data != MBEDTLS_SSL_EARLY_DATA_ON )
+        return( SSL_EARLY_DATA_SKIP );
+
+    /* Activate early data transform */
+    MBEDTLS_SSL_DEBUG_MSG( 1, ( "Switch to 0-RTT keys for inbound traffic" ) );
+    mbedtls_ssl_set_inbound_transform( ssl, ssl->transform_earlydata );
+
+    /* Fetching step */
+    if ( ( ret = mbedtls_ssl_read_record( ssl, 0 ) ) != 0 )
+    {
+        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_read_record", ret );
+        return( ret );
+    }
+
+    ssl->keep_current_message = 1;
+
+    /* Check for EndOfEarlyData */
+    if( ssl->in_msgtype == MBEDTLS_SSL_MSG_HANDSHAKE )
+    {
+        return( SSL_EARLY_DATA_SKIP );
+    }
+
+    return( SSL_EARLY_DATA_EXPECT );
+}
+#endif /* MBEDTLS_ZERO_RTT */
 
 static int ssl_read_early_data_parse( mbedtls_ssl_context* ssl,
-    unsigned char const* buf,
-    size_t buflen )
+                                      unsigned char const* buf,
+                                      size_t buflen )
 {
     /* Check whether we have enough buffer space. */
     if ( buflen <= ssl->conf->early_data_len )
@@ -1719,11 +1760,13 @@ static int ssl_read_early_data_parse( mbedtls_ssl_context* ssl,
         /* copy data to staging area */
         memcpy( ssl->conf->early_data_buf, buf, buflen );
         /* execute callback to process application data */
-        ssl->conf->early_data_callback( ssl, (unsigned char*)ssl->conf->early_data_buf, buflen );
+        ssl->conf->early_data_callback( ssl, (unsigned char*)ssl->conf->early_data_buf,
+                                        buflen );
     }
     else
     {
-        MBEDTLS_SSL_DEBUG_MSG( 1, ( "Buffer too small ( received early data size = %d, buffer size = %d", buflen, ssl->conf->early_data_len ) );
+        MBEDTLS_SSL_DEBUG_MSG( 1, ( "Buffer too small (recv %d bytes, buffer %d bytes)",
+                                    buflen, ssl->conf->early_data_len ) );
         return ( MBEDTLS_ERR_SSL_ALLOC_FAILED );
     }
 
@@ -1735,7 +1778,6 @@ static int ssl_read_early_data_postprocess( mbedtls_ssl_context* ssl )
     mbedtls_ssl_handshake_set_state( ssl, MBEDTLS_SSL_END_OF_EARLY_DATA );
     return ( 0 );
 }
-#endif /* MBEDTLS_ZERO_RTT */
 
 
 /*
@@ -4288,11 +4330,9 @@ int mbedtls_ssl_handshake_server_step( mbedtls_ssl_context *ssl )
             break;
 
             /* ----- WRITE EARLY APP DATA  ----*/
-#if defined(MBEDTLS_ZERO_RTT)
         case MBEDTLS_SSL_EARLY_APP_DATA:
 
             ret = ssl_read_early_data_process( ssl );
-
             if( ret != 0 )
             {
                 MBEDTLS_SSL_DEBUG_RET( 1, "ssl_read_early_data_process", ret );
@@ -4300,7 +4340,6 @@ int mbedtls_ssl_handshake_server_step( mbedtls_ssl_context *ssl )
             }
 
             break;
-#endif /* MBEDTLS_ZERO_RTT */
 
             /* ----- WRITE HELLO RETRY REQUEST ----*/
 

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -4521,6 +4521,7 @@ int mbedtls_ssl_handshake_server_step( mbedtls_ssl_context *ssl )
         case MBEDTLS_SSL_HANDSHAKE_WRAPUP:
             MBEDTLS_SSL_DEBUG_MSG( 2, ( "handshake: done" ) );
 
+            MBEDTLS_SSL_DEBUG_MSG( 1, ( "Switch to application keys for all traffic" ) );
             mbedtls_ssl_set_inbound_transform ( ssl, ssl->transform_application );
             mbedtls_ssl_set_outbound_transform( ssl, ssl->transform_application );
 


### PR DESCRIPTION
This PR simplifies the evolution of client and server-side state machine by always progressing through the `EarlyData` and `EndOfEarlyData` states, regardless of whether 0-RTT is compile-time or runtime enabled, and by making the respective handlers essentially no-ops if the state should be skipped. This makes the state machine logic easier to follow, and also simplifies correct placement of key material changes.