### PR TITLE
Do not set keep_current_message flag when receive certificate request

### DIFF
--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -2439,7 +2439,6 @@ static int ssl_certificate_request_coordinate( mbedtls_ssl_context* ssl )
         MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_read_record", ret );
         return( ret );
     }
-    ssl->keep_current_message = 1;
 
     if( ssl->in_msgtype != MBEDTLS_SSL_MSG_HANDSHAKE )
     {
@@ -2452,6 +2451,7 @@ static int ssl_certificate_request_coordinate( mbedtls_ssl_context* ssl )
     {
         return( SSL_CERTIFICATE_REQUEST_EXPECT_REQUEST );
     }
+    ssl->keep_current_message = 1;
 
     return( SSL_CERTIFICATE_REQUEST_SKIP );
 }


### PR DESCRIPTION
Summary:

Consider the case that server sends Cert Request, and then Certificates. When the client process the CertRequest, it will set to keep_current_message to 1. When the client wants to process Certificates, is it possible client read out CertRequest again?

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags: