### PR TITLE
Allow TLS / DTLS - only builds and compiling MPS in a single translation unit

### DIFF
--- a/include/mbedtls/mps/common.h
+++ b/include/mbedtls/mps/common.h
@@ -255,13 +255,13 @@ typedef uint8_t mbedtls_mps_epoch_offset_t;
 #define MBEDTLS_MPS_STATE_VALIDATE( cond, string )               \
     do                                                           \
     {                                                            \
-        ( cond );                                                \
+        (void) ( cond );                                         \
     } while( 0 )
 
 #define MBEDTLS_MPS_STATE_VALIDATE_RAW( cond, string )           \
     do                                                           \
     {                                                            \
-        ( cond );                                                \
+        (void)( cond );                                          \
     } while( 0 )
 
 #endif /* MBEDTLS_MPS_STATE_VALIDATION */
@@ -290,7 +290,8 @@ typedef uint8_t mbedtls_mps_epoch_offset_t;
 
 #else /* MBEDTLS_MPS_ENABLE_ASSERTIONS */
 
-#define MBEDTLS_MPS_ASSERT( cond, string ) do {} while( 0 )
+#define MBEDTLS_MPS_ASSERT( cond, string )     do {} while( 0 )
+#define MBEDTLS_MPS_ASSERT_RAW( cond, string ) do {} while( 0 )
 
 #endif /* MBEDTLS_MPS_ENABLE_ASSERTIONS */
 
@@ -309,9 +310,9 @@ typedef uint8_t mbedtls_mps_epoch_offset_t;
 #endif /* MBEDTLS_MPS_NO_STATIC_FUNCTIONS */
 
 #if !defined(MBEDTLS_MPS_SEPARATE_LAYERS)
-#define MBEDTLS_MPS_PUBLIC MBEDTLS_MPS_STATIC
+#define MBEDTLS_MPS_INTERNAL_API MBEDTLS_MPS_STATIC
 #else
-#define MBEDTLS_MPS_PUBLIC
+#define MBEDTLS_MPS_INTERNAL_API
 #endif /* MBEDTLS_MPS_SEPARATE_LAYERS */
 
 /** Internal macro sanity check. */
@@ -398,8 +399,10 @@ typedef uint8_t mbedtls_mps_transport_type;
 #if defined(MBEDTLS_MPS_PROTO_BOTH)
 #define MBEDTLS_MPS_IS_DTLS( mode )               \
     ( (mode) == MBEDTLS_MPS_MODE_DATAGRAM )
+/* Define `1` in a roundabout way using `mode` to avoid unused
+ * variable warnings. */
 #define MBEDTLS_MPS_ELSE_IF_DTLS( mode )         \
-    else
+    else if( ( mode ) == ( mode ) )
 #else
 /* Define `1` in a roundabout way using `mode` to avoid unused
  * variable warnings. */

--- a/include/mbedtls/mps/layer1.h
+++ b/include/mbedtls/mps/layer1.h
@@ -322,10 +322,9 @@ mbedtls_mps_l1_get_mode( mps_l1 *l1 )
  * \return         A negative error code on failure.
  *
  */
-
-MBEDTLS_MPS_PUBLIC int mps_l1_init( mps_l1 *ctx, uint8_t mode, mps_alloc *alloc,
-                                    void* send_ctx, mps_l0_send_t *send,
-                                    void* recv_ctx, mps_l0_recv_t *recv );
+int mps_l1_init( mps_l1 *ctx, uint8_t mode, mps_alloc *alloc,
+                 void* send_ctx, mps_l0_send_t *send,
+                 void* recv_ctx, mps_l0_recv_t *recv );
 
 /**
  * \brief          Set the callbacks to the underlying transport.
@@ -358,9 +357,9 @@ MBEDTLS_MPS_PUBLIC int mps_l1_init( mps_l1 *ctx, uint8_t mode, mps_alloc *alloc,
  * \return         A negative error code on failure.
  *
  */
-MBEDTLS_MPS_PUBLIC int mps_l1_set_bio( mps_l1 *ctx,
-                                       void* send_ctx, mps_l0_send_t *send,
-                                       void* recv_ctx, mps_l0_recv_t *recv );
+int mps_l1_set_bio( mps_l1 *ctx,
+                    void* send_ctx, mps_l0_send_t *send,
+                    void* recv_ctx, mps_l0_recv_t *recv );
 
 /**
  * \brief          Free a Layer 1 context.
@@ -371,8 +370,11 @@ MBEDTLS_MPS_PUBLIC int mps_l1_set_bio( mps_l1 *ctx,
  *                 Layer 1 context.
  *
  */
+void mps_l1_free( mps_l1 *ctx );
 
-MBEDTLS_MPS_PUBLIC void mps_l1_free( mps_l1 *ctx );
+#if defined(MBEDTLS_MPS_SEPARATE_LAYERS)      ||       \
+    defined(MBEDTLS_MPS_TOP_TRANSLATION_UNIT) ||       \
+    defined(MBEDTLS_MPS_NO_STATIC_FUNCTIONS)
 
 /*
  * Read interface
@@ -397,8 +399,8 @@ MBEDTLS_MPS_PUBLIC void mps_l1_free( mps_l1 *ctx );
  *
  */
 
-MBEDTLS_MPS_PUBLIC int mps_l1_fetch( mps_l1 *ctx, unsigned char **buf,
-                                     mbedtls_mps_size_t desired );
+MBEDTLS_MPS_INTERNAL_API int mps_l1_fetch( mps_l1 *ctx, unsigned char **buf,
+                                           mbedtls_mps_size_t desired );
 
 /**
  * \brief          Mark the previously fetched data as consumed.
@@ -412,7 +414,7 @@ MBEDTLS_MPS_PUBLIC int mps_l1_fetch( mps_l1 *ctx, unsigned char **buf,
  *                 are invalid after this call and must not be accessed anymore.
  */
 
-MBEDTLS_MPS_PUBLIC int mps_l1_consume( mps_l1 *ctx );
+MBEDTLS_MPS_INTERNAL_API int mps_l1_consume( mps_l1 *ctx );
 
 #if defined(MBEDTLS_MPS_PROTO_DTLS)
 /**
@@ -429,7 +431,7 @@ MBEDTLS_MPS_PUBLIC int mps_l1_consume( mps_l1 *ctx );
  *                 it should ignore the currently processed datagram.
  */
 
-MBEDTLS_MPS_PUBLIC int mps_l1_skip( mps_l1 *ctx );
+MBEDTLS_MPS_INTERNAL_API int mps_l1_skip( mps_l1 *ctx );
 #endif /* MBEDTLS_MPS_PROTO_DTLS */
 
 /*
@@ -457,7 +459,7 @@ MBEDTLS_MPS_PUBLIC int mps_l1_skip( mps_l1 *ctx );
  *
  */
 
-MBEDTLS_MPS_PUBLIC int mps_l1_write( mps_l1 *ctx, unsigned char **buf,
+MBEDTLS_MPS_INTERNAL_API int mps_l1_write( mps_l1 *ctx, unsigned char **buf,
                                      mbedtls_mps_size_t *buflen );
 
 /**
@@ -477,7 +479,7 @@ MBEDTLS_MPS_PUBLIC int mps_l1_write( mps_l1 *ctx, unsigned char **buf,
  *
  */
 
-MBEDTLS_MPS_PUBLIC int mps_l1_dispatch( mps_l1 *ctx,
+MBEDTLS_MPS_INTERNAL_API int mps_l1_dispatch( mps_l1 *ctx,
                                         mbedtls_mps_size_t len,
                                         mbedtls_mps_size_t *pending );
 
@@ -503,7 +505,7 @@ MBEDTLS_MPS_PUBLIC int mps_l1_dispatch( mps_l1 *ctx,
  *
  */
 
-MBEDTLS_MPS_PUBLIC int mps_l1_flush( mps_l1 *ctx );
+MBEDTLS_MPS_INTERNAL_API int mps_l1_flush( mps_l1 *ctx );
 
 /**
  * \brief          Check if a read request will necessarily involve
@@ -523,7 +525,7 @@ MBEDTLS_MPS_PUBLIC int mps_l1_flush( mps_l1 *ctx );
  *
  */
 
-MBEDTLS_MPS_PUBLIC int mps_l1_read_dependency( mps_l1 *ctx );
+MBEDTLS_MPS_INTERNAL_API int mps_l1_read_dependency( mps_l1 *ctx );
 
 /**
  * \brief          Check if a write request can be potentially be served
@@ -549,7 +551,10 @@ MBEDTLS_MPS_PUBLIC int mps_l1_read_dependency( mps_l1 *ctx );
  *
  */
 
-MBEDTLS_MPS_PUBLIC int mps_l1_write_dependency( mps_l1 *ctx );
+MBEDTLS_MPS_INTERNAL_API int mps_l1_write_dependency( mps_l1 *ctx );
 
+#endif /* MBEDTLS_MPS_SEPARATE_LAYERS      ||
+          MBEDTLS_MPS_TOP_TRANSLATION_UNIT ||
+          MBEDTLS_MPS_NO_STATIC_FUNCTIONS  */
 
 #endif /* MBEDTLS_MPS_BUFFER_LAYER_H */

--- a/include/mbedtls/mps/layer2.h
+++ b/include/mbedtls/mps/layer2.h
@@ -956,11 +956,11 @@ static inline mps_l1* mbedtls_mps_l2_get_l1( mbedtls_mps_l2 *l2 )
  *
  */
 
-MBEDTLS_MPS_PUBLIC int mps_l2_init( mbedtls_mps_l2 *ctx, mps_l1 *l1, uint8_t mode,
-                                    mbedtls_mps_size_t max_read,
-                                    mbedtls_mps_size_t max_write,
-                                    int (*f_rng)(void *, unsigned char *, size_t),
-                                    void *p_rng );
+int mps_l2_init( mbedtls_mps_l2 *ctx, mps_l1 *l1, uint8_t mode,
+                 mbedtls_mps_size_t max_read,
+                 mbedtls_mps_size_t max_write,
+                 int (*f_rng)(void *, unsigned char *, size_t),
+                 void *p_rng );
 
 /**
  * \brief          This functions frees a Layer 2 context.
@@ -971,8 +971,7 @@ MBEDTLS_MPS_PUBLIC int mps_l2_init( mbedtls_mps_l2 *ctx, mps_l1 *l1, uint8_t mod
  * \return         A negative error code on failure.
  *
  */
-
-MBEDTLS_MPS_PUBLIC int mps_l2_free( mbedtls_mps_l2 *ctx );
+int mps_l2_free( mbedtls_mps_l2 *ctx );
 
 typedef uint8_t mbedtls_mps_record_split_config_t;
 #define MBEDTLS_MPS_SPLIT_DISABLED ( (mbedtls_mps_record_split_config_t) 0 )
@@ -1062,6 +1061,10 @@ static inline int mps_l2_config_add_type( mbedtls_mps_l2 *ctx,
     return( 0 );
 }
 
+#if defined(MBEDTLS_MPS_SEPARATE_LAYERS)      ||       \
+    defined(MBEDTLS_MPS_TOP_TRANSLATION_UNIT) ||       \
+    defined(MBEDTLS_MPS_NO_STATIC_FUNCTIONS)
+
 /**
  * \brief          Configure the TLS/DTLS version to be used
  *                 by a Layer 2 context.
@@ -1075,7 +1078,7 @@ static inline int mps_l2_config_add_type( mbedtls_mps_l2 *ctx,
  *
  */
 
-MBEDTLS_MPS_PUBLIC int mps_l2_config_version( mbedtls_mps_l2 *ctx, uint8_t version );
+int mps_l2_config_version( mbedtls_mps_l2 *ctx, uint8_t version );
 
 /**
  * \brief          Query a Layer 2 context for incoming data.
@@ -1095,7 +1098,7 @@ MBEDTLS_MPS_PUBLIC int mps_l2_config_version( mbedtls_mps_l2 *ctx, uint8_t versi
  *
  */
 
-MBEDTLS_MPS_PUBLIC int mps_l2_read_start( mbedtls_mps_l2 *ctx, mps_l2_in *in );
+MBEDTLS_MPS_INTERNAL_API int mps_l2_read_start( mbedtls_mps_l2 *ctx, mps_l2_in *in );
 
 /**
  * \brief          Signal that incoming data previously
@@ -1109,7 +1112,7 @@ MBEDTLS_MPS_PUBLIC int mps_l2_read_start( mbedtls_mps_l2 *ctx, mps_l2_in *in );
  *
  */
 
-MBEDTLS_MPS_PUBLIC int mps_l2_read_done( mbedtls_mps_l2 *ctx );
+MBEDTLS_MPS_INTERNAL_API int mps_l2_read_done( mbedtls_mps_l2 *ctx );
 
 /**
  * \brief          Request to prepare the writing of data of
@@ -1128,7 +1131,7 @@ MBEDTLS_MPS_PUBLIC int mps_l2_read_done( mbedtls_mps_l2 *ctx );
  *
  */
 
-MBEDTLS_MPS_PUBLIC int mps_l2_write_start( mbedtls_mps_l2 *ctx, mps_l2_out *out );
+MBEDTLS_MPS_INTERNAL_API int mps_l2_write_start( mbedtls_mps_l2 *ctx, mps_l2_out *out );
 
 /**
  * \brief          Signal that the writing of outgoing data via
@@ -1147,7 +1150,7 @@ MBEDTLS_MPS_PUBLIC int mps_l2_write_start( mbedtls_mps_l2 *ctx, mps_l2_out *out 
  *
  */
 
-MBEDTLS_MPS_PUBLIC int mps_l2_write_done( mbedtls_mps_l2 *ctx );
+MBEDTLS_MPS_INTERNAL_API int mps_l2_write_done( mbedtls_mps_l2 *ctx );
 
 /**
  * \brief          Attempt to deliver all outgoing data previously
@@ -1165,7 +1168,7 @@ MBEDTLS_MPS_PUBLIC int mps_l2_write_done( mbedtls_mps_l2 *ctx );
  *
  */
 
-MBEDTLS_MPS_PUBLIC int mps_l2_write_flush( mbedtls_mps_l2 *ctx );
+MBEDTLS_MPS_INTERNAL_API int mps_l2_write_flush( mbedtls_mps_l2 *ctx );
 
 /**
  * \brief          Configure Layer 2 context to allow communication
@@ -1212,8 +1215,7 @@ MBEDTLS_MPS_PUBLIC int mps_l2_write_flush( mbedtls_mps_l2 *ctx );
  * \return         A negative error code on failure.
  *
  */
-
-MBEDTLS_MPS_PUBLIC int mps_l2_epoch_add( mbedtls_mps_l2 *ctx,
+MBEDTLS_MPS_INTERNAL_API int mps_l2_epoch_add( mbedtls_mps_l2 *ctx,
                                  mbedtls_mps_transform_t *transform,
                                  mbedtls_mps_epoch_id *epoch );
 
@@ -1233,11 +1235,12 @@ MBEDTLS_MPS_PUBLIC int mps_l2_epoch_add( mbedtls_mps_l2 *ctx,
  *
  */
 
-int mps_l2_epoch_usage( mbedtls_mps_l2 *ctx,
+MBEDTLS_MPS_INTERNAL_API int mps_l2_epoch_usage( mbedtls_mps_l2 *ctx,
                         mbedtls_mps_epoch_id epoch_id,
                         mbedtls_mps_epoch_usage clear,
                         mbedtls_mps_epoch_usage set );
 
+#if defined(MBEDTLS_MPS_PROTO_DTLS)
 /**
  * \brief          Enforce that the next outgoing record of the
  *                 specified epoch uses a particular record sequence number.
@@ -1259,7 +1262,7 @@ int mps_l2_epoch_usage( mbedtls_mps_l2 *ctx,
  * \return         \c 0 on success.
  *
  */
-MBEDTLS_MPS_PUBLIC int mps_l2_force_next_sequence_number( mbedtls_mps_l2 *ctx,
+MBEDTLS_MPS_INTERNAL_API int mps_l2_force_next_sequence_number( mbedtls_mps_l2 *ctx,
                                                   mbedtls_mps_epoch_id epoch_id,
                                                   uint64_t ctr );
 
@@ -1284,8 +1287,12 @@ MBEDTLS_MPS_PUBLIC int mps_l2_force_next_sequence_number( mbedtls_mps_l2 *ctx,
  * \return         \c 0 on success.
  *
  */
-MBEDTLS_MPS_PUBLIC int mps_l2_get_last_sequence_number( mbedtls_mps_l2 *ctx,
+MBEDTLS_MPS_INTERNAL_API int mps_l2_get_last_sequence_number( mbedtls_mps_l2 *ctx,
                                                 mbedtls_mps_epoch_id epoch_id,
                                                 uint64_t *ctr );
+#endif /* MBEDTLS_MPS_PROTO_DTLS */
+
+#endif /* MBEDTLS_MPS_SEPARATE_LAYERS) ||
+          MBEDTLS_MPS_TOP_TRANSLATION_UNIT */
 
 #endif /* MBEDTLS_MPS_RECORD_LAYER_H */

--- a/include/mbedtls/mps/layer3.h
+++ b/include/mbedtls/mps/layer3.h
@@ -533,7 +533,7 @@ static inline mbedtls_mps_l2* mbedtls_mps_l3_get_l2( mps_l3 *l3 )
  * \return        A negative error code on failure.
  */
 
-MBEDTLS_MPS_PUBLIC int mps_l3_init( mps_l3 *l3, mbedtls_mps_l2 *l2, uint8_t mode );
+int mps_l3_init( mps_l3 *l3, mbedtls_mps_l2 *l2, uint8_t mode );
 
 /**
  * \brief         Free a Layer 3 context.
@@ -546,7 +546,11 @@ MBEDTLS_MPS_PUBLIC int mps_l3_init( mps_l3 *l3, mbedtls_mps_l2 *l2, uint8_t mode
  * \return        \c 0 on success.
  * \return        A negative error code on failure.
  */
-MBEDTLS_MPS_PUBLIC int mps_l3_free( mps_l3 *l3 );
+int mps_l3_free( mps_l3 *l3 );
+
+#if defined(MBEDTLS_MPS_SEPARATE_LAYERS)      ||       \
+    defined(MBEDTLS_MPS_TOP_TRANSLATION_UNIT) ||       \
+    defined(MBEDTLS_MPS_NO_STATIC_FUNCTIONS)
 
 /**
  * \brief         Request an incoming message from Layer 3.
@@ -570,7 +574,7 @@ MBEDTLS_MPS_PUBLIC int mps_l3_free( mps_l3 *l3 );
 /* OPTIMIZATION:
  * Subsume mps_l3_read() with mps_l3_read_XXX() by filling
  * an indexed union of mps_l3_in_xxx on success. */
-MBEDTLS_MPS_PUBLIC int mps_l3_read( mps_l3 *l3 );
+MBEDTLS_MPS_INTERNAL_API int mps_l3_read( mps_l3 *l3 );
 
 /**
  * \brief       Check if a message has been read.
@@ -588,7 +592,7 @@ MBEDTLS_MPS_PUBLIC int mps_l3_read( mps_l3 *l3 );
  *              and only reports if a message is available
  *              through a prior call to mps_l3_read().
  */
-MBEDTLS_MPS_PUBLIC int mps_l3_read_check( mps_l3 * l3 );
+MBEDTLS_MPS_INTERNAL_API int mps_l3_read_check( mps_l3 * l3 );
 
 /**
  * \brief         Get a handle to the contents of an incoming handshake message.
@@ -607,7 +611,7 @@ MBEDTLS_MPS_PUBLIC int mps_l3_read_check( mps_l3 * l3 );
  */
 /* TODO: Consider making this function static inline
  * to avoid a layer of indirection. */
-MBEDTLS_MPS_PUBLIC int mps_l3_read_handshake( mps_l3 *l3, mps_l3_handshake_in *hs );
+MBEDTLS_MPS_INTERNAL_API int mps_l3_read_handshake( mps_l3 *l3, mps_l3_handshake_in *hs );
 
 /**
  * \brief         Get a handle to the contents of an incoming
@@ -626,7 +630,7 @@ MBEDTLS_MPS_PUBLIC int mps_l3_read_handshake( mps_l3 *l3, mps_l3_handshake_in *h
  *                through a call to mps_l3_dispatch().
  */
 
-MBEDTLS_MPS_PUBLIC int mps_l3_read_app( mps_l3 *l3, mps_l3_app_in *app );
+MBEDTLS_MPS_INTERNAL_API int mps_l3_read_app( mps_l3 *l3, mps_l3_app_in *app );
 
 /**
  * \brief         Get a handle to the contents of an incoming alert message.
@@ -638,7 +642,7 @@ MBEDTLS_MPS_PUBLIC int mps_l3_read_app( mps_l3 *l3, mps_l3_app_in *app );
  * \return        A negative error code on failure.
  *
  */
-MBEDTLS_MPS_PUBLIC int mps_l3_read_alert( mps_l3 *l3, mps_l3_alert_in *alert );
+MBEDTLS_MPS_INTERNAL_API int mps_l3_read_alert( mps_l3 *l3, mps_l3_alert_in *alert );
 
 /**
  * \brief         Get a handle to the contents of an incoming CCS message.
@@ -650,7 +654,7 @@ MBEDTLS_MPS_PUBLIC int mps_l3_read_alert( mps_l3 *l3, mps_l3_alert_in *alert );
  * \return        A negative error code on failure.
  *
  */
-MBEDTLS_MPS_PUBLIC int mps_l3_read_ccs( mps_l3 *l3, mps_l3_ccs_in *ccs );
+MBEDTLS_MPS_INTERNAL_API int mps_l3_read_ccs( mps_l3 *l3, mps_l3_ccs_in *ccs );
 
 #if defined(MBEDTLS_MPS_PROTO_TLS)
 /**
@@ -676,7 +680,7 @@ MBEDTLS_MPS_PUBLIC int mps_l3_read_ccs( mps_l3 *l3, mps_l3_ccs_in *ccs );
  *                the user must call mps_l3_read_handshake() again to
  *                retrieve the handle to use.
  */
-MBEDTLS_MPS_PUBLIC int mps_l3_read_pause_handshake( mps_l3 *l3 );
+MBEDTLS_MPS_INTERNAL_API int mps_l3_read_pause_handshake( mps_l3 *l3 );
 #endif /* MBEDTLS_MPS_PROTO_TLS */
 
 /**
@@ -699,7 +703,7 @@ MBEDTLS_MPS_PUBLIC int mps_l3_read_pause_handshake( mps_l3 *l3 );
  * \return        Another negative error code for other kinds of failure.
  *
  */
-MBEDTLS_MPS_PUBLIC int mps_l3_read_consume( mps_l3 *l3 );
+MBEDTLS_MPS_INTERNAL_API int mps_l3_read_consume( mps_l3 *l3 );
 
 /**
  * \brief           Start writing an outgoing handshake message.
@@ -710,7 +714,7 @@ MBEDTLS_MPS_PUBLIC int mps_l3_read_consume( mps_l3 *l3 );
  * \return          \c 0 on success.
  * \return          A negative error code on failure.
  */
-MBEDTLS_MPS_PUBLIC int mps_l3_write_handshake( mps_l3 *l3, mps_l3_handshake_out *hs );
+MBEDTLS_MPS_INTERNAL_API int mps_l3_write_handshake( mps_l3 *l3, mps_l3_handshake_out *hs );
 
 /**
  * \brief           Start writing outgoing application data.
@@ -721,7 +725,7 @@ MBEDTLS_MPS_PUBLIC int mps_l3_write_handshake( mps_l3 *l3, mps_l3_handshake_out 
  * \return          \c 0 on success.
  * \return          A negative error code on failure.
  */
-MBEDTLS_MPS_PUBLIC int mps_l3_write_app( mps_l3 *l3, mps_l3_app_out *app );
+MBEDTLS_MPS_INTERNAL_API int mps_l3_write_app( mps_l3 *l3, mps_l3_app_out *app );
 
 /**
  * \brief           Start writing an outgoing alert message.
@@ -732,7 +736,7 @@ MBEDTLS_MPS_PUBLIC int mps_l3_write_app( mps_l3 *l3, mps_l3_app_out *app );
  * \return          \c 0 on success.
  * \return          A negative error code on failure.
  */
-MBEDTLS_MPS_PUBLIC int mps_l3_write_alert( mps_l3 *l3, mps_l3_alert_out *alert );
+MBEDTLS_MPS_INTERNAL_API int mps_l3_write_alert( mps_l3 *l3, mps_l3_alert_out *alert );
 
 /**
  * \brief           Start writing an outgoing CCS message.
@@ -749,7 +753,7 @@ MBEDTLS_MPS_PUBLIC int mps_l3_write_alert( mps_l3 *l3, mps_l3_alert_out *alert )
  *                  in the same way as the writing of messages of
  *                  other content types.
  */
-MBEDTLS_MPS_PUBLIC int mps_l3_write_ccs( mps_l3 *l3, mps_l3_ccs_out *ccs );
+MBEDTLS_MPS_INTERNAL_API int mps_l3_write_ccs( mps_l3 *l3, mps_l3_ccs_out *ccs );
 
 #if defined(MBEDTLS_MPS_PROTO_TLS)
 /**
@@ -775,7 +779,7 @@ MBEDTLS_MPS_PUBLIC int mps_l3_write_ccs( mps_l3 *l3, mps_l3_ccs_out *ccs );
  *                  the user must call mps_l3_write_handshake() again to
  *                  retrieve the handle to use.
  */
-MBEDTLS_MPS_PUBLIC int mps_l3_pause_handshake( mps_l3 *l3 );
+MBEDTLS_MPS_INTERNAL_API int mps_l3_pause_handshake( mps_l3 *l3 );
 #endif /* MBEDTLS_MPS_PROTO_TLS */
 
 /**
@@ -791,7 +795,7 @@ MBEDTLS_MPS_PUBLIC int mps_l3_pause_handshake( mps_l3 *l3 );
  * \return          0 on success, a negative error code on failure.
  *
  */
-MBEDTLS_MPS_PUBLIC int mps_l3_write_abort_handshake( mps_l3 *l3 );
+MBEDTLS_MPS_INTERNAL_API int mps_l3_write_abort_handshake( mps_l3 *l3 );
 
 /**
  * \brief         Conclude the writing of the current outgoing message.
@@ -811,7 +815,7 @@ MBEDTLS_MPS_PUBLIC int mps_l3_write_abort_handshake( mps_l3 *l3 );
  * \return        A negative error code on failure.
  *
  */
-MBEDTLS_MPS_PUBLIC int mps_l3_dispatch( mps_l3 *l3 );
+MBEDTLS_MPS_INTERNAL_API int mps_l3_dispatch( mps_l3 *l3 );
 
 /**
  * \brief         Flush all outgoing messages dispatched so far
@@ -831,37 +835,30 @@ MBEDTLS_MPS_PUBLIC int mps_l3_dispatch( mps_l3 *l3 );
  * \note          In case #MPS_ERR_WANT_WRITE is returned, the function can
  *                be called again to retry the flush.
  */
-MBEDTLS_MPS_PUBLIC int mps_l3_flush( mps_l3 *l3 );
+MBEDTLS_MPS_INTERNAL_API int mps_l3_flush( mps_l3 *l3 );
 
+MBEDTLS_MPS_INTERNAL_API int mps_l3_epoch_add( mps_l3 *ctx,
+                                      mbedtls_mps_transform_t *transform,
+                                      mbedtls_mps_epoch_id *epoch );
 
-static inline int mps_l3_epoch_add( mps_l3 *ctx,
-                                    mbedtls_mps_transform_t *transform,
-                                    mbedtls_mps_epoch_id *epoch )
-{
-    return( mps_l2_epoch_add( ctx->conf.l2, transform, epoch ) );
-}
-
-
-static inline int mps_l3_epoch_usage( mps_l3 *ctx,
+MBEDTLS_MPS_INTERNAL_API int mps_l3_epoch_usage( mps_l3 *ctx,
                                       mbedtls_mps_epoch_id epoch_id,
                                       mbedtls_mps_epoch_usage clear,
-                                      mbedtls_mps_epoch_usage set )
-{
-    return( mps_l2_epoch_usage( ctx->conf.l2, epoch_id, clear, set ) );
-}
+                                      mbedtls_mps_epoch_usage set );
 
-static inline int mps_l3_force_next_sequence_number( mps_l3 *ctx,
-                                                mbedtls_mps_epoch_id epoch_id,
-                                                uint64_t ctr )
-{
-    return( mps_l2_force_next_sequence_number( ctx->conf.l2, epoch_id, ctr ) );
-}
+#if defined(MBEDTLS_MPS_PROTO_DTLS)
+MBEDTLS_MPS_INTERNAL_API int mps_l3_force_next_sequence_number(
+                                      mps_l3 *ctx,
+                                      mbedtls_mps_epoch_id epoch_id,
+                                      uint64_t ctr );
 
-static inline int mps_l3_get_last_sequence_number( mps_l3 *ctx,
-                                                mbedtls_mps_epoch_id epoch_id,
-                                                uint64_t *ctr )
-{
-    return( mps_l2_get_last_sequence_number( ctx->conf.l2, epoch_id, ctr ) );
-}
+MBEDTLS_MPS_INTERNAL_API int mps_l3_get_last_sequence_number(
+                                      mps_l3 *ctx,
+                                      mbedtls_mps_epoch_id epoch_id,
+                                      uint64_t *ctr );
+#endif /* MBEDTLS_MPS_PROTO_DTLS */
+
+#endif /* MBEDTLS_MPS_SEPARATE_LAYERS) ||
+          MBEDTLS_MPS_TOP_TRANSLATION_UNIT */
 
 #endif /* MBEDTLS_MPS_MESSAGE_EXTRACTION_LAYER_H */

--- a/include/mbedtls/mps/trace.h
+++ b/include/mbedtls/mps/trace.h
@@ -154,7 +154,7 @@ void trace_indent( int level, trace_type ty );
 #define TRACE( type, fmt, ... ) do { } while( 0 )
 #define TRACE_INIT( fmt, ... )  do { } while( 0 )
 #define TRACE_END               do { } while( 0 )
-#define RETURN( val ) return( val );
+#define RETURN( val ) return( val )
 
 #endif /* MBEDTLS_MPS_TRACE */
 

--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -138,7 +138,18 @@
 #define MBEDTLS_VARINT_HDR_2 64
 enum varint_length_enum { VARINT_LENGTH_FAILURE = 0, VARINT_LENGTH_1_BYTE = 1, VARINT_LENGTH_2_BYTE = 2, VARINT_LENGTH_3_BYTE = 3 };
 
-#define MBEDTLS_SSL_PROC_CHK(f) do { if( ( ret = f ) < 0 ) goto cleanup; } while( 0 )
+#define MBEDTLS_SSL_PROC_CHK(f)     \
+    do {                                                        \
+        ret = (f);                                              \
+        if( ret != 0 )                                          \
+        {                                                       \
+            if( ret > 0 )                                       \
+                ret = MBEDTLS_ERR_SSL_INTERNAL_ERROR;           \
+            goto cleanup;                                       \
+        }                                                       \
+    } while( 0 )
+
+#define MBEDTLS_SSL_PROC_CHK_NEG(f) do { if( ( ret = f ) < 0 )  goto cleanup; } while( 0 )
 
 /*
  * DTLS retransmission states, see RFC 6347 4.2.4

--- a/library/mps/layer1.c
+++ b/library/mps/layer1.c
@@ -25,109 +25,13 @@
 #if defined(MBEDTLS_MPS_SEPARATE_LAYERS) ||     \
     defined(MBEDTLS_MPS_TOP_TRANSLATION_UNIT)
 
+#include "layer1_internal.h"
+
 #if defined(MBEDTLS_MPS_TRACE)
 static int trace_id = TRACE_BIT_LAYER_1;
 #endif /* MBEDTLS_MPS_TRACE */
 
 #include <string.h>
-
-MBEDTLS_MPS_STATIC void l1_release_if_set( unsigned char **buf_ptr,
-                               mps_alloc *ctx,
-                               mps_alloc_type purpose );
-MBEDTLS_MPS_STATIC int l1_acquire_if_unset( unsigned char **buf_ptr,
-                                mbedtls_mps_size_t *buflen,
-                                mps_alloc *ctx,
-                                mps_alloc_type purpose );
-
-#if defined(MBEDTLS_MPS_PROTO_TLS)
-
-MBEDTLS_MPS_INLINE int l1_check_flush_stream( mps_l1_stream_write *p );
-MBEDTLS_MPS_INLINE void l1_init_stream_read( mps_l1_stream_read *p,
-                                        mps_alloc *ctx,
-                                        void *recv_ctx,
-                                        mps_l0_recv_t *recv );
-MBEDTLS_MPS_INLINE void l1_set_bio_stream_read( mps_l1_stream_read *p,
-                                                void *recv_ctx,
-                                                mps_l0_recv_t *recv );
-MBEDTLS_MPS_INLINE void l1_init_stream_write( mps_l1_stream_write *p,
-                                         mps_alloc *ctx,
-                                         void *send_ctx,
-                                         mps_l0_send_t *send );
-MBEDTLS_MPS_INLINE void l1_set_bio_stream_write( mps_l1_stream_write *p,
-                                                 void *send_ctx,
-                                                 mps_l0_send_t *send );
-MBEDTLS_MPS_INLINE void l1_init_stream( mps_l1_stream *p,
-                                   mps_alloc *ctx,
-                                   void *send_ctx,
-                                   mps_l0_send_t *send,
-                                   void *recv_ctx,
-                                   mps_l0_recv_t *recv );
-MBEDTLS_MPS_INLINE void l1_set_bio_stream( mps_l1_stream *p,
-                                           void *send_ctx,
-                                           mps_l0_send_t *send,
-                                           void *recv_ctx,
-                                           mps_l0_recv_t *recv );
-MBEDTLS_MPS_INLINE void l1_free_stream_read( mps_l1_stream_read *p );
-MBEDTLS_MPS_INLINE void l1_free_stream_write( mps_l1_stream_write *p );
-MBEDTLS_MPS_INLINE void l1_free_stream( mps_l1_stream *p );
-MBEDTLS_MPS_INLINE int l1_consume_stream( mps_l1_stream_read *p );
-MBEDTLS_MPS_INLINE int l1_flush_stream( mps_l1_stream_write *p );
-MBEDTLS_MPS_INLINE int l1_write_stream( mps_l1_stream_write *p,
-                                   unsigned char **dst,
-                                   mbedtls_mps_size_t *buflen );
-MBEDTLS_MPS_INLINE int l1_check_flush_stream( mps_l1_stream_write *p );
-MBEDTLS_MPS_INLINE int l1_write_dependency_stream( mps_l1_stream_write *p );
-MBEDTLS_MPS_INLINE int l1_read_dependency_stream( mps_l1_stream_read *p );
-MBEDTLS_MPS_INLINE int l1_dispatch_stream( mps_l1_stream_write *p,
-                                           mbedtls_mps_size_t len,
-                                           mbedtls_mps_size_t *pending );
-#endif /* MBEDTLS_MPS_PROTO_TLS */
-
-#if defined(MBEDTLS_MPS_PROTO_DTLS)
-MBEDTLS_MPS_INLINE int l1_check_flush_dgram( mps_l1_dgram_write *p );
-MBEDTLS_MPS_INLINE void l1_init_dgram_read( mps_l1_dgram_read *p,
-                                       mps_alloc *ctx,
-                                       void *recv_ctx,
-                                       mps_l0_recv_t *recv );
-MBEDTLS_MPS_INLINE void l1_set_bio_dgram_read( mps_l1_dgram_read *p,
-                                               void *recv_ctx,
-                                               mps_l0_recv_t *recv );
-MBEDTLS_MPS_INLINE void l1_init_dgram_write( mps_l1_dgram_write *p,
-                                        mps_alloc *ctx,
-                                        void *send_ctx,
-                                        mps_l0_send_t *send );
-MBEDTLS_MPS_INLINE void l1_set_bio_dgram_write( mps_l1_dgram_write *p,
-                                                void *send_ctx,
-                                                mps_l0_send_t *send );
-MBEDTLS_MPS_INLINE void l1_init_dgram( mps_l1_dgram *p,
-                                  mps_alloc *ctx,
-                                  void *send_ctx,
-                                  mps_l0_send_t *send,
-                                  void *recv_ctx,
-                                  mps_l0_recv_t *recv );
-MBEDTLS_MPS_INLINE void l1_set_bio_dgram( mps_l1_dgram *p,
-                                          void *send_ctx,
-                                          mps_l0_send_t *send,
-                                          void *recv_ctx,
-                                          mps_l0_recv_t *recv );
-MBEDTLS_MPS_INLINE void l1_free_dgram_read( mps_l1_dgram_read *p );
-MBEDTLS_MPS_INLINE void l1_free_dgram_write( mps_l1_dgram_write *p );
-MBEDTLS_MPS_INLINE void l1_free_dgram( mps_l1_dgram *p );
-MBEDTLS_MPS_INLINE int l1_ensure_in_dgram( mps_l1_dgram_read *p );
-MBEDTLS_MPS_INLINE int l1_write_dependency_dgram( mps_l1_dgram_write *p );
-MBEDTLS_MPS_INLINE int l1_read_dependency_dgram( mps_l1_dgram_read *p );
-MBEDTLS_MPS_INLINE int l1_fetch_dgram( mps_l1_dgram_read *p,
-                                  unsigned char **dst,
-                                  mbedtls_mps_size_t len );
-MBEDTLS_MPS_INLINE int l1_consume_dgram( mps_l1_dgram_read *p );
-MBEDTLS_MPS_INLINE int l1_write_dgram( mps_l1_dgram_write *p,
-                                       unsigned char **buf,
-                                       mbedtls_mps_size_t *buflen );
-MBEDTLS_MPS_INLINE int l1_dispatch_dgram( mps_l1_dgram_write *p,
-                                          mbedtls_mps_size_t len,
-                                          mbedtls_mps_size_t *pending );
-MBEDTLS_MPS_INLINE int l1_flush_dgram( mps_l1_dgram_write *p );
-#endif /* MBEDTLS_MPS_PROTO_DTLS */
 
 /*
  * GENERAL NOTE ON CODING STYLE
@@ -1056,16 +960,14 @@ int l1_dispatch_dgram( mps_l1_dgram_write *p,
                        mbedtls_mps_size_t len,
                        mbedtls_mps_size_t *pending )
 {
-    mbedtls_mps_size_t bl, br;
+    mbedtls_mps_size_t br;
     TRACE_INIT( "l1_dispatch_dgram, length %u", (unsigned) len );
 
     MBEDTLS_MPS_STATE_VALIDATE_RAW( p->buf != NULL,
                   "l1_dispatch_dgram() called, but no datagram open" );
 
-    bl = p->buf_len;
     br = p->bytes_ready;
-
-    MBEDTLS_MPS_ASSERT_RAW( len <= bl - br,
+    MBEDTLS_MPS_ASSERT_RAW( len <= p->buf_len - p->bytes_ready,
                             "l1_dispatch_dgram() length too large" );
 
     br += len;
@@ -1205,10 +1107,12 @@ int mps_l1_set_bio( mps_l1 *ctx,
                     void *send_ctx, mps_l0_send_t *send,
                     void *recv_ctx, mps_l0_recv_t *recv )
 {
+    mbedtls_mps_transport_type const mode =
+        mbedtls_mps_l1_get_mode( ctx );
     TRACE_INIT( "mps_l1_set_bio" );
 
 #if defined(MBEDTLS_MPS_PROTO_TLS)
-    MBEDTLS_MPS_IF_TLS( ctx->mode )
+    MBEDTLS_MPS_IF_TLS( mode )
     {
         l1_set_bio_stream( &ctx->raw.stream,
                            send_ctx, send,
@@ -1216,7 +1120,7 @@ int mps_l1_set_bio( mps_l1 *ctx,
     }
 #endif /* MBEDTLS_MPS_PROTO_TLS */
 #if defined(MBEDTLS_MPS_PROTO_DTLS)
-    MBEDTLS_MPS_ELSE_IF_DTLS( ctx->mode )
+    MBEDTLS_MPS_ELSE_IF_DTLS( mode )
     {
         l1_set_bio_dgram( &ctx->raw.dgram,
                           send_ctx, send,
@@ -1321,6 +1225,8 @@ int mps_l1_flush( mps_l1 *ctx )
 #endif /* MBEDTLS_MPS_PROTO_DTLS */
 }
 
+/* TODO: Will we need this at some point? */
+__attribute__((unused))
 int mps_l1_read_dependency( mps_l1 *ctx )
 {
     mbedtls_mps_transport_type const mode =
@@ -1336,6 +1242,8 @@ int mps_l1_read_dependency( mps_l1 *ctx )
 #endif /* MBEDTLS_MPS_PROTO_DTLS */
 }
 
+/* TODO: Will we need this at some point? */
+__attribute__((unused))
 int mps_l1_write_dependency( mps_l1 *ctx )
 {
     mbedtls_mps_transport_type const mode =

--- a/library/mps/layer1_internal.h
+++ b/library/mps/layer1_internal.h
@@ -1,0 +1,154 @@
+/*
+ *  Message Processing Stack, Layer 1 implementation
+ *
+ *  Copyright (C) 2006-2018, ARM Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of Mbed TLS (https://tls.mbed.org)
+ */
+
+#ifndef MBEDTLS_MPS_BUFFER_LAYER_INTERNAL_H
+#define MBEDTLS_MPS_BUFFER_LAYER_INTERNAL_H
+
+#include "mbedtls/mps/layer1.h"
+
+/*
+ * Allocator related functions
+ */
+
+MBEDTLS_MPS_STATIC void l1_release_if_set( unsigned char **buf_ptr,
+                               mps_alloc *ctx,
+                               mps_alloc_type purpose );
+MBEDTLS_MPS_STATIC int l1_acquire_if_unset( unsigned char **buf_ptr,
+                                mbedtls_mps_size_t *buflen,
+                                mps_alloc *ctx,
+                                mps_alloc_type purpose );
+
+/*
+ * Functions related to stream-based implementation of Layer 1
+ */
+
+#if defined(MBEDTLS_MPS_PROTO_TLS)
+
+MBEDTLS_MPS_INLINE void l1_init_stream_read( mps_l1_stream_read *p,
+                                        mps_alloc *ctx,
+                                        void *recv_ctx,
+                                        mps_l0_recv_t *recv );
+MBEDTLS_MPS_INLINE void l1_init_stream_write( mps_l1_stream_write *p,
+                                         mps_alloc *ctx,
+                                         void *send_ctx,
+                                         mps_l0_send_t *send );
+MBEDTLS_MPS_INLINE void l1_init_stream( mps_l1_stream *p,
+                                   mps_alloc *ctx,
+                                   void *send_ctx,
+                                   mps_l0_send_t *send,
+                                   void *recv_ctx,
+                                   mps_l0_recv_t *recv );
+
+MBEDTLS_MPS_INLINE void l1_free_stream_read( mps_l1_stream_read *p );
+MBEDTLS_MPS_INLINE void l1_free_stream_write( mps_l1_stream_write *p );
+MBEDTLS_MPS_INLINE void l1_free_stream( mps_l1_stream *p );
+
+MBEDTLS_MPS_INLINE void l1_set_bio_stream_read( mps_l1_stream_read *p,
+                                                void *recv_ctx,
+                                                mps_l0_recv_t *recv );
+MBEDTLS_MPS_INLINE void l1_set_bio_stream_write( mps_l1_stream_write *p,
+                                                 void *send_ctx,
+                                                 mps_l0_send_t *send );
+MBEDTLS_MPS_INLINE void l1_set_bio_stream( mps_l1_stream *p,
+                                           void *send_ctx,
+                                           mps_l0_send_t *send,
+                                           void *recv_ctx,
+                                           mps_l0_recv_t *recv );
+
+MBEDTLS_MPS_INLINE int l1_fetch_stream( mps_l1_stream_read *p,
+                                        unsigned char **dst,
+                                        mbedtls_mps_size_t len );
+MBEDTLS_MPS_INLINE int l1_write_stream( mps_l1_stream_write *p,
+                                   unsigned char **dst,
+                                   mbedtls_mps_size_t *buflen );
+
+MBEDTLS_MPS_INLINE int l1_check_flush_stream( mps_l1_stream_write *p );
+MBEDTLS_MPS_INLINE int l1_flush_stream( mps_l1_stream_write *p );
+MBEDTLS_MPS_INLINE int l1_consume_stream( mps_l1_stream_read *p );
+MBEDTLS_MPS_INLINE int l1_dispatch_stream( mps_l1_stream_write *p,
+                                           mbedtls_mps_size_t len,
+                                           mbedtls_mps_size_t *pending );
+
+MBEDTLS_MPS_INLINE int l1_write_dependency_stream( mps_l1_stream_write *p );
+MBEDTLS_MPS_INLINE int l1_read_dependency_stream( mps_l1_stream_read *p );
+
+#endif /* MBEDTLS_MPS_PROTO_TLS */
+
+/*
+ * Functions related to datagram-based implementation of Layer 1
+ */
+
+#if defined(MBEDTLS_MPS_PROTO_DTLS)
+
+MBEDTLS_MPS_INLINE void l1_init_dgram_read( mps_l1_dgram_read *p,
+                                       mps_alloc *ctx,
+                                       void *recv_ctx,
+                                       mps_l0_recv_t *recv );
+MBEDTLS_MPS_INLINE void l1_init_dgram_write( mps_l1_dgram_write *p,
+                                        mps_alloc *ctx,
+                                        void *send_ctx,
+                                        mps_l0_send_t *send );
+MBEDTLS_MPS_INLINE void l1_init_dgram( mps_l1_dgram *p,
+                                  mps_alloc *ctx,
+                                  void *send_ctx,
+                                  mps_l0_send_t *send,
+                                  void *recv_ctx,
+                                  mps_l0_recv_t *recv );
+
+MBEDTLS_MPS_INLINE void l1_free_dgram_read( mps_l1_dgram_read *p );
+MBEDTLS_MPS_INLINE void l1_free_dgram_write( mps_l1_dgram_write *p );
+MBEDTLS_MPS_INLINE void l1_free_dgram( mps_l1_dgram *p );
+
+MBEDTLS_MPS_INLINE void l1_set_bio_dgram_write( mps_l1_dgram_write *p,
+                                                void *send_ctx,
+                                                mps_l0_send_t *send );
+
+MBEDTLS_MPS_INLINE void l1_set_bio_dgram_read( mps_l1_dgram_read *p,
+                                               void *recv_ctx,
+                                               mps_l0_recv_t *recv );
+
+MBEDTLS_MPS_INLINE void l1_set_bio_dgram( mps_l1_dgram *p,
+                                          void *send_ctx,
+                                          mps_l0_send_t *send,
+                                          void *recv_ctx,
+                                          mps_l0_recv_t *recv );
+MBEDTLS_MPS_INLINE int l1_fetch_dgram( mps_l1_dgram_read *p,
+                                  unsigned char **dst,
+                                  mbedtls_mps_size_t len );
+MBEDTLS_MPS_INLINE int l1_consume_dgram( mps_l1_dgram_read *p );
+MBEDTLS_MPS_INLINE int l1_write_dgram( mps_l1_dgram_write *p,
+                                       unsigned char **buf,
+                                       mbedtls_mps_size_t *buflen );
+MBEDTLS_MPS_INLINE int l1_dispatch_dgram( mps_l1_dgram_write *p,
+                                          mbedtls_mps_size_t len,
+                                          mbedtls_mps_size_t *pending );
+
+MBEDTLS_MPS_INLINE int l1_flush_dgram( mps_l1_dgram_write *p );
+MBEDTLS_MPS_INLINE int l1_check_flush_dgram( mps_l1_dgram_write *p );
+
+MBEDTLS_MPS_INLINE int l1_ensure_in_dgram( mps_l1_dgram_read *p );
+
+MBEDTLS_MPS_INLINE int l1_write_dependency_dgram( mps_l1_dgram_write *p );
+MBEDTLS_MPS_INLINE int l1_read_dependency_dgram( mps_l1_dgram_read *p );
+
+#endif /* MBEDTLS_MPS_PROTO_DTLS */
+
+#endif /* MBEDTLS_MPS_BUFFER_LAYER_INTERNAL */

--- a/library/mps/layer2_internal.h
+++ b/library/mps/layer2_internal.h
@@ -1,0 +1,287 @@
+/*
+ *  Message Processing Stack, Layer 1 implementation
+ *
+ *  Copyright (C) 2006-2018, ARM Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of Mbed TLS (https://tls.mbed.org)
+ */
+
+#ifndef MBEDTLS_MPS_RECORD_LAYER_INTERNAL_H
+#define MBEDTLS_MPS_RECORD_LAYER_INTERNAL_H
+
+/*
+ * Read/Write of (D)TLS versions
+ */
+
+#if defined(MBEDTLS_MPS_PROTO_TLS)
+MBEDTLS_MPS_STATIC void l2_read_version_tls( uint8_t *major, uint8_t *minor,
+                                             const unsigned char ver[2] );
+#endif /* MBEDTLS_MPS_PROTO_TLS */
+
+#if defined(MBEDTLS_MPS_PROTO_DTLS)
+MBEDTLS_MPS_STATIC void l2_read_version_dtls( uint8_t *major, uint8_t *minor,
+                                              const unsigned char ver[2] );
+#endif /* MBEDTLS_MPS_PROTO_DTLS */
+MBEDTLS_MPS_STATIC void l2_out_write_version( int major, int minor,
+                                  mbedtls_mps_transport_type transport,
+                                  unsigned char ver[2] );
+
+/*
+ * Management for readers / input queues
+ */
+
+/* Initialize readers / input queues. */
+MBEDTLS_MPS_STATIC void mps_l2_readers_init( mbedtls_mps_l2 *ctx );
+/* Free readers / input queues. */
+MBEDTLS_MPS_STATIC void mps_l2_readers_free( mbedtls_mps_l2 *ctx );
+/* Get the active reader / input queue, or NULL if there isn't any. */
+MBEDTLS_MPS_STATIC
+mbedtls_mps_l2_in_internal* mps_l2_readers_get_active( mbedtls_mps_l2 *ctx );
+/* Close the active reader / input queue. */
+MBEDTLS_MPS_STATIC int mps_l2_readers_close_active( mbedtls_mps_l2 *ctx );
+/* Pause the active reader / input queue; this happens if we need more
+ * than what's currently available, and we need to accumulate more data
+ * from the respective input stream. */
+#if defined(MBEDTLS_MPS_PROTO_TLS)
+MBEDTLS_MPS_STATIC int mps_l2_readers_pause_active( mbedtls_mps_l2 *ctx );
+#endif /* MBEDTLS_MPS_PROTO_TLS */
+/* Check if data is available in one of the readers / input queues. */
+MBEDTLS_MPS_STATIC
+mbedtls_mps_l2_reader_state mps_l2_readers_active_state( mbedtls_mps_l2 *ctx );
+/* Get an unused reader / input queue to manage new incoming data. */
+MBEDTLS_MPS_STATIC
+mbedtls_mps_l2_in_internal* mps_l2_readers_get_unused( mbedtls_mps_l2 *ctx );
+#if defined(MBEDTLS_MPS_PROTO_TLS)
+/* The implementation currently maintains a single accumulator for all
+ * readers / input queues. Check whether its currently in use. */
+MBEDTLS_MPS_STATIC
+int mps_l2_readers_accumulator_taken( mbedtls_mps_l2 *ctx );
+#endif /* MBEDTLS_MPS_PROTO_TLS */
+/* TODO: Document */
+MBEDTLS_MPS_INLINE
+void mps_l2_reader_slots_changed( mbedtls_mps_l2 *ctx );
+/* Match a pair of type and epoch for new incoming data against the set
+ * of currently opened readers / input streams. If there's a matching one,
+ * return it. If there's one matching the type but with different epoch,
+ * fail. */
+MBEDTLS_MPS_INLINE
+int mps_l2_find_suitable_slot( mbedtls_mps_l2 *ctx,
+                               mbedtls_mps_msg_type_t type,
+                               mbedtls_mps_epoch_id epoch,
+                               mbedtls_mps_l2_in_internal **dst );
+
+/*
+ * Reading related
+ */
+
+/* Various record header parsing functions
+ *
+ * These functions fetch and validate record headers for various TLS/DTLS
+ * versions from Layer 1 and feed them into the provided record structure.
+ *
+ * Checks these functions perform:
+ * - The epoch is not a valid epoch for incoming records.
+ * - The record content type is not valid.
+ * - The length field in the record header exceeds the
+ *   configured maximum record size.
+ * - The datagram didn't contain as much data after
+ *   the record header as indicated in the record
+ *   header length field.
+ * - There wasn't enough space remaining in the datagram
+ *   to load a DTLS 1.2 record header.
+ * - The record sequence number has been seen before,
+ *   so the record is likely duplicated / replayed.
+ */
+MBEDTLS_MPS_STATIC int l2_in_fetch_record( mbedtls_mps_l2 *ctx, mps_rec *rec );
+MBEDTLS_MPS_STATIC int l2_in_fetch_protected_record( mbedtls_mps_l2 *ctx,
+                                                     mps_rec *rec );
+#if defined(MBEDTLS_MPS_PROTO_TLS)
+MBEDTLS_MPS_STATIC int l2_in_fetch_protected_record_tls( mbedtls_mps_l2 *ctx,
+                                                         mps_rec *rec );
+#endif /* MBEDTLS_MPS_PROTO_TLS */
+#if defined(MBEDTLS_MPS_PROTO_DTLS)
+MBEDTLS_MPS_STATIC int l2_in_fetch_protected_record_dtls12( mbedtls_mps_l2 *ctx,
+                                                            mps_rec *rec );
+
+/* TODO */__attribute__((unused))
+MBEDTLS_MPS_STATIC int l2_in_fetch_protected_record_dtls13( mbedtls_mps_l2 *ctx,
+                                                            mps_rec *rec );
+MBEDTLS_MPS_STATIC int l2_handle_invalid_record( mbedtls_mps_l2 *ctx, int ret );
+#endif /* MBEDTLS_MPS_PROTO_DTLS */
+
+MBEDTLS_MPS_STATIC int l2_handle_record_content( mbedtls_mps_l2 *ctx, mps_rec *rec );
+
+/* Signal to the underlying Layer 1 that the last
+ * incoming record has been fully processed. */
+MBEDTLS_MPS_STATIC int l2_in_release_record( mbedtls_mps_l2 *ctx );
+
+/*
+ * Writing related
+ */
+
+MBEDTLS_MPS_STATIC int l2_out_prepare_record( mbedtls_mps_l2 *ctx,
+                                              mbedtls_mps_epoch_id epoch );
+MBEDTLS_MPS_STATIC int l2_out_track_record( mbedtls_mps_l2 *ctx );
+MBEDTLS_MPS_STATIC int l2_out_release_record( mbedtls_mps_l2 *ctx,
+                                              uint8_t force );
+MBEDTLS_MPS_STATIC int l2_out_dispatch_record( mbedtls_mps_l2 *ctx );
+
+/* Various record header writing functions */
+MBEDTLS_MPS_STATIC int l2_out_write_protected_record( mbedtls_mps_l2 *ctx,
+                                                      mps_rec *rec );
+#if defined(MBEDTLS_MPS_PROTO_TLS)
+MBEDTLS_MPS_STATIC int l2_out_write_protected_record_tls( mbedtls_mps_l2 *ctx,
+                                              mps_rec *rec );
+#endif /* MBEDTLS_MPS_PROTO_TLS */
+#if defined(MBEDTLS_MPS_PROTO_DTLS)
+MBEDTLS_MPS_STATIC int l2_out_write_protected_record_dtls12( mbedtls_mps_l2 *ctx,
+                                                 mps_rec *rec );
+#endif /* MBEDTLS_MPS_PROTO_DTLS */
+
+MBEDTLS_MPS_STATIC int l2_out_release_and_dispatch( mbedtls_mps_l2 *ctx,
+                                                    uint8_t force );
+MBEDTLS_MPS_STATIC int l2_out_clear_pending( mbedtls_mps_l2 *ctx );
+
+MBEDTLS_MPS_STATIC mbedtls_mps_size_t l2_get_header_len( mbedtls_mps_l2 *ctx,
+                                                   mbedtls_mps_epoch_id epoch );
+
+#if defined(MBEDTLS_MPS_PROTO_TLS)
+MBEDTLS_MPS_ALWAYS_INLINE
+int l2_version_wire_matches_logical( uint8_t wire_version,
+                                     int logical_version );
+#endif /* MBEDTLS_MPS_PROTO_TLS */
+
+/* Configuration related */
+/* OPTIMIZATION: The flexibility of Layer 2 in terms of valid types,
+ *               pausing, merging, and the acceptance of empty records
+ *               is nice for testing, but on a low-profile production build
+ *               targeted at a specific version of [D]TLS, code can be saved
+ *               by implementing the l2_type_can_be_yyy() functions in a
+ *               static way (comparing against a mask / list of types fixed
+ *               at compile-time). */
+#if defined(MBEDTLS_MPS_PROTO_TLS)
+MBEDTLS_MPS_STATIC int l2_type_can_be_paused( mbedtls_mps_l2 *ctx,
+                                  mbedtls_mps_msg_type_t type );
+#endif /* MBEDTLS_MPS_PROTO_TLS */
+MBEDTLS_MPS_STATIC int l2_type_can_be_merged( mbedtls_mps_l2 *ctx,
+                                  mbedtls_mps_msg_type_t type );
+MBEDTLS_MPS_STATIC int l2_type_is_valid( mbedtls_mps_l2 *ctx,
+                             mbedtls_mps_msg_type_t type );
+MBEDTLS_MPS_STATIC int l2_type_empty_allowed( mbedtls_mps_l2 *ctx,
+                                  mbedtls_mps_msg_type_t type );
+
+/*
+ * Epoch handling
+ */
+
+/* Print human-readable description of epoch usage flags. */
+MBEDTLS_MPS_STATIC void l2_print_usage( unsigned usage );
+
+#if defined(MBEDTLS_MPS_TRACE)
+static inline const char * l2_epoch_usage_to_string(
+    mbedtls_mps_epoch_usage usage )
+{
+    if( ( usage & MPS_EPOCH_READ_MASK  ) != 0 &&
+        ( usage & MPS_EPOCH_WRITE_MASK ) != 0 )
+    {
+        return( "READ | WRITE" );
+    }
+    else if( ( usage & MPS_EPOCH_READ_MASK ) != 0 )
+        return( "READ" );
+    else if( ( usage & MPS_EPOCH_WRITE_MASK ) != 0 )
+        return( "WRITE" );
+
+    return( "NONE" );
+}
+#endif /* MBEDTLS_MPS_TRACE */
+
+/* Internal macro used to indicate internal usage of an epoch,
+ * e.g. because data it still pending to be dispatched.
+ *
+ * The `reason` parameter may range from 0 to 3.
+ */
+#define MPS_EPOCH_USAGE_INTERNAL( reason )  \
+    ( (mbedtls_mps_epoch_usage) ( 1u << ( 4 + ( reason ) ) ) )
+
+#define MPS_EPOCH_USAGE_INTERNAL_OUT_RECORD_OPEN \
+    MPS_EPOCH_USAGE_INTERNAL( 0 )
+#define MPS_EPOCH_USAGE_INTERNAL_OUT_PROTECTED  \
+    MPS_EPOCH_USAGE_INTERNAL( 1 )
+
+MBEDTLS_MPS_STATIC void l2_epoch_free( mbedtls_mps_l2_epoch_t *epoch );
+MBEDTLS_MPS_STATIC void l2_epoch_init( mbedtls_mps_l2_epoch_t *epoch );
+
+/* Check if an epoch can be used for a given purpose. */
+MBEDTLS_MPS_STATIC int l2_epoch_check( mbedtls_mps_l2 *ctx,
+                           mbedtls_mps_epoch_id epoch,
+                           uint8_t purpose );
+
+/* Lookup the transform associated to an epoch.
+ *
+ * The epoch ID is fully untrusted (this function is called
+ * as part of replay protection for not yet authenticated
+ * records).
+ */
+MBEDTLS_MPS_STATIC int l2_epoch_lookup( mbedtls_mps_l2 *ctx,
+                            mbedtls_mps_epoch_id epoch_id,
+                            mbedtls_mps_l2_epoch_t **epoch );
+
+/* Check if some epochs are no longer needed and can be removed. */
+MBEDTLS_MPS_STATIC int l2_epoch_cleanup( mbedtls_mps_l2 *ctx );
+
+/*
+ * Sequence number handling
+ */
+
+#if defined(MBEDTLS_MPS_PROTO_TLS)
+MBEDTLS_MPS_STATIC int l2_tls_in_get_epoch_and_counter( mbedtls_mps_l2 *ctx,
+                                                        uint16_t *dst_epoch,
+                                                        uint32_t dst_ctr[2] );
+#endif /* MBEDTLS_MPS_PROTO_TLS */
+
+MBEDTLS_MPS_STATIC int l2_in_update_counter( mbedtls_mps_l2 *ctx,
+                                             uint16_t epoch,
+                                             uint32_t ctr_hi,
+                                             uint32_t ctr_lo );
+
+MBEDTLS_MPS_STATIC int l2_out_get_and_update_rec_seq( mbedtls_mps_l2 *ctx,
+                                          mbedtls_mps_l2_epoch_t *epoch,
+                                          uint32_t *dst_ctr );
+
+MBEDTLS_MPS_STATIC int l2_increment_counter( uint32_t ctr[2] );
+
+/*
+ * DTLS replay protection
+ */
+
+#if defined(MBEDTLS_MPS_PROTO_DTLS)
+/* This function checks whether the record sequence number represented
+ * by `ctr_lo` and `ctr_hi` is 'fresh' in the following sense:
+ * - It hasn't been seen before.
+ * - It's not too old.
+ *
+ * - Returns `0` if the sequence number is fresh.
+ * - Returns `-1` otherwise.
+ *
+ * This function does not update the replay protection window.
+ */
+MBEDTLS_MPS_STATIC int l2_counter_replay_check( mbedtls_mps_l2 *ctx,
+                                                mbedtls_mps_epoch_id epoch,
+                                                uint32_t ctr_hi,
+                                                uint32_t ctr_lo );
+#endif /* MBEDTLS_MPS_PROTO_DTLS */
+
+#endif /* MBEDTLS_MPS_RECORD_LAYER_INTERNAL_H */

--- a/library/mps/layer3_internal.h
+++ b/library/mps/layer3_internal.h
@@ -1,0 +1,73 @@
+/*
+ *  Message Processing Stack, Layer 1 implementation
+ *
+ *  Copyright (C) 2006-2018, ARM Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of Mbed TLS (https://tls.mbed.org)
+ */
+
+#ifndef MBEDTLS_MPS_MESSAGE_EXTRACTION_LAYER_INTERNAL_H
+#define MBEDTLS_MPS_MESSAGE_EXTRACTION_LAYER_INTERNAL_H
+
+#include "mbedtls/mps/layer3.h"
+
+/*
+ * Handshake header parsing/writing
+ */
+
+#if defined(MBEDTLS_MPS_PROTO_TLS)
+MBEDTLS_MPS_STATIC int l3_check_write_hs_hdr_tls( mps_l3 *l3 );
+#endif /* MBEDTLS_MPS_PROTO_TLS */
+#if defined(MBEDTLS_MPS_PROTO_DTLS)
+MBEDTLS_MPS_STATIC int l3_check_write_hs_hdr_dtls( mps_l3 *l3 );
+#endif /* MBEDTLS_MPS_PROTO_DTLS */
+MBEDTLS_MPS_STATIC int l3_check_write_hs_hdr( mps_l3 *l3 );
+
+#if defined(MBEDTLS_MPS_PROTO_TLS)
+MBEDTLS_MPS_STATIC int l3_parse_hs_header_tls( mbedtls_reader *rd,
+                                               mps_l3_hs_in_internal *in );
+MBEDTLS_MPS_STATIC int l3_write_hs_header_tls( mps_l3_hs_out_internal *hs );
+#endif /* MBEDTLS_MPS_PROTO_TLS */
+
+#if defined(MBEDTLS_MPS_PROTO_DTLS)
+MBEDTLS_MPS_STATIC int l3_parse_hs_header_dtls( mbedtls_reader *rd,
+                                                mps_l3_hs_in_internal *in );
+MBEDTLS_MPS_STATIC int l3_write_hs_header_dtls( mps_l3_hs_out_internal *hs );
+#endif /* MBEDTLS_MPS_PROTO_DTLS */
+
+MBEDTLS_MPS_STATIC int l3_parse_hs_header( uint8_t mode, mbedtls_reader *rd,
+                               mps_l3_hs_in_internal *in );
+
+/*
+ * Other message types
+ */
+
+MBEDTLS_MPS_STATIC int l3_parse_alert( mbedtls_reader *rd,
+                           mps_l3_alert_in_internal *alert );
+MBEDTLS_MPS_STATIC int l3_parse_ccs( mbedtls_reader *rd );
+
+/*
+ * Miscellanious
+ *
+ * TODO: Document
+ */
+
+MBEDTLS_MPS_STATIC int l3_prepare_write( mps_l3 *l3,
+                                         mbedtls_mps_msg_type_t type,
+                                         mbedtls_mps_epoch_id epoch );
+MBEDTLS_MPS_STATIC int l3_check_clear( mps_l3 *l3 );
+
+#endif /* MBEDTLS_MPS_MESSAGE_EXTRACTION_LAYER_INTERNAL_H */

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -5814,7 +5814,7 @@ int mbedtls_ssl_read( mbedtls_ssl_context *ssl, unsigned char *buf, size_t len )
     size_t data_read;
     unsigned char *src;
     mbedtls_reader *rd;
-    MBEDTLS_SSL_PROC_CHK( mbedtls_mps_read( &ssl->mps.l4 ) );
+    MBEDTLS_SSL_PROC_CHK_NEG( mbedtls_mps_read( &ssl->mps.l4 ) );
     msg_type = ret;
 
     if( msg_type == MBEDTLS_MPS_MSG_HS )

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -131,7 +131,7 @@ int ssl_write_early_data_process( mbedtls_ssl_context* ssl )
 #endif /* MBEDTLS_SSL_USE_MPS */
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> write early data" ) );
 
-    MBEDTLS_SSL_PROC_CHK( ssl_write_early_data_coordinate( ssl ) );
+    MBEDTLS_SSL_PROC_CHK_NEG( ssl_write_early_data_coordinate( ssl ) );
     if( ret == SSL_EARLY_DATA_WRITE )
     {
 #if defined(MBEDTLS_ZERO_RTT)
@@ -344,8 +344,7 @@ int ssl_write_end_of_early_data_process( mbedtls_ssl_context* ssl )
     int ret;
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> write EndOfEarlyData" ) );
 
-    MBEDTLS_SSL_PROC_CHK( ssl_write_end_of_early_data_coordinate( ssl ) );
-
+    MBEDTLS_SSL_PROC_CHK_NEG( ssl_write_end_of_early_data_coordinate( ssl ) );
     if( ret == SSL_END_OF_EARLY_DATA_WRITE )
     {
 #if defined(MBEDTLS_SSL_USE_MPS)
@@ -1320,7 +1319,7 @@ static int ssl_client_hello_process( mbedtls_ssl_context* ssl )
     mbedtls_mps_handshake_out msg;
     unsigned char *buf;
     mbedtls_mps_size_t buf_len, msg_len;
-#else
+#else /* MBEDTLS_SSL_USE_MPS */
     size_t msg_len, len_without_binders;
     unsigned char *buf;
     size_t len;
@@ -1356,8 +1355,7 @@ static int ssl_client_hello_process( mbedtls_ssl_context* ssl )
                                         msg_len );
     ssl->handshake->update_checksum( ssl, buf, len_without_binders );
 
-#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && \
-    defined(MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED)
+#if defined(MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED)
     /* Patch the PSK binder after updating the HS checksum. */
     {
 
@@ -1372,8 +1370,7 @@ static int ssl_client_hello_process( mbedtls_ssl_context* ssl )
         ssl->handshake->update_checksum( ssl, buf + len_without_binders,
                                          msg_len - len_without_binders );
     }
-#endif /* MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED &&
-          MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
+#endif /* MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED */
 
     /* Commit message */
     MBEDTLS_SSL_PROC_CHK( mbedtls_writer_commit_partial_ext( msg.handle,
@@ -2307,7 +2304,7 @@ static int ssl_certificate_request_process( mbedtls_ssl_context* ssl )
      * - Fetch record
      * - Make sure it's either a CertificateRequest or a ServerHelloDone
      */
-    MBEDTLS_SSL_PROC_CHK( ssl_certificate_request_coordinate( ssl ) );
+    MBEDTLS_SSL_PROC_CHK_NEG( ssl_certificate_request_coordinate( ssl ) );
 
 #if defined(MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED)
     if( ret == SSL_CERTIFICATE_REQUEST_EXPECT_REQUEST )
@@ -2379,7 +2376,7 @@ static int ssl_certificate_request_coordinate( mbedtls_ssl_context* ssl )
         return( SSL_CERTIFICATE_REQUEST_SKIP );
     }
 
-    MBEDTLS_SSL_PROC_CHK( mbedtls_mps_read( &ssl->mps.l4 ) );
+    MBEDTLS_SSL_PROC_CHK_NEG( mbedtls_mps_read( &ssl->mps.l4 ) );
     if( ret != MBEDTLS_MPS_MSG_HS )
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "bad certificate request message" ) );
@@ -2402,7 +2399,7 @@ static int ssl_certificate_request_fetch( mbedtls_ssl_context* ssl,
                                           mbedtls_mps_handshake_in *msg )
 {
     int ret;
-    MBEDTLS_SSL_PROC_CHK( mbedtls_mps_read( &ssl->mps.l4 ) );
+    MBEDTLS_SSL_PROC_CHK_NEG( mbedtls_mps_read( &ssl->mps.l4 ) );
     if( ret != MBEDTLS_MPS_MSG_HS )
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "bad certificate request message" ) );
@@ -2712,7 +2709,7 @@ static int ssl_encrypted_extensions_fetch( mbedtls_ssl_context* ssl,
                                            mbedtls_mps_handshake_in *msg )
 {
     int ret;
-    MBEDTLS_SSL_PROC_CHK( mbedtls_mps_read( &ssl->mps.l4 ) );
+    MBEDTLS_SSL_PROC_CHK_NEG( mbedtls_mps_read( &ssl->mps.l4 ) );
     if( ret != MBEDTLS_MPS_MSG_HS )
     {
         SSL_PEND_FATAL_ALERT( MBEDTLS_SSL_ALERT_MSG_UNEXPECTED_MESSAGE );
@@ -2979,10 +2976,10 @@ static int ssl_server_hello_process( mbedtls_ssl_context* ssl )
      */
 
 #if defined(MBEDTLS_SSL_USE_MPS)
-    MBEDTLS_SSL_PROC_CHK( ssl_server_hello_coordinate( ssl, &msg,
+    MBEDTLS_SSL_PROC_CHK_NEG( ssl_server_hello_coordinate( ssl, &msg,
                                                  &buf, &buflen ) );
 #else /* MBEDTLS_SSL_USE_MPS */
-    MBEDTLS_SSL_PROC_CHK( ssl_server_hello_coordinate( ssl,
+    MBEDTLS_SSL_PROC_CHK_NEG( ssl_server_hello_coordinate( ssl,
                                                  &buf, &buflen ) );
 #endif /* MBEDTLS_SSL_USE_MPS */
 
@@ -3067,7 +3064,7 @@ static int ssl_server_hello_coordinate( mbedtls_ssl_context* ssl,
     int ret;
     unsigned char *peak;
 
-    MBEDTLS_SSL_PROC_CHK( mbedtls_mps_read( &ssl->mps.l4 ) );
+    MBEDTLS_SSL_PROC_CHK_NEG( mbedtls_mps_read( &ssl->mps.l4 ) );
 
 #if defined(MBEDTLS_SSL_TLS13_COMPATIBILITY_MODE)
     if( ret == MBEDTLS_MPS_MSG_CCS )

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -762,7 +762,7 @@ int mbedtls_ssl_write_change_cipher_spec_process( mbedtls_ssl_context* ssl )
 
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> write change cipher spec" ) );
 
-    MBEDTLS_SSL_PROC_CHK( ssl_write_change_cipher_spec_coordinate( ssl ) );
+    MBEDTLS_SSL_PROC_CHK_NEG( ssl_write_change_cipher_spec_coordinate( ssl ) );
 
     if( ret == SSL_WRITE_CCS_NEEDED )
     {
@@ -1801,7 +1801,7 @@ int mbedtls_ssl_certificate_verify_process( mbedtls_ssl_context* ssl )
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> write certificate verify" ) );
 
     /* Coordination step: Check if we need to send a CertificateVerify */
-    MBEDTLS_SSL_PROC_CHK( ssl_certificate_verify_coordinate( ssl ) );
+    MBEDTLS_SSL_PROC_CHK_NEG( ssl_certificate_verify_coordinate( ssl ) );
 
     if( ret == SSL_CERTIFICATE_VERIFY_SEND )
     {
@@ -2176,7 +2176,7 @@ int mbedtls_ssl_read_certificate_verify_process( mbedtls_ssl_context* ssl )
     /* Coordination step */
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> parse certificate verify" ) );
 
-    MBEDTLS_SSL_PROC_CHK( ssl_read_certificate_verify_coordinate( ssl ) );
+    MBEDTLS_SSL_PROC_CHK_NEG( ssl_read_certificate_verify_coordinate( ssl ) );
 
 #if defined(MBEDTLS_KEY_EXCHANGE_WITH_CERT_ENABLED) // TBD: double-check
     if( ret == SSL_CERTIFICATE_VERIFY_READ )
@@ -2271,7 +2271,7 @@ static int ssl_read_certificate_verify_fetch( mbedtls_ssl_context *ssl,
 {
     int ret;
 
-    MBEDTLS_SSL_PROC_CHK( mbedtls_mps_read( &ssl->mps.l4 ) );
+    MBEDTLS_SSL_PROC_CHK_NEG( mbedtls_mps_read( &ssl->mps.l4 ) );
 
     if( ret != MBEDTLS_MPS_MSG_HS )
         return( MBEDTLS_ERR_SSL_UNEXPECTED_MESSAGE );
@@ -2573,7 +2573,7 @@ int mbedtls_ssl_write_certificate_process( mbedtls_ssl_context* ssl )
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> write certificate" ) );
 
     /* Coordination: Check if we need to send a certificate. */
-    MBEDTLS_SSL_PROC_CHK( ssl_write_certificate_coordinate( ssl ) );
+    MBEDTLS_SSL_PROC_CHK_NEG( ssl_write_certificate_coordinate( ssl ) );
 
 #if defined(MBEDTLS_KEY_EXCHANGE_WITH_CERT_ENABLED)
     if( ret == SSL_WRITE_CERTIFICATE_AVAILABLE )
@@ -2912,7 +2912,7 @@ int mbedtls_ssl_read_certificate_process( mbedtls_ssl_context* ssl )
     /* Coordination:
      * Check if we expect a certificate, and if yes,
      * check if a non-empty certificate has been sent. */
-    MBEDTLS_SSL_PROC_CHK( ssl_read_certificate_coordinate( ssl ) );
+    MBEDTLS_SSL_PROC_CHK_NEG( ssl_read_certificate_coordinate( ssl ) );
 #if defined(MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED)
     if( ret == SSL_CERTIFICATE_EXPECTED )
     {
@@ -2979,7 +2979,7 @@ static int ssl_read_certificate_fetch( mbedtls_ssl_context *ssl,
 {
     int ret;
 
-    MBEDTLS_SSL_PROC_CHK( mbedtls_mps_read( &ssl->mps.l4 ) );
+    MBEDTLS_SSL_PROC_CHK_NEG( mbedtls_mps_read( &ssl->mps.l4 ) );
 
     if( ret != MBEDTLS_MPS_MSG_HS )
         return( MBEDTLS_ERR_SSL_UNEXPECTED_MESSAGE );
@@ -4548,7 +4548,7 @@ static int ssl_read_finished_fetch( mbedtls_ssl_context *ssl,
 {
     int ret;
 
-    MBEDTLS_SSL_PROC_CHK( mbedtls_mps_read( &ssl->mps.l4 ) );
+    MBEDTLS_SSL_PROC_CHK_NEG( mbedtls_mps_read( &ssl->mps.l4 ) );
 
     if( ret != MBEDTLS_MPS_MSG_HS )
         return( MBEDTLS_ERR_SSL_UNEXPECTED_MESSAGE );
@@ -4937,7 +4937,7 @@ static int ssl_new_session_ticket_fetch( mbedtls_ssl_context *ssl,
                                          mbedtls_mps_handshake_in *msg )
 {
     int ret;
-    MBEDTLS_SSL_PROC_CHK( mbedtls_mps_read( &ssl->mps.l4 ) );
+    MBEDTLS_SSL_PROC_CHK_NEG( mbedtls_mps_read( &ssl->mps.l4 ) );
 
     if( ret != MBEDTLS_MPS_MSG_HS )
         return( MBEDTLS_ERR_SSL_UNEXPECTED_MESSAGE );

--- a/tests/suites/test_suite_ccm.function
+++ b/tests/suites/test_suite_ccm.function
@@ -197,7 +197,7 @@ void mbedtls_ccm_star_encrypt_and_tag( int cipher_id,
                             int sec_level, data_t *add,
                             data_t *expected_result, int output_ret )
 {
-    unsigned char iv[13];
+    unsigned char iv[15];
     unsigned char result[50];
     mbedtls_ccm_context ctx;
     size_t i, iv_len, tag_len;
@@ -250,7 +250,7 @@ void mbedtls_ccm_star_auth_decrypt( int cipher_id,
                             int sec_level, data_t *add,
                             data_t *expected_result, int output_ret )
 {
-    unsigned char iv[13];
+    unsigned char iv[15];
     unsigned char result[50];
     mbedtls_ccm_context ctx;
     size_t i, iv_len, tag_len;

--- a/tests/suites/test_suite_mps.data
+++ b/tests/suites/test_suite_mps.data
@@ -188,67 +188,51 @@ MPS Writer: Random usage #2
 mbedtls_mps_writer_random_usage:10000:100:50:100
 
 MPS TLS: Init + Free for all Layers
-depends_on:MBEDTLS_MPS_PROTO_TLS
 mbedtls_mps_init_free:MBEDTLS_MPS_MODE_STREAM
 
 MPS DTLS: Init + Free for all Layers
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_init_free:MBEDTLS_MPS_MODE_DATAGRAM
 
 MPS Layer 1 TLS: Single chunk send and receive
-depends_on:MBEDTLS_MPS_PROTO_TLS
 mbedtls_mps_l1_basic:MBEDTLS_MPS_MODE_STREAM:0:0:0:0
 
 MPS Layer 1 TLS: Multiple chunk send, single chunk receive
-depends_on:MBEDTLS_MPS_PROTO_TLS
 mbedtls_mps_l1_basic:MBEDTLS_MPS_MODE_STREAM:1:0:0:0
 
 MPS Layer 1 TLS: Multiple chunk send & flush, single chunk receive
-depends_on:MBEDTLS_MPS_PROTO_TLS
 mbedtls_mps_l1_basic:MBEDTLS_MPS_MODE_STREAM:1:1:0:0
 
 MPS Layer 1 TLS: Single chunk send, multiple chunk receive
-depends_on:MBEDTLS_MPS_PROTO_TLS
 mbedtls_mps_l1_basic:MBEDTLS_MPS_MODE_STREAM:0:0:1:1
 
 MPS Layer 1 TLS: Single chunk send, multiple chunk receive no comsume
-depends_on:MBEDTLS_MPS_PROTO_TLS
 mbedtls_mps_l1_basic:MBEDTLS_MPS_MODE_STREAM:0:0:1:0
 
 MPS Layer 1 TLS: Multiple chunk send, multiple chunk receive
-depends_on:MBEDTLS_MPS_PROTO_TLS
 mbedtls_mps_l1_basic:MBEDTLS_MPS_MODE_STREAM:1:0:1:1
 
 MPS Layer 1 TLS: Multiple chunk send & flush, multiple chunk receive
-depends_on:MBEDTLS_MPS_PROTO_TLS
 mbedtls_mps_l1_basic:MBEDTLS_MPS_MODE_STREAM:1:1:1:1
 
 MPS Layer 1 DTLS: Single chunk send and receive
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l1_basic:MBEDTLS_MPS_MODE_DATAGRAM:0:0:0:0
 
 MPS Layer 1 DTLS: Multiple chunk send, single chunk receive
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l1_basic:MBEDTLS_MPS_MODE_DATAGRAM:1:0:0:0
 
 MPS Layer 1 DTLS: Multiple chunk send & flush, single chunk receive
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l1_basic:MBEDTLS_MPS_MODE_DATAGRAM:1:1:0:0
 
 MPS Layer 1 DTLS: Single chunk send, multiple chunk receive
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l1_basic:MBEDTLS_MPS_MODE_DATAGRAM:0:0:1:1
 
 MPS Layer 1 DTLS: Single chunk send, multiple chunk receive no comsume
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l1_basic:MBEDTLS_MPS_MODE_DATAGRAM:0:0:1:0
 
 MPS Layer 1 DTLS: Multiple chunk send, multiple chunk receive
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l1_basic:MBEDTLS_MPS_MODE_DATAGRAM:1:0:1:1
 
 MPS Layer 1 DTLS: Multiple chunk send & flush, multiple chunk receive
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l1_basic:MBEDTLS_MPS_MODE_DATAGRAM:1:1:1:1
 
 MPS Layer 1 TLS: Underlying stream transport isn't ready to send #0
@@ -288,95 +272,72 @@ MPS Layer 1 TLS Random Communication #7 (Alloc 1b, L0 1b)
 mbedtls_mps_l1_random_communication_stream:1:1:
 
 MPS Layer 2 TLS: Exchange of messages of two types, fake transform
-depends_on:MBEDTLS_MPS_PROTO_TLS
 mbedtls_mps_l2_basic:MBEDTLS_MPS_MODE_STREAM:20:0
 
 MPS Layer 2 TLS: Exchange of messages of two types, empty, fake transform
-depends_on:MBEDTLS_MPS_PROTO_TLS
 mbedtls_mps_l2_basic:MBEDTLS_MPS_MODE_STREAM:0:0
 
 MPS Layer 2 TLS: Exchange of messages of two types, real transform
-depends_on:MBEDTLS_MPS_PROTO_TLS
 mbedtls_mps_l2_basic:MBEDTLS_MPS_MODE_STREAM:20:1
 
 MPS Layer 2 TLS: Exchange of messages of two types, empty, real transform
-depends_on:MBEDTLS_MPS_PROTO_TLS
 mbedtls_mps_l2_basic:MBEDTLS_MPS_MODE_STREAM:0:1
 
 MPS Layer 2 DTLS: Exchange of messages of two types, fake transform
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l2_basic:MBEDTLS_MPS_MODE_DATAGRAM:20:0
 
 MPS Layer 2 DTLS: Exchange of messages of two types, empty, fake transform
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l2_basic:MBEDTLS_MPS_MODE_DATAGRAM:0:0
 
 MPS Layer 2 DTLS: Exchange of messages of two types, real transform
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l2_basic:MBEDTLS_MPS_MODE_DATAGRAM:20:1
 
 MPS Layer 2 DTLS: Exchange of messages of two types, empty, real transform
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l2_basic:MBEDTLS_MPS_MODE_DATAGRAM:0:1
 
 MPS Layer 2 TLS: Bad record - invalid content type
-depends_on:MBEDTLS_MPS_PROTO_TLS
 mbedtls_mps_l2_bad_record:MBEDTLS_MPS_MODE_STREAM:0
 
 MPS Layer 2 TLS: Bad record - invalid minor version
-depends_on:MBEDTLS_MPS_PROTO_TLS
 mbedtls_mps_l2_bad_record:MBEDTLS_MPS_MODE_STREAM:1
 
 MPS Layer 2 TLS: Bad record - invalid major version
-depends_on:MBEDTLS_MPS_PROTO_TLS
 mbedtls_mps_l2_bad_record:MBEDTLS_MPS_MODE_STREAM:2
 
 MPS Layer 2 TLS: Bad record - invalid MAC
-depends_on:MBEDTLS_MPS_PROTO_TLS
 mbedtls_mps_l2_bad_record:MBEDTLS_MPS_MODE_STREAM:3
 
 MPS Layer 2 DTLS: Bad record - invalid content type
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l2_bad_record:MBEDTLS_MPS_MODE_DATAGRAM:0
 
 MPS Layer 2 DTLS: Bad record - invalid MAC
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l2_bad_record:MBEDTLS_MPS_MODE_DATAGRAM:4
 
 MPS Layer 2 DTLS: Bad record - invalid record length
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l2_bad_record:MBEDTLS_MPS_MODE_DATAGRAM:3
 
 MPS Layer 2 DTLS: Bad record - invalid major version
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l2_bad_record:MBEDTLS_MPS_MODE_DATAGRAM:2
 
 MPS Layer 2 DTLS: Bad record - invalid minor version
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l2_bad_record:MBEDTLS_MPS_MODE_DATAGRAM:1
 
 MPS Layer 2 DTLS: Bad record - invalid content type
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l2_bad_record:MBEDTLS_MPS_MODE_DATAGRAM:0
 
 MPS Layer 2 DTLS: Replay protection #0
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l2_anti_replay:0
 
 MPS Layer 2 DTLS: Replay protection #1
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l2_anti_replay:1
 
 MPS Layer 2 DTLS: Replay protection #2
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l2_anti_replay:2
 
 MPS Layer 2 DTLS: Replay protection #3
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l2_anti_replay:3
 
 MPS Layer 2 DTLS: Replay protection #4
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l2_anti_replay:4
 
 MPS Layer 2 TLS: Exchange of messages of two types, with pausing
@@ -398,51 +359,39 @@ MPS Layer 2 TLS: Exchange of single large message, with queueing, non-pausable f
 mbedtls_mps_l2_queueing:100:20000:1000:0
 
 MPS Layer 2 TLS: Exchange of messages of two types and two epochs, fake transforms
-depends_on:MBEDTLS_MPS_PROTO_TLS
 mbedtls_mps_l2_switch_epoch:MBEDTLS_MPS_MODE_STREAM:100:100:0
 
 MPS Layer 2 TLS: Exchange of messages of two types and two epochs, real transforms
-depends_on:MBEDTLS_MPS_PROTO_TLS
 mbedtls_mps_l2_switch_epoch:MBEDTLS_MPS_MODE_STREAM:200:1000:1
 
 MPS Layer 2 DTLS: Exchange of messages of two types and two epochs, fake transforms
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l2_switch_epoch:MBEDTLS_MPS_MODE_DATAGRAM:100:100:0
 
 MPS Layer 2 DTLS: Exchange of messages of two types and two epochs, real transforms
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l2_switch_epoch:MBEDTLS_MPS_MODE_DATAGRAM:200:1000:1
 
 MPS Layer 2 TLS: Exchange of messages of two types, many epochs, fake transforms
-depends_on:MBEDTLS_MPS_PROTO_TLS
 mbedtls_mps_l2_many_epochs:MBEDTLS_MPS_MODE_STREAM:200:20000:100:0
 
 MPS Layer 2 TLS: Exchange of messages of two types, many epochs, real transforms
-depends_on:MBEDTLS_MPS_PROTO_TLS
 mbedtls_mps_l2_many_epochs:MBEDTLS_MPS_MODE_STREAM:200:20000:100:1
 
 MPS Layer 2 DTLS: Exchange of messages of two types, many epochs, fake transforms
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l2_many_epochs:MBEDTLS_MPS_MODE_DATAGRAM:200:20000:100:0
 
 MPS Layer 2 DTLS: Exchange of messages of two types, many epochs, real transforms
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l2_many_epochs:MBEDTLS_MPS_MODE_DATAGRAM:200:20000:100:1
 
 MPS Layer 2 TLS: Piggy-backed record content after epoch switch, real transforms
-depends_on:MBEDTLS_MPS_PROTO_TLS
 mbedtls_mps_l2_piggyback_data:MBEDTLS_MPS_MODE_STREAM:1
 
 MPS Layer 2 DTLS: Piggy-backed record content after epoch switch, real transforms
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l2_piggyback_data:MBEDTLS_MPS_MODE_DATAGRAM:1
 
 MPS Layer 2 TLS: Piggy-backed record content after epoch switch, mock transforms
-depends_on:MBEDTLS_MPS_PROTO_TLS
 mbedtls_mps_l2_piggyback_data:MBEDTLS_MPS_MODE_STREAM:0
 
 MPS Layer 2 DTLS: Piggy-backed record content after epoch switch, mock transforms
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l2_piggyback_data:MBEDTLS_MPS_MODE_DATAGRAM:0
 
 MPS Layer 2 TLS: Random communication, fake transforms
@@ -474,219 +423,165 @@ depends_on:MBEDTLS_MPS_PROTO_TLS
 mbedtls_mps_l2_random:1000:1:5:5:10:1000:1:50:50:100
 
 MPS Layer 3 TLS: HS, fake transform, unknown length #0
-depends_on:MBEDTLS_MPS_PROTO_TLS
 mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_STREAM:0:0:0:0:0:0
 
 MPS Layer 3 TLS: HS, fake transform, unknown length #1
-depends_on:MBEDTLS_MPS_PROTO_TLS
 mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_STREAM:0:0:0:0:0:1
 
 MPS Layer 3 TLS: HS, fake transform, unknown length #2
-depends_on:MBEDTLS_MPS_PROTO_TLS
 mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_STREAM:0:0:0:1:0:0
 
 MPS Layer 3 TLS: HS, fake transform, unknown length #3
-depends_on:MBEDTLS_MPS_PROTO_TLS
 mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_STREAM:0:0:0:1:0:1
 
 MPS Layer 3 TLS: HS, fake transform, unknown length #4
-depends_on:MBEDTLS_MPS_PROTO_TLS
 mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_STREAM:0:0:0:1:1:0
 
 MPS Layer 3 TLS: HS, fake transform, unknown length #5
-depends_on:MBEDTLS_MPS_PROTO_TLS
 mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_STREAM:0:0:0:1:1:1
 
 MPS Layer 3 TLS: HS, fake transform, known length #0
-depends_on:MBEDTLS_MPS_PROTO_TLS
 mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_STREAM:0:0:1:0:0:0
 
 MPS Layer 3 TLS: HS, fake transform, known length #1
-depends_on:MBEDTLS_MPS_PROTO_TLS
 mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_STREAM:0:0:1:1:0:0
 
 MPS Layer 3 TLS: HS, fake transform, known length #2
-depends_on:MBEDTLS_MPS_PROTO_TLS
 mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_STREAM:0:0:1:1:1:0
 
 MPS Layer 3 TLS: HS, real transform, unknown length #0
-depends_on:MBEDTLS_MPS_PROTO_TLS
 mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_STREAM:0:1:0:0:0:0
 
 MPS Layer 3 TLS: HS, real transform, unknown length #1
-depends_on:MBEDTLS_MPS_PROTO_TLS
 mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_STREAM:0:1:0:0:0:1
 
 MPS Layer 3 TLS: HS, real transform, unknown length #2
-depends_on:MBEDTLS_MPS_PROTO_TLS
 mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_STREAM:0:1:0:1:0:0
 
 MPS Layer 3 TLS: HS, real transform, unknown length #3
-depends_on:MBEDTLS_MPS_PROTO_TLS
 mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_STREAM:0:1:0:1:0:1
 
 MPS Layer 3 TLS: HS, real transform, unknown length #4
-depends_on:MBEDTLS_MPS_PROTO_TLS
 mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_STREAM:0:1:0:1:1:0
 
 MPS Layer 3 TLS: HS, real transform, unknown length #5
-depends_on:MBEDTLS_MPS_PROTO_TLS
 mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_STREAM:0:1:0:1:1:1
 
 MPS Layer 3 TLS: HS, real transform, known length #0
-depends_on:MBEDTLS_MPS_PROTO_TLS
 mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_STREAM:0:1:1:0:0:0
 
 MPS Layer 3 TLS: HS, real transform, known length #1
-depends_on:MBEDTLS_MPS_PROTO_TLS
 mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_STREAM:0:1:1:1:0:0
 
 MPS Layer 3 TLS: HS, real transform, known length #2
-depends_on:MBEDTLS_MPS_PROTO_TLS
 mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_STREAM:0:1:1:1:1:0
 
 MPS Layer 3 TLS: HS, fake transform, unknown length, with abort
-depends_on:MBEDTLS_MPS_PROTO_TLS
 mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_STREAM:1:0:0:0:0:0
 
 MPS Layer 3 TLS: HS, fake transform, known length, with abort
-depends_on:MBEDTLS_MPS_PROTO_TLS
 mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_STREAM:1:0:0:0:0:0
 
 MPS Layer 3 TLS: HS, abort after commit
-depends_on:MBEDTLS_MPS_PROTO_TLS
 mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_STREAM:2:0:0:0:0:0
 
 MPS Layer 3 DTLS: HS, fake transform, unknown length #0
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:0:0:0:0:0
 
 MPS Layer 3 DTLS: HS, fake transform, unknown length #1
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:0:0:0:0:1
 
 MPS Layer 3 DTLS: HS, fake transform, unknown length #2
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:0:0:1:0:0
 
 MPS Layer 3 DTLS: HS, fake transform, unknown length #3
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:0:0:1:0:1
 
 MPS Layer 3 DTLS: HS, fake transform, unknown length #4
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:0:0:1:1:0
 
 MPS Layer 3 DTLS: HS, fake transform, unknown length #5
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:0:0:1:1:1
 
 MPS Layer 3 DTLS: HS, fake transform, unknown length #6
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:0:1:0:0:0
 
 MPS Layer 3 DTLS: HS, fake transform, unknown length #7
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:0:1:0:0:1
 
 MPS Layer 3 DTLS: HS, fake transform, unknown length #8
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:0:1:1:0:0
 
 MPS Layer 3 DTLS: HS, fake transform, unknown length #9
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:0:1:1:0:1
 
 MPS Layer 3 DTLS: HS, fake transform, unknown length #10
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:0:1:1:1:0
 
 MPS Layer 3 DTLS: HS, fake transform, unknown length #11
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:0:1:1:1:1
 
 MPS Layer 3 DTLS: HS, fake transform, known length #0
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:0:2:0:0:0
 
 MPS Layer 3 DTLS: HS, fake transform, known length #1
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:0:2:1:0:0
 
 MPS Layer 3 DTLS: HS, fake transform, known length #2
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:0:2:1:1:0
 
 MPS Layer 3 DTLS: HS, real transform, unknown length #0
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:1:0:0:0:0
 
 MPS Layer 3 DTLS: HS, real transform, unknown length #1
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:1:0:0:0:1
 
 MPS Layer 3 DTLS: HS, real transform, unknown length #2
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:1:0:1:0:0
 
 MPS Layer 3 DTLS: HS, real transform, unknown length #3
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:1:0:1:0:1
 
 MPS Layer 3 DTLS: HS, real transform, unknown length #4
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:1:0:1:1:0
 
 MPS Layer 3 DTLS: HS, real transform, unknown length #5
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:1:0:1:1:1
 
 MPS Layer 3 DTLS: HS, real transform, unknown length #6
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:1:1:0:0:0
 
 MPS Layer 3 DTLS: HS, real transform, unknown length #7
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:1:1:0:0:1
 
 MPS Layer 3 DTLS: HS, real transform, unknown length #8
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:1:1:1:0:0
 
 MPS Layer 3 DTLS: HS, real transform, unknown length #9
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:1:1:1:0:1
 
 MPS Layer 3 DTLS: HS, real transform, unknown length #10
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:1:1:1:1:0
 
 MPS Layer 3 DTLS: HS, real transform, unknown length #11
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:1:1:1:1:1
 
 MPS Layer 3 DTLS: HS, real transform, known length #0
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:1:2:0:0:0
 
 MPS Layer 3 DTLS: HS, real transform, known length #1
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:1:2:1:0:0
 
 MPS Layer 3 DTLS: HS, real transform, known length #2
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:1:2:1:1:0
 
 MPS Layer 3 DTLS: HS, fake transform, unknown length, with abort
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:1:0:0:0:0:0
 
 MPS Layer 3 DTLS: HS, fake transform, known length, with abort
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:1:0:0:0:0:0
 
 MPS Layer 3 DTLS: HS, abort after commit
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:2:0:0:0:0:0
 
 MPS Layer 3 DTLS: HS, incomplete header
@@ -728,71 +623,54 @@ MPS Layer 3 TLS: Multiple handshake messages, real transform
 mbedtls_mps_l3_handshake_gradual:100:10000:1:100:0
 
 MPS Layer 3 TLS: Application data message, fake transform
-depends_on:MBEDTLS_MPS_PROTO_TLS
 mbedtls_mps_l3_basic_application:MBEDTLS_MPS_MODE_STREAM:1000:1000:0
 
 MPS Layer 3 TLS: Application data message, real transform
-depends_on:MBEDTLS_MPS_PROTO_TLS
 mbedtls_mps_l3_basic_application:MBEDTLS_MPS_MODE_STREAM:1000:1000:1
 
 MPS Layer 3 DTLS: Application data message, fake transform
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l3_basic_application:MBEDTLS_MPS_MODE_DATAGRAM:1000:1000:0
 
 MPS Layer 3 DTLS: Application data message, real transform
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l3_basic_application:MBEDTLS_MPS_MODE_DATAGRAM:1000:1000:1
 
 MPS Layer 3 TLS: Alert message, fake transform
-depends_on:MBEDTLS_MPS_PROTO_TLS
 mbedtls_mps_l3_basic_alert:MBEDTLS_MPS_MODE_STREAM:100:1000:0:0:1:0
 
 MPS Layer 3 TLS: Alert message, real transform
-depends_on:MBEDTLS_MPS_PROTO_TLS
 mbedtls_mps_l3_basic_alert:MBEDTLS_MPS_MODE_STREAM:100:1000:1:0:1:0
 
 MPS Layer 3 TLS: Alert message, real transform, fragmented
-depends_on:MBEDTLS_MPS_PROTO_TLS
 mbedtls_mps_l3_basic_alert:MBEDTLS_MPS_MODE_STREAM:58:1000:1:1:1:1
 
 MPS Layer 3 DTLS: Alert message, fake transform
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l3_basic_alert:MBEDTLS_MPS_MODE_DATAGRAM:100:1000:0:0:1:0
 
 MPS Layer 3 DTLS: Alert message, real transform
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l3_basic_alert:MBEDTLS_MPS_MODE_DATAGRAM:100:1000:1:0:1:0
 
 MPS Layer 3 TLS: Multiple alert messages, fake transform, merge
-depends_on:MBEDTLS_MPS_PROTO_TLS
 mbedtls_mps_l3_basic_alert:MBEDTLS_MPS_MODE_STREAM:100:10000:0:0:100:1
 
 MPS Layer 3 TLS: Multiple alert messages, fake transform, no merge
-depends_on:MBEDTLS_MPS_PROTO_TLS
 mbedtls_mps_l3_basic_alert:MBEDTLS_MPS_MODE_STREAM:100:10000:0:0:100:0
 
 MPS Layer 3 TLS: Multiple alert messages, real transform, merge
-depends_on:MBEDTLS_MPS_PROTO_TLS
 mbedtls_mps_l3_basic_alert:MBEDTLS_MPS_MODE_STREAM:100:10000:1:0:100:1
 
 MPS Layer 3 TLS: Multiple alert messages, real transform, no merge
-depends_on:MBEDTLS_MPS_PROTO_TLS
 mbedtls_mps_l3_basic_alert:MBEDTLS_MPS_MODE_STREAM:100:10000:1:0:100:0
 
 MPS Layer 3 DTLS: Multiple alert messages, fake transform, merge
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l3_basic_alert:MBEDTLS_MPS_MODE_DATAGRAM:100:10000:0:0:100:1
 
 MPS Layer 3 DTLS: Multiple alert messages, fake transform, no merge
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l3_basic_alert:MBEDTLS_MPS_MODE_DATAGRAM:100:10000:0:0:100:0
 
 MPS Layer 3 DTLS: Multiple alert messages, real transform, merge
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l3_basic_alert:MBEDTLS_MPS_MODE_DATAGRAM:100:10000:1:0:100:1
 
 MPS Layer 3 DTLS: Multiple alert messages, real transform, no merge
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l3_basic_alert:MBEDTLS_MPS_MODE_DATAGRAM:100:10000:1:0:100:0
 
 MPS Layer 3 TLS: CCS message, fake transform
@@ -844,147 +722,111 @@ MPS Layer 4 TLS: Basic - CCS
 mbedtls_mps_l4_ccs:MBEDTLS_MPS_MODE_STREAM:1000
 
 MPS Layer 4 TLS: HS, fake transform, unknown length #0
-depends_on:MBEDTLS_MPS_PROTO_TLS
 mbedtls_mps_l4_basic_handshake:MBEDTLS_MPS_MODE_STREAM:1000:1000:0:0:0:0:0
 
 MPS Layer 4 TLS: HS, fake transform, unknown length #1
-depends_on:MBEDTLS_MPS_PROTO_TLS
 mbedtls_mps_l4_basic_handshake:MBEDTLS_MPS_MODE_STREAM:1000:1000:0:0:0:0:1
 
 MPS Layer 4 TLS: HS, fake transform, unknown length #2
-depends_on:MBEDTLS_MPS_PROTO_TLS
 mbedtls_mps_l4_basic_handshake:MBEDTLS_MPS_MODE_STREAM:1000:1000:0:0:1:0:0
 
 MPS Layer 4 TLS: HS, fake transform, unknown length #3
-depends_on:MBEDTLS_MPS_PROTO_TLS
 mbedtls_mps_l4_basic_handshake:MBEDTLS_MPS_MODE_STREAM:1000:1000:0:0:1:0:1
 
 MPS Layer 4 TLS: HS, fake transform, unknown length #4
-depends_on:MBEDTLS_MPS_PROTO_TLS
 mbedtls_mps_l4_basic_handshake:MBEDTLS_MPS_MODE_STREAM:1000:1000:0:0:1:1:0
 
 MPS Layer 4 TLS: HS, fake transform, unknown length #5
-depends_on:MBEDTLS_MPS_PROTO_TLS
 mbedtls_mps_l4_basic_handshake:MBEDTLS_MPS_MODE_STREAM:1000:1000:0:0:1:1:1
 
 MPS Layer 4 TLS: HS, fake transform, known length #0
-depends_on:MBEDTLS_MPS_PROTO_TLS
 mbedtls_mps_l4_basic_handshake:MBEDTLS_MPS_MODE_STREAM:1000:1000:0:1:0:0:0
 
 MPS Layer 4 TLS: HS, fake transform, known length #1
-depends_on:MBEDTLS_MPS_PROTO_TLS
 mbedtls_mps_l4_basic_handshake:MBEDTLS_MPS_MODE_STREAM:1000:1000:0:1:1:0:0
 
 MPS Layer 4 TLS: HS, fake transform, known length #2
-depends_on:MBEDTLS_MPS_PROTO_TLS
 mbedtls_mps_l4_basic_handshake:MBEDTLS_MPS_MODE_STREAM:1000:1000:0:1:1:1:0
 
 MPS Layer 4 TLS: HS, real transform, unknown length #0
-depends_on:MBEDTLS_MPS_PROTO_TLS
 mbedtls_mps_l4_basic_handshake:MBEDTLS_MPS_MODE_STREAM:1000:1000:1:0:0:0:0
 
 MPS Layer 4 TLS: HS, real transform, unknown length #1
-depends_on:MBEDTLS_MPS_PROTO_TLS
 mbedtls_mps_l4_basic_handshake:MBEDTLS_MPS_MODE_STREAM:1000:1000:1:0:0:0:1
 
 MPS Layer 4 TLS: HS, real transform, unknown length #2
-depends_on:MBEDTLS_MPS_PROTO_TLS
 mbedtls_mps_l4_basic_handshake:MBEDTLS_MPS_MODE_STREAM:1000:1000:1:0:1:0:0
 
 MPS Layer 4 TLS: HS, real transform, unknown length #3
-depends_on:MBEDTLS_MPS_PROTO_TLS
 mbedtls_mps_l4_basic_handshake:MBEDTLS_MPS_MODE_STREAM:1000:1000:1:0:1:0:1
 
 MPS Layer 4 TLS: HS, real transform, unknown length #4
-depends_on:MBEDTLS_MPS_PROTO_TLS
 mbedtls_mps_l4_basic_handshake:MBEDTLS_MPS_MODE_STREAM:1000:1000:1:0:1:1:0
 
 MPS Layer 4 TLS: HS, real transform, unknown length #5
-depends_on:MBEDTLS_MPS_PROTO_TLS
 mbedtls_mps_l4_basic_handshake:MBEDTLS_MPS_MODE_STREAM:1000:1000:1:0:1:1:1
 
 MPS Layer 4 TLS: HS, real transform, known length #0
-depends_on:MBEDTLS_MPS_PROTO_TLS
 mbedtls_mps_l4_basic_handshake:MBEDTLS_MPS_MODE_STREAM:1000:1000:1:1:0:0:0
 
 MPS Layer 4 TLS: HS, real transform, known length #1
-depends_on:MBEDTLS_MPS_PROTO_TLS
 mbedtls_mps_l4_basic_handshake:MBEDTLS_MPS_MODE_STREAM:1000:1000:1:1:1:0:0
 
 MPS Layer 4 TLS: HS, real transform, known length #2
-depends_on:MBEDTLS_MPS_PROTO_TLS
 mbedtls_mps_l4_basic_handshake:MBEDTLS_MPS_MODE_STREAM:1000:1000:1:1:1:1:0
 
 MPS Layer 4 DTLS: HS, fake transform, unknown length #0
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l4_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:1000:1000:0:0:0:0:0
 
 MPS Layer 4 DTLS: HS, fake transform, unknown length #1
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l4_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:1000:1000:0:0:0:0:1
 
 MPS Layer 4 DTLS: HS, fake transform, unknown length #2
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l4_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:1000:1000:0:0:1:0:0
 
 MPS Layer 4 DTLS: HS, fake transform, unknown length #3
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l4_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:1000:1000:0:0:1:0:1
 
 MPS Layer 4 DTLS: HS, fake transform, unknown length #4
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l4_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:1000:1000:0:0:1:1:0
 
 MPS Layer 4 DTLS: HS, fake transform, unknown length #5
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l4_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:1000:1000:0:0:1:1:1
 
 MPS Layer 4 DTLS: HS, fake transform, known length #0
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l4_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:1000:1000:0:1:0:0:0
 
 MPS Layer 4 DTLS: HS, fake transform, known length #1
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l4_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:1000:1000:0:1:1:0:0
 
 MPS Layer 4 DTLS: HS, fake transform, known length #2
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l4_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:1000:1000:0:1:1:1:0
 
 MPS Layer 4 DTLS: HS, real transform, unknown length #0
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l4_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:1000:1000:1:0:0:0:0
 
 MPS Layer 4 DTLS: HS, real transform, unknown length #1
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l4_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:1000:1000:1:0:0:0:1
 
 MPS Layer 4 DTLS: HS, real transform, unknown length #2
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l4_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:1000:1000:1:0:1:0:0
 
 MPS Layer 4 DTLS: HS, real transform, unknown length #3
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l4_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:1000:1000:1:0:1:0:1
 
 MPS Layer 4 DTLS: HS, real transform, unknown length #4
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l4_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:1000:1000:1:0:1:1:0
 
 MPS Layer 4 DTLS: HS, real transform, unknown length #5
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l4_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:1000:1000:1:0:1:1:1
 
 MPS Layer 4 DTLS: HS, real transform, known length #0
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l4_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:1000:1000:1:1:0:0:0
 
 MPS Layer 4 DTLS: HS, real transform, known length #1
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l4_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:1000:1000:1:1:1:0:0
 
 MPS Layer 4 DTLS: HS, real transform, known length #2
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l4_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:1000:1000:1:1:1:1:0
 
 MPS Layer 4 DTLS: HS, inconsistent fragments, bad total length
@@ -1003,19 +845,15 @@ MPS Layer 4 DTLS: Epoch switch at flight boundary, next HS message with old epoc
 mbedtls_mps_l4_hs_inconsistent_continuation:3
 
 MPS Layer 4 TLS: Connection closure #0, real transforms
-depends_on:MBEDTLS_MPS_PROTO_TLS
 mbedtls_mps_l4_disruption:MBEDTLS_MPS_MODE_STREAM:1000:1000:1
 
 MPS Layer 4 TLS: Fatal alert #0, real transforms
-depends_on:MBEDTLS_MPS_PROTO_TLS
 mbedtls_mps_l4_disruption:MBEDTLS_MPS_MODE_STREAM:1000:1000:0
 
 MPS Layer 4 DTLS: Connection closure #0, real transforms
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l4_disruption:MBEDTLS_MPS_MODE_DATAGRAM:1000:1000:1
 
 MPS Layer 4 DTLS: Fatal alert #0, real transforms
-depends_on:MBEDTLS_MPS_PROTO_DTLS
 mbedtls_mps_l4_disruption:MBEDTLS_MPS_MODE_DATAGRAM:1000:1000:0
 
 MPS Layer 4 DTLS: Fragmentation of HS msg with raw backup

--- a/tests/suites/test_suite_mps.function
+++ b/tests/suites/test_suite_mps.function
@@ -22,6 +22,13 @@
  * Compile-time configuration for test suite.
  */
 
+/* We need visibility of the lower Layers for the MPS test suites. */
+
+#if defined(MBEDTLS_MPS_SEPARATE_LAYERS) || \
+    defined(MBEDTLS_MPS_NO_STATIC_FUNCTIONS)
+
+#define TEST_SUITE_MPS
+
 /* Comment/Uncomment this to disable/enable the
  * testing of the various MPS layers.
  * This can be useful for time-consuming instrumentation
@@ -33,6 +40,9 @@
 #define TEST_SUITE_MPS_L2
 #define TEST_SUITE_MPS_L3
 #define TEST_SUITE_MPS_L4
+
+#endif /* MBEDTLS_MPS_SEPARATE_LAYERS     ||
+        * MBEDTLS_MPS_NO_STATIC_FUNCTIONS */
 
 /* Comment/Uncomment this to disable/enable the testing
  * of the production SSL record transformations as implemented
@@ -91,6 +101,8 @@
 #if !defined(TEST_SUITE_MPS_NO_SSL) && defined(MBEDTLS_DEBUG_C)
 #error Real record transformations can only be tested without MBEDTLS_DEBUG_C!
 #endif
+
+#if defined(TEST_SUITE_MPS)
 
 /*
  *
@@ -1350,6 +1362,7 @@ static void set_transform_pointers()
     mbedtls_mps_transform_decrypt = mps_transform_decrypt;
     mbedtls_mps_transform_get_expansion = mps_transform_get_expansion;
 }
+#endif /* TEST_SUITE_MPS */
 
 /* END_HEADER */
 
@@ -3381,9 +3394,16 @@ void mbedtls_mps_writer_random_usage( int data_amount,
 }
 /* END_CASE */
 
-/* BEGIN_CASE */
+/* BEGIN_CASE depends_on:TEST_SUITE_MPS */
 void mbedtls_mps_init_free( int mode )
 {
+#if !defined(MBEDTLS_MPS_PROTO_TLS)
+    TEST_ASSUME( mode == MBEDTLS_MPS_MODE_DATAGRAM );
+#endif
+#if !defined(MBEDTLS_MPS_PROTO_DTLS)
+    TEST_ASSUME( mode == MBEDTLS_MPS_MODE_STREAM );
+#endif
+
     /* This test checks that a plain free-after-init always works. */
     mps_set_default_config();
     mps_test_config.mode = mode;
@@ -3428,6 +3448,13 @@ void mbedtls_mps_l1_basic( int mode,
     mps_test_config.io_buffer_size        = 2 * data_len;
     mps_test_config.l0_stream_buffer_sz = 2 * data_len;
     TEST_ASSERT( init_mps_layers() == 0 );
+
+#if !defined(MBEDTLS_MPS_PROTO_TLS)
+    TEST_ASSUME( mode == MBEDTLS_MPS_MODE_DATAGRAM );
+#endif
+#if !defined(MBEDTLS_MPS_PROTO_DTLS)
+    TEST_ASSUME( mode == MBEDTLS_MPS_MODE_STREAM );
+#endif
 
     /* Generate the random content to be exchanged */
     TEST_ASSERT( mbedtls_test_rnd_std_rand( NULL, data, data_len ) == 0 );
@@ -4099,6 +4126,13 @@ void mbedtls_mps_l2_basic( int mode,
     mps_test_config.mode = mode;
     TEST_ASSERT( init_mps_layers() == 0 );
 
+#if !defined(MBEDTLS_MPS_PROTO_TLS)
+    TEST_ASSUME( mode == MBEDTLS_MPS_MODE_DATAGRAM );
+#endif
+#if !defined(MBEDTLS_MPS_PROTO_DTLS)
+    TEST_ASSUME( mode == MBEDTLS_MPS_MODE_STREAM );
+#endif
+
     TEST_ASSERT( mps_l2_config_add_type( &cli_l2, ty_A,
                                          MBEDTLS_MPS_SPLIT_DISABLED,
                                          MBEDTLS_MPS_PACK_ENABLED,
@@ -4408,6 +4442,13 @@ void mbedtls_mps_l2_bad_record( int mode,
     mps_set_default_config();
     mps_test_config.mode = mode;
     TEST_ASSERT( init_mps_layers() == 0 );
+
+#if !defined(MBEDTLS_MPS_PROTO_TLS)
+    TEST_ASSUME( mode == MBEDTLS_MPS_MODE_DATAGRAM );
+#endif
+#if !defined(MBEDTLS_MPS_PROTO_DTLS)
+    TEST_ASSUME( mode == MBEDTLS_MPS_MODE_STREAM );
+#endif
 
     TEST_ASSERT( mps_l2_config_add_type( &cli_l2, ty_A, 0, 1, 1 ) == 0 );
     TEST_ASSERT( mps_l2_config_add_type( &srv_l2, ty_A, 0, 1, 1 ) == 0 );
@@ -5162,6 +5203,13 @@ void mbedtls_mps_l2_switch_epoch( int mode,
     mps_test_config.l2_queue_size = 0;
     TEST_ASSERT( init_mps_layers() == 0 );
 
+#if !defined(MBEDTLS_MPS_PROTO_TLS)
+    TEST_ASSUME( mode == MBEDTLS_MPS_MODE_DATAGRAM );
+#endif
+#if !defined(MBEDTLS_MPS_PROTO_DTLS)
+    TEST_ASSUME( mode == MBEDTLS_MPS_MODE_STREAM );
+#endif
+
     TEST_ASSERT( mps_l2_config_add_type( &cli_l2, ty_A,
                                          MBEDTLS_MPS_SPLIT_DISABLED,
                                          MBEDTLS_MPS_PACK_ENABLED,
@@ -5447,6 +5495,13 @@ void mbedtls_mps_l2_many_epochs( int mode,
     mps_test_config.l2_queue_size = 0;
     TEST_ASSERT( init_mps_layers() == 0 );
 
+#if !defined(MBEDTLS_MPS_PROTO_TLS)
+    TEST_ASSUME( mode == MBEDTLS_MPS_MODE_DATAGRAM );
+#endif
+#if !defined(MBEDTLS_MPS_PROTO_DTLS)
+    TEST_ASSUME( mode == MBEDTLS_MPS_MODE_STREAM );
+#endif
+
     TEST_ASSERT( mps_l2_config_add_type( &cli_l2, ty_A,
                                          MBEDTLS_MPS_SPLIT_DISABLED,
                                          MBEDTLS_MPS_PACK_ENABLED,
@@ -5675,6 +5730,13 @@ void mbedtls_mps_l2_piggyback_data( int mode,
     mps_test_config.l2_accumulator_size = 0;
     mps_test_config.l2_queue_size = 0;
     TEST_ASSERT( init_mps_layers() == 0 );
+
+#if !defined(MBEDTLS_MPS_PROTO_TLS)
+    TEST_ASSUME( mode == MBEDTLS_MPS_MODE_DATAGRAM );
+#endif
+#if !defined(MBEDTLS_MPS_PROTO_DTLS)
+    TEST_ASSUME( mode == MBEDTLS_MPS_MODE_STREAM );
+#endif
 
     TEST_ASSERT( mps_l2_config_add_type( &cli_l2, ty_A,
                                          MBEDTLS_MPS_SPLIT_DISABLED,
@@ -6271,6 +6333,13 @@ void mbedtls_mps_l3_basic_handshake(
     mps_test_config.mode = mode;
     TEST_ASSERT( init_mps_layers() == 0 );
 
+#if !defined(MBEDTLS_MPS_PROTO_TLS)
+    TEST_ASSUME( mode == MBEDTLS_MPS_MODE_DATAGRAM );
+#endif
+#if !defined(MBEDTLS_MPS_PROTO_DTLS)
+    TEST_ASSUME( mode == MBEDTLS_MPS_MODE_STREAM );
+#endif
+
     TEST_ASSERT( mps_l2_config_add_type( &cli_l2, MBEDTLS_MPS_MSG_HS,
                                          MBEDTLS_MPS_SPLIT_DISABLED,
                                          MBEDTLS_MPS_PACK_ENABLED,
@@ -6350,10 +6419,12 @@ void mbedtls_mps_l3_basic_handshake(
                                                  &tmp, NULL ) == 0 );
             TEST_ASSERT( mbedtls_writer_commit_ext( hs_out.wr_ext ) == 0 );
 
+#if defined(MBEDTLS_MPS_ENABLE_ASSERTIONS)
             /* We shouldn't be allowed to abort once we have
              * committed something. */
             TEST_ASSERT( mps_l3_write_abort_handshake( &cli_l3 ) ==
                          MBEDTLS_ERR_MPS_INTERNAL_ERROR );
+#endif /* MBEDTLS_MPS_ENABLE_ASSERTIONS */
 
             goto exit;
         }
@@ -7055,6 +7126,13 @@ void mbedtls_mps_l3_basic_application( int mode,
     mps_test_config.l0_stream_buffer_sz = layer0_buffer_sz;
     TEST_ASSERT( init_mps_layers() == 0 );
 
+#if !defined(MBEDTLS_MPS_PROTO_TLS)
+    TEST_ASSUME( mode == MBEDTLS_MPS_MODE_DATAGRAM );
+#endif
+#if !defined(MBEDTLS_MPS_PROTO_DTLS)
+    TEST_ASSUME( mode == MBEDTLS_MPS_MODE_STREAM );
+#endif
+
     TEST_ASSERT( mps_l2_config_add_type( &cli_l2, MBEDTLS_MPS_MSG_APP,
                                          1, 0, 1) == 0 );
     TEST_ASSERT( mps_l2_config_add_type( &srv_l2, MBEDTLS_MPS_MSG_APP,
@@ -7155,6 +7233,13 @@ void mbedtls_mps_l3_basic_alert( int mode,
     mps_test_config.io_buffer_size = allocator_buffer_sz;
     mps_test_config.l0_stream_buffer_sz = layer0_buffer_sz;
     TEST_ASSERT( init_mps_layers() == 0 );
+
+#if !defined(MBEDTLS_MPS_PROTO_TLS)
+    TEST_ASSUME( mode == MBEDTLS_MPS_MODE_DATAGRAM );
+#endif
+#if !defined(MBEDTLS_MPS_PROTO_DTLS)
+    TEST_ASSUME( mode == MBEDTLS_MPS_MODE_STREAM );
+#endif
 
     TEST_ASSERT( mps_l2_config_add_type( &cli_l2, MBEDTLS_MPS_MSG_ALERT,
                                          handle_fragmentation ?
@@ -8475,6 +8560,13 @@ void mbedtls_mps_l4_basic_handshake(
     mps_test_config.l0_stream_buffer_sz = layer0_buffer_sz;
     TEST_ASSERT( init_mps_layers() == 0 );
 
+#if !defined(MBEDTLS_MPS_PROTO_TLS)
+    TEST_ASSUME( mode == MBEDTLS_MPS_MODE_DATAGRAM );
+#endif
+#if !defined(MBEDTLS_MPS_PROTO_DTLS)
+    TEST_ASSUME( mode == MBEDTLS_MPS_MODE_STREAM );
+#endif
+
     TEST_ASSERT( mps_l2_config_add_type( &cli_l2, MBEDTLS_MPS_MSG_HS,
                                          1, 1, 0 ) == 0 );
     TEST_ASSERT( mps_l2_config_add_type( &srv_l2, MBEDTLS_MPS_MSG_HS,
@@ -8613,6 +8705,13 @@ void mbedtls_mps_l4_warning( int mode,
     mps_test_config.l0_stream_buffer_sz = layer0_buffer_sz;
     TEST_ASSERT( init_mps_layers() == 0 );
 
+#if !defined(MBEDTLS_MPS_PROTO_TLS)
+    TEST_ASSUME( mode == MBEDTLS_MPS_MODE_DATAGRAM );
+#endif
+#if !defined(MBEDTLS_MPS_PROTO_DTLS)
+    TEST_ASSUME( mode == MBEDTLS_MPS_MODE_STREAM );
+#endif
+
     TEST_ASSERT( mps_l2_config_add_type( &cli_l2, MBEDTLS_MPS_MSG_ALERT,
                                          1, 1, 0 ) == 0 );
     TEST_ASSERT( mps_l2_config_add_type( &srv_l2, MBEDTLS_MPS_MSG_ALERT,
@@ -8730,6 +8829,13 @@ void mbedtls_mps_l4_ccs( int mode,
     mps_test_config.l0_stream_buffer_sz = layer0_buffer_sz;
     TEST_ASSERT( init_mps_layers() == 0 );
 
+#if !defined(MBEDTLS_MPS_PROTO_TLS)
+    TEST_ASSUME( mode == MBEDTLS_MPS_MODE_DATAGRAM );
+#endif
+#if !defined(MBEDTLS_MPS_PROTO_DTLS)
+    TEST_ASSUME( mode == MBEDTLS_MPS_MODE_STREAM );
+#endif
+
     TEST_ASSERT( mps_l2_config_add_type( &cli_l2, MBEDTLS_MPS_MSG_CCS,
                                          1, 1, 0 ) == 0 );
     TEST_ASSERT( mps_l2_config_add_type( &srv_l2, MBEDTLS_MPS_MSG_CCS,
@@ -8814,7 +8920,7 @@ exit:
 /* END_CASE */
 
 
-/* BEGIN_CASE depends_on:TEST_SUITE_MPS_L4 */
+/* BEGIN_CASE depends_on:MBEDTLS_MPS_PROTO_DTLS:TEST_SUITE_MPS_L4 */
 void mbedtls_mps_l4_hs_inconsistent_continuation( int variant )
 {
     /* This test exercises the behaviour of the retransmission state machine
@@ -9097,6 +9203,13 @@ void mbedtls_mps_l4_disruption( int mode,
     mps_test_config.io_buffer_size = allocator_buffer_sz;
     mps_test_config.l0_stream_buffer_sz = layer0_buffer_sz;
     TEST_ASSERT( init_mps_layers() == 0 );
+
+#if !defined(MBEDTLS_MPS_PROTO_TLS)
+    TEST_ASSUME( mode == MBEDTLS_MPS_MODE_DATAGRAM );
+#endif
+#if !defined(MBEDTLS_MPS_PROTO_DTLS)
+    TEST_ASSUME( mode == MBEDTLS_MPS_MODE_STREAM );
+#endif
 
     TEST_ASSERT( mps_l2_config_add_type( &cli_l2, MBEDTLS_MPS_MSG_HS,
                                          1, 1, 0 ) == 0 );
@@ -9630,7 +9743,7 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_CASE depends_on:MBEDTLS_MPS_PROTO_DTLS:TEST_SUITE_MPS_L4 */
+/* BEGIN_CASE depends_on:TEST_SUITE_MPS_L4 */
 void mbedtls_mps_l4_flight_exchange( int mode,
                                      int allocator_buffer_sz,
                                      int retransmission_callback,
@@ -9754,6 +9867,13 @@ void mbedtls_mps_l4_flight_exchange( int mode,
     mps_test_config.l2_accumulator_size = ( 3 * hs_len ) / 2;
     mps_test_config.l4_queue_size       = ( 3 * hs_len ) / 2;
     TEST_ASSERT( init_mps_layers() == 0 );
+
+#if !defined(MBEDTLS_MPS_PROTO_TLS)
+    TEST_ASSUME( mode == MBEDTLS_MPS_MODE_DATAGRAM );
+#endif
+#if !defined(MBEDTLS_MPS_PROTO_DTLS)
+    TEST_ASSUME( mode == MBEDTLS_MPS_MODE_STREAM );
+#endif
 
     TEST_ASSERT( mps_l2_config_add_type( &cli_l2, MBEDTLS_MPS_MSG_HS,
                                          1, 1, 0 ) == 0 );


### PR DESCRIPTION
MPS allows to selectively enable/disable various components, such as
- TLS (`MBEDTLS_MPS_PROTO_TLS`)
- DTLS (`MBEDTLS_MPS_PROTO_DTLS`)
- Assertions (`MBEDTLS_MPS_ENABLE_ASSERTIONS`)
- State validation (`MBEDTLS_MPS_STATE_VALIDATION`)
- Tracing (`MBEDTLS_MPS_TRACE`)

Moreover, it offers the option `MBEDTLS_MPS_SEPARATE_LAYERS` to compile most of MPS into a single compilation unit, thereby allowing the compiler to inline Layers 1-3 into Layer 4 where suitable, and thus saving significant code.

However, those compilation options haven't been tested for a while, and the build broke for them as a result. This PR makes various changes to regain support for enabling/disabling those options.