### PR TITLE
Fix non-MPS build with CCS compatibility mode enabled

### DIFF
--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -3061,7 +3061,7 @@ static int ssl_server_hello_coordinate( mbedtls_ssl_context* ssl,
                                         unsigned char **buf,
                                         size_t *buflen )
 {
-    int ret;
+    int ret = 0;
     unsigned char *peak;
 
     MBEDTLS_SSL_PROC_CHK_NEG( mbedtls_mps_read( &ssl->mps.l4 ) );
@@ -3112,12 +3112,7 @@ static int ssl_server_hello_coordinate( mbedtls_ssl_context* ssl,
 {
     int ret;
 
-    if( ( ret = mbedtls_ssl_read_record( ssl, 0 ) ) != 0 )
-    {
-        /* No alert on a read error. */
-        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_read_record", ret );
-        return( ret );
-    }
+    MBEDTLS_SSL_PROC_CHK( mbedtls_ssl_read_record( ssl, 0 ) );
 
     /* TBD: If we do an HRR, keep track of the number
      * of ClientHello's we sent, and fail if it
@@ -3144,6 +3139,8 @@ static int ssl_server_hello_coordinate( mbedtls_ssl_context* ssl,
     {
         ret = SSL_SERVER_HELLO_COORDINATE_HELLO;
     }
+
+cleanup:
 
     return( ret );
 }

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -2122,7 +2122,7 @@ static int ssl_client_hello_process( mbedtls_ssl_context* ssl )
 #else /* MBEDTLS_SSL_USE_MPS */
 
     MBEDTLS_SSL_PROC_CHK( ssl_client_hello_fetch( ssl, &buf, &buflen ) );
-    MBEDTLS_SSL_PROC_CHK( ssl_client_hello_parse( ssl, buf, buflen ) );
+    MBEDTLS_SSL_PROC_CHK_NEG( ssl_client_hello_parse( ssl, buf, buflen ) );
     hrr_required = ret;
 
 #endif /* MBEDTLS_SSL_USE_MPS */


### PR DESCRIPTION
This PR fixes build and tests if MPS is disabled (that is, `MBEDTLS_SSL_USE_MPS` is unset) and the CCS compatibility mode is enabled (that is, `MBEDTLS_SSL_TLS13_COMPATIBILITY_MODE` is enabled). 

See the two commits for detailed descriptions of the fixes.