### PR TITLE
Fix build and tests if 0-RTT is disabled

### DIFF
--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -1391,8 +1391,12 @@ static inline int mbedtls_ssl_tls13_key_exchange_with_psk( mbedtls_ssl_context *
  */
 static inline int mbedtls_ssl_conf_tls13_0rtt_enabled( mbedtls_ssl_context *ssl )
 {
+#if defined(MBEDTLS_ZERO_RTT)
     if( ssl->conf->early_data == MBEDTLS_SSL_EARLY_DATA_ENABLED )
         return( 1 );
+#else
+    ((void) ssl);
+#endif /* MBEDTLS_ZERO_RTT */
 
     return( 0 );
 }

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -1664,8 +1664,6 @@ static int ssl_write_new_session_ticket_write( mbedtls_ssl_context* ssl,
   * Overview
   */
 
-#if defined(MBEDTLS_ZERO_RTT)
-
   /* Main state-handling entry point; orchestrates the other functions. */
 int ssl_read_end_of_early_data_process( mbedtls_ssl_context* ssl );
 
@@ -1691,6 +1689,8 @@ int ssl_read_end_of_early_data_process( mbedtls_ssl_context* ssl )
     MBEDTLS_SSL_PROC_CHK( ssl_read_end_of_early_data_coordinate( ssl ) );
     if( ret == SSL_END_OF_EARLY_DATA_EXPECT )
     {
+#if defined(MBEDTLS_ZERO_RTT)
+
 #if defined(MBEDTLS_SSL_USE_MPS)
         MBEDTLS_SSL_PROC_CHK( ssl_end_of_early_data_fetch( ssl ) );
         MBEDTLS_SSL_PROC_CHK( mbedtls_mps_read_consume( &ssl->mps.l4 ) );
@@ -1701,6 +1701,14 @@ int ssl_read_end_of_early_data_process( mbedtls_ssl_context* ssl )
 #else /* MBEDTLS_SSL_USE_MPS */
         MBEDTLS_SSL_PROC_CHK( ssl_end_of_early_data_fetch( ssl ) );
 #endif /* MBEDTLS_SSL_USE_MPS */
+
+#else /* MBEDTLS_ZERO_RTT */
+
+        /* Should never happen */
+        return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
+
+#endif /* MBEDTLS_ZERO_RTT */
+
     }
 
     /* Postprocessing step: Update state machine */
@@ -1712,6 +1720,8 @@ cleanup:
     return( ret );
 
 }
+
+#if defined(MBEDTLS_ZERO_RTT)
 
 #if defined(MBEDTLS_SSL_USE_MPS)
 static int ssl_end_of_early_data_fetch( mbedtls_ssl_context *ssl )
@@ -1768,9 +1778,12 @@ cleanup:
 }
 #endif /* MBEDTLS_SSL_USE_MPS */
 
+#endif /* MBEDTLS_ZERO_RTT */
+
 #if !defined(MBEDTLS_ZERO_RTT)
 static int ssl_read_end_of_early_data_coordinate( mbedtls_ssl_context* ssl )
 {
+    ((void) ssl);
     return( SSL_END_OF_EARLY_DATA_SKIP );
 }
 #else /* MBEDTLS_ZERO_RTT */
@@ -1788,7 +1801,6 @@ static int ssl_read_end_of_early_data_postprocess( mbedtls_ssl_context* ssl )
     mbedtls_ssl_handshake_set_state( ssl, MBEDTLS_SSL_CLIENT_CERTIFICATE );
     return ( 0 );
 }
-#endif /* MBEDTLS_ZERO_RTT */
 
 /*
  *
@@ -1817,10 +1829,12 @@ static int ssl_early_data_fetch( mbedtls_ssl_context* ssl,
 
 static int ssl_read_early_data_coordinate( mbedtls_ssl_context* ssl );
 
+#if defined(MBEDTLS_ZERO_RTT)
 /* Parse early data send by the peer. */
 static int ssl_read_early_data_parse( mbedtls_ssl_context* ssl,
     unsigned char const* buf,
     size_t buflen );
+#endif /* MBEDTLS_ZERO_RTT */
 
 /* Update the state after handling the incoming early data message. */
 static int ssl_read_early_data_postprocess( mbedtls_ssl_context* ssl );
@@ -1838,6 +1852,7 @@ int ssl_read_early_data_process( mbedtls_ssl_context* ssl )
 
     if( ret == SSL_EARLY_DATA_EXPECT )
     {
+#if defined(MBEDTLS_ZERO_RTT)
         unsigned char *buf;
         size_t buflen;
 #if defined(MBEDTLS_SSL_USE_MPS)
@@ -1863,6 +1878,13 @@ int ssl_read_early_data_process( mbedtls_ssl_context* ssl )
 
         /* No state machine update at this point -- we might receive
          * multiple 0-RTT messages. */
+
+#else /* MBEDTLS_ZERO_RTT */
+
+        /* Should never happen */
+        return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
+
+#endif /* MBEDTLS_ZERO_RTT */
     }
     else
     {
@@ -1924,6 +1946,7 @@ cleanup:
 #if !defined(MBEDTLS_ZERO_RTT)
 static int ssl_read_early_data_coordinate( mbedtls_ssl_context* ssl )
 {
+    ((void) ssl);
     return( SSL_EARLY_DATA_SKIP );
 }
 #else /* MBEDTLS_ZERO_RTT */
@@ -1971,7 +1994,6 @@ cleanup:
 
 #endif /* MBEDTLS_SSL_USE_MPS */
 }
-#endif /* MBEDTLS_ZERO_RTT */
 
 static int ssl_read_early_data_parse( mbedtls_ssl_context* ssl,
                                       unsigned char const* buf,
@@ -1998,6 +2020,7 @@ static int ssl_read_early_data_parse( mbedtls_ssl_context* ssl,
 
     return( 0 );
 }
+#endif /* MBEDTLS_ZERO_RTT */
 
 static int ssl_read_early_data_postprocess( mbedtls_ssl_context* ssl )
 {
@@ -3220,14 +3243,14 @@ static int ssl_client_hello_postprocess( mbedtls_ssl_context* ssl,
         if( ret != 0 )
         {
             MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_generate_early_data_keys", ret );
-            goto cleanup;
+            return( ret );
         }
 
         ret = mbedtls_ssl_tls13_build_transform( ssl, &traffic_keys, ssl->transform_earlydata, 0 );
         if( ret != 0 )
         {
             MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_tls13_build_transform", ret );
-            goto cleanup;
+            return( ret );
         }
 
 #if defined(MBEDTLS_SSL_USE_MPS)
@@ -3249,17 +3272,14 @@ static int ssl_client_hello_postprocess( mbedtls_ssl_context* ssl,
         }
 #endif /* MBEDTLS_SSL_USE_MPS */
     }
+
+    mbedtls_platform_zeroize( &traffic_keys, sizeof( traffic_keys ) );
+
 #endif /* MBEDTLS_ZERO_RTT */
 
     mbedtls_ssl_handshake_set_state( ssl, MBEDTLS_SSL_SERVER_HELLO );
+    return( 0 );
 
-#if defined(MBEDTLS_ZERO_RTT)
-cleanup:
-
-    mbedtls_platform_zeroize( &traffic_keys, sizeof( traffic_keys ) );
-#endif /* MBEDTLS_ZERO_RTT */
-
-    return( ret );
 }
 
 
@@ -4799,13 +4819,9 @@ int mbedtls_ssl_handshake_server_step( mbedtls_ssl_context *ssl )
             ret = mbedtls_ssl_read_certificate_verify_process( ssl );
             break;
 
-#if defined(MBEDTLS_ZERO_RTT)
-
         case MBEDTLS_SSL_END_OF_EARLY_DATA:
             ret = ssl_read_end_of_early_data_process( ssl );
             break;
-
-#endif /* MBEDTLS_ZERO_RTT */
 
             /* ----- READ FINISHED ----*/
 

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -1459,6 +1459,7 @@ run_test    "TLS 1.3, TLS_AES_256_GCM_SHA384 with ECDHE-ECDSA (server auth only)
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL
 requires_config_enabled MBEDTLS_DEBUG_C
 requires_config_disabled MBEDTLS_RSA_C
+requires_config_enabled MBEDTLS_ZERO_RTT
 run_test    "TLS 1.3, TLS_AES_256_GCM_SHA384, ext PSK, early data" \
             "$P_SRV debug_level=5 force_version=tls1_3 early_data=1 key_exchange_modes=psk psk=010203 psk_identity=0a0b0c" \
             "$P_CLI debug_level=5 force_version=tls1_3 force_ciphersuite=TLS_AES_256_GCM_SHA384 key_exchange_modes=psk early_data=1 psk=010203 psk_identity=0a0b0c" \
@@ -1476,6 +1477,7 @@ run_test    "TLS 1.3, TLS_AES_256_GCM_SHA384, ext PSK, early data" \
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL
 requires_config_enabled MBEDTLS_DEBUG_C
 requires_config_disabled MBEDTLS_RSA_C
+requires_config_enabled MBEDTLS_ZERO_RTT
 run_test    "TLS 1.3, TLS_AES_128_CCM_SHA256, ext PSK, early data" \
             "$P_SRV debug_level=5 force_version=tls1_3 early_data=1 key_exchange_modes=psk psk=010203 psk_identity=0a0b0c" \
             "$P_CLI debug_level=5 force_version=tls1_3 force_ciphersuite=TLS_AES_128_CCM_SHA256 key_exchange_modes=psk early_data=1 psk=010203 psk_identity=0a0b0c" \
@@ -1493,6 +1495,7 @@ run_test    "TLS 1.3, TLS_AES_128_CCM_SHA256, ext PSK, early data" \
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL
 requires_config_enabled MBEDTLS_DEBUG_C
 requires_config_disabled MBEDTLS_RSA_C
+requires_config_enabled MBEDTLS_ZERO_RTT
 run_test    "TLS 1.3, TLS_AES_128_GCM_SHA256, ext PSK, early data" \
             "$P_SRV debug_level=5 force_version=tls1_3 early_data=1 key_exchange_modes=psk psk=010203 psk_identity=0a0b0c" \
             "$P_CLI debug_level=5 force_version=tls1_3 force_ciphersuite=TLS_AES_128_GCM_SHA256 key_exchange_modes=psk early_data=1 psk=010203 psk_identity=0a0b0c" \
@@ -1510,6 +1513,7 @@ run_test    "TLS 1.3, TLS_AES_128_GCM_SHA256, ext PSK, early data" \
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL
 requires_config_enabled MBEDTLS_DEBUG_C
 requires_config_disabled MBEDTLS_RSA_C
+requires_config_enabled MBEDTLS_ZERO_RTT
 run_test    "TLS 1.3, TLS_AES_128_CCM_8_SHA256, ext PSK, early data" \
             "$P_SRV debug_level=5 force_version=tls1_3 early_data=1 key_exchange_modes=psk psk=010203 psk_identity=0a0b0c" \
             "$P_CLI debug_level=5 force_version=tls1_3 force_ciphersuite=TLS_AES_128_CCM_8_SHA256 key_exchange_modes=psk early_data=1 psk=010203 psk_identity=0a0b0c" \
@@ -1563,6 +1567,7 @@ run_test    "TLS 1.3, TLS_AES_128_CCM_SHA256 with ECDHE-ECDSA, SRV auth, HRR enf
 # test early data status - not sent
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL
 requires_config_enabled MBEDTLS_DEBUG_C
+requires_config_enabled MBEDTLS_ZERO_RTT
 requires_config_disabled MBEDTLS_RSA_C
 run_test    "TLS 1.3, TLS_AES_256_GCM_SHA384, ext PSK, early data status - not sent" \
             "$P_SRV debug_level=5 force_version=tls1_3 psk=010203 psk_identity=0a0b0c" \
@@ -1573,6 +1578,7 @@ run_test    "TLS 1.3, TLS_AES_256_GCM_SHA384, ext PSK, early data status - not s
 # test early data status - accepted
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL
 requires_config_enabled MBEDTLS_DEBUG_C
+requires_config_enabled MBEDTLS_ZERO_RTT
 requires_config_disabled MBEDTLS_RSA_C
 run_test    "TLS 1.3, TLS_AES_256_GCM_SHA384, ext PSK, early data status - accepted" \
             "$P_SRV debug_level=5 force_version=tls1_3 early_data=1 key_exchange_modes=psk psk=010203 psk_identity=0a0b0c" \


### PR DESCRIPTION
Build and tests were broken when `MBEDTLS_ZERO_RTT` was disabled, partly because of the issues pointed out by @lhuang04 in #140. 

This PR fixes those issues and makes sure that the prototype builds and passes tests if `MBEDTLS_ZERO_RTT` is disabled. It also adds some missing dependencies in `ssl-opt.sh` for tests related to 0-RTT.