### PR TITLE
Remove redundant mbedtls_ssl_transform_free

### DIFF
--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -7538,18 +7538,6 @@ void mbedtls_ssl_free( mbedtls_ssl_context *ssl )
         mbedtls_free( ssl->transform_negotiate );
 #endif
 
-#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
-        mbedtls_ssl_transform_free( ssl->transform_handshake   );
-        mbedtls_ssl_transform_free( ssl->transform_earlydata   );
-        mbedtls_ssl_transform_free( ssl->transform_application );
-        mbedtls_free( ssl->transform_handshake   );
-        mbedtls_free( ssl->transform_earlydata   );
-        mbedtls_free( ssl->transform_application );
-        ssl->transform_handshake   = NULL;
-        ssl->transform_earlydata   = NULL;
-        ssl->transform_application = NULL;
-#endif
-
         mbedtls_ssl_session_free( ssl->session_negotiate );
         mbedtls_free( ssl->session_negotiate );
     }


### PR DESCRIPTION
Summary:
The block of `mbedtls_ssl_transform_free` is redundnant as it is
executed [above](https://github.com/hannestschofenig/mbedtls/blob/tls13-prototype/library/ssl_tls.c#L7519-L7529).

Test Plan:
ssl-opt.sh

Reviewers:

Subscribers:

Tasks:

Tags: