### PR TITLE
Add QUIC support based on existing TLS1.3 modules.

### DIFF
--- a/include/mbedtls/debug.h
+++ b/include/mbedtls/debug.h
@@ -31,6 +31,11 @@
 #endif
 
 #if defined(MBEDTLS_DEBUG_C)
+#include <assert.h>
+#endif
+
+#define MBEDTLS_SSL_DEBUG_QUIC_HS_MSG( level, text, hs_msg ) do { } while ( 0 )
+#if defined(MBEDTLS_DEBUG_C)
 
 #define MBEDTLS_DEBUG_STRIP_PARENS( ... )   __VA_ARGS__
 
@@ -68,6 +73,8 @@
     mbedtls_debug_printf_ecdh( ssl, level, __FILE__, __LINE__, ecdh, attr )
 #endif
 
+#define MBEDTLS_ASSERT(cond) assert(cond)
+
 #else /* MBEDTLS_DEBUG_C */
 
 #define MBEDTLS_SSL_DEBUG_MSG( level, args )            do { } while( 0 )
@@ -77,6 +84,7 @@
 #define MBEDTLS_SSL_DEBUG_ECP( level, text, X )         do { } while( 0 )
 #define MBEDTLS_SSL_DEBUG_CRT( level, text, crt )       do { } while( 0 )
 #define MBEDTLS_SSL_DEBUG_ECDH( level, ecdh, attr )     do { } while( 0 )
+#define MBEDTLS_ASSERT(cond)                            do { } while( 0 )
 
 #endif /* MBEDTLS_DEBUG_C */
 

--- a/include/mbedtls/quic.h
+++ b/include/mbedtls/quic.h
@@ -1,0 +1,214 @@
+
+#ifndef MBEDTLS_SSL_QIUC_H
+#define MBEDTLS_SSL_QIUC_H
+
+#if defined(MBEDTLS_SSL_PROTO_QUIC)
+
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct mbedtls_ssl_context mbedtls_ssl_context;
+typedef struct mbedtls_ssl_ticket  mbedtls_ssl_ticket;
+typedef struct mbedtls_quic_input  mbedtls_quic_input;
+typedef struct quic_input_msg      quic_input_msg;
+typedef struct quic_input_queue    quic_input_queue;
+
+/**
+ * \brief Encryption level used by the QUIC callbacks.
+ */
+typedef enum {
+  MBEDTLS_SSL_CRYPTO_LEVEL_INITIAL,
+  MBEDTLS_SSL_CRYPTO_LEVEL_HANDSHAKE,
+  MBEDTLS_SSL_CRYPTO_LEVEL_APPLICATION,
+  MBEDTLS_SSL_CRYPTO_LEVEL_EARLY_DATA,
+  MBEDTLS_SSL_CRYPTO_LEVEL_MAX,
+} mbedtls_ssl_crypto_level ;
+
+/**
+ * \brief Array of incoming queues - the top level structure.
+ */
+struct mbedtls_quic_input {
+  // Array of queues, one for each of Initial, Handshake and Application levels.
+  // We can not inline the storage for the queues inside
+  // `mbedtls_quic_input`, since `sizeof(quic_input_queue)` is only known in
+  // "mbedtls/quic_internal.h"
+  quic_input_queue *queues_;
+};
+
+
+/**
+ * \brief Send handshake data to mbedtls.
+ *
+ * This is the top level `provide_data` function. It dispatches
+ * the incoming data to the appropriate queue, and invokes
+ * `quic_input_provide_data` to do the heavy lifting.
+ *
+ * \param ssl SSL context.
+ * \param level encryption level.
+ * \param data handshake data.
+ * \param len data length.
+ */
+int mbedtls_quic_input_provide_data(
+    mbedtls_ssl_context      *ssl,
+    mbedtls_ssl_crypto_level  level,
+    const uint8_t            *data,
+    size_t                    len);
+
+/**
+ * \brief Init the QUIC input subsystem.
+ *
+ * \param ssl     SSL context.
+ * \param input   QUIC input structure.
+ */
+void mbedtls_quic_input_init(mbedtls_ssl_context *ssl, mbedtls_quic_input  *input);
+
+/**
+ * \brief Setup the QUIC input subsystem.
+ *
+ * \param ssl     SSL context.
+ * \param input   QUIC input structure.
+ */
+int mbedtls_quic_input_setup(mbedtls_ssl_context *ssl, mbedtls_quic_input  *input);
+
+/**
+ * \brief Deallocate the QUIC input subsystem.
+ *
+ * Deallocates any messages that have not been consumed. In the happy path
+ * scenario every handshake message is being fed to the state machine,
+ * but in case of an aborted handshake, pending messages have to be cleaned up.
+ *
+ * \param ssl     SSL context.
+ * \param input   QUIC input structure.
+ */
+void mbedtls_quic_input_free(mbedtls_ssl_context *ssl, mbedtls_quic_input *input);
+
+/**
+ * \brief Check whether a message is available for reading.
+ *
+ * This routine is used to check whether the input subsystem has enough data
+ * for the next state.
+ *
+ * It's second duty is to allow distinguishing between multiple potential messages,
+ * e.g. CERTIFICATE_REQUEST, CERTIFICATE or FINISHED, which can all follow the
+ * ENCRYPTED_EXTENSIONS.
+ *
+ * \param ssl        SSL context.
+ * \param level      the encryption level.
+ * \param otype      type of the next available handshake message (only if a message is avaiable).
+ * \param osize      size of the next available handshake message (only if a message is avaiable).
+ * \param olen       length of the next available handshake message (only if a message is avaiable).
+ *
+ * \return 0 if a message is available to be read, MBEDTLS_ERR_SSL_WANT_READ otherwise.
+ */
+int mbedtls_quic_input_peek(
+    mbedtls_ssl_context       *ssl,
+    mbedtls_ssl_crypto_level   level,
+    uint8_t                   *otype,
+    size_t                    *osize,
+    size_t                    *olen);
+
+/**
+ * \brief Get a message from the appropriate queue, and remove it from the input system.
+ *
+ * \param ssl        SSL context.
+ * \param level      the encryption level.
+ * \param data       Buffer to which the data will be copied.
+ * \param datalen    Size of the data buffer.
+ *
+ * \return number of bytes written into the data buffer, or a negative error value.
+ */
+int mbedtls_quic_input_read(
+    mbedtls_ssl_context       *ssl,
+    mbedtls_ssl_crypto_level  level,
+    uint8_t                  *data,
+    size_t                    datalen);
+
+/**
+ * \brief Callback to set the encryption secrets for a level.
+ *
+ * \param param the context parameter provided via `mbedtls_ssl_set_hs_quic_method`.
+ * \param level the corresponding crypto level.
+ * \param read_secret secret used for the incoming data, NULL if not applicaable.
+ * \param write_secret secret used for the outgoing data, NULL if not applicable.
+ * \param len length of the secret buffers.
+ */
+typedef int mbedtls_quic_set_encryption_secrets_t(
+    void                     *param,
+    mbedtls_ssl_crypto_level  level,
+    const uint8_t            *read_secret,
+    const uint8_t            *write_secret,
+    size_t                    len);
+
+/**
+ * \brief Callback to deliver the handshake data to the remote endpoint.
+ *
+ * \param param the context parameter provided via `mbedtls_ssl_set_hs_quic_method`.
+ * \param level the corresponding crypto level.
+ * \param data handshake data to be delivered to the remote endpoint.
+ * \param len length of the handshake data.
+ */
+typedef int mbedtls_quic_add_handshake_data_t(
+    void                     *param,
+    mbedtls_ssl_crypto_level  level,
+    const uint8_t            *data,
+    size_t                    len);
+
+/**
+ * \brief Callback to deliver a TLS alert to the remote endpoint.
+ *
+ * \param param the context parameter provided via `mbedtls_ssl_set_hs_quic_method`.
+ * \param level the corresponding crypto level.
+ * \param alert TLS alert code to be delivered.
+ */
+typedef int mbedtls_quic_send_alert_t(
+    void                     *param,
+    mbedtls_ssl_crypto_level   level,
+    uint8_t                    alert);
+
+/**
+ * \brief Callback to notify the MNS on a new TLS session.
+ *
+ * \param param the context parameter provided via `mbedtls_ssl_set_hs_quic_method`.
+ * \param session_ticket TLS session ticket to be transfered to caller.
+ */
+typedef void mbedtls_quic_process_new_session_t(
+    void                     *param,
+    mbedtls_ssl_ticket       *session_ticket);
+/**
+ * \brief QUIC method callbacks.
+ */
+typedef struct mbedtls_quic_method {
+    mbedtls_quic_set_encryption_secrets_t  *set_encryption_secrets;
+    mbedtls_quic_add_handshake_data_t      *add_handshake_data;
+    mbedtls_quic_send_alert_t              *send_alert;
+    mbedtls_quic_process_new_session_t     *process_new_session;
+} mbedtls_quic_method;
+
+/**
+ * \brief   Set the QUIC method callbacks.
+ *
+ * \param ssl            SSL context.
+ * \param p_quic_method  parameter (context) shared by BIO callbacks
+ * \param quic_method QUIC method callbacks.
+ */
+void mbedtls_ssl_set_hs_quic_method(mbedtls_ssl_context *ssl,
+    void *p_quic_method, mbedtls_quic_method *quic_method);
+
+/**
+ * \brief check that the quic_method callbacks can be safely invoked.
+ *
+ * \param ssl        SSL context.
+ */
+bool mbedtls_ssl_is_quic_client(mbedtls_ssl_context* ssl);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif /* MBEDTLS_SSL_PROTO_QUIC */
+
+
+#endif /* MBEDTLS_SSL_QIUC_H */

--- a/include/mbedtls/quic.h
+++ b/include/mbedtls/quic.h
@@ -11,7 +11,7 @@ extern "C" {
 #endif
 
 typedef struct mbedtls_ssl_context mbedtls_ssl_context;
-typedef struct mbedtls_ssl_ticket  mbedtls_ssl_ticket;
+typedef struct mbedtls_ssl_session  mbedtls_ssl_session;
 typedef struct mbedtls_quic_input  mbedtls_quic_input;
 typedef struct quic_input_msg      quic_input_msg;
 typedef struct quic_input_queue    quic_input_queue;
@@ -176,7 +176,7 @@ typedef int mbedtls_quic_send_alert_t(
  */
 typedef void mbedtls_quic_process_new_session_t(
     void                     *param,
-    mbedtls_ssl_ticket       *session_ticket);
+    mbedtls_ssl_session       *session_ticket);
 /**
  * \brief QUIC method callbacks.
  */

--- a/include/mbedtls/quic_internal.h
+++ b/include/mbedtls/quic_internal.h
@@ -1,0 +1,343 @@
+#ifndef MBEDTLS_SSL_QIUC_INTERNAL_H
+#define MBEDTLS_SSL_QIUC_INTERNAL_H
+
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "mbedtls/config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif /* MBEDTLS_CONFIG_FILE */
+
+#if defined(MBEDTLS_SSL_PROTO_QUIC)
+#include "mbedtls/quic.h"
+
+#include <string.h>
+#if defined(MBEDTLS_PLATFORM_C)
+#include "mbedtls/platform.h"
+#else
+#include <stdlib.h>
+#include <stdbool.h>
+#define mbedtls_calloc    calloc
+#define mbedtls_free       free
+#endif
+
+#if ( defined(__ARMCC_VERSION) || defined(_MSC_VER) ) && \
+    !defined(inline) && !defined(__cplusplus)
+#define inline __inline
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct mbedtls_ssl_context mbedtls_ssl_context;
+typedef struct quic_input_msg      quic_input_msg;
+typedef struct quic_input_queue    quic_input_queue;
+
+/**
+ * \brief Size of the TLS handshake message header.
+ */
+#define QUIC_HS_HDR_SIZE 4
+
+/**
+ * \brief Labels for different input queues.
+ */
+typedef enum {
+  QUIC_QUEUE_INITIAL,
+  QUIC_QUEUE_HANDSHAKE,
+  QUIC_QUEUE_APPLICATION,
+  QUIC_QUEUE_MAX_QUEUES,
+} quic_queue_label;
+
+/**
+ * \brief Contiguous block of QUIC handshake message, at a given level.
+ *
+ * The quic data for the different levels is kept in a singly linked
+ * list of "quic_input_msg" structs.
+ *
+ * Each struct is allocated for the entire handshake message, even
+ * in the case when only part of the handshake message is available.
+ *
+ * The individual handshake messages are chained into a single-linked
+ * list, which forms a queue of messages.
+ *
+ * This representation is trading off memory space for the ease of debugging.
+ * Once the implementation is rock solid, this can be replaced with
+ * a contiguous arena of data, with the parsing complexity moved to the
+ * reading routine. In the mean time, the current representation allows
+ * finding logical inconsistencies with ease.
+ *
+ * Layout of the "quic_input_msg"
+ * 0-------8-------16--------------32-----------------------------63
+ * | size                          |  on 64bit arch                |
+ * +-------------------------------+-------------------------------+
+ * | len                           |  on 64bit arch                |
+ * +-------------------------------+-------------------------------+
+ * | next                          |  on 64bit arch                |
+ * +-------------------------------+-------------------------------+
+ * | level                         |  num                          |
+ * +-------+----+------------------+-------------------------------+
+ * | type  |hdr |       handshake                                  |
+ * +-------+----+         data              +----------------------+
+ * |                      ....              |   compiler padding
+ * +-------+-----------------------+-------------------------------+
+ *
+ *
+ * The functions `hs_msg_data_begin` and `hs_msg_data_end` provide
+ * pointers to the beginning of the handshake data, and one byte past
+ * the end of the data in the message. The function `hs_msg_append_data`
+ * is a convenient way to append data to the message. All three functions
+ * assert that the message is allocated.
+ */
+struct quic_input_msg {
+  size_t                     size;   /*!< Total size of the handshake data. */
+  size_t                     len;    /*!< Available data, including header. */
+  quic_input_msg            *next;   /*!< Next msg in the chain. */
+  mbedtls_ssl_crypto_level   level;  /*!< Crypto level. */
+  int                        num;    /*!< Number of this msg in queue. */
+  char                       type;   /*!< Handshake msg type. */
+};
+
+/**
+ * \brief Incoming queue of handshake messages.
+ *
+ * This is a sequence of handshake messages in a given encryption level.
+ * The messages are added to the tail of the queue and are read from the
+ * head of the queue. The queue struct keeps the `level` field for
+ * debugging purposes. `msg_count` is incremented with every new message
+ * that gets added to the queue (and is being copied to the `num` field
+ * in that message. The purpose of the `msg_count` is debugging.
+ *
+ * The `tmp_hdr` and `tmp_hdr_len` fields store the header of the
+ * incoming message. Since the stream of messages can be fragmented
+ * on the header boundary, the writing routine `quic_input_provide_data`
+ * first writes the temporary header from the data (and uses `tmp_hdr_len`
+ * to keep track on whether the header is complete or not).
+ * Once the header has been fully consumed, `quic_input_provide_data`
+ * appends a new message to the tail of the queue, and resets `tmp_hdr_len`.
+ */
+struct quic_input_queue {
+  size_t                     msg_count;
+  mbedtls_ssl_crypto_level   level;
+  quic_input_msg            *head;
+  quic_input_msg            *tail;
+  uint8_t                    tmp_hdr[QUIC_HS_HDR_SIZE];
+  size_t                     tmp_hdr_len;
+};
+
+
+/**
+ * \brief Provide data to a single queue. Used by `mbedtls_quic_input_provide_data`, and by tests.
+ *
+ * \param ssl        SSL context.
+ * \param input      single-level message queue.
+ * \param data       handshake data.
+ * \param daltalen   handshake data len.
+ */
+int quic_input_provide_data(
+    mbedtls_ssl_context *ssl, quic_input_queue *input, const uint8_t *data, size_t datalen);
+
+/**
+ * \brief Peek in the single queue. Used by `mbedtls_quic_input_peek`, and by tests.
+ */
+int quic_input_peek(
+    mbedtls_ssl_context       *ssl,
+    quic_input_queue          *input,
+    uint8_t                   *otype,
+    size_t                    *osize,
+    size_t                    *olen);
+/**
+ * \brief Get a message from a single queue. Used by `mbedtls_quic_input_read`, and by tests.
+ *
+ * \return number of bytes written into the data buffer, or a negative error value.
+ */
+int quic_input_read(
+    mbedtls_ssl_context  *ssl,
+    quic_input_queue     *input,
+    uint8_t              *data,
+    size_t                datalen);
+
+/**
+ * \brief Deallocate single queue. Used by `mbedtls_quic_input_free`, and by tests.
+ */
+void quic_input_free(mbedtls_ssl_context *ssl, quic_input_queue *input);
+
+
+/**
+ * \brief Lookup a queue by the input label. Used by mbedtls_quic_*`, and by tests.
+ *
+ * \return NULL if not found, a pointer to the appropriate queue otherwise.
+ */
+static inline quic_input_queue* quic_input_lookup_queue(
+    mbedtls_ssl_context *ssl,
+    mbedtls_ssl_crypto_level level) {
+
+  MBEDTLS_ASSERT(level < QUIC_QUEUE_MAX_QUEUES);
+
+  quic_input_queue *queue = &(ssl->quic_input.queues_[level]);
+
+  MBEDTLS_ASSERT(level == queue->level);
+
+  return queue;
+}
+
+#define hs_msg_body_size(p) ((uint32_t)(p[1]) << 16) | ((uint32_t)(p[2]) << 8)  | (uint32_t)(p[3])
+
+static inline uint8_t *hs_msg_data_begin(const quic_input_msg *msg) {
+  MBEDTLS_ASSERT(msg != NULL);
+  return (uint8_t*)(msg) + sizeof(quic_input_msg);
+}
+
+static inline uint8_t *hs_msg_data_end(const quic_input_msg *msg) {
+  MBEDTLS_ASSERT(msg != NULL);
+  return (uint8_t*)(msg) + sizeof(quic_input_msg) + msg->len;
+}
+
+static inline uint8_t *hs_msg_append_data(quic_input_msg *msg,
+    const uint8_t* data, size_t len) {
+  MBEDTLS_ASSERT(msg != NULL);
+  uint8_t *p = (uint8_t*)(msg) + sizeof(quic_input_msg) + msg->len;
+  memcpy(p, data, len);
+  msg->len += len;
+  return p + len;
+}
+
+/**
+ * \brief Checks if the message type can be accepted.
+ */
+static inline bool quic_input_hs_type_valid(uint8_t hs_type) {
+  switch (hs_type) {
+  case MBEDTLS_SSL_HS_CLIENT_HELLO:
+  case MBEDTLS_SSL_HS_SERVER_HELLO:
+  case MBEDTLS_SSL_HS_NEW_SESSION_TICKET:
+  case MBEDTLS_SSL_HS_HELLO_RETRY_REQUEST:
+  case MBEDTLS_SSL_HS_ENCRYPTED_EXTENSION:
+  case MBEDTLS_SSL_HS_CERTIFICATE:
+  case MBEDTLS_SSL_HS_CERTIFICATE_REQUEST:
+  case MBEDTLS_SSL_HS_CERTIFICATE_VERIFY:
+  case MBEDTLS_SSL_HS_FINISHED:
+  case MBEDTLS_SSL_HS_MESSAGE_HASH:
+    return true;
+  default:
+    return false;
+  }
+}
+
+/**
+ * \brief Checks whether more data is required for the last message in the queue.
+ */
+static inline bool quic_input_last_msg_is_partial(mbedtls_ssl_context *ssl,
+    quic_input_queue *queue) {
+
+  quic_input_msg *hs_msg;
+
+  if ((hs_msg = queue->tail) == NULL) {
+    return false;
+  }
+
+  if (hs_msg->size == hs_msg->len) {
+    return false;
+  }
+
+  MBEDTLS_ASSERT(hs_msg->size > hs_msg->len);
+
+  return true;
+}
+
+/**
+ * \brief Attempt to fill the last message in the queue from the data.
+ * \return number of bytes consumed from the data.
+ */
+static inline size_t quic_input_fill_last_msg(mbedtls_ssl_context *ssl,
+    quic_input_queue *queue, const uint8_t *data, const uint8_t *data_end) {
+  quic_input_msg *hs_msg;
+
+  if ((hs_msg = queue->tail) == NULL) {
+    return 0;
+  }
+
+  size_t len = hs_msg->size - hs_msg->len;
+  size_t available = data_end - data;
+  if (len > available) {
+    len = available;
+  }
+
+  MBEDTLS_SSL_DEBUG_MSG( 3, ( "quic_input_fill_msg_data: "
+        "appending %u bytes to the partial message: size: %u len: %u",
+        len, hs_msg->size, hs_msg->len) );
+
+  hs_msg_append_data(hs_msg, data, len);
+
+  return len;
+}
+
+/**
+ * \brief Checks whether more data is required for the last message header.
+ */
+static inline bool quic_input_last_msg_hdr_is_partial(mbedtls_ssl_context *ssl,
+    quic_input_queue *queue) {
+  return queue->tmp_hdr_len < QUIC_HS_HDR_SIZE;
+}
+
+/**
+ * \brief Attempt to fill the last message header from the data.
+ * \return number of bytes consumed from the data.
+ */
+static inline size_t quic_input_fill_last_msg_hdr(mbedtls_ssl_context *ssl,
+    quic_input_queue *queue, const uint8_t *data, const uint8_t *data_end) {
+  size_t len = 0;
+
+  MBEDTLS_SSL_DEBUG_MSG( 3, ( "quic_input_fill_last_msg_hdr: "
+        "parsing new handshake message header: hdr_len %u", queue->tmp_hdr_len));
+  while (queue->tmp_hdr_len < QUIC_HS_HDR_SIZE && (data + len) < data_end) {
+    queue->tmp_hdr[queue->tmp_hdr_len++] = data[len++];
+  }
+  return len;
+}
+
+/**
+ * \brief Checks whether the last message header is valid.
+ */
+static inline int quic_input_validate_last_hdr(mbedtls_ssl_context *ssl,
+    quic_input_queue *queue) {
+  MBEDTLS_ASSERT(queue->tmp_hdr_len == QUIC_HS_HDR_SIZE);
+
+  /* Extract the message's type from the temporary message header */
+  char hs_msg_type = queue->tmp_hdr[0];
+
+  if (!quic_input_hs_type_valid(hs_msg_type)) {
+    MBEDTLS_SSL_DEBUG_MSG( 1, ( "quic_input_validate_last_hdr: FATAL ERR "
+          "invalid handshake message type %c", hs_msg_type));
+    return MBEDTLS_ERR_SSL_BAD_HS_UNKNOWN_MSG;
+  }
+
+  const size_t hs_msg_size = hs_msg_body_size(queue->tmp_hdr) + QUIC_HS_HDR_SIZE;
+
+  if (hs_msg_size > MBEDTLS_SSL_MAX_CONTENT_LEN) {
+    MBEDTLS_SSL_DEBUG_MSG( 1, ( "quic_input_validate_last_hdr: FATAL ERR "
+          "handshake message size %u exceeds max %u",
+          hs_msg_type, MBEDTLS_SSL_MAX_CONTENT_LEN));
+    return MBEDTLS_ERR_SSL_INVALID_RECORD;
+  }
+
+  return 0;
+}
+
+static inline void quic_input_reset_last_msg_hdr(mbedtls_ssl_context *ssl,
+    quic_input_queue *queue) {
+  queue->tmp_hdr_len = 0;
+}
+
+/**
+ * \brief Uses the last message header to allocate an element in the queue.
+ */
+int quic_input_allocate_msg(mbedtls_ssl_context *ssl, quic_input_queue *queue);
+
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif /* MBEDTLS_SSL_PROTO_QUIC */
+
+
+#endif /* MBEDTLS_SSL_QIUC_INTERNAL_H */

--- a/include/mbedtls/quic_internal.h
+++ b/include/mbedtls/quic_internal.h
@@ -1,11 +1,7 @@
 #ifndef MBEDTLS_SSL_QIUC_INTERNAL_H
 #define MBEDTLS_SSL_QIUC_INTERNAL_H
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif /* MBEDTLS_CONFIG_FILE */
+#include "mbedtls/build_info.h"
 
 #if defined(MBEDTLS_SSL_PROTO_QUIC)
 #include "mbedtls/quic.h"
@@ -307,15 +303,15 @@ static inline int quic_input_validate_last_hdr(mbedtls_ssl_context *ssl,
   if (!quic_input_hs_type_valid(hs_msg_type)) {
     MBEDTLS_SSL_DEBUG_MSG( 1, ( "quic_input_validate_last_hdr: FATAL ERR "
           "invalid handshake message type %c", hs_msg_type));
-    return MBEDTLS_ERR_SSL_BAD_HS_UNKNOWN_MSG;
+    return MBEDTLS_ERR_SSL_INVALID_RECORD;
   }
 
   const size_t hs_msg_size = hs_msg_body_size(queue->tmp_hdr) + QUIC_HS_HDR_SIZE;
 
-  if (hs_msg_size > MBEDTLS_SSL_MAX_CONTENT_LEN) {
+  if (hs_msg_size > MBEDTLS_SSL_IN_CONTENT_LEN) {
     MBEDTLS_SSL_DEBUG_MSG( 1, ( "quic_input_validate_last_hdr: FATAL ERR "
           "handshake message size %u exceeds max %u",
-          hs_msg_type, MBEDTLS_SSL_MAX_CONTENT_LEN));
+          hs_msg_type, MBEDTLS_SSL_IN_CONTENT_LEN));
     return MBEDTLS_ERR_SSL_INVALID_RECORD;
   }
 

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -56,6 +56,10 @@
 #include "psa/crypto.h"
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 
+#if defined(MBEDTLS_SSL_PROTO_QUIC)
+#include "quic.h"
+#endif /* MBEDTLS_SSL_PROTO_QUIC */
+
 /*
  * SSL Error codes
  */
@@ -241,6 +245,7 @@
 
 #define MBEDTLS_SSL_TRANSPORT_STREAM            0   /*!< TLS      */
 #define MBEDTLS_SSL_TRANSPORT_DATAGRAM          1   /*!< DTLS     */
+#define MBEDTLS_SSL_TRANSPORT_QUIC              2   /*!< QUIC     */
 
 #define MBEDTLS_SSL_MAX_HOST_NAME_LEN           255 /*!< Maximum host name defined in RFC 1035 */
 #define MBEDTLS_SSL_MAX_ALPN_NAME_LEN           255 /*!< Maximum size in bytes of a protocol name in alpn ext., RFC 7301 */
@@ -571,6 +576,10 @@
 
 #define MBEDTLS_TLS_EXT_RENEGOTIATION_INFO      0xFF01
 
+#define MBEDTLS_TLS_EXT_QUIC_TRANSPORT_PARAMS   0xFFA5
+
+#define MBEDTLS_QUIC_TRANSPORT_PARAMS_MAX_LEN   65535
+
 /*
  * Size defines
  */
@@ -826,6 +835,28 @@ typedef enum
     allow_dhe_resumption = 2,
     allow_psk_resumption = 4,
 } mbedtls_ssl_ticket_flags;
+
+#if defined(MBEDTLS_SSL_PROTO_QUIC)
+/**
+ * \brief set the QUIC transport params buffer for this endpoint.
+ *
+ * \param ssl        SSL context.
+ * \param params     the QUIC transport params buffer.
+ * \param len        length of the the QUIC transport params buffer.
+ */
+int mbedtls_ssl_set_quic_transport_params(mbedtls_ssl_context *ssl,
+    const uint8_t *params, size_t len);
+
+/**
+ * \brief get the quic transport params for the peer endpoint.
+ *
+ * \param ssl        SSL context.
+ */
+void mbedtls_ssl_get_peer_quic_transport_params(mbedtls_ssl_context *ssl,
+    const uint8_t **params, size_t *len);
+
+int mbedtls_ssl_quic_post_handshake(mbedtls_ssl_context *ssl);
+#endif /* MBEDTLS_SSL_PROTO_QUIC */
 
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL && MBEDTLS_SSL_NEW_SESSION_TICKET */
 
@@ -1516,7 +1547,7 @@ struct mbedtls_ssl_config
      */
 
     unsigned int MBEDTLS_PRIVATE(endpoint) : 1;      /*!< 0: client, 1: server               */
-    unsigned int MBEDTLS_PRIVATE(transport) : 1;     /*!< stream (TLS) or datagram (DTLS)    */
+    unsigned int MBEDTLS_PRIVATE(transport) : 2;     /*!< 0: TLS, 1: DTLS, 2: QUIC           */
     unsigned int MBEDTLS_PRIVATE(authmode) : 2;      /*!< MBEDTLS_SSL_VERIFY_XXX             */
     /* needed even with renego disabled for LEGACY_BREAK_HANDSHAKE          */
     unsigned int MBEDTLS_PRIVATE(allow_legacy_renegotiation) : 2 ; /*!< MBEDTLS_LEGACY_XXX   */
@@ -1835,6 +1866,39 @@ struct mbedtls_ssl_context
     void *MBEDTLS_PRIVATE(p_export_keys);            /*!< context for key export callback    */
 #endif
 
+#if defined(MBEDTLS_SSL_PROTO_QUIC)
+    /*
+     * QUIC method callbacks and the callback context pointer.
+     */
+    mbedtls_quic_method           *quic_method;
+
+    /*
+     * Context parameter for the QUIC method callbacks.
+     */
+    void                          *p_quic_method;
+
+    /*
+     * QUIC outgoing and incoming crypto levels.
+     */
+    mbedtls_ssl_crypto_level      quic_hs_crypto_level;
+
+    /*
+     * The QUIC input data queue.
+     */
+    mbedtls_quic_input            quic_input;
+
+    /*
+     * QUIC transport parameters.
+     */
+    uint8_t                       *quic_transport_params;
+    size_t                        quic_transport_params_len;
+
+    /*
+     * QUIC peer transport parameters.
+     */
+    uint8_t                       *peer_quic_transport_params;
+    size_t                        peer_quic_transport_params_len;
+#endif /* MBEDTLS_SSL_PROTO_QUIC */
 };
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)

--- a/library/quic.c
+++ b/library/quic.c
@@ -1,0 +1,391 @@
+/*
+ *  SSLv3/TLSv1 shared functions
+ *
+ *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of mbed TLS (https://tls.mbed.org)
+ */
+/*
+ *  The SSL 3.0 specification was drafted by Netscape in 1996,
+ *  and became an IETF standard in 1999.
+ *
+ *  http://wp.netscape.com/eng/ssl3/
+ *  http://www.ietf.org/rfc/rfc2246.txt
+ *  http://www.ietf.org/rfc/rfc4346.txt
+ */
+
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "mbedtls/config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+
+#if defined(MBEDTLS_SSL_PROTO_QUIC)
+
+#include <stdbool.h>
+
+#include "mbedtls/ssl.h"
+#include "mbedtls/debug.h"
+#include "mbedtls/quic.h"
+#include "mbedtls/quic_internal.h"
+
+int mbedtls_quic_input_provide_data(mbedtls_ssl_context* ssl,
+    mbedtls_ssl_crypto_level level,
+    const uint8_t* data,
+    size_t len) {
+
+  int rv = MBEDTLS_ERR_SSL_INTERNAL_ERROR;
+
+  MBEDTLS_SSL_DEBUG_MSG( 2,
+      ( "=> mbedtls_quic_input_provide_data: level: %d len: %u", level, len ) );
+
+  quic_input_queue *queue = quic_input_lookup_queue(ssl, level);
+
+  rv = quic_input_provide_data(ssl, queue, data, len);
+
+  MBEDTLS_SSL_DEBUG_RET(1, "mbedtls_quic_input_provide_data", rv);
+  return rv;
+}
+
+int quic_input_allocate_msg(mbedtls_ssl_context *ssl, quic_input_queue *queue) {
+  int rv = 0;
+  quic_input_msg *hs_msg = NULL;
+  char hs_msg_type = queue->tmp_hdr[0];
+  const size_t hs_msg_size = hs_msg_body_size(queue->tmp_hdr) + QUIC_HS_HDR_SIZE;
+
+  /* Allocate QD block for the `quic_input_msg` + hs_msg_len bytes */
+  if ((hs_msg = mbedtls_calloc(1, sizeof(quic_input_msg) + hs_msg_size)) == NULL) {
+    MBEDTLS_SSL_DEBUG_MSG( 1, ( "quic_input_provide_data: FATAL ERR "
+          "failed to allocate %u bytes", sizeof(quic_input_msg) + hs_msg_size));
+    rv = MBEDTLS_ERR_SSL_ALLOC_FAILED;
+    goto cleanup;
+  }
+
+  /* Initialize the handshake message header */
+  hs_msg->next       = NULL;
+  hs_msg->size       = hs_msg_size;
+  hs_msg->num        = queue->msg_count++;
+  hs_msg->type       = hs_msg_type;
+  hs_msg->level      = queue->level;
+  hs_msg->len        = 0;
+
+  hs_msg_append_data(hs_msg, queue->tmp_hdr, QUIC_HS_HDR_SIZE);
+
+  /* Append the new handshake message to the chain */
+  if (queue->tail != NULL) {
+    queue->tail->next = hs_msg;
+  } else {
+    queue->head = hs_msg;
+  }
+  queue->tail = hs_msg;
+
+  MBEDTLS_SSL_DEBUG_QUIC_HS_MSG(3, "quic_input_provide_data: "
+      "allocated new message", hs_msg);
+
+  // Release the pointer to the message, since the ownership
+  // has been transferred to the queue.
+  hs_msg = NULL;
+
+cleanup:
+  mbedtls_free(hs_msg);
+  queue->tmp_hdr_len = 0;
+  return rv;
+}
+
+int quic_input_provide_data(mbedtls_ssl_context *ssl, quic_input_queue* queue, const uint8_t* data, size_t datalen) {
+
+  MBEDTLS_SSL_DEBUG_MSG( 3, ( "=> quic_input_provide_data" ) );
+
+  if (data == NULL || datalen == 0) {
+    MBEDTLS_SSL_DEBUG_MSG( 3, ( "<= quic_input_provide_data (null input)" ) );
+    return 0;
+  }
+
+  /* Start consuming the data, while splitting it into handshake messages. */
+  int rv = 0;
+
+  const uint8_t *data_end = data + datalen;
+  while (data < data_end) {
+
+    /* ---- CONSUME HANDSHAKE MESSAGE BODY ----
+     *
+     * The last element in the input queue may contain only
+     * a part of the handshake message. In such case, the
+     * actual length of the message will not match the length field
+     * in the headshake header: `queue->tail->len < queue->tail-size`.
+     *
+     * If this is the case, this means that the handshake message
+     * has been fragmented in the body area, and that the `data`
+     * pointer carries the continuation data.
+     *
+     * Check for the partial message body, and provide the
+     * necessary data.
+     */
+    if (quic_input_last_msg_is_partial(ssl, queue)) {
+      data += quic_input_fill_last_msg(ssl, queue, data, data_end);
+      continue;
+    }
+
+    /* ---- CONSUME HANDSHAKE MESSAGE HEADER -----
+     *
+     * The header message is first being read from the `data` pointer
+     * into the `queue->tmp_hdr`. This way, if the CRYPTO frame payload
+     * has been fragmented for some reason, the code is able to continue
+     * reading the header bytes.
+     */
+    if (quic_input_last_msg_hdr_is_partial(ssl, queue)) {
+      data += quic_input_fill_last_msg_hdr(ssl, queue, data, data_end);
+      continue;
+    }
+
+    /* ---- VALIDATE THE HANDSHAKE HEADER ----
+     *
+     * The header has been fully consumed and stored in the `queue->tmp_hdr`
+     * array. Validate the header.
+     */
+    if ((rv = quic_input_validate_last_hdr(ssl, queue)) != 0) {
+      //  The header is not valid. Reset the header state and return early,
+      //  ignoring the rest of the data. If the next invocation of
+      //  `quic_input_provide_data` will start with a valid message, the
+      //  queue will start from parsing the header.
+      quic_input_reset_last_msg_hdr(ssl, queue);
+      MBEDTLS_SSL_DEBUG_RET(2, "quic_input_provide_data", rv);
+      return rv;
+    }
+
+    /* ---- ALLOCATE A NEW MESSAAGE IN THE QUEUE ----
+     *
+     * The header has been fully consumed and stored in the `queue->tmp_hdr`
+     * array. Proceed to parsing the header, and allocate the memory.
+     */
+    if ((rv = quic_input_allocate_msg(ssl, queue)) != 0) {
+      MBEDTLS_SSL_DEBUG_RET(2, "quic_input_provide_data", rv);
+      return rv;
+    }
+  } /* while data < data_end */
+
+  return rv;
+}
+
+int quic_input_read(
+    mbedtls_ssl_context *ssl,
+    quic_input_queue    *queue,
+    uint8_t             *data,
+    size_t               datalen) {
+
+  int rv = MBEDTLS_ERR_SSL_INTERNAL_ERROR;
+
+  MBEDTLS_SSL_DEBUG_MSG( 3,
+      ( "=> quic_input_read: data: %p len: %u", data, datalen ) );
+
+  quic_input_msg  *hs_msg = NULL;
+
+  if (data == NULL || datalen == 0) {
+    // nowhere to read, not an error.
+    rv = 0;
+    goto cleanup;
+  }
+
+  if ((hs_msg = queue->head) == NULL) {
+    // nothing to read, not an error.
+    rv = 0;
+    goto cleanup;
+  }
+
+  MBEDTLS_SSL_DEBUG_QUIC_HS_MSG(3, "quic_input_read", hs_msg);
+
+  if (hs_msg->len < datalen) {
+    datalen = hs_msg->len;
+  }
+
+  memcpy(data, (uint8_t*)(hs_msg + 1), datalen);
+
+  rv = (int)datalen;
+
+  // Currently, a partial read on the message will purge the
+  // message from the queue.
+  queue->head = hs_msg->next;
+
+  if (hs_msg->next == NULL) {
+    MBEDTLS_SSL_DEBUG_MSG( 3, ( "quic_input_read: empty queue" ) );
+    queue->tail = NULL;
+  }
+
+cleanup:
+  mbedtls_free(hs_msg);
+
+  MBEDTLS_SSL_DEBUG_RET(2, "quic_input_read", rv);
+  return rv;
+}
+
+int mbedtls_quic_input_read(
+    mbedtls_ssl_context *ssl,
+    mbedtls_ssl_crypto_level level,
+    uint8_t *data,
+    size_t datalen) {
+
+  int rv = MBEDTLS_ERR_SSL_INTERNAL_ERROR;
+
+  MBEDTLS_SSL_DEBUG_MSG( 2,
+      ( "=> mbedtls_quic_input_read: level %d data: %p len: %u", level, data, datalen ) );
+
+  quic_input_queue *queue = quic_input_lookup_queue(ssl, level);
+
+  // Dispatch the data to the appropriate queuue.
+  rv =  quic_input_read(ssl, queue, data, datalen);
+
+  MBEDTLS_SSL_DEBUG_RET(1, "mbedtls_quic_input_read", rv);
+  return rv;
+}
+
+void mbedtls_quic_input_init(mbedtls_ssl_context *ssl, mbedtls_quic_input *mqueue) {
+
+  MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> mbedtls_quic_input_init" ) );
+
+  memset(mqueue, 0, sizeof(mbedtls_quic_input));
+
+  MBEDTLS_SSL_DEBUG_MSG( 2, ( "<= mbedtls_quic_input_init" ) );
+}
+
+int mbedtls_quic_input_setup(mbedtls_ssl_context *ssl, mbedtls_quic_input *mqueue) {
+
+  int rv = 0;
+
+  MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> mbedtls_quic_input_setup" ) );
+
+  mqueue->queues_ = mbedtls_calloc(QUIC_QUEUE_MAX_QUEUES, sizeof(quic_input_queue));
+  if (mqueue->queues_ == NULL) {
+    rv = MBEDTLS_ERR_SSL_ALLOC_FAILED;
+    goto cleanup;
+  }
+
+  mqueue->queues_[QUIC_QUEUE_INITIAL].level     = MBEDTLS_SSL_CRYPTO_LEVEL_INITIAL;
+  mqueue->queues_[QUIC_QUEUE_HANDSHAKE].level   = MBEDTLS_SSL_CRYPTO_LEVEL_HANDSHAKE;
+  mqueue->queues_[QUIC_QUEUE_APPLICATION].level = MBEDTLS_SSL_CRYPTO_LEVEL_APPLICATION;
+
+  MBEDTLS_SSL_DEBUG_RET(1, "mbedtls_quic_input_setup", rv);
+cleanup:
+  return rv;
+}
+
+void quic_input_free(mbedtls_ssl_context *ssl, quic_input_queue *queue) {
+
+  MBEDTLS_SSL_DEBUG_MSG( 3, ( "=> quic_input_free: level: %d", queue->level ) );
+
+  quic_input_msg *hs_msg = queue->head;
+
+  while (hs_msg != NULL) {
+
+    MBEDTLS_SSL_DEBUG_QUIC_HS_MSG(3, "ssl_quic_single_level_queue_free", hs_msg);
+
+    quic_input_msg *p = hs_msg;
+    hs_msg = hs_msg->next;
+    mbedtls_free(p);
+  }
+
+  MBEDTLS_SSL_DEBUG_MSG( 2, ( "<= quic_input_free: level: %d", queue->level ) );
+}
+
+void mbedtls_quic_input_free(mbedtls_ssl_context *ssl, mbedtls_quic_input *mqueue) {
+
+  MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> mbedtls_quic_input_free" ) );
+
+  quic_input_free(ssl, &mqueue->queues_[MBEDTLS_SSL_CRYPTO_LEVEL_INITIAL]);
+  quic_input_free(ssl, &mqueue->queues_[MBEDTLS_SSL_CRYPTO_LEVEL_HANDSHAKE]);
+  quic_input_free(ssl, &mqueue->queues_[MBEDTLS_SSL_CRYPTO_LEVEL_APPLICATION]);
+
+  mbedtls_free(mqueue->queues_);
+
+  MBEDTLS_SSL_DEBUG_MSG( 1, ( "<= mbedtls_quic_input_free" ) );
+}
+
+int quic_input_peek(
+    mbedtls_ssl_context *ssl,
+    quic_input_queue* queue,
+    uint8_t *otype,
+    size_t *osize,
+    size_t *olen) {
+
+  MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> quic_input_peek" ) );
+
+  quic_input_msg     *hs_msg = queue->head;
+
+  if (hs_msg == NULL ) {
+
+    MBEDTLS_SSL_DEBUG_MSG( 2, ( "<= quic_input_peek: WANT_READ" ) );
+
+    *olen  = 0;
+    return MBEDTLS_ERR_SSL_WANT_READ;
+  }
+
+  *otype = hs_msg->type;
+  *osize  = hs_msg->size;
+  *olen  = hs_msg->len;
+
+  if (hs_msg->size != hs_msg->len) {
+    MBEDTLS_SSL_DEBUG_QUIC_HS_MSG(2, "<= quic_input_peek: WANT_READ", hs_msg);
+    return MBEDTLS_ERR_SSL_WANT_READ;
+  }
+
+  MBEDTLS_SSL_DEBUG_QUIC_HS_MSG(2, "<= quic_input_peek: ", hs_msg);
+
+  return 0;
+}
+
+int mbedtls_quic_input_peek(
+    mbedtls_ssl_context *ssl,
+    mbedtls_ssl_crypto_level level,
+    uint8_t *otype,
+    size_t *osize,
+    size_t *olen) {
+
+  MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> mbedtls_quic_input_peek" ) );
+
+  quic_input_queue *queue = quic_input_lookup_queue(ssl, level);
+
+  int rv = quic_input_peek(ssl, queue, otype, osize, olen);
+
+  MBEDTLS_SSL_DEBUG_MSG( 2, ( "<= mbedtls_quic_input_peek" ) );
+
+  return rv;
+}
+
+void mbedtls_ssl_set_hs_quic_method(mbedtls_ssl_context *ssl, void *p_quic_method, mbedtls_quic_method *quic_method) {
+  ssl->p_quic_method = p_quic_method;
+  ssl->quic_method = quic_method;
+}
+
+bool mbedtls_ssl_is_quic_client(mbedtls_ssl_context* ssl) {
+  if (!ssl || !ssl->conf) {
+    return false;
+  }
+
+  if (ssl->conf->endpoint != MBEDTLS_SSL_IS_CLIENT) {
+    return false;
+  }
+
+  if (ssl->conf->transport != MBEDTLS_SSL_TRANSPORT_QUIC) {
+    return false;
+  }
+
+  if (!ssl->quic_method || !ssl->p_quic_method) {
+    return false;
+  }
+
+  return true;
+}
+
+#endif /* MBEDTLS_SSL_PROTO_QUIC */

--- a/library/quic.c
+++ b/library/quic.c
@@ -27,11 +27,7 @@
  *  http://www.ietf.org/rfc/rfc4346.txt
  */
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "common.h"
 
 #if defined(MBEDTLS_SSL_PROTO_QUIC)
 

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -1799,6 +1799,14 @@ int mbedtls_ssl_double_retransmit_timeout( mbedtls_ssl_context *ssl );
 void mbedtls_ssl_reset_retransmit_timeout( mbedtls_ssl_context *ssl );
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
 
+#if defined(MBEDTLS_SSL_PROTO_QUIC)
+int mbedtls_set_quic_traffic_key(mbedtls_ssl_context *ssl, mbedtls_ssl_crypto_level level);
+/* Shared implementation for the QUIC transport params setting */
+int ssl_set_quic_transport_params(mbedtls_ssl_context *ssl,
+    const uint8_t *params, size_t len,
+    uint8_t **oparams, size_t *olen);
+#endif
+
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
 #if defined(MBEDTLS_ECDH_C)
 /**

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -2136,6 +2136,12 @@ cleanup:
  */
 int mbedtls_ssl_flush_output( mbedtls_ssl_context *ssl )
 {
+#if defined(MBEDTLS_SSL_PROTO_QUIC)
+    // In QUIC mode, we do not employ byte-granular I/O. Therefore,
+    // there is no leftover output to flush.
+    if (ssl->conf->transport == MBEDTLS_SSL_TRANSPORT_QUIC)
+        return 0;
+#endif /* MBEDTLS_SSL_PROTO_QUIC */
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     unsigned char *buf;
 
@@ -2724,6 +2730,22 @@ int mbedtls_ssl_write_handshake_msg_ext( mbedtls_ssl_context *ssl,
  */
 int mbedtls_ssl_write_record( mbedtls_ssl_context *ssl, uint8_t force_flush )
 {
+#if defined(MBEDTLS_SSL_PROTO_QUIC)
+    if (ssl->conf->transport == MBEDTLS_SSL_TRANSPORT_QUIC)
+    {
+        MBEDTLS_SSL_DEBUG_MSG(5, ("=> write record (quic)"));
+
+        ssl->quic_method->add_handshake_data(
+                ssl->p_quic_method,
+                ssl->quic_hs_crypto_level,
+                ssl->out_msg,
+                ssl->out_msglen);
+
+        MBEDTLS_SSL_DEBUG_MSG(5, ("<= write record (quic)"));
+
+        return(0);
+    }
+#endif /* MBEDTLS_SSL_PROTO_QUIC */
     int ret, done = 0;
     size_t len = ssl->out_msglen;
     uint8_t flush = force_flush;
@@ -3903,6 +3925,47 @@ static int ssl_record_is_in_progress( mbedtls_ssl_context *ssl );
 int mbedtls_ssl_read_record( mbedtls_ssl_context *ssl,
                              unsigned update_hs_digest )
 {
+#if defined(MBEDTLS_SSL_PROTO_QUIC)
+    if (ssl->conf->transport == MBEDTLS_SSL_TRANSPORT_QUIC)
+    {
+        if( ssl->keep_current_message == 0 )
+        {
+            /*  Check for sufficient space in the `ssl->in_buf` buffer.
+             *  We can use the entire span of the allocated memory past the `ssl->in_msg`:
+             *
+             *                           *- ssl->in_msg
+             *                          /
+             *                         v
+             * ssl->in_buf = [         |              ...   ]
+             *               |    MBEDTLS_SSL_IN_BUFFER_LEN |
+             */
+            size_t available = MBEDTLS_SSL_IN_BUFFER_LEN -
+                (size_t)( ssl->in_msg - ssl->in_buf );
+
+            size_t len = mbedtls_quic_input_read(
+                    ssl, ssl->quic_hs_crypto_level, ssl->in_msg, available);
+
+            if ( len == 0 ) 
+            {
+                return (MBEDTLS_ERR_SSL_INTERNAL_ERROR);
+            }
+
+            // Successfully read the message, store the length.
+            ssl->in_msglen = len;
+
+            // Mark the message type as handshake
+            ssl->in_msgtype = MBEDTLS_SSL_MSG_HANDSHAKE;
+
+            return mbedtls_ssl_prepare_handshake_record( ssl );
+        }
+        else
+        {
+            MBEDTLS_SSL_DEBUG_MSG( 2, ( "reuse previously read message" ) );
+            ssl->keep_current_message = 0;
+            return 0;
+        }
+    }
+#endif /* MBEDTLS_SSL_PROTO_QUIC */
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
 
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> read record" ) );
@@ -4954,15 +5017,27 @@ int mbedtls_ssl_send_alert_message( mbedtls_ssl_context *ssl,
 
 #else /* MBEDTLS_SSL_USE_MPS */
 
-    ssl->out_msgtype = MBEDTLS_SSL_MSG_ALERT;
-    ssl->out_msglen = 2;
-    ssl->out_msg[0] = level;
-    ssl->out_msg[1] = message;
-
-    if( ( ret = mbedtls_ssl_write_record( ssl, SSL_FORCE_FLUSH ) ) != 0 )
+#if defined(MBEDTLS_SSL_PROTO_QUIC)
+    if (ssl->conf->transport == MBEDTLS_SSL_TRANSPORT_QUIC)
     {
+        if ( ( ret = ssl->quic_method->send_alert(ssl->p_quic_method, ssl->quic_hs_crypto_level, message ) ) != 0 )
+        {
+            return ret;
+        }
+    }
+    else
+#endif /* MBEDTLS_SSL_PROTO_QUIC */
+    {
+      ssl->out_msgtype = MBEDTLS_SSL_MSG_ALERT;
+      ssl->out_msglen = 2;
+      ssl->out_msg[0] = level;
+      ssl->out_msg[1] = message;
+
+      if( ( ret = mbedtls_ssl_write_record( ssl, SSL_FORCE_FLUSH ) ) != 0 )
+      {
         MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_write_record", ret );
         return( ret );
+      }
     }
 
 #endif /* MBEDTLS_SSL_USE_MPS */

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -3746,6 +3746,18 @@ int mbedtls_ssl_setup( mbedtls_ssl_context *ssl,
         else
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
         {
+#if defined(MBEDTLS_SSL_PROTO_QUIC)
+            if (conf->transport == MBEDTLS_SSL_TRANSPORT_QUIC)
+            {
+                mbedtls_quic_input_init(ssl, &ssl->quic_input);
+                if ((ret = mbedtls_quic_input_setup(ssl, &ssl->quic_input)) != 0)
+                {
+                    MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_quic_input_setup", ret );
+                    return ret;
+                }
+                ssl->quic_hs_crypto_level = MBEDTLS_SSL_CRYPTO_LEVEL_INITIAL;
+            }
+#endif /* MBEDTLS_SSL_PROTO_QUIC */
             ssl->out_ctr = ssl->out_buf;
             ssl->out_hdr = ssl->out_buf + 8;
             ssl->out_len = ssl->out_buf + 11;
@@ -7188,6 +7200,15 @@ void mbedtls_ssl_free( mbedtls_ssl_context *ssl )
         mbedtls_free( ssl->early_data_server_buf );
     }
 #endif /* MBEDTLS_ZERO_RTT && MBEDTLS_SSL_SRV_C */
+
+#if defined(MBEDTLS_SSL_PROTO_QUIC)
+    if (ssl->conf != NULL && ssl->conf->transport == MBEDTLS_SSL_TRANSPORT_QUIC)
+    {
+        mbedtls_quic_input_free(ssl, &ssl->quic_input);
+        mbedtls_free(ssl->quic_transport_params);
+        mbedtls_free(ssl->peer_quic_transport_params);
+    }
+#endif /* MBEDTLS_SSL_PROTO_QUIC */
 
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "<= free" ) );
 

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -162,13 +162,11 @@ int ssl_write_early_data_process( mbedtls_ssl_context* ssl )
         MBEDTLS_SSL_PROC_CHK( ssl_write_early_data_postprocess( ssl ) );
 
 #else  /* MBEDTLS_SSL_USE_MPS */
+
 #if defined(MBEDTLS_SSL_PROTO_QUIC)
         if (ssl->conf->transport != MBEDTLS_SSL_TRANSPORT_QUIC)
 #endif /* MBEDTLS_SSL_PROTO_QUIC */
         {
-            /* Make sure we can write a new message. */
-            MBEDTLS_SSL_PROC_CHK( mbedtls_ssl_flush_output( ssl ) );
-
             /* Write early-data to message buffer. */
             MBEDTLS_SSL_PROC_CHK( ssl_write_early_data_write( ssl, ssl->out_msg,
                                                               MBEDTLS_SSL_OUT_CONTENT_LEN,
@@ -3068,8 +3066,8 @@ static int ssl_server_hello_session_id_check( mbedtls_ssl_context* ssl,
 }
 
 static int ssl_server_hello_parse( mbedtls_ssl_context* ssl,
-        const unsigned char* buf,
-        size_t buflen )
+                                   const unsigned char* buf,
+                                   size_t buflen )
 {
 
     int ret; /* return value */
@@ -3158,7 +3156,7 @@ static int ssl_server_hello_parse( mbedtls_ssl_context* ssl,
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "ciphersuite info for %04x not found", i ) );
         SSL_PEND_FATAL_ALERT( MBEDTLS_SSL_ALERT_MSG_INTERNAL_ERROR,
-                MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
+                              MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
         return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
     }
 
@@ -4061,9 +4059,19 @@ static int ssl_new_session_ticket_process( mbedtls_ssl_context* ssl )
 
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> parse new session ticket" ) );
 
+#if defined(MBEDTLS_SSL_PROTO_QUIC)
+    if (ssl->conf->transport == MBEDTLS_SSL_TRANSPORT_QUIC)
+    {
+        buf = ssl->in_msg + mbedtls_ssl_hs_hdr_len( ssl );
+        buflen = ssl->in_hslen - mbedtls_ssl_hs_hdr_len( ssl );
+    }
+    else
+#endif /* MBEDTLS_SSL_PROTO_QUIC */
+    {
     MBEDTLS_SSL_PROC_CHK( mbedtls_ssl_fetch_handshake_msg( ssl,
                                           MBEDTLS_SSL_HS_NEW_SESSION_TICKET,
                                           &buf, &buflen ) );
+    }
 
     MBEDTLS_SSL_PROC_CHK( ssl_new_session_ticket_parse( ssl, buf, buflen ) );
 
@@ -4307,26 +4315,29 @@ int mbedtls_ssl_quic_post_handshake(mbedtls_ssl_context *ssl)
     {
         MBEDTLS_SSL_DEBUG_MSG(3, ("NewSessionTicket received"));
 
-        if ((ret = mbedtls_ssl_new_session_ticket_process(ssl)) != 0)
+        if ((ret = ssl_new_session_ticket_process(ssl)) != 0)
         {
             MBEDTLS_SSL_DEBUG_RET(1, "mbedtls_ssl_parse_new_session_ticket", ret);
             return(ret);
         }
-        mbedtls_ssl_ticket* ticket = mbedtls_calloc(1, sizeof(mbedtls_ssl_ticket));
-        if (ticket == NULL)
+
+        mbedtls_ssl_session* session_ticket = mbedtls_calloc(1, sizeof(mbedtls_ssl_session));
+        if (session_ticket == NULL)
         {
             return (MBEDTLS_ERR_SSL_ALLOC_FAILED);
         }
-        if ((mbedtls_ssl_get_client_ticket(ssl, ticket) != 0))
+
+        if( ( ret = mbedtls_ssl_get_session( ssl, session_ticket ) ) != 0 )
         {
-            mbedtls_free(ticket->ticket);
-            mbedtls_free(ticket);
-            return (MBEDTLS_ERR_SSL_INTERNAL_ERROR);
+            MBEDTLS_SSL_DEBUG_RET(1, "mbedtls_ssl_get_session", ret);
+            mbedtls_ssl_session_free(session_ticket);
+            return(ret);
         }
+
         // the ticket will be transfered to and be released by the app
         ssl->quic_method->process_new_session(
                 ssl->p_quic_method,
-                ticket);
+                session_ticket);
         return (ret);
     }
 

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -33,6 +33,7 @@
 #include "mbedtls/error.h"
 
 #include "ssl_misc.h"
+#include "mbedtls/ssl_ticket.h"
 #include "ssl_tls13_keys.h"
 #if defined(MBEDTLS_SSL_USE_MPS)
 #include "mps_all.h"
@@ -161,19 +162,31 @@ int ssl_write_early_data_process( mbedtls_ssl_context* ssl )
         MBEDTLS_SSL_PROC_CHK( ssl_write_early_data_postprocess( ssl ) );
 
 #else  /* MBEDTLS_SSL_USE_MPS */
+#if defined(MBEDTLS_SSL_PROTO_QUIC)
+        if (ssl->conf->transport != MBEDTLS_SSL_TRANSPORT_QUIC)
+#endif /* MBEDTLS_SSL_PROTO_QUIC */
+        {
+            /* Make sure we can write a new message. */
+            MBEDTLS_SSL_PROC_CHK( mbedtls_ssl_flush_output( ssl ) );
 
-        /* Write early-data to message buffer. */
-        MBEDTLS_SSL_PROC_CHK( ssl_write_early_data_write( ssl, ssl->out_msg,
-                                                          MBEDTLS_SSL_OUT_CONTENT_LEN,
-                                                          &ssl->out_msglen ) );
+            /* Write early-data to message buffer. */
+            MBEDTLS_SSL_PROC_CHK( ssl_write_early_data_write( ssl, ssl->out_msg,
+                                                              MBEDTLS_SSL_OUT_CONTENT_LEN,
+                                                              &ssl->out_msglen ) );
 
-        ssl->out_msgtype = MBEDTLS_SSL_MSG_APPLICATION_DATA;
+            ssl->out_msgtype = MBEDTLS_SSL_MSG_APPLICATION_DATA;
+        }
 
         /* Update state */
         MBEDTLS_SSL_PROC_CHK( ssl_write_early_data_postprocess( ssl ) );
 
-        /* Dispatch message */
-        MBEDTLS_SSL_PROC_CHK( mbedtls_ssl_write_record( ssl, SSL_FORCE_FLUSH ) );
+#if defined(MBEDTLS_SSL_PROTO_QUIC)
+        if (ssl->conf->transport != MBEDTLS_SSL_TRANSPORT_QUIC)
+#endif /* MBEDTLS_SSL_PROTO_QUIC */
+        {
+            /* Dispatch message */
+            MBEDTLS_SSL_PROC_CHK( mbedtls_ssl_write_record( ssl, SSL_FORCE_FLUSH ) );
+        }
 
 #endif /* MBEDTLS_SSL_USE_MPS */
 
@@ -264,6 +277,11 @@ static int ssl_write_early_data_prepare( mbedtls_ssl_context* ssl )
         mbedtls_calloc( 1, sizeof( mbedtls_ssl_transform ) );
     if( transform_earlydata == NULL )
         return( MBEDTLS_ERR_SSL_ALLOC_FAILED );
+
+#if defined(MBEDTLS_SSL_PROTO_QUIC)
+    if (ssl->conf->transport == MBEDTLS_SSL_TRANSPORT_QUIC)
+        mbedtls_set_quic_traffic_key(ssl, MBEDTLS_SSL_CRYPTO_LEVEL_EARLY_DATA);
+#endif /* MBEDTLS_SSL_PROTO_QUIC */
 
     ret = mbedtls_ssl_tls13_populate_transform(
                           transform_earlydata,
@@ -406,6 +424,11 @@ static int ssl_write_end_of_early_data_coordinate( mbedtls_ssl_context* ssl )
 {
     ((void) ssl);
 
+#if defined(MBEDTLS_SSL_PROTO_QUIC)
+    if (ssl->conf->transport == MBEDTLS_SSL_TRANSPORT_QUIC)
+        return( SSL_END_OF_EARLY_DATA_SKIP );
+#endif /* MBEDTLS_SSL_PROTO_QUIC */
+
 #if defined(MBEDTLS_ZERO_RTT)
     if( ssl->handshake->early_data == MBEDTLS_SSL_EARLY_DATA_ON )
     {
@@ -428,6 +451,14 @@ static int ssl_write_end_of_early_data_coordinate( mbedtls_ssl_context* ssl )
 
 static int ssl_write_end_of_early_data_postprocess( mbedtls_ssl_context* ssl )
 {
+#if defined(MBEDTLS_SSL_PROTO_QUIC)
+    if (ssl->conf->transport == MBEDTLS_SSL_TRANSPORT_QUIC)
+    {
+        mbedtls_ssl_handshake_set_state( ssl, MBEDTLS_SSL_CLIENT_CERTIFICATE );
+        return ( 0 );
+    }
+#endif /* MBEDTLS_SSL_PROTO_QUIC */
+
 #if defined(MBEDTLS_SSL_TLS13_COMPATIBILITY_MODE)
     if( ssl_write_end_of_early_data_coordinate( ssl ) != SSL_END_OF_EARLY_DATA_WRITE )
     {
@@ -440,6 +471,56 @@ static int ssl_write_end_of_early_data_postprocess( mbedtls_ssl_context* ssl )
     return( 0 );
 }
 
+#if defined(MBEDTLS_SSL_PROTO_QUIC)
+
+/* QUIC transport parameters extensions. [draft-ietf-quic-tls 8.2]
+ *
+ *  QUIC transport parameters are carried in a TLS extension. Different
+ *  versions of QUIC might define a different method for negotiating
+ *  transport configuration.
+ *
+ *  Including transport parameters in the TLS handshake provides
+ *  integrity protection for these values.
+ *
+ *  QUIC transport parameters MUST be included in the ClientHello message.
+ *
+ *  enum {
+ *     quic_transport_parameters(0xffa5), (65535)
+ *  } ExtensionType;
+ *
+ */
+static void ssl_write_quic_transport_parameters_ext(mbedtls_ssl_context *ssl,
+	unsigned char *buf,
+  unsigned char* end,
+	size_t *olen)
+{
+    unsigned char *p = buf;
+    const uint8_t *tp = ssl->quic_transport_params;
+    size_t tp_len = ssl->quic_transport_params_len;
+    // Extension wire size - ext_header[2] + ext_length[2] + tp_len
+    size_t  ext_len = sizeof(uint16_t) + sizeof(uint16_t) + tp_len;
+
+    *olen = 0;
+
+    MBEDTLS_SSL_DEBUG_MSG(3, ("client hello, adding quic_transport_parameters extension: %p %u",
+                tp, tp_len));
+
+    if ((end - p) < (ptrdiff_t)ext_len)
+    {
+        MBEDTLS_SSL_DEBUG_MSG(1, ("buffer too small"));
+        return;
+    }
+
+    *p++ = (unsigned char)((MBEDTLS_TLS_EXT_QUIC_TRANSPORT_PARAMS >> 8) & 0xFF);
+    *p++ = (unsigned char)((MBEDTLS_TLS_EXT_QUIC_TRANSPORT_PARAMS) & 0xFF);
+
+    *p++ = (unsigned char)((tp_len >> 8) & 0xFF);
+    *p++ = (unsigned char)(tp_len & 0xFF);
+
+    memcpy(p, tp, tp_len);
+    *olen = ext_len;
+}
+#endif /* MBEDTLS_SSL_PROTO_QUIC */
 
 #if defined(MBEDTLS_SSL_SERVER_NAME_INDICATION)
 static void ssl_write_hostname_ext( mbedtls_ssl_context *ssl,
@@ -1433,19 +1514,24 @@ static int ssl_client_hello_prepare( mbedtls_ssl_context* ssl )
     }
 
 #if defined(MBEDTLS_SSL_TLS13_COMPATIBILITY_MODE)
-    /* Determine whether session id has not been created already */
-    if( ssl->session_negotiate->id_len == 0 )
+#if defined(MBEDTLS_SSL_PROTO_QUIC)
+    if (ssl->conf->transport != MBEDTLS_SSL_TRANSPORT_QUIC)
+#endif /* MBEDTLS_SSL_PROTO_QUIC */
     {
+      /* Determine whether session id has not been created already */
+      if( ssl->session_negotiate->id_len == 0 )
+      {
 
         /* Creating a session id with 32 byte length */
         if( ( ret = ssl->conf->f_rng( ssl->conf->p_rng, ssl->session_negotiate->id, 32 ) ) != 0 )
         {
-            MBEDTLS_SSL_DEBUG_RET( 1, "creating session id failed", ret );
-            return( ret );
+          MBEDTLS_SSL_DEBUG_RET( 1, "creating session id failed", ret );
+          return( ret );
         }
-    }
+      }
 
-    ssl->session_negotiate->id_len = 32;
+      ssl->session_negotiate->id_len = 32;
+    }
 #endif /* MBEDTLS_SSL_TLS13_COMPATIBILITY_MODE */
 
     return( 0 );
@@ -1543,21 +1629,39 @@ static int ssl_client_hello_write_partial( mbedtls_ssl_context* ssl,
      * ( i.e., a zero-valued single byte length field ).
      */
 #if defined(MBEDTLS_SSL_TLS13_COMPATIBILITY_MODE)
-    if( buflen < ( ssl->session_negotiate->id_len + 1 ) )
-    {
-        MBEDTLS_SSL_DEBUG_MSG( 1, ( "buffer too small to hold ClientHello" ) );
-        return( MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL );
-    }
+#if defined(MBEDTLS_SSL_PROTO_QUIC)
+        if (ssl->conf->transport != MBEDTLS_SSL_TRANSPORT_QUIC)
+#endif /* MBEDTLS_SSL_PROTO_QUIC */
+        {
+            if( buflen < ( ssl->session_negotiate->id_len + 1 ) )
+            {
+                MBEDTLS_SSL_DEBUG_MSG( 1, ( "buffer too small to hold ClientHello" ) );
+                return( MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL );
+            }
 
-    *buf++ = (unsigned char)ssl->session_negotiate->id_len; /* write session id length */
-    memcpy( buf, ssl->session_negotiate->id, ssl->session_negotiate->id_len ); /* write session id */
+            *buf++ = (unsigned char)ssl->session_negotiate->id_len; /* write session id length */
+            memcpy( buf, ssl->session_negotiate->id, ssl->session_negotiate->id_len ); /* write session id */
 
-    buf += ssl->session_negotiate->id_len;
-    buflen -= ssl->session_negotiate->id_len;
+            buf += ssl->session_negotiate->id_len;
+            buflen -= ssl->session_negotiate->id_len;
 
 
-    MBEDTLS_SSL_DEBUG_MSG( 3, ( "session id len.: %" MBEDTLS_PRINTF_SIZET , ssl->session_negotiate->id_len ) );
-    MBEDTLS_SSL_DEBUG_BUF( 3, "session id", ssl->session_negotiate->id, ssl->session_negotiate->id_len );
+            MBEDTLS_SSL_DEBUG_MSG( 3, ( "session id len.: %" MBEDTLS_PRINTF_SIZET , ssl->session_negotiate->id_len ) );
+            MBEDTLS_SSL_DEBUG_BUF( 3, "session id", ssl->session_negotiate->id, ssl->session_negotiate->id_len );
+        }
+#if defined(MBEDTLS_SSL_PROTO_QUIC)
+        else
+        {
+            if( buflen < 1 )
+            {
+                MBEDTLS_SSL_DEBUG_MSG( 1, ( "buffer too small to hold ClientHello" ) );
+                return( MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL );
+            }
+
+            *buf++ = 0; /* session id length set to zero */
+            buflen -= 1;
+        }
+#endif /* MBEDTLS_SSL_PROTO_QUIC */
 #else
     if( buflen < 1 )
     {
@@ -1699,6 +1803,15 @@ static int ssl_client_hello_write_partial( mbedtls_ssl_context* ssl,
     total_ext_len += cur_ext_len;
     buf += cur_ext_len;
 #endif /* MBEDTLS_SSL_SERVER_NAME_INDICATION */
+
+#if defined(MBEDTLS_SSL_PROTO_QUIC)
+    if (ssl->conf->transport == MBEDTLS_SSL_TRANSPORT_QUIC)
+    {
+        ssl_write_quic_transport_parameters_ext( ssl, buf, end, &cur_ext_len );
+        total_ext_len += cur_ext_len;
+        buf += cur_ext_len;
+    }
+#endif
 
 #if defined(MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED)
     /* For PSK-based ciphersuites we need the pre-shared-key extension
@@ -1986,6 +2099,40 @@ int mbedtls_ssl_set_early_data( mbedtls_ssl_context *ssl,
     return( 0 );
 }
 #endif /* MBEDTLS_ZERO_RTT */
+
+#if defined(MBEDTLS_SSL_PROTO_QUIC)
+
+/* QUIC transport parameters extensions. [draft-ietf-quic-tls 8.2]
+ *
+ *  QUIC transport parameters are carried in a TLS extension. Different
+ *  versions of QUIC might define a different method for negotiating
+ *  transport configuration.
+ *
+ *  Including transport parameters in the TLS handshake provides
+ *  integrity protection for these values.
+ *
+ *  QUIC transport parameters MUST be included in the ServerHello handshake message.
+ *
+ *  enum {
+ *     quic_transport_parameters(0xffa5), (65535)
+ *  } ExtensionType;
+ *
+ */
+static int ssl_parse_quic_transport_parameters_ext(mbedtls_ssl_context *ssl,
+	const unsigned char *buf, size_t len)
+{
+    // We are not expecting peer transport params to be communicated
+    // more than once.
+    if (ssl->peer_quic_transport_params != NULL)
+    {
+        return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
+    }
+
+    return ssl_set_quic_transport_params(ssl, buf, len,
+            &ssl->peer_quic_transport_params, &ssl->peer_quic_transport_params_len);
+}
+
+#endif /* MBEDTLS_SSL_PROTO_QUIC */
 
 #if ( defined(MBEDTLS_ECDH_C) || defined(MBEDTLS_ECDSA_C) )
 
@@ -2585,6 +2732,18 @@ static int ssl_encrypted_extensions_parse( mbedtls_ssl_context* ssl,
                 break;
 #endif /* MBEDTLS_ZERO_RTT */
 
+#if defined(MBEDTLS_SSL_PROTO_QUIC)
+            case MBEDTLS_TLS_EXT_QUIC_TRANSPORT_PARAMS:
+                MBEDTLS_SSL_DEBUG_MSG(3, ("found quic_transport_parameters extension"));
+
+                if ((ret =  ssl_parse_quic_transport_parameters_ext(ssl, ext + 4, (size_t)ext_size)) != 0)
+                {
+                    MBEDTLS_SSL_DEBUG_RET(1, "ssl_parse_quic_transport_parameters_ext", ret);
+                    return(ret);
+                }
+                break;
+#endif /* MBEDTLS_SSL_PROTO_QUIC */
+
             default:
                 MBEDTLS_SSL_DEBUG_MSG( 3, ( "unknown extension found: %d ( ignoring )", ext_id ) );
                 break;
@@ -2909,8 +3068,8 @@ static int ssl_server_hello_session_id_check( mbedtls_ssl_context* ssl,
 }
 
 static int ssl_server_hello_parse( mbedtls_ssl_context* ssl,
-                                   const unsigned char* buf,
-                                   size_t buflen )
+        const unsigned char* buf,
+        size_t buflen )
 {
 
     int ret; /* return value */
@@ -2999,7 +3158,7 @@ static int ssl_server_hello_parse( mbedtls_ssl_context* ssl,
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "ciphersuite info for %04x not found", i ) );
         SSL_PEND_FATAL_ALERT( MBEDTLS_SSL_ALERT_MSG_INTERNAL_ERROR,
-                              MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
+                MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
         return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
     }
 
@@ -3212,6 +3371,13 @@ static int ssl_server_hello_postprocess( mbedtls_ssl_context* ssl )
         mbedtls_calloc( 1, sizeof( mbedtls_ssl_transform ) );
     if( transform_handshake == NULL )
         return( MBEDTLS_ERR_SSL_ALLOC_FAILED );
+
+#if defined(MBEDTLS_SSL_PROTO_QUIC)
+    if (ssl->conf->transport == MBEDTLS_SSL_TRANSPORT_QUIC)
+    {
+        mbedtls_set_quic_traffic_key(ssl, MBEDTLS_SSL_CRYPTO_LEVEL_HANDSHAKE);
+    }
+#endif /* MBEDTLS_SSL_PROTO_QUIC */
 
     ret = mbedtls_ssl_tls13_populate_transform(
                               transform_handshake,
@@ -3914,6 +4080,25 @@ cleanup:
 }
 #endif /* MBEDTLS_SSL_NEW_SESSION_TICKET */
 
+#if defined(MBEDTLS_SSL_PROTO_QUIC)
+static int ssl_handshake_state_requires_input(int state)
+{
+    switch (state)
+    {
+        case MBEDTLS_SSL_SERVER_HELLO:
+        case MBEDTLS_SSL_SECOND_SERVER_HELLO:
+        case MBEDTLS_SSL_ENCRYPTED_EXTENSIONS:
+        case MBEDTLS_SSL_CERTIFICATE_REQUEST:
+        case MBEDTLS_SSL_SERVER_CERTIFICATE:
+        case MBEDTLS_SSL_CERTIFICATE_VERIFY:
+        case MBEDTLS_SSL_SERVER_FINISHED:
+            return 1;
+        default:
+            return 0;
+    }
+}
+#endif /* MBEDTLS_SSL_PROTO_QUIC */
+
 /*
  * TLS and DTLS 1.3 State Maschine -- client side
  */
@@ -3930,6 +4115,27 @@ int mbedtls_ssl_handshake_client_step_tls1_3( mbedtls_ssl_context *ssl )
 
     if( ( ret = mbedtls_ssl_flush_output( ssl ) ) != 0 )
         return( ret );
+#if defined(MBEDTLS_SSL_PROTO_QUIC)
+    if ((ssl->conf->transport == MBEDTLS_SSL_TRANSPORT_QUIC)
+            && ssl_handshake_state_requires_input(ssl->state))
+    {
+        uint8_t msg_type = 0; // Sentinel value for debugging.
+        size_t msg_size = 0;
+        size_t available_len = 0;
+        if ((ret = mbedtls_quic_input_peek(ssl, ssl->quic_hs_crypto_level,
+                        &msg_type, &msg_size, &available_len)) != 0)
+        {
+            // We are not ready to consume a message.
+            // The `ret` is either "MBEDTLS_ERR_SSL_WANT_READ", in which
+            // case more data is required, or some other error code
+            // that should be surfaced to the callsite.
+            MBEDTLS_SSL_DEBUG_MSG(1,
+                    ("mbedtls_quic_input_peek: ret: %d type: %hhu size: %u len: %u",
+                     ret, msg_type, msg_size, available_len));
+            return ret;
+        }
+    }
+#endif /* MBEDTLS_SSL_PROTO_QUIC */
 
     switch( ssl->state )
     {
@@ -4066,6 +4272,67 @@ int mbedtls_ssl_handshake_client_step_tls1_3( mbedtls_ssl_context *ssl )
 
     return( ret );
 }
+
+#if defined(MBEDTLS_SSL_PROTO_QUIC)
+
+int mbedtls_ssl_quic_post_handshake(mbedtls_ssl_context *ssl)
+{
+    MBEDTLS_ASSERT(
+            ssl->quic_hs_crypto_level == MBEDTLS_SSL_CRYPTO_LEVEL_APPLICATION);
+
+    uint8_t msg_type;
+    size_t msg_size = 0;
+    size_t available_len = 0;
+    int ret = 0;
+
+    if ((ret = mbedtls_quic_input_peek(ssl, ssl->quic_hs_crypto_level,
+                    &msg_type, &msg_size, &available_len)) != 0)
+    {
+        MBEDTLS_SSL_DEBUG_RET(1, "mbedtls_quic_input_peek", ret);
+        return(ret);
+    }
+
+    if (available_len != msg_size)
+    {
+        return MBEDTLS_ERR_SSL_WANT_READ;
+    }
+
+    if ((ret = mbedtls_ssl_read_record(ssl, 0)) != 0 )
+    {
+        MBEDTLS_SSL_DEBUG_RET(1, "mbedtls_ssl_read_record", ret);
+        return(ret);
+    }
+
+    if (ssl->in_msg[0] == MBEDTLS_SSL_HS_NEW_SESSION_TICKET)
+    {
+        MBEDTLS_SSL_DEBUG_MSG(3, ("NewSessionTicket received"));
+
+        if ((ret = mbedtls_ssl_new_session_ticket_process(ssl)) != 0)
+        {
+            MBEDTLS_SSL_DEBUG_RET(1, "mbedtls_ssl_parse_new_session_ticket", ret);
+            return(ret);
+        }
+        mbedtls_ssl_ticket* ticket = mbedtls_calloc(1, sizeof(mbedtls_ssl_ticket));
+        if (ticket == NULL)
+        {
+            return (MBEDTLS_ERR_SSL_ALLOC_FAILED);
+        }
+        if ((mbedtls_ssl_get_client_ticket(ssl, ticket) != 0))
+        {
+            mbedtls_free(ticket->ticket);
+            mbedtls_free(ticket);
+            return (MBEDTLS_ERR_SSL_INTERNAL_ERROR);
+        }
+        // the ticket will be transfered to and be released by the app
+        ssl->quic_method->process_new_session(
+                ssl->p_quic_method,
+                ticket);
+        return (ret);
+    }
+
+    return 0;
+}
+#endif /* MBEDTLS_SSL_PROTO_QUIC */
 #endif /* MBEDTLS_SSL_CLI_C */
 
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -2186,6 +2186,11 @@ int mbedtls_ssl_finished_out_process( mbedtls_ssl_context* ssl )
     MBEDTLS_SSL_PROC_CHK( mbedtls_ssl_finish_handshake_msg( ssl,
                                               buf_len, msg_len ) );
     MBEDTLS_SSL_PROC_CHK( mbedtls_ssl_flush_output( ssl ) );
+#if defined(MBEDTLS_SSL_PROTO_QUIC)
+    if (ssl->conf->transport == MBEDTLS_SSL_TRANSPORT_QUIC)
+      mbedtls_set_quic_traffic_key(ssl, MBEDTLS_SSL_CRYPTO_LEVEL_APPLICATION);
+#endif /* MBEDTLS_SSL_PROTO_QUIC */
+
 
 cleanup:
 
@@ -2229,10 +2234,6 @@ static int ssl_finished_out_postprocess( mbedtls_ssl_context* ssl )
             return ( ret );
         }
 
-#if defined(MBEDTLS_SSL_PROTO_QUIC)
-        if (ssl->conf->transport == MBEDTLS_SSL_TRANSPORT_QUIC)
-            mbedtls_set_quic_traffic_key(ssl, MBEDTLS_SSL_CRYPTO_LEVEL_APPLICATION);
-#endif /* MBEDTLS_SSL_PROTO_QUIC */
         mbedtls_ssl_handshake_set_state( ssl, MBEDTLS_SSL_FLUSH_BUFFERS );
     }
     else
@@ -2681,6 +2682,51 @@ int mbedtls_ssl_write_early_data_ext( mbedtls_ssl_context *ssl,
 }
 #endif /* MBEDTLS_ZERO_RTT */
 
+#if defined(MBEDTLS_SSL_PROTO_QUIC)
+
+/* declared in ssl_internal.h */
+int ssl_set_quic_transport_params(mbedtls_ssl_context *ssl,
+        const uint8_t *params, size_t len,
+        uint8_t **oparams, size_t *olen) 
+{
+    if (len > MBEDTLS_QUIC_TRANSPORT_PARAMS_MAX_LEN)
+    {
+        MBEDTLS_SSL_DEBUG_MSG(1, ("ssl_set_quic_transport_params: bad transport_params length"));
+        return MBEDTLS_ERR_SSL_INTERNAL_ERROR;
+    }
+
+    if ((*oparams = mbedtls_calloc(1, len)) == NULL)
+    {
+        return MBEDTLS_ERR_SSL_ALLOC_FAILED;
+    }
+
+    memcpy(*oparams, params, len);
+    *olen = len;
+
+    return 0;
+}
+
+int mbedtls_ssl_set_quic_transport_params(mbedtls_ssl_context *ssl,
+        const uint8_t *params, size_t len)
+{
+    // Setting transport params more than once is not expected, but
+    // permitted.
+    mbedtls_free(ssl->quic_transport_params);
+    ssl->quic_transport_params = NULL;
+
+    return ssl_set_quic_transport_params(ssl, params, len,
+            &ssl->quic_transport_params, &ssl->quic_transport_params_len);
+}
+
+void mbedtls_ssl_get_peer_quic_transport_params(mbedtls_ssl_context *ssl,
+    const uint8_t **oparams, size_t *olen)
+{
+    *oparams = (const uint8_t*)(ssl->peer_quic_transport_params);
+    *olen = ssl->peer_quic_transport_params_len;
+}
+
+#endif /* MBEDTLS_SSL_PROTO_QUIC */
+
 
 #if defined(MBEDTLS_ECDH_C)
 #if defined(MBEDTLS_ECDH_LEGACY_CONTEXT)
@@ -3028,52 +3074,6 @@ int mbedtls_ecp_tls_13_write_group( const mbedtls_ecp_group *grp, size_t *olen,
 }
 
 #endif /* MBEDTLS_ECP_C */
-
-#if defined(MBEDTLS_SSL_PROTO_QUIC)
-
-/* declared in ssl_internal.h */
-int ssl_set_quic_transport_params(mbedtls_ssl_context *ssl,
-        const uint8_t *params, size_t len,
-        uint8_t **oparams, size_t *olen) 
-{
-    if (len > MBEDTLS_QUIC_TRANSPORT_PARAMS_MAX_LEN)
-    {
-        MBEDTLS_SSL_DEBUG_MSG(1, ("ssl_set_quic_transport_params: bad transport_params length"));
-        return MBEDTLS_ERR_SSL_INTERNAL_ERROR;
-    }
-
-    if ((*oparams = mbedtls_calloc(1, len)) == NULL)
-    {
-        return MBEDTLS_ERR_SSL_ALLOC_FAILED;
-    }
-
-    memcpy(*oparams, params, len);
-    *olen = len;
-
-    return 0;
-}
-
-int mbedtls_ssl_set_quic_transport_params(mbedtls_ssl_context *ssl,
-        const uint8_t *params, size_t len)
-{
-    // Setting transport params more than once is not expected, but
-    // permitted.
-    mbedtls_free(ssl->quic_transport_params);
-    ssl->quic_transport_params = NULL;
-
-    return ssl_set_quic_transport_params(ssl, params, len,
-            &ssl->quic_transport_params, &ssl->quic_transport_params_len);
-}
-
-void mbedtls_ssl_get_peer_quic_transport_params(mbedtls_ssl_context *ssl,
-    const uint8_t **oparams, size_t *olen)
-{
-    *oparams = (const uint8_t*)(ssl->peer_quic_transport_params);
-    *olen = ssl->peer_quic_transport_params_len;
-}
-
-#endif /* MBEDTLS_SSL_PROTO_QUIC */
-
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 
 #endif /* MBEDTLS_SSL_TLS_C */

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -314,6 +314,11 @@ static int ssl_write_change_cipher_spec_coordinate( mbedtls_ssl_context* ssl )
 {
     int ret = SSL_WRITE_CCS_NEEDED;
 
+#if defined(MBEDTLS_SSL_PROTO_QUIC)
+    if (ssl->conf->transport == MBEDTLS_SSL_TRANSPORT_QUIC)
+        return( SSL_WRITE_CCS_SKIP );
+#endif /* MBEDTLS_SSL_PROTO_QUIC */
+
 #if defined(MBEDTLS_SSL_SRV_C)
     if( ssl->conf->endpoint == MBEDTLS_SSL_IS_SERVER )
     {
@@ -2001,6 +2006,10 @@ int mbedtls_ssl_tls13_populate_transform( mbedtls_ssl_transform *transform,
                                           mbedtls_ssl_key_set const *traffic_keys,
                                           mbedtls_ssl_context *ssl /* DEBUG ONLY */ )
 {
+#if defined(MBEDTLS_SSL_PROTO_QUIC)
+    if (ssl->conf->transport == MBEDTLS_SSL_TRANSPORT_QUIC)
+        return 0;
+#endif /* MBEDTLS_SSL_PROTO_QUIC */
     int ret;
     mbedtls_cipher_info_t const *cipher_info;
     const mbedtls_ssl_ciphersuite_t *ciphersuite_info;
@@ -2220,6 +2229,10 @@ static int ssl_finished_out_postprocess( mbedtls_ssl_context* ssl )
             return ( ret );
         }
 
+#if defined(MBEDTLS_SSL_PROTO_QUIC)
+        if (ssl->conf->transport == MBEDTLS_SSL_TRANSPORT_QUIC)
+            mbedtls_set_quic_traffic_key(ssl, MBEDTLS_SSL_CRYPTO_LEVEL_APPLICATION);
+#endif /* MBEDTLS_SSL_PROTO_QUIC */
         mbedtls_ssl_handshake_set_state( ssl, MBEDTLS_SSL_FLUSH_BUFFERS );
     }
     else
@@ -2492,6 +2505,49 @@ static int ssl_finished_in_postprocess( mbedtls_ssl_context* ssl )
 
     return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
 }
+
+#if defined(MBEDTLS_SSL_PROTO_QUIC)
+/**
+ * Install the secrets into the QUIC transport.
+ */
+int mbedtls_set_quic_traffic_key(mbedtls_ssl_context *ssl, mbedtls_ssl_crypto_level level)
+{
+    uint8_t *read_secret = NULL;
+    uint8_t *write_secret = NULL;
+
+    const mbedtls_ssl_ciphersuite_t *ciphersuite_info = ssl->handshake->ciphersuite_info;
+
+    size_t secret_len = mbedtls_hash_size_for_ciphersuite(ciphersuite_info);
+
+    switch (level)
+    {
+        case MBEDTLS_SSL_CRYPTO_LEVEL_HANDSHAKE:
+            ssl->quic_hs_crypto_level = level;
+            read_secret = ssl->handshake->hs_secrets.server_handshake_traffic_secret;
+            write_secret = ssl->handshake->hs_secrets.client_handshake_traffic_secret;
+            break;
+        case MBEDTLS_SSL_CRYPTO_LEVEL_EARLY_DATA:
+            read_secret = NULL;
+            write_secret = ssl->handshake->early_secrets.client_early_traffic_secret;
+            break;
+        case MBEDTLS_SSL_CRYPTO_LEVEL_APPLICATION:
+            ssl->quic_hs_crypto_level = level;
+            read_secret = ssl->session_negotiate->app_secrets.server_application_traffic_secret_N;
+            write_secret = ssl->session_negotiate->app_secrets.client_application_traffic_secret_N;
+            break;
+        default:
+            break;
+    }
+
+    MBEDTLS_SSL_DEBUG_MSG(2, ("setting QUIC secrets, level = %d", level));
+    return ssl->quic_method->set_encryption_secrets(
+            ssl->p_quic_method,
+            level,
+            read_secret,
+            write_secret,
+            secret_len);
+}
+#endif /* MBEDTLS_SSL_PROTO_QUIC */
 
 #if defined(MBEDTLS_ZERO_RTT)
 void mbedtls_ssl_conf_early_data( mbedtls_ssl_config* conf, int early_data,
@@ -2972,6 +3028,52 @@ int mbedtls_ecp_tls_13_write_group( const mbedtls_ecp_group *grp, size_t *olen,
 }
 
 #endif /* MBEDTLS_ECP_C */
+
+#if defined(MBEDTLS_SSL_PROTO_QUIC)
+
+/* declared in ssl_internal.h */
+int ssl_set_quic_transport_params(mbedtls_ssl_context *ssl,
+        const uint8_t *params, size_t len,
+        uint8_t **oparams, size_t *olen) 
+{
+    if (len > MBEDTLS_QUIC_TRANSPORT_PARAMS_MAX_LEN)
+    {
+        MBEDTLS_SSL_DEBUG_MSG(1, ("ssl_set_quic_transport_params: bad transport_params length"));
+        return MBEDTLS_ERR_SSL_INTERNAL_ERROR;
+    }
+
+    if ((*oparams = mbedtls_calloc(1, len)) == NULL)
+    {
+        return MBEDTLS_ERR_SSL_ALLOC_FAILED;
+    }
+
+    memcpy(*oparams, params, len);
+    *olen = len;
+
+    return 0;
+}
+
+int mbedtls_ssl_set_quic_transport_params(mbedtls_ssl_context *ssl,
+        const uint8_t *params, size_t len)
+{
+    // Setting transport params more than once is not expected, but
+    // permitted.
+    mbedtls_free(ssl->quic_transport_params);
+    ssl->quic_transport_params = NULL;
+
+    return ssl_set_quic_transport_params(ssl, params, len,
+            &ssl->quic_transport_params, &ssl->quic_transport_params_len);
+}
+
+void mbedtls_ssl_get_peer_quic_transport_params(mbedtls_ssl_context *ssl,
+    const uint8_t **oparams, size_t *olen)
+{
+    *oparams = (const uint8_t*)(ssl->peer_quic_transport_params);
+    *olen = ssl->peer_quic_transport_params_len;
+}
+
+#endif /* MBEDTLS_SSL_PROTO_QUIC */
+
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 
 #endif /* MBEDTLS_SSL_TLS_C */


### PR DESCRIPTION
* Add QUIC input queue
* Integrate QUIC with TLS1.3 modules.
* It can be used with ngtcp2 and its glue layer. Here are [steps](https://github.com/JunqiWang/ngtcp2/blob/mbedtls/README-mbedtls) to build mbedtls-quic client, and to talk to a QUIC server.