### PR TITLE
Re-applying the ticket code to the latest code version

### DIFF
--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -1453,7 +1453,7 @@
  *
  * TODO: Document
  */
-#define MBEDTLS_SSL_USE_MPS
+//#define MBEDTLS_SSL_USE_MPS
 
 /**
  * \def MBEDTLS_SSL_DTLS_CONNECTION_ID
@@ -3324,7 +3324,7 @@
  *
  * This module adds support for SHA-384 and SHA-512.
  */
-#define MBEDTLS_SHA512_C
+// #define MBEDTLS_SHA512_C
 
 /**
  * \def MBEDTLS_SSL_CACHE_C

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -1453,7 +1453,7 @@
  *
  * TODO: Document
  */
-//#define MBEDTLS_SSL_USE_MPS
+#define MBEDTLS_SSL_USE_MPS
 
 /**
  * \def MBEDTLS_SSL_DTLS_CONNECTION_ID

--- a/include/mbedtls/mps/common.h
+++ b/include/mbedtls/mps/common.h
@@ -715,4 +715,11 @@ typedef size_t mbedtls_mps_size_t;
 
 /* \} name SECTION: Parsing and writing macros */
 
+#if ( defined(__ARMCC_VERSION) || defined(_MSC_VER) ) && \
+    !defined(inline) && !defined(__cplusplus)
+#define UNUSED
+#else
+#define UNUSED __attribute__((unused))
+#endif
+
 #endif /* MBEDTLS_MPS_COMMON_H */

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -3033,7 +3033,7 @@ int mbedtls_ssl_session_load( mbedtls_ssl_session *session,
  *
  * \return         \c 0 if successful.
  * \return         #MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL if \p buf is too small.
- * \return.........#MBEDTLS_ERR_SSL_INTERNAL_ERROR if session is NULL.
+ * \return         #MBEDTLS_ERR_SSL_INTERNAL_ERROR if session is NULL.
  */
 int mbedtls_ssl_session_save( const mbedtls_ssl_session *session,
                               unsigned char *buf,

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -3326,7 +3326,7 @@ int mbedtls_ssl_conf_own_cert( mbedtls_ssl_config *conf,
  * \returns A negative error code on failure.
  */
 
-int mbedtls_ssl_conf_ke( mbedtls_ssl_config* conf,
+int mbedtls_ssl_conf_tls13_key_exchange( mbedtls_ssl_config* conf,
                          const int key_exchange_mode );
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 

--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -1488,7 +1488,7 @@ int mbedtls_ssl_write_early_data_ext(mbedtls_ssl_context* ssl, unsigned char* bu
 int mbedtls_ssl_parse_supported_groups_ext(mbedtls_ssl_context* ssl, const unsigned char* buf, size_t len);
 #endif /* MBEDTLS_ECDH_C ||  MBEDTLS_ECDSA_C */
 #if defined(MBEDTLS_SSL_NEW_SESSION_TICKET)
-int mbedtls_ssl_parse_new_session_ticket_server(mbedtls_ssl_context* ssl, unsigned char* buf, size_t len, mbedtls_ssl_ticket* ticket);
+int mbedtls_ssl_parse_new_session_ticket_server(mbedtls_ssl_context* ssl, unsigned char* buf, size_t len);
 #endif /* MBEDTLS_SSL_NEW_SESSION_TICKET */
 #if defined(MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED)
 int mbedtls_ssl_parse_client_psk_identity_ext(mbedtls_ssl_context* ssl, const unsigned char* buf, size_t len);

--- a/include/mbedtls/ssl_ticket.h
+++ b/include/mbedtls/ssl_ticket.h
@@ -87,15 +87,6 @@ mbedtls_ssl_ticket_context;
  */
 void mbedtls_ssl_ticket_init( mbedtls_ssl_ticket_context *ctx );
 
-#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && defined(MBEDTLS_SSL_NEW_SESSION_TICKET)
-void mbedtls_ssl_del_client_ticket(mbedtls_ssl_ticket* ticket);
-void mbedtls_ssl_init_client_ticket(mbedtls_ssl_ticket* ticket);
-void mbedtls_ssl_conf_client_ticket_disable(mbedtls_ssl_context* ssl);
-void mbedtls_ssl_conf_client_ticket_enable(mbedtls_ssl_context* ssl);
-int mbedtls_ssl_get_client_ticket(const mbedtls_ssl_context* ssl, mbedtls_ssl_ticket* ticket);
-int mbedtls_ssl_conf_client_ticket(const mbedtls_ssl_context* ssl, mbedtls_ssl_ticket* ticket);
-#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL && MBEDTLS_SSL_NEW_SESSION_TICKET */
-
 /**
  * \brief           Prepare context to be actually used
  *
@@ -118,17 +109,10 @@ int mbedtls_ssl_conf_client_ticket(const mbedtls_ssl_context* ssl, mbedtls_ssl_t
  * \return          0 if successful,
  *                  or a specific MBEDTLS_ERR_XXX error code
  */
-#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
-int mbedtls_ssl_ticket_setup( mbedtls_ssl_ticket_context *ctx,
-    int (*f_rng)(void *, unsigned char *, size_t), void *p_rng,
-    mbedtls_cipher_type_t cipher,
-    uint32_t lifetime, mbedtls_ssl_ticket_flags flags);
-#else 
 int mbedtls_ssl_ticket_setup(mbedtls_ssl_ticket_context* ctx,
     int (*f_rng)(void*, unsigned char*, size_t), void* p_rng,
     mbedtls_cipher_type_t cipher,
     uint32_t lifetime);
-#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 
 /**
  * \brief           Implementation of the ticket write callback

--- a/library/mps/layer1.c
+++ b/library/mps/layer1.c
@@ -1226,8 +1226,7 @@ int mps_l1_flush( mps_l1 *ctx )
 }
 
 /* TODO: Will we need this at some point? */
-__attribute__((unused))
-int mps_l1_read_dependency( mps_l1 *ctx )
+int UNUSED mps_l1_read_dependency( mps_l1 *ctx )
 {
     mbedtls_mps_transport_type const mode =
         mbedtls_mps_l1_get_mode( ctx );
@@ -1243,8 +1242,7 @@ int mps_l1_read_dependency( mps_l1 *ctx )
 }
 
 /* TODO: Will we need this at some point? */
-__attribute__((unused))
-int mps_l1_write_dependency( mps_l1 *ctx )
+int UNUSED mps_l1_write_dependency( mps_l1 *ctx )
 {
     mbedtls_mps_transport_type const mode =
         mbedtls_mps_l1_get_mode( ctx );

--- a/library/mps/layer2_internal.h
+++ b/library/mps/layer2_internal.h
@@ -116,8 +116,8 @@ MBEDTLS_MPS_STATIC int l2_in_fetch_protected_record_tls( mbedtls_mps_l2 *ctx,
 MBEDTLS_MPS_STATIC int l2_in_fetch_protected_record_dtls12( mbedtls_mps_l2 *ctx,
                                                             mps_rec *rec );
 
-/* TODO */__attribute__((unused))
-MBEDTLS_MPS_STATIC int l2_in_fetch_protected_record_dtls13( mbedtls_mps_l2 *ctx,
+/* TODO */
+MBEDTLS_MPS_STATIC int UNUSED l2_in_fetch_protected_record_dtls13( mbedtls_mps_l2 *ctx,
                                                             mps_rec *rec );
 MBEDTLS_MPS_STATIC int l2_handle_invalid_record( mbedtls_mps_l2 *ctx, int ret );
 #endif /* MBEDTLS_MPS_PROTO_DTLS */

--- a/library/mps/layer3.c
+++ b/library/mps/layer3.c
@@ -100,9 +100,8 @@ int mps_l3_free( mps_l3 *l3 )
  */
 
 /* TODO: Will we need this at some point? */
-__attribute__((unused))
 /* Check if a message is ready to be processed. */
-int mps_l3_read_check( mps_l3 *l3 )
+int UNUSED mps_l3_read_check( mps_l3 *l3 )
 {
     return( l3->io.in.state );
 }
@@ -1247,9 +1246,8 @@ int mps_l3_pause_handshake( mps_l3 *l3 )
 #endif /* MBEDTLS_MPS_PROTO_TLS */
 
 /* TODO: Will we need this at some point? */
-__attribute__((unused))
 /* Abort the writing of a handshake message. */
-int mps_l3_write_abort_handshake( mps_l3 *l3 )
+int UNUSED mps_l3_write_abort_handshake( mps_l3 *l3 )
 {
     int res;
     mbedtls_mps_size_t committed;

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -5641,6 +5641,7 @@ static int ssl_handle_hs_message_post_handshake( mbedtls_ssl_context *ssl )
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
 
+#if defined(MBEDTLS_SSL_NEW_SESSION_TICKET)
 static int ssl_check_new_session_ticket( mbedtls_ssl_context *ssl )
 {
     int ret;
@@ -5671,10 +5672,14 @@ static int ssl_check_new_session_ticket( mbedtls_ssl_context *ssl )
 
     return( MBEDTLS_ERR_SSL_RECEIVED_NEW_SESSION_TICKET );
 }
+#endif /* MBEDTLS_SSL_NEW_SESSION_TICKET */
 
 static int ssl_handle_hs_message_post_handshake_tls13( mbedtls_ssl_context *ssl )
 {
+#if defined(MBEDTLS_SSL_NEW_SESSION_TICKET)
     int ret;
+#endif /* MBEDTLS_SSL_NEW_SESSION_TICKET */
+
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "received post-handshake message" ) );
 
 #if defined(MBEDTLS_SSL_NEW_SESSION_TICKET)

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -5105,8 +5105,8 @@ int mbedtls_ssl_conf_psk( mbedtls_ssl_config *conf,
 
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
-/* mbedtls_ssl_conf_ke( ) allows to set the key exchange mode. */
-int mbedtls_ssl_conf_ke( mbedtls_ssl_config* conf,
+/* mbedtls_ssl_conf_tls13_key_exchange( ) allows to set the key exchange mode. */
+int mbedtls_ssl_conf_tls13_key_exchange( mbedtls_ssl_config* conf,
     const int key_exchange_mode )
 {
     conf->key_exchange_modes = key_exchange_mode;

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -6011,7 +6011,8 @@ static int ssl_session_save( const mbedtls_ssl_session *session,
     minor_ver = session->minor_ver;
 
 #if defined(MBEDTLS_SSL_CLI_C)
-    if( ( session->endpoint == MBEDTLS_SSL_IS_CLIENT ) && ( minor_ver == MBEDTLS_SSL_MINOR_VERSION_4 ) )
+    if( ( session->endpoint == MBEDTLS_SSL_IS_CLIENT ) && 
+        ( minor_ver == MBEDTLS_SSL_MINOR_VERSION_4 ) )
     {
         /* Check whether we got a ticket already */
         if( session->ticket == NULL )

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -4840,8 +4840,10 @@ int mbedtls_ssl_set_session( mbedtls_ssl_context *ssl, const mbedtls_ssl_session
 #if defined(MBEDTLS_SSL_NEW_SESSION_TICKET) && defined(MBEDTLS_SSL_CLI_C)
     if( ssl->conf->endpoint == MBEDTLS_SSL_IS_CLIENT )
     {
-        mbedtls_ssl_set_hs_psk( ssl, ssl->session_negotiate->key, ssl->session_negotiate->resumption_key_len );
-        MBEDTLS_SSL_DEBUG_BUF( 5, "ticket: key", ssl->session_negotiate->key, ssl->session_negotiate->resumption_key_len );
+        mbedtls_ssl_set_hs_psk( ssl, ssl->session_negotiate->key, 
+                                     ssl->session_negotiate->resumption_key_len );
+        MBEDTLS_SSL_DEBUG_BUF( 5, "ticket: key", ssl->session_negotiate->key, 
+                                     ssl->session_negotiate->resumption_key_len );
     }
 #endif /* MBEDTLS_SSL_NEW_SESSION_TICKET && MBEDTLS_SSL_CLI_C */
 

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -6003,7 +6003,8 @@ static int ssl_session_save( const mbedtls_ssl_session *session,
 #endif /* MBEDTLS_SSL_KEEP_PEER_CERTIFICATE */
 #endif /* MBEDTLS_X509_CRT_PARSE_C */
 
-    if( session == NULL ) return ( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
+    if( session == NULL ) 
+        return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
 
 #if defined(MBEDTLS_SSL_NEW_SESSION_TICKET)
     /* Ticket format depends on the TLS version negotiated. */

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -5972,7 +5972,7 @@ static unsigned char ssl_serialized_session_header[] = {
  * verify_result is put before peer_cert so that all mandatory fields come
  * together in one block.
  *
- * In TLS/DTLS 1.3 the ticket contains the following content:
+ * For TLS/DTLS 1.3 the ticket contains the following content:
  *
  *  - ticket creation time ( start )
  *  - ciphersuite ( ciphersuite )
@@ -5981,6 +5981,10 @@ static unsigned char ssl_serialized_session_header[] = {
  *  - key length ( key_len )
  *  - flags ( flags )
  *  - key ( key )
+ * 
+ * Note: This is not the NewSessionTicket message but rather
+ *       the encrypted content of the opaque ticket structure
+ *        within that message.
  */
 static int ssl_session_save( const mbedtls_ssl_session *session,
                              unsigned char omit_header,

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -225,7 +225,8 @@ int mbedtls_ssl_session_copy( mbedtls_ssl_session *dst,
 
 #endif /* MBEDTLS_X509_CRT_PARSE_C */
 
-#if ( defined(MBEDTLS_SSL_SESSION_TICKETS) || defined(MBEDTLS_SSL_NEW_SESSION_TICKET) ) && defined(MBEDTLS_SSL_CLI_C)
+#if ( defined(MBEDTLS_SSL_SESSION_TICKETS) || defined(MBEDTLS_SSL_NEW_SESSION_TICKET) ) && \ 
+    defined(MBEDTLS_SSL_CLI_C)
     if( src->ticket != NULL )
     {
         dst->ticket = mbedtls_calloc( 1, src->ticket_len );

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -225,7 +225,7 @@ int mbedtls_ssl_session_copy( mbedtls_ssl_session *dst,
 
 #endif /* MBEDTLS_X509_CRT_PARSE_C */
 
-#if defined(MBEDTLS_SSL_SESSION_TICKETS) && defined(MBEDTLS_SSL_CLI_C)
+#if ( defined(MBEDTLS_SSL_SESSION_TICKETS) || defined(MBEDTLS_SSL_NEW_SESSION_TICKET) ) && defined(MBEDTLS_SSL_CLI_C)
     if( src->ticket != NULL )
     {
         dst->ticket = mbedtls_calloc( 1, src->ticket_len );
@@ -234,7 +234,22 @@ int mbedtls_ssl_session_copy( mbedtls_ssl_session *dst,
 
         memcpy( dst->ticket, src->ticket, src->ticket_len );
     }
-#endif /* MBEDTLS_SSL_SESSION_TICKETS && MBEDTLS_SSL_CLI_C */
+#endif /* (MBEDTLS_SSL_SESSION_TICKETS || MBEDTLS_SSL_NEW_SESSION_TICKET) && MBEDTLS_SSL_CLI_C */
+
+#if defined(MBEDTLS_SSL_NEW_SESSION_TICKET)
+
+    /* Resumption Key */
+    memcpy( dst->key, src->key, src->resumption_key_len );
+
+    if( src->ticket_nonce != NULL )
+    {
+        dst->ticket_nonce = mbedtls_calloc( 1, src->ticket_nonce_len );
+        if( dst->ticket_nonce == NULL )
+            return( MBEDTLS_ERR_SSL_ALLOC_FAILED );
+
+        memcpy( dst->ticket_nonce, src->ticket_nonce, src->ticket_nonce_len );
+    }
+#endif /* MBEDTLS_SSL_NEW_SESSION_TICKET */
 
     return( 0 );
 }
@@ -794,7 +809,7 @@ static int ssl_hash_transcript_core( mbedtls_ssl_context *ssl,
     transcript[0] = MBEDTLS_SSL_HS_MESSAGE_HASH;
     transcript[1] = 0;
     transcript[2] = 0;
-    transcript[3] = hash_size;
+    transcript[3] = (unsigned char) hash_size;
 
     *olen = 4 + hash_size;
     return( 0 );
@@ -3131,10 +3146,10 @@ static void ssl_update_checksum_start( mbedtls_ssl_context *ssl,
 #if defined(MBEDTLS_SSL_DEBUG_HANDSHAKE_HASHES)
 #if defined(MBEDTLS_SHA256_C)
     mbedtls_sha256_context sha256_debug;
-#endif // MBEDTLS_SHA256_C
+#endif /* MBEDTLS_SHA256_C */
 #if defined(MBEDTLS_SHA512_C)
     mbedtls_sha512_context sha512_debug;
-#endif // MBEDTLS_SHA512_C
+#endif /* MBEDTLS_SHA512_C */
     unsigned char padbuf[MBEDTLS_MD_MAX_SIZE];
 #endif /* MBEDTLS_SSL_DEBUG_HANDSHAKE_HASHES */
 
@@ -3153,7 +3168,7 @@ static void ssl_update_checksum_start( mbedtls_ssl_context *ssl,
     mbedtls_sha256_free( &sha256_debug );
     MBEDTLS_SSL_DEBUG_BUF( 4, "SHA-256 handshake hash", (unsigned char*)
                            padbuf, 32 );
-#endif // MBEDTLS_SSL_DEBUG_HANDSHAKE_HASHES
+#endif /* MBEDTLS_SSL_DEBUG_HANDSHAKE_HASHES */
 #endif /* MBEDTLS_SHA256_C */
 
 #if defined(MBEDTLS_SHA512_C)
@@ -3172,7 +3187,7 @@ static void ssl_update_checksum_start( mbedtls_ssl_context *ssl,
     mbedtls_sha512_free( &sha512_debug );
     MBEDTLS_SSL_DEBUG_BUF( 4, "SHA-384 handshake hash", ( unsigned char* )
                            padbuf, 48 );
-#endif // MBEDTLS_SSL_DEBUG_HANDSHAKE_HASHES
+#endif /* MBEDTLS_SSL_DEBUG_HANDSHAKE_HASHES */
 #endif /* MBEDTLS_SHA512_C */
 }
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
@@ -4803,7 +4818,7 @@ void mbedtls_ssl_conf_session_cache( mbedtls_ssl_config *conf,
 }
 #endif /* MBEDTLS_SSL_SRV_C */
 
-#if defined(MBEDTLS_SSL_CLI_C)
+#if defined(MBEDTLS_SSL_CLI_C) && defined(MBEDTLS_SSL_NEW_SESSION_TICKET)
 int mbedtls_ssl_set_session( mbedtls_ssl_context *ssl, const mbedtls_ssl_session *session )
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
@@ -4822,9 +4837,17 @@ int mbedtls_ssl_set_session( mbedtls_ssl_context *ssl, const mbedtls_ssl_session
 
     ssl->handshake->resume = 1;
 
+#if defined(MBEDTLS_SSL_NEW_SESSION_TICKET) && defined(MBEDTLS_SSL_CLI_C)
+    if( ssl->conf->endpoint == MBEDTLS_SSL_IS_CLIENT )
+    {
+        mbedtls_ssl_set_hs_psk( ssl, ssl->session_negotiate->key, ssl->session_negotiate->resumption_key_len );
+        MBEDTLS_SSL_DEBUG_BUF( 5, "ticket: key", ssl->session_negotiate->key, ssl->session_negotiate->resumption_key_len );
+    }
+#endif /* MBEDTLS_SSL_NEW_SESSION_TICKET && MBEDTLS_SSL_CLI_C */
+
     return( 0 );
 }
-#endif /* MBEDTLS_SSL_CLI_C */
+#endif /* MBEDTLS_SSL_CLI_C && MBEDTLS_SSL_NEW_SESSION_TICKET */
 
 void mbedtls_ssl_conf_ciphersuites( mbedtls_ssl_config *conf,
                                    const int *ciphersuites )
@@ -5070,10 +5093,6 @@ int mbedtls_ssl_conf_psk( mbedtls_ssl_config *conf,
     conf->psk_len = psk_len;
     memcpy( conf->psk, psk, conf->psk_len );
 
-#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
-    conf->ticket_age_add = 0;
-#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
-
     /* Check and set PSK Identity */
     ret = ssl_conf_set_psk_identity( conf, psk_identity, psk_identity_len );
     if( ret != 0 )
@@ -5084,8 +5103,8 @@ int mbedtls_ssl_conf_psk( mbedtls_ssl_config *conf,
 
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
-/* mbedtls_ssl_conf_tls13_key_exchange() allows to set the key exchange mode. */
-int mbedtls_ssl_conf_tls13_key_exchange( mbedtls_ssl_config* conf,
+/* mbedtls_ssl_conf_ke( ) allows to set the key exchange mode. */
+int mbedtls_ssl_conf_ke( mbedtls_ssl_config* conf,
     const int key_exchange_mode )
 {
     conf->key_exchange_modes = key_exchange_mode;
@@ -5469,17 +5488,16 @@ void mbedtls_ssl_conf_renegotiation_period( mbedtls_ssl_config *conf,
 }
 #endif /* MBEDTLS_SSL_RENEGOTIATION */
 
-#if defined(MBEDTLS_SSL_SESSION_TICKETS) || ( defined(MBEDTLS_SSL_NEW_SESSION_TICKET) && defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) )
-#if defined(MBEDTLS_SSL_CLI_C)
+#if ( ( defined(MBEDTLS_SSL_SESSION_TICKETS) && defined(MBEDTLS_SSL_CLI_C) ) || \
+      ( defined(MBEDTLS_SSL_NEW_SESSION_TICKET) ) )
 void mbedtls_ssl_conf_session_tickets( mbedtls_ssl_config *conf, int use_tickets )
 {
     conf->session_tickets = use_tickets;
 }
-#endif
+#endif /* ( MBEDTLS_SSL_SESSION_TICKETS && MBEDTLS_SSL_CLI_C ) || MBEDTLS_SSL_NEW_SESSION_TICKET */
 
-#if defined(MBEDTLS_SSL_SRV_C)
-#if !defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
-
+#if ( ( defined(MBEDTLS_SSL_SESSION_TICKETS) || defined(MBEDTLS_SSL_NEW_SESSION_TICKET) ) && \
+      defined(MBEDTLS_SSL_SRV_C) )
 void mbedtls_ssl_conf_session_tickets_cb( mbedtls_ssl_config* conf,
     mbedtls_ssl_ticket_write_t* f_ticket_write,
     mbedtls_ssl_ticket_parse_t* f_ticket_parse,
@@ -5487,23 +5505,9 @@ void mbedtls_ssl_conf_session_tickets_cb( mbedtls_ssl_config* conf,
 {
     conf->f_ticket_write = f_ticket_write;
     conf->f_ticket_parse = f_ticket_parse;
-    conf->p_ticket       = p_ticket;
-}
-#else
-void mbedtls_ssl_conf_session_tickets_cb( mbedtls_ssl_config* conf,
-    mbedtls_ssl_ticket_write_t* f_ticket_write,
-    mbedtls_ssl_ticket_parse_t* f_ticket_parse,
-    void* p_ticket, int use_tickets )
-{
-    conf->f_ticket_write = f_ticket_write;
-    conf->f_ticket_parse = f_ticket_parse;
     conf->p_ticket = p_ticket;
-    conf->session_tickets = use_tickets;
-
 }
-#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
-#endif /* MBEDTLS_SSL_SRV_C */
-#endif /* MBEDTLS_SSL_SESSION_TICKETS || ( MBEDTLS_SSL_NEW_SESSION_TICKET && MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL ) */
+#endif /* ( MBEDTLS_SSL_SESSION_TICKETS || MBEDTLS_SSL_NEW_SESSION_TICKET ) && MBEDTLS_SSL_SRV_C */
 
 #if defined(MBEDTLS_SSL_EXPORT_KEYS)
 #if defined(MBEDTLS_SSL_PROTO_TLS1) || defined(MBEDTLS_SSL_PROTO_TLS1_1) || \
@@ -5837,6 +5841,7 @@ int mbedtls_ssl_get_session( const mbedtls_ssl_context *ssl,
 }
 #endif /* MBEDTLS_SSL_CLI_C */
 
+#if defined(MBEDTLS_SSL_SESSION_TICKETS) || defined(MBEDTLS_SSL_NEW_SESSION_TICKET)
 const mbedtls_ssl_session *mbedtls_ssl_get_session_pointer( const mbedtls_ssl_context *ssl )
 {
     if( ssl == NULL )
@@ -5844,6 +5849,7 @@ const mbedtls_ssl_session *mbedtls_ssl_get_session_pointer( const mbedtls_ssl_co
 
     return( ssl->session );
 }
+#endif /* MBEDTLS_SSL_SESSION_TICKETS || defined(MBEDTLS_SSL_NEW_SESSION_TICKET */
 
 /*
  * Define ticket header determining Mbed TLS version
@@ -5915,6 +5921,7 @@ const mbedtls_ssl_session *mbedtls_ssl_get_session_pointer( const mbedtls_ssl_co
         ( SSL_SERIALIZED_SESSION_CONFIG_ETM           << SSL_SERIALIZED_SESSION_CONFIG_ETM_BIT           ) | \
         ( SSL_SERIALIZED_SESSION_CONFIG_TICKET        << SSL_SERIALIZED_SESSION_CONFIG_TICKET_BIT        ) ) )
 
+#if defined(MBEDTLS_SSL_SESSION_TICKETS) || defined(MBEDTLS_SSL_NEW_SESSION_TICKET)
 static unsigned char ssl_serialized_session_header[] = {
     MBEDTLS_VERSION_MAJOR,
     MBEDTLS_VERSION_MINOR,
@@ -5922,7 +5929,9 @@ static unsigned char ssl_serialized_session_header[] = {
     ( SSL_SERIALIZED_SESSION_CONFIG_BITFLAG >> 8 ) & 0xFF,
     ( SSL_SERIALIZED_SESSION_CONFIG_BITFLAG >> 0 ) & 0xFF,
 };
+#endif /* MBEDTLS_SSL_SESSION_TICKETS || defined(MBEDTLS_SSL_NEW_SESSION_TICKET */
 
+#if defined(MBEDTLS_SSL_SESSION_TICKETS) || ( defined(MBEDTLS_SSL_NEW_SESSION_TICKET) && defined(MBEDTLS_SSL_SRV_C) )
 /*
  * Serialize a session in the following format:
  * (in the presentation language of TLS, RFC 8446 section 3)
@@ -5935,7 +5944,10 @@ static unsigned char ssl_serialized_session_header[] = {
  *  Note: When updating the format, remember to keep
  *        these version+format bytes.
  *
- *                               // In this version, `session_format` determines
+ *  Note: The format below is used by TLS/DTLS versions prior to 1.3.
+          The ticket format used in TLS/DTLS 1.3 is shown further below.
+ * 
+  *                               // In this version, `session_format` determines
  *                               // the setting of those compile-time
  *                               // configuration options which influence
  *                               // the structure of mbedtls_ssl_session.
@@ -5956,6 +5968,17 @@ static unsigned char ssl_serialized_session_header[] = {
  * The order is the same as in the definition of the structure, except
  * verify_result is put before peer_cert so that all mandatory fields come
  * together in one block.
+ *
+ * In TLS/DTLS 1.3 the ticket contains the following content:
+ *
+ *  - ticket creation time ( start )
+ *  - ciphersuite ( ciphersuite )
+ *  - ticket lifetime ( ticket_lifetime )
+ *  - ticket-age-add parameter ( ticket_age_add )
+ *  - key length ( key_len )
+ *  - flags ( flags )
+ *  - key ( key )
+ *  - certificate of the peer ( peer_cert )
  */
 static int ssl_session_save( const mbedtls_ssl_session *session,
                              unsigned char omit_header,
@@ -5965,6 +5988,9 @@ static int ssl_session_save( const mbedtls_ssl_session *session,
 {
     unsigned char *p = buf;
     size_t used = 0;
+#if defined(MBEDTLS_SSL_NEW_SESSION_TICKET)
+    int minor_ver = 0;
+#endif /* MBEDTLS_SSL_NEW_SESSION_TICKET */
 #if defined(MBEDTLS_HAVE_TIME)
     uint64_t start;
 #endif
@@ -5974,6 +6000,24 @@ static int ssl_session_save( const mbedtls_ssl_session *session,
 #endif /* MBEDTLS_SSL_KEEP_PEER_CERTIFICATE */
 #endif /* MBEDTLS_X509_CRT_PARSE_C */
 
+    if( session == NULL ) return ( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
+
+#if defined(MBEDTLS_SSL_NEW_SESSION_TICKET)
+    /* Ticket format depends on the TLS version negotiated. */
+    minor_ver = session->minor_ver;
+
+#if defined(MBEDTLS_SSL_CLI_C)
+    if( ( session->endpoint == MBEDTLS_SSL_IS_CLIENT ) && ( minor_ver == MBEDTLS_SSL_MINOR_VERSION_4 ) )
+    {
+        /* Check whether we got a ticket already */
+        if( session->ticket == NULL )
+        {
+            *olen = used;
+            return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
+        }
+    }
+#endif /* MBEDTLS_SSL_CLI_C */
+#endif /* MBEDTLS_SSL_NEW_SESSION_TICKET */
 
     if( !omit_header )
     {
@@ -5991,56 +6035,165 @@ static int ssl_session_save( const mbedtls_ssl_session *session,
         }
     }
 
-    /*
-     * Time
-     */
-#if defined(MBEDTLS_HAVE_TIME)
-    used += 8;
-
-    if( used <= buf_len )
+#if defined(MBEDTLS_SSL_NEW_SESSION_TICKET) && defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+    if( minor_ver == MBEDTLS_SSL_MINOR_VERSION_4 )
     {
-        start = (uint64_t) session->start;
+        /*
+         * Time
+         */
+#if defined(MBEDTLS_HAVE_TIME)
+        used += 8;
 
-        *p++ = (unsigned char)( ( start >> 56 ) & 0xFF );
-        *p++ = (unsigned char)( ( start >> 48 ) & 0xFF );
-        *p++ = (unsigned char)( ( start >> 40 ) & 0xFF );
-        *p++ = (unsigned char)( ( start >> 32 ) & 0xFF );
-        *p++ = (unsigned char)( ( start >> 24 ) & 0xFF );
-        *p++ = (unsigned char)( ( start >> 16 ) & 0xFF );
-        *p++ = (unsigned char)( ( start >>  8 ) & 0xFF );
-        *p++ = (unsigned char)( ( start       ) & 0xFF );
-    }
+        if( used <= buf_len )
+        {
+            start = (uint64_t) session->start;
+
+            *p++ = (unsigned char)( ( start >> 56 ) & 0xFF );
+            *p++ = (unsigned char)( ( start >> 48 ) & 0xFF );
+            *p++ = (unsigned char)( ( start >> 40 ) & 0xFF );
+            *p++ = (unsigned char)( ( start >> 32 ) & 0xFF );
+            *p++ = (unsigned char)( ( start >> 24 ) & 0xFF );
+            *p++ = (unsigned char)( ( start >> 16 ) & 0xFF );
+            *p++ = (unsigned char)( ( start >>  8 ) & 0xFF );
+            *p++ = (unsigned char)( ( start       ) & 0xFF );
+        }
 #endif /* MBEDTLS_HAVE_TIME */
 
-    /*
-     * Basic mandatory fields
-     */
-    used += 2   /* ciphersuite */
-          + 1   /* compression */
-          + 1   /* id_len */
-          + sizeof( session->id )
-          + sizeof( session->master )
-          + 4;  /* verify_result */
+        /*
+         * Basic mandatory fields
+         */
+        used += 2   /* ciphersuite */
+              + 4   /* ticket_lifetime */
+              + 4   /* ticket_age_add */
+              + 1   /* key_len */
+              + 1;  /* flags */
 
-    if( used <= buf_len )
-    {
-        *p++ = (unsigned char)( ( session->ciphersuite >> 8 ) & 0xFF );
-        *p++ = (unsigned char)( ( session->ciphersuite      ) & 0xFF );
+        if( used <= buf_len )
+        {
+            *p++ = (unsigned char)( ( session->ciphersuite >> 8 ) & 0xFF );
+            *p++ = (unsigned char)( ( session->ciphersuite      ) & 0xFF );
 
-        *p++ = (unsigned char)( session->compression & 0xFF );
+            *p++ = (unsigned char)( ( session->ticket_lifetime >> 24 ) & 0xFF );
+            *p++ = (unsigned char)( ( session->ticket_lifetime >> 16 ) & 0xFF );
+            *p++ = (unsigned char)( ( session->ticket_lifetime >>  8 ) & 0xFF );
+            *p++ = (unsigned char)( ( session->ticket_lifetime       ) & 0xFF );
 
-        *p++ = (unsigned char)( session->id_len & 0xFF );
-        memcpy( p, session->id, 32 );
-        p += 32;
 
-        memcpy( p, session->master, 48 );
-        p += 48;
+            *p++ = (unsigned char)( ( session->ticket_age_add >> 24 ) & 0xFF );
+            *p++ = (unsigned char)( ( session->ticket_age_add >> 16 ) & 0xFF );
+            *p++ = (unsigned char)( ( session->ticket_age_add >>  8 ) & 0xFF );
+            *p++ = (unsigned char)( ( session->ticket_age_add       ) & 0xFF );
 
-        *p++ = (unsigned char)( ( session->verify_result >> 24 ) & 0xFF );
-        *p++ = (unsigned char)( ( session->verify_result >> 16 ) & 0xFF );
-        *p++ = (unsigned char)( ( session->verify_result >>  8 ) & 0xFF );
-        *p++ = (unsigned char)( ( session->verify_result       ) & 0xFF );
+            *p++ = (unsigned char)( ( session->resumption_key_len      ) & 0xFF );
+
+            *p++ = (unsigned char)( ( session->ticket_flags      ) & 0xFF );
+        }
+
+        used += session->resumption_key_len;
+
+        if( used <= buf_len )
+        {
+            memcpy( p, session->key, session->resumption_key_len );
+            p += session->resumption_key_len;
+        }
+
+#if defined(MBEDTLS_SSL_CLI_C)
+        if( session->endpoint == MBEDTLS_SSL_IS_CLIENT )
+        {
+            /* Store ticket itself */
+            used += 2                     /* ticket length */
+                 + session->ticket_len;   /* ticket */
+
+            if( used <= buf_len )
+            {
+                *p++ = (unsigned char)( ( session->ticket_len >> 8 ) & 0xFF );
+                *p++ = (unsigned char)( ( session->ticket_len      ) & 0xFF );
+
+                memcpy( p, session->ticket, session->ticket_len );
+                p +=  session->ticket_len;
+            }
+
+#if defined(MBEDTLS_HAVE_TIME)
+            used += 8;
+
+            if( used <= buf_len )
+            {
+                start = (uint64_t) session->ticket_received;
+
+                *p++ = (unsigned char)( ( start >> 56 ) & 0xFF );
+                *p++ = (unsigned char)( ( start >> 48 ) & 0xFF );
+                *p++ = (unsigned char)( ( start >> 40 ) & 0xFF );
+                *p++ = (unsigned char)( ( start >> 32 ) & 0xFF );
+                *p++ = (unsigned char)( ( start >> 24 ) & 0xFF );
+                *p++ = (unsigned char)( ( start >> 16 ) & 0xFF );
+                *p++ = (unsigned char)( ( start >>  8 ) & 0xFF );
+                *p++ = (unsigned char)( ( start       ) & 0xFF );
+            }
+#endif /* MBEDTLS_HAVE_TIME */
+        }
+
+#endif /* MBEDTLS_SSL_CLI_C */
     }
+    else
+#endif /* MBEDTLS_SSL_NEW_SESSION_TICKET && MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
+#if defined(MBEDTLS_SSL_PROTO_TLS1_2_OR_EARLIER)
+    {
+        /*
+         * Time
+         */
+#if defined(MBEDTLS_HAVE_TIME)
+        used += 8;
+
+        if( used <= buf_len )
+        {
+            start = (uint64_t) session->start;
+
+            *p++ = (unsigned char)( ( start >> 56 ) & 0xFF );
+            *p++ = (unsigned char)( ( start >> 48 ) & 0xFF );
+            *p++ = (unsigned char)( ( start >> 40 ) & 0xFF );
+            *p++ = (unsigned char)( ( start >> 32 ) & 0xFF );
+            *p++ = (unsigned char)( ( start >> 24 ) & 0xFF );
+            *p++ = (unsigned char)( ( start >> 16 ) & 0xFF );
+            *p++ = (unsigned char)( ( start >>  8 ) & 0xFF );
+            *p++ = (unsigned char)( ( start       ) & 0xFF );
+        }
+#endif /* MBEDTLS_HAVE_TIME */
+
+        /*
+         * Basic mandatory fields
+         */
+        used += 2   /* ciphersuite */
+              + 1   /* compression */
+              + 1   /* id_len */
+              + sizeof( session->id )
+              + sizeof( session->master )
+              + 4;  /* verify_result */
+
+        if( used <= buf_len )
+        {
+            *p++ = (unsigned char)( ( session->ciphersuite >> 8 ) & 0xFF );
+            *p++ = (unsigned char)( ( session->ciphersuite      ) & 0xFF );
+
+            *p++ = (unsigned char)( session->compression & 0xFF );
+
+            *p++ = (unsigned char)( session->id_len & 0xFF );
+            memcpy( p, session->id, 32 );
+            p += 32;
+
+            memcpy( p, session->master, 48 );
+            p += 48;
+
+            *p++ = (unsigned char)( ( session->verify_result >> 24 ) & 0xFF );
+            *p++ = (unsigned char)( ( session->verify_result >> 16 ) & 0xFF );
+            *p++ = (unsigned char)( ( session->verify_result >>  8 ) & 0xFF );
+            *p++ = (unsigned char)( ( session->verify_result       ) & 0xFF );
+        }
+    }
+#else
+    {
+        return ( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
+    }
+#endif /* MBEDTLS_SSL_PROTO_TLS1_2_OR_EARLIER */
 
     /*
      * Peer's end-entity certificate
@@ -6094,51 +6247,54 @@ static int ssl_session_save( const mbedtls_ssl_session *session,
     /*
      * Session ticket if any, plus associated data
      */
-#if defined(MBEDTLS_SSL_SESSION_TICKETS) && defined(MBEDTLS_SSL_CLI_C)
-    used += 3 + session->ticket_len + 4; /* len + ticket + lifetime */
-
-    if( used <= buf_len )
+    if( minor_ver != MBEDTLS_SSL_MINOR_VERSION_4 )
     {
-        *p++ = (unsigned char)( ( session->ticket_len >> 16 ) & 0xFF );
-        *p++ = (unsigned char)( ( session->ticket_len >>  8 ) & 0xFF );
-        *p++ = (unsigned char)( ( session->ticket_len       ) & 0xFF );
+#if defined(MBEDTLS_SSL_SESSION_TICKETS) && defined(MBEDTLS_SSL_CLI_C)
+        used += 3 + session->ticket_len + 4; /* len + ticket + lifetime */
 
-        if( session->ticket != NULL )
+        if( used <= buf_len )
         {
-            memcpy( p, session->ticket, session->ticket_len );
-            p += session->ticket_len;
-        }
+            *p++ = (unsigned char)( ( session->ticket_len >> 16 ) & 0xFF );
+            *p++ = (unsigned char)( ( session->ticket_len >>  8 ) & 0xFF );
+            *p++ = (unsigned char)( ( session->ticket_len       ) & 0xFF );
 
-        *p++ = (unsigned char)( ( session->ticket_lifetime >> 24 ) & 0xFF );
-        *p++ = (unsigned char)( ( session->ticket_lifetime >> 16 ) & 0xFF );
-        *p++ = (unsigned char)( ( session->ticket_lifetime >>  8 ) & 0xFF );
-        *p++ = (unsigned char)( ( session->ticket_lifetime       ) & 0xFF );
-    }
+            if( session->ticket != NULL )
+            {
+                memcpy( p, session->ticket, session->ticket_len );
+                p += session->ticket_len;
+            }
+
+            *p++ = (unsigned char)( ( session->ticket_lifetime >> 24 ) & 0xFF );
+            *p++ = (unsigned char)( ( session->ticket_lifetime >> 16 ) & 0xFF );
+            *p++ = (unsigned char)( ( session->ticket_lifetime >>  8 ) & 0xFF );
+            *p++ = (unsigned char)( ( session->ticket_lifetime       ) & 0xFF );
+        }
 #endif /* MBEDTLS_SSL_SESSION_TICKETS && MBEDTLS_SSL_CLI_C */
 
-    /*
-     * Misc extension-related info
-     */
+        /*
+         * Misc extension-related info
+         */
 #if defined(MBEDTLS_SSL_MAX_FRAGMENT_LENGTH)
-    used += 1;
+        used += 1;
 
-    if( used <= buf_len )
-        *p++ = session->mfl_code;
+        if( used <= buf_len )
+            *p++ = session->mfl_code;
 #endif
 
 #if defined(MBEDTLS_SSL_TRUNCATED_HMAC)
-    used += 1;
+        used += 1;
 
-    if( used <= buf_len )
-        *p++ = (unsigned char)( ( session->trunc_hmac ) & 0xFF );
+        if( used <= buf_len )
+            *p++ = (unsigned char)( ( session->trunc_hmac ) & 0xFF );
 #endif
 
 #if defined(MBEDTLS_SSL_ENCRYPT_THEN_MAC)
-    used += 1;
+        used += 1;
 
-    if( used <= buf_len )
-        *p++ = (unsigned char)( ( session->encrypt_then_mac ) & 0xFF );
+        if( used <= buf_len )
+            *p++ = (unsigned char)( ( session->encrypt_then_mac ) & 0xFF );
 #endif
+    }
 
     /* Done */
     *olen = used;
@@ -6173,7 +6329,8 @@ static int ssl_session_load( mbedtls_ssl_session *session,
 {
     const unsigned char *p = buf;
     const unsigned char * const end = buf + len;
-#if defined(MBEDTLS_HAVE_TIME)
+    int minor_ver = 0;
+#if defined(MBEDTLS_HAVE_TIME) && defined(MBEDTLS_SSL_SESSION_TICKETS)
     uint64_t start;
 #endif
 #if defined(MBEDTLS_X509_CRT_PARSE_C)
@@ -6199,49 +6356,160 @@ static int ssl_session_load( mbedtls_ssl_session *session,
         p += sizeof( ssl_serialized_session_header );
     }
 
-    /*
-     * Time
-     */
+#if defined(MBEDTLS_SSL_NEW_SESSION_TICKET) && defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+
+    minor_ver = MBEDTLS_SSL_MINOR_VERSION_4; /* TBD: For testing only */
+
+    if( minor_ver == MBEDTLS_SSL_MINOR_VERSION_4 )
+    {
+
 #if defined(MBEDTLS_HAVE_TIME)
-    if( 8 > (size_t)( end - p ) )
-        return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
+        if( 8 > (size_t)( end - p ) )
+            return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
 
-    start = ( (uint64_t) p[0] << 56 ) |
-            ( (uint64_t) p[1] << 48 ) |
-            ( (uint64_t) p[2] << 40 ) |
-            ( (uint64_t) p[3] << 32 ) |
-            ( (uint64_t) p[4] << 24 ) |
-            ( (uint64_t) p[5] << 16 ) |
-            ( (uint64_t) p[6] <<  8 ) |
-            ( (uint64_t) p[7]       );
-    p += 8;
-
-    session->start = (time_t) start;
+        session->start =
+                ( (uint64_t) p[0] << 56 ) |
+                ( (uint64_t) p[1] << 48 ) |
+                ( (uint64_t) p[2] << 40 ) |
+                ( (uint64_t) p[3] << 32 ) |
+                ( (uint64_t) p[4] << 24 ) |
+                ( (uint64_t) p[5] << 16 ) |
+                ( (uint64_t) p[6] <<  8 ) |
+                ( (uint64_t) p[7]       );
+        p += 8;
 #endif /* MBEDTLS_HAVE_TIME */
 
-    /*
-     * Basic mandatory fields
-     */
-    if( 2 + 1 + 1 + 32 + 48 + 4 > (size_t)( end - p ) )
-        return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
+        /* 2 bytes for ciphersuite,
+         * 4 bytes for ticket_lifetime,
+         * 4 bytes ticket_age_add,
+         * 1 byte for key_len,
+         * 1 byte for flags.
+         */
 
-    session->ciphersuite = ( p[0] << 8 ) | p[1];
-    p += 2;
+        if( 2 + 4 + 4 + 1 + 1  > (size_t)( end - p ) )
+            return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
 
-    session->compression = *p++;
+        session->ciphersuite = ( p[0] << 8 ) | p[1];
+        p += 2;
 
-    session->id_len = *p++;
-    memcpy( session->id, p, 32 );
-    p += 32;
+        session->ticket_lifetime =
+                            ( (uint32_t) p[0] << 24 ) |
+                            ( (uint32_t) p[1] << 16 ) |
+                            ( (uint32_t) p[2] <<  8 ) |
+                            ( (uint32_t) p[3]       );
+        p += 4;
 
-    memcpy( session->master, p, 48 );
-    p += 48;
+        session->ticket_age_add =
+                            ( (uint32_t) p[0] << 24 ) |
+                            ( (uint32_t) p[1] << 16 ) |
+                            ( (uint32_t) p[2] <<  8 ) |
+                            ( (uint32_t) p[3]       );
+        p += 4;
 
-    session->verify_result = ( (uint32_t) p[0] << 24 ) |
-                             ( (uint32_t) p[1] << 16 ) |
-                             ( (uint32_t) p[2] <<  8 ) |
-                             ( (uint32_t) p[3]       );
-    p += 4;
+        session->resumption_key_len = *p++;
+
+        session->ticket_flags = *p++;
+
+        if( session->resumption_key_len > (size_t)( end - p ) )
+            return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
+        
+        memcpy( session->key, p, session->resumption_key_len );
+        p += session->resumption_key_len;
+
+#if defined(MBEDTLS_SSL_CLI_C)
+        if( session->endpoint == MBEDTLS_SSL_IS_CLIENT )
+        {
+            if( 2 > (size_t)( end - p ) )
+                return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
+
+            session->ticket_len = ( p[0] << 8 ) | p[1];
+            p += 2;
+
+            if( session->ticket_len > (size_t)( end - p ) )
+                return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
+
+            session->ticket = mbedtls_calloc( session->ticket_len, 1 );
+            if( session->ticket == NULL )
+            {
+                return ( MBEDTLS_ERR_SSL_ALLOC_FAILED );
+            }
+            else
+            {
+                memcpy( session->ticket, p, session->ticket_len );
+                p += session->ticket_len;
+            }
+
+#if defined(MBEDTLS_HAVE_TIME)
+            if( 8 > (size_t)( end - p ) )
+                return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
+
+            session->ticket_received =
+                    ( (uint64_t) p[0] << 56 ) |
+                    ( (uint64_t) p[1] << 48 ) |
+                    ( (uint64_t) p[2] << 40 ) |
+                    ( (uint64_t) p[3] << 32 ) |
+                    ( (uint64_t) p[4] << 24 ) |
+                    ( (uint64_t) p[5] << 16 ) |
+                    ( (uint64_t) p[6] <<  8 ) |
+                    ( (uint64_t) p[7]       );
+            p += 8;
+#endif /* MBEDTLS_HAVE_TIME */
+        }
+#endif /* MBEDTLS_SSL_CLI_C */
+    }
+    else
+#endif /* MBEDTLS_SSL_NEW_SESSION_TICKET && MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
+#if defined(MBEDTLS_SSL_PROTO_TLS1_2_OR_EARLIER)
+    {
+        /*
+         * Time
+         */
+#if defined(MBEDTLS_HAVE_TIME)
+        if( 8 > (size_t)( end - p ) )
+            return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
+
+        start = ( (uint64_t) p[0] << 56 ) |
+                ( (uint64_t) p[1] << 48 ) |
+                ( (uint64_t) p[2] << 40 ) |
+                ( (uint64_t) p[3] << 32 ) |
+                ( (uint64_t) p[4] << 24 ) |
+                ( (uint64_t) p[5] << 16 ) |
+                ( (uint64_t) p[6] <<  8 ) |
+                ( (uint64_t) p[7]       );
+        p += 8;
+
+        session->start = (time_t) start;
+#endif /* MBEDTLS_HAVE_TIME */
+
+        /*
+         * Basic mandatory fields
+         */
+        if( 2 + 1 + 1 + 32 + 48 + 4 > (size_t)( end - p ) )
+            return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
+
+        session->ciphersuite = ( p[0] << 8 ) | p[1];
+        p += 2;
+
+        session->compression = *p++;
+
+        session->id_len = *p++;
+        memcpy( session->id, p, 32 );
+        p += 32;
+
+        memcpy( session->master, p, 48 );
+        p += 48;
+
+        session->verify_result = ( (uint32_t) p[0] << 24 ) |
+                                 ( (uint32_t) p[1] << 16 ) |
+                                 ( (uint32_t) p[2] <<  8 ) |
+                                 ( (uint32_t) p[3]       );
+        p += 4;
+        }
+#else
+    {
+        return ( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
+    }
+#endif /* MBEDTLS_SSL_PROTO_TLS1_2_OR_EARLIER */
 
     /* Immediately clear invalid pointer values that have been read, in case
      * we exit early before we replaced them with valid ones. */
@@ -6328,59 +6596,62 @@ static int ssl_session_load( mbedtls_ssl_session *session,
     /*
      * Session ticket and associated data
      */
-#if defined(MBEDTLS_SSL_SESSION_TICKETS) && defined(MBEDTLS_SSL_CLI_C)
-    if( 3 > (size_t)( end - p ) )
-        return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
-
-    session->ticket_len = ( p[0] << 16 ) | ( p[1] << 8 ) | p[2];
-    p += 3;
-
-    if( session->ticket_len != 0 )
+    if( minor_ver != MBEDTLS_SSL_MINOR_VERSION_4 )
     {
-        if( session->ticket_len > (size_t)( end - p ) )
+#if defined(MBEDTLS_SSL_SESSION_TICKETS) && defined(MBEDTLS_SSL_CLI_C)
+        if( 3 > (size_t)( end - p ) )
             return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
 
-        session->ticket = mbedtls_calloc( 1, session->ticket_len );
-        if( session->ticket == NULL )
-            return( MBEDTLS_ERR_SSL_ALLOC_FAILED );
+        session->ticket_len = ( p[0] << 16 ) | ( p[1] << 8 ) | p[2];
+        p += 3;
 
-        memcpy( session->ticket, p, session->ticket_len );
-        p += session->ticket_len;
-    }
+        if( session->ticket_len != 0 )
+        {
+            if( session->ticket_len > (size_t)( end - p ) )
+                return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
 
-    if( 4 > (size_t)( end - p ) )
-        return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
+            session->ticket = mbedtls_calloc( 1, session->ticket_len );
+            if( session->ticket == NULL )
+                return( MBEDTLS_ERR_SSL_ALLOC_FAILED );
 
-    session->ticket_lifetime = ( (uint32_t) p[0] << 24 ) |
-                               ( (uint32_t) p[1] << 16 ) |
-                               ( (uint32_t) p[2] <<  8 ) |
-                               ( (uint32_t) p[3]       );
-    p += 4;
+            memcpy( session->ticket, p, session->ticket_len );
+            p += session->ticket_len;
+        }
+
+        if( 4 > (size_t)( end - p ) )
+            return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
+
+        session->ticket_lifetime = ( (uint32_t) p[0] << 24 ) |
+                                   ( (uint32_t) p[1] << 16 ) |
+                                   ( (uint32_t) p[2] <<  8 ) |
+                                   ( (uint32_t) p[3]       );
+        p += 4;
 #endif /* MBEDTLS_SSL_SESSION_TICKETS && MBEDTLS_SSL_CLI_C */
 
-    /*
-     * Misc extension-related info
-     */
+        /*
+         * Misc extension-related info
+         */
 #if defined(MBEDTLS_SSL_MAX_FRAGMENT_LENGTH)
-    if( 1 > (size_t)( end - p ) )
-        return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
+        if( 1 > (size_t)( end - p ) )
+            return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
 
-    session->mfl_code = *p++;
+        session->mfl_code = *p++;
 #endif
 
 #if defined(MBEDTLS_SSL_TRUNCATED_HMAC)
-    if( 1 > (size_t)( end - p ) )
-        return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
+        if( 1 > (size_t)( end - p ) )
+            return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
 
-    session->trunc_hmac = *p++;
+        session->trunc_hmac = *p++;
 #endif
 
 #if defined(MBEDTLS_SSL_ENCRYPT_THEN_MAC)
-    if( 1 > (size_t)( end - p ) )
-        return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
+        if( 1 > (size_t)( end - p ) )
+            return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
 
-    session->encrypt_then_mac = *p++;
+        session->encrypt_then_mac = *p++;
 #endif
+    }
 
     /* Done, should have consumed entire buffer */
     if( p != end )
@@ -6403,6 +6674,7 @@ int mbedtls_ssl_session_load( mbedtls_ssl_session *session,
 
     return( ret );
 }
+#endif /* MBEDTLS_SSL_SESSION_TICKETS || ( MBEDTLS_SSL_NEW_SESSION_TICKET && MBEDTLS_SSL_SRV_C ) */
 
 /*
  * Perform a single step of the SSL handshake
@@ -6825,14 +7097,14 @@ void mbedtls_ssl_session_free( mbedtls_ssl_session *session )
 #endif
 
 #if( defined(MBEDTLS_SSL_SESSION_TICKETS) || ( defined(MBEDTLS_SSL_NEW_SESSION_TICKET) && defined(MBEDTLS_SSL_CLI_C) ) )
+
     mbedtls_free( session->ticket );
 
-
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
-    mbedtls_free( session->ticket_nonce );
+    if( session->ticket_nonce_len > 0 ) mbedtls_free( session->ticket_nonce );
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 
-#endif
+#endif /* MBEDTLS_SSL_SESSION_TICKETS || ( MBEDTLS_SSL_NEW_SESSION_TICKET && MBEDTLS_SSL_CLI_C ) */
 
     mbedtls_platform_zeroize( session, sizeof( mbedtls_ssl_session ) );
 }

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -5948,9 +5948,9 @@ static unsigned char ssl_serialized_session_header[] = {
  *        these version+format bytes.
  *
  *  Note: The format below is used by TLS/DTLS versions prior to 1.3.
-          The ticket format used in TLS/DTLS 1.3 is shown further below.
+ *        The ticket format used in TLS/DTLS 1.3 is shown further below.
  * 
-  *                               // In this version, `session_format` determines
+ *                               // In this version, `session_format` determines
  *                               // the setting of those compile-time
  *                               // configuration options which influence
  *                               // the structure of mbedtls_ssl_session.

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -776,6 +776,10 @@ int mbedtls_ssl_write_pre_shared_key_ext( mbedtls_ssl_context *ssl,
     const mbedtls_ssl_ciphersuite_t *suite_info;
     const int *ciphersuites;
     int hash_len;
+    unsigned char *psk_identity;
+    size_t psk_identity_len;
+    unsigned char *psk;
+    size_t psk_len;
 
     *total_ext_len = 0;
     *bytes_written = 0;
@@ -784,7 +788,7 @@ int mbedtls_ssl_write_pre_shared_key_ext( mbedtls_ssl_context *ssl,
         return( 0 );
 
     /* Check whether we have any PSK credentials configured. */
-    if( mbedtls_ssl_get_psk( ssl, NULL, NULL ) != 0 )
+    if( mbedtls_ssl_get_psk( ssl, (const unsigned char**) &psk, &psk_len ) != 0 )
     {
         MBEDTLS_SSL_DEBUG_MSG( 3, ( "client hello, skip pre_shared_key extensions" ) );
         return( 0 );
@@ -812,12 +816,24 @@ int mbedtls_ssl_write_pre_shared_key_ext( mbedtls_ssl_context *ssl,
     if( hash_len == -1 )
         return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
 
+#if defined(MBEDTLS_SSL_NEW_SESSION_TICKET)
+    if( ssl->handshake->resume == 1 )
+    {
+        psk_identity = ssl->session_negotiate->ticket;
+        psk_identity_len = ssl->session_negotiate->ticket_len;
+    }
+    else
+ #endif /* MBEDTLS_SSL_NEW_SESSION_TICKET */
+    {
+        psk_identity = ssl->conf->psk_identity;
+        psk_identity_len = ssl->conf->psk_identity_len;
+    }
 
     size_t const ext_type_bytes           = 2;
     size_t const ext_len_bytes            = 2;
     size_t const psk_identities_len_bytes = 2;
     size_t const psk_identity_len_bytes   = 2;
-    size_t const psk_identity_bytes       = ssl->conf->psk_identity_len;
+    size_t const psk_identity_bytes       = psk_identity_len;
     size_t const obfuscated_ticket_bytes  = 4;
     size_t const psk_binders_len_bytes    = 2;
     size_t const psk_binder_len_bytes     = 1;
@@ -879,27 +895,29 @@ int mbedtls_ssl_write_pre_shared_key_ext( mbedtls_ssl_context *ssl,
         *p++ = (unsigned char)( ( ext_len >> 0 ) & 0xFF );
 
         /* 2 bytes length field for array of PskIdentity */
-        *p++ = (unsigned char)( ( ( ssl->conf->psk_identity_len + 4 + 2 ) >> 8 ) & 0xFF );
-        *p++ = (unsigned char)( ( ( ssl->conf->psk_identity_len + 4 + 2 ) >> 0 ) & 0xFF );
+        *p++ = (unsigned char)( ( ( psk_identity_len + 4 + 2 ) >> 8 ) & 0xFF );
+        *p++ = (unsigned char)( ( ( psk_identity_len + 4 + 2 ) >> 0 ) & 0xFF );
 
         /* 2 bytes length field for psk_identity */
-        *p++ = (unsigned char)( ( ( ssl->conf->psk_identity_len ) >> 8 ) & 0xFF );
-        *p++ = (unsigned char)( ( ( ssl->conf->psk_identity_len ) >> 0 ) & 0xFF );
+        *p++ = (unsigned char)( ( ( psk_identity_len ) >> 8 ) & 0xFF );
+        *p++ = (unsigned char)( ( ( psk_identity_len ) >> 0 ) & 0xFF );
 
         /* actual psk_identity */
-        memcpy( p, ssl->conf->psk_identity, ssl->conf->psk_identity_len );
-        p += ssl->conf->psk_identity_len;
+        memcpy( p, psk_identity, psk_identity_len );
+        p += psk_identity_len;
+
+#if defined(MBEDTLS_SSL_NEW_SESSION_TICKET)
 
         /* Calculate obfuscated_ticket_age (omitted for external PSKs). */
-        if( ssl->conf->ticket_age_add > 0 )
+        if( ssl->session_negotiate->ticket_age_add > 0 )
         {
             /* TODO: Should we somehow fail if TIME is disabled here?
              * TODO: Use Mbed TLS' time abstraction? */
 #if defined(MBEDTLS_HAVE_TIME)
             time_t now = time( NULL );
 
-            if( !( ssl->conf->ticket_received <= now &&
-                   now - ssl->conf->ticket_received < 7 * 86400 * 1000 ) )
+            if( !( ssl->session_negotiate->ticket_received <= now &&
+                   now - ssl->session_negotiate->ticket_received < 7 * 86400 * 1000 ) )
             {
                 MBEDTLS_SSL_DEBUG_MSG( 3, ( "ticket expired" ) );
                 /* TBD: We would have to fall back to another PSK */
@@ -907,13 +925,14 @@ int mbedtls_ssl_write_pre_shared_key_ext( mbedtls_ssl_context *ssl,
             }
 
             obfuscated_ticket_age =
-                (uint32_t)( now - ssl->conf->ticket_received ) +
-                ssl->conf->ticket_age_add;
+                (uint32_t)( now - ssl->session_negotiate->ticket_received ) +
+                ssl->session_negotiate->ticket_age_add;
 
             MBEDTLS_SSL_DEBUG_MSG( 5, ( "obfuscated_ticket_age: %u",
                                         obfuscated_ticket_age ) );
 #endif /* MBEDTLS_HAVE_TIME */
         }
+#endif /* MBEDTLS_SSL_NEW_SESSION_TICKET */
 
         /* add obfuscated ticket age */
         *p++ = ( obfuscated_ticket_age >> 24 ) & 0xFF;
@@ -938,14 +957,14 @@ int mbedtls_ssl_write_pre_shared_key_ext( mbedtls_ssl_context *ssl,
         /* 1 bytes length field for next psk binder */
         *p++ = (unsigned char)( ( hash_len ) & 0xFF );
 
-        if( ssl->conf->resumption_mode )
+        if( ssl->handshake->resume )
             external_psk = 0;
         else
             external_psk = 1;
 
         ret = mbedtls_ssl_create_binder( ssl,
                   external_psk,
-                  ssl->conf->psk, ssl->conf->psk_len,
+                  psk, psk_len,
                   mbedtls_md_info_from_type( suite_info->mac ),
                   suite_info, p );
 
@@ -1963,6 +1982,15 @@ static int ssl_parse_supported_version_ext( mbedtls_ssl_context* ssl,
             return( MBEDTLS_ERR_SSL_BAD_HS_SERVER_HELLO );
         }
     }
+
+#if defined(MBEDTLS_SSL_NEW_SESSION_TICKET)
+    /* For ticket handling, we need to populate the version 
+    * and the endpoint information into the session structure
+    * since only session information is available in that API.
+    */
+    ssl->session_negotiate->minor_ver = ssl->minor_ver;
+    ssl->session_negotiate->endpoint = ssl->conf->endpoint;
+#endif /* MBEDTLS_SSL_NEW_SESSION_TICKET */
 
     return( 0 );
 }
@@ -4195,6 +4223,10 @@ int mbedtls_ssl_handshake_client_step( mbedtls_ssl_context *ssl )
                 mbedtls_ack_clear_all( ssl, MBEDTLS_SSL_ACK_RECORDS_RECEIVED );
             }
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
+
+#if defined(MBEDTLS_SSL_NEW_SESSION_TICKET)
+            ssl->session_negotiate->endpoint = ssl->conf->endpoint;
+#endif /* MBEDTLS_SSL_NEW_SESSION_TICKET */
             break;
 
             /* ----- WRITE CLIENT HELLO ----*/

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -5153,9 +5153,10 @@ static int ssl_new_session_ticket_parse( mbedtls_ssl_context* ssl,
         return ( ret );
     }
 
-    ssl->session->resumption_key_len =  mbedtls_hash_size_for_ciphersuite( suite_info );
+    ssl->session->resumption_key_len = mbedtls_hash_size_for_ciphersuite( suite_info );
 
-    MBEDTLS_SSL_DEBUG_BUF( 3, "Ticket-resumed PSK", ssl->session->key, ssl->session->resumption_key_len );
+    MBEDTLS_SSL_DEBUG_BUF( 3, "Ticket-resumed PSK", ssl->session->key, 
+                           ssl->session->resumption_key_len );
 
 #if defined(MBEDTLS_HAVE_TIME)
     /* Store ticket creation time */

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -1125,6 +1125,10 @@ int mbedtls_ssl_parse_signature_algorithms_ext( mbedtls_ssl_context *ssl,
         for( md_cur = ssl->conf->sig_hashes; *md_cur != SIGNATURE_NONE; md_cur++ )
             num_supported_hashes++;
     }
+    
+    /* Clear previously allocated memory */
+    if( ssl->handshake->received_signature_schemes_list != NULL )
+        mbedtls_free( ssl->handshake->received_signature_schemes_list );
 
     /* Store the received and compatible signature algorithms for later use. */
     ssl->handshake->received_signature_schemes_list =
@@ -3461,13 +3465,12 @@ static int ssl_read_certificate_postprocess( mbedtls_ssl_context* ssl )
     return( 0 );
 }
 
-
 /* Generate resumption_master_secret for use with the ticket exchange. */
+
+#if defined(MBEDTLS_SSL_NEW_SESSION_TICKET)
 int mbedtls_ssl_generate_resumption_master_secret( mbedtls_ssl_context *ssl )
 {
     int ret = 0;
-
-#if defined(MBEDTLS_SSL_NEW_SESSION_TICKET)
     const mbedtls_md_info_t *md_info;
     const mbedtls_ssl_ciphersuite_t *suite_info;
     unsigned char hash[MBEDTLS_MD_MAX_SIZE];
@@ -3544,7 +3547,6 @@ int mbedtls_ssl_generate_resumption_master_secret( mbedtls_ssl_context *ssl )
                            ssl->session_negotiate->resumption_master_secret,
                            mbedtls_hash_size_for_ciphersuite( suite_info ) );
 
-#endif /* MBEDTLS_SSL_NEW_SESSION_TICKET */
 
 exit:
 #if defined(MBEDTLS_SHA256_C)
@@ -3568,6 +3570,13 @@ exit:
 
     return( ret );
 }
+#else
+int mbedtls_ssl_generate_resumption_master_secret( mbedtls_ssl_context *ssl )
+{
+    ((void) ssl);
+    return( 0 );
+}
+#endif /* MBEDTLS_SSL_NEW_SESSION_TICKET */
 
 /* Generate application traffic keys since any records following a 1-RTT Finished message
  * MUST be encrypted under the application traffic key.
@@ -4853,7 +4862,6 @@ void mbedtls_ssl_conf_early_data( mbedtls_ssl_config *conf, int early_data, char
 
 #if defined(MBEDTLS_SSL_NEW_SESSION_TICKET) && defined(MBEDTLS_SSL_CLI_C)
 
-
 /*
  * Overview
  */
@@ -4969,11 +4977,11 @@ static int ssl_new_session_ticket_parse( mbedtls_ssl_context* ssl,
                                          size_t buflen )
 {
     int ret;
-    uint8_t ticket_nonce_len;
     uint16_t ticket_len, ext_len;
     unsigned char *ticket;
     const mbedtls_ssl_ciphersuite_t *suite_info;
     size_t used = 0;
+    int hash_length;
 
     /*
      * struct {
@@ -5011,14 +5019,12 @@ static int ssl_new_session_ticket_parse( mbedtls_ssl_context* ssl,
                      ( (unsigned) buf[6] << 8  ) |
                      ( (unsigned) buf[7] << 0  );
 
-    MBEDTLS_SSL_DEBUG_MSG( 3, ( "ticket->age_add: %u", ssl->session->ticket_age_add ) );
+    MBEDTLS_SSL_DEBUG_MSG( 3, ( "ticket->ticket_age_add: %u", ssl->session->ticket_age_add ) );
 
     /* Ticket Nonce */
-    ticket_nonce_len = buf[8];
+    ssl->session->ticket_nonce_len = buf[8];
 
-    MBEDTLS_SSL_DEBUG_MSG( 3, ( "ticket->nonce_length: %d", ticket_nonce_len ) );
-
-    used += ticket_nonce_len;
+    used += ssl->session->ticket_nonce_len;
 
     if( used > buflen )
     {
@@ -5026,33 +5032,35 @@ static int ssl_new_session_ticket_parse( mbedtls_ssl_context* ssl,
          return( MBEDTLS_ERR_SSL_BAD_HS_NEW_SESSION_TICKET );
     }
 
-    MBEDTLS_SSL_DEBUG_BUF( 3, "ticket->nonce:", (unsigned char*)&buf[9], ticket_nonce_len );
-
     /* Check if we previously received a ticket already. If we did, then we should
      * re-use already allocated nonce-space.
      */
-    if( ssl->session->ticket_nonce != NULL || ssl->session->ticket_nonce_len > 0 )
+    if( ssl->session->ticket_nonce != NULL && ssl->session->ticket_nonce_len > 0 )
     {
         mbedtls_free( ssl->session->ticket_nonce );
         ssl->session->ticket_nonce = NULL;
         ssl->session->ticket_nonce_len = 0;
     }
 
-    if( ticket_nonce_len > 0 )
+    if( ssl->session->ticket_nonce_len > 0 )
     {
-        if( ( ssl->session->ticket_nonce = mbedtls_calloc( 1, ticket_nonce_len ) ) == NULL )
+        if( ( ssl->session->ticket_nonce = mbedtls_calloc( 1,
+            ssl->session->ticket_nonce_len ) ) == NULL )
         {
             MBEDTLS_SSL_DEBUG_MSG( 1, ( "ticket_nonce alloc failed" ) );
             return( MBEDTLS_ERR_SSL_ALLOC_FAILED );
         }
 
-        memcpy( ssl->session->ticket_nonce, &buf[9], ticket_nonce_len );
+        memcpy( ssl->session->ticket_nonce, &buf[9], ssl->session->ticket_nonce_len );
+
+        MBEDTLS_SSL_DEBUG_BUF( 3, "ticket->nonce:", (unsigned char*)&buf[9], 
+        ssl->session->ticket_nonce_len );
+
     }
 
-    ssl->session->ticket_nonce_len = ticket_nonce_len;
-
     /* Ticket */
-    ticket_len = ( buf[9+ ticket_nonce_len] << 8 ) | ( buf[10+ ticket_nonce_len] );
+    ticket_len = ( buf[9 + ssl->session->ticket_nonce_len] << 8 ) | 
+                 ( buf[10 + ssl->session->ticket_nonce_len] );
 
     used += ticket_len;
 
@@ -5065,8 +5073,8 @@ static int ssl_new_session_ticket_parse( mbedtls_ssl_context* ssl,
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "ticket->length: %d", ticket_len ) );
 
     /* Ticket Extension */
-    ext_len = ( (unsigned) buf[ 11 + ticket_nonce_len + ticket_len ] << 8 ) |
-              ( (unsigned) buf[ 12 + ticket_nonce_len + ticket_len ] );
+    ext_len = ( (unsigned) buf[ 11 + ssl->session->ticket_nonce_len + ticket_len ] << 8 ) |
+              ( (unsigned) buf[ 12 + ssl->session->ticket_nonce_len + ticket_len ] );
 
     used += ext_len;
 
@@ -5090,17 +5098,15 @@ static int ssl_new_session_ticket_parse( mbedtls_ssl_context* ssl,
         return( MBEDTLS_ERR_SSL_ALLOC_FAILED );
     }
 
-    memcpy( ticket, buf + 11 + ticket_nonce_len, ticket_len );
+    memcpy( ticket, buf + 11 + ssl->session->ticket_nonce_len, ticket_len );
     ssl->session->ticket = ticket;
     ssl->session->ticket_len = ticket_len;
 
-    MBEDTLS_SSL_DEBUG_BUF( 3, "ticket", ticket, ticket_len );
-
-    MBEDTLS_SSL_DEBUG_MSG( 3, ( "ticket->extension length: %d", ext_len ) );
+    MBEDTLS_SSL_DEBUG_MSG( 5, ( "ticket->extension length: %d", ext_len ) );
 
     /* We are not storing any extensions at the moment */
     MBEDTLS_SSL_DEBUG_BUF( 3, "ticket->extension",
-                           &buf[ 13 + ticket_nonce_len + ticket_len ],
+                           &buf[ 13 + ssl->session->ticket_nonce_len + ticket_len ],
                            ext_len );
 
     /* Compute PSK based on received nonce and resumption_master_secret
@@ -5118,17 +5124,28 @@ static int ssl_new_session_ticket_parse( mbedtls_ssl_context* ssl,
         return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
     }
 
+    hash_length = mbedtls_hash_size_for_ciphersuite( suite_info );
+    
+    if( hash_length == -1 )
+        return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
+
     MBEDTLS_SSL_DEBUG_BUF( 3, "resumption_master_secret",
                            ssl->session->resumption_master_secret,
-        mbedtls_hash_size_for_ciphersuite( suite_info ) );
+                           hash_length );
 
+    /* Computer resumption key
+     * 
+     *  HKDF-Expand-Label( resumption_master_secret,
+     *                    "resumption", ticket_nonce, Hash.length )
+     */
     ret = mbedtls_ssl_tls1_3_hkdf_expand_label( suite_info->mac,
                     ssl->session->resumption_master_secret,
-                    mbedtls_hash_size_for_ciphersuite( suite_info ),
+                    hash_length,
                     MBEDTLS_SSL_TLS1_3_LBL_WITH_LEN( resumption ),
-                    ssl->session->ticket_nonce, ssl->session->ticket_nonce_len,
+                    ssl->session->ticket_nonce,
+                    ssl->session->ticket_nonce_len,
                     ssl->session->key,
-                    mbedtls_hash_size_for_ciphersuite( suite_info ) );
+                    hash_length );
 
     if( ret != 0 )
     {
@@ -5136,14 +5153,16 @@ static int ssl_new_session_ticket_parse( mbedtls_ssl_context* ssl,
         return ( ret );
     }
 
-    MBEDTLS_SSL_DEBUG_BUF( 3, "Ticket-resumed PSK", ssl->session->key, mbedtls_hash_size_for_ciphersuite( suite_info ) );
-    MBEDTLS_SSL_DEBUG_MSG( 3, ( "Key_len: %d", mbedtls_hash_size_for_ciphersuite( suite_info ) ) );
+    ssl->session->resumption_key_len =  mbedtls_hash_size_for_ciphersuite( suite_info );
 
+    MBEDTLS_SSL_DEBUG_BUF( 3, "Ticket-resumed PSK", ssl->session->key, ssl->session->resumption_key_len );
 
 #if defined(MBEDTLS_HAVE_TIME)
     /* Store ticket creation time */
     ssl->session->ticket_received = time( NULL );
 #endif
+
+    MBEDTLS_SSL_DEBUG_BUF( 5, "ticket", buf, buflen );
 
     return( 0 );
 }
@@ -5152,28 +5171,6 @@ static int ssl_new_session_ticket_postprocess( mbedtls_ssl_context* ssl, int ret
 {
     ((void ) ssl);
     ((void ) ret);
-    return( 0 );
-}
-
-/* mbedtls_ssl_conf_ticket_meta( ) allows to set a 32-bit value that is
- * used to obscure the age of the ticket. For externally configured PSKs
- * this value is zero. Additionally, the time when the ticket was
- * received will be set.
- */
-
-#if defined(MBEDTLS_HAVE_TIME)
-int mbedtls_ssl_conf_ticket_meta( mbedtls_ssl_config *conf,
-                                  const uint32_t ticket_age_add,
-                                  const time_t ticket_received )
-#else
-    int mbedtls_ssl_conf_ticket_meta( mbedtls_ssl_config *conf,
-                                      const uint32_t ticket_age_add )
-#endif /* MBEDTLS_HAVE_TIME */
-{
-    conf->ticket_age_add = ticket_age_add;
-#if defined(MBEDTLS_HAVE_TIME)
-    conf->ticket_received = ticket_received;
-#endif /* MBEDTLS_HAVE_TIME */
     return( 0 );
 }
 #endif /* MBEDTLS_SSL_NEW_SESSION_TICKET && MBEDTLS_SSL_CLI_C */
@@ -5185,195 +5182,6 @@ void mbedtls_ssl_conf_signature_algorithms( mbedtls_ssl_config *conf,
     conf->sig_hashes = sig_algs;
 }
 #endif /* MBEDTLS_X509_CRT_PARSE_C */
-
-#if defined(MBEDTLS_SSL_NEW_SESSION_TICKET)
-
-/*
- * Init ticket structure
- */
-
-void mbedtls_ssl_init_client_ticket( mbedtls_ssl_ticket *ticket )
-{
-    if( ticket == NULL )
-        return;
-
-    ticket->ticket = NULL;
-    memset( ticket->key,0,sizeof( ticket->key ) );
-}
-
-
-/*
- * Free an ticket structure
- */
-void mbedtls_ssl_del_client_ticket( mbedtls_ssl_ticket *ticket )
-{
-    if( ticket == NULL )
-        return;
-
-    if( ticket->ticket != NULL )
-    {
-        mbedtls_platform_zeroize( ticket->ticket, ticket->ticket_len );
-        mbedtls_free( ticket->ticket );
-    }
-
-    mbedtls_platform_zeroize( ticket->key, sizeof( ticket->key ) );
-}
-
-#if defined(MBEDTLS_SSL_CLI_C)
-int mbedtls_ssl_conf_client_ticket( const mbedtls_ssl_context *ssl,
-                                    mbedtls_ssl_ticket *ticket )
-{
-    int ret;
-    mbedtls_ssl_config *conf = ( mbedtls_ssl_config * ) ssl->conf;
-
-    /* TODO: Remove some of these checks? We sometimes omit explicit NULL
-     * pointer checks and leave those as preconditions. */
-
-    if( conf == NULL )
-    {
-        MBEDTLS_SSL_DEBUG_MSG( 1, ( "Invalid configuration in "
-                                    "mbedtls_ssl_conf_client_ticket()" ) );
-        return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
-    }
-    if( ticket == NULL )
-    {
-        MBEDTLS_SSL_DEBUG_MSG( 1, ( "Invalid ticket in "
-                                    "mbedtls_ssl_conf_client_ticket()" ) );
-        return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
-    }
-    if( ticket->key_len == 0 )
-    {
-        MBEDTLS_SSL_DEBUG_MSG( 1, ( "Invalid ticket key length in "
-                                    "mbedtls_ssl_conf_client_ticket()" ) );
-        return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
-    }
-    if( ticket->ticket_len == 0 )
-    {
-        MBEDTLS_SSL_DEBUG_MSG( 1, ( "Invalid ticket length in "
-                                    "mbedtls_ssl_conf_client_ticket()" ) );
-        return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
-    }
-    if( ticket->ticket == NULL )
-    {
-        MBEDTLS_SSL_DEBUG_MSG( 1, ( "Invalid ticket in "
-                                    "mbedtls_ssl_conf_client_ticket()" ) );
-        return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
-    }
-
-    /* We don't request another ticket from the server.
-     * TBD: This function could be moved to an application-visible API call.
-     */
-    mbedtls_ssl_conf_session_tickets( conf, 0 );
-
-    /* Set the psk and psk_identity */
-    ret = mbedtls_ssl_conf_psk( conf, ticket->key, ticket->key_len,
-                                (const unsigned char *)ticket->ticket,
-                                ticket->ticket_len );
-    if( ret != 0 )
-        return( ret );
-
-    /* We set the ticket_age_add and the time we received the ticket */
-#if defined(MBEDTLS_HAVE_TIME)
-    ret = mbedtls_ssl_conf_ticket_meta( conf,
-                                        ticket->ticket_age_add,
-                                        ticket->start );
-#else
-    ret = mbedtls_ssl_conf_ticket_meta( conf, ticket->ticket_age_add );
-#endif /* MBEDTLS_HAVE_TIME */
-
-    if( ret != 0 )
-        return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
-
-    return( 0 );
-}
-#endif /* MBEDTLS_SSL_CLI_C */
-
-#if defined(MBEDTLS_SSL_NEW_SESSION_TICKET) && defined(MBEDTLS_SSL_CLI_C)
-int mbedtls_ssl_get_client_ticket( const mbedtls_ssl_context *ssl, mbedtls_ssl_ticket *ticket )
-{
-    const mbedtls_ssl_ciphersuite_t *cur;
-    int hash_size;
-
-    if( ssl->session == NULL ) return( -1 );
-
-    /* Check whether we got a ticket already */
-    if( ssl->session->ticket != NULL )
-    {
-
-        /* store ticket */
-        ticket->ticket_len = ssl->session->ticket_len;
-        if( ticket->ticket_len == 0 ) return( -1 );
-        ticket->ticket = mbedtls_calloc( ticket->ticket_len,1 );
-        if( ticket->ticket == NULL ) return( -1 );
-        memcpy( ticket->ticket, ssl->session->ticket, ticket->ticket_len );
-
-        /* store ticket lifetime */
-        ticket->ticket_lifetime = ssl->session->ticket_lifetime;
-
-        /* store psk key and key length */
-        cur = mbedtls_ssl_ciphersuite_from_id( ssl->session->ciphersuite );
-        if( cur == NULL )
-        {
-            mbedtls_free( ticket->ticket );
-            return( -1 );
-        }
-
-        hash_size=mbedtls_hash_size_for_ciphersuite( cur );
-
-        if( hash_size < 0 )
-        {
-            mbedtls_free( ticket->ticket );
-            return( -1 );
-        }
-        else
-        {
-            ticket->key_len = hash_size;
-        }
-        memcpy( ticket->key, ssl->session->key, ticket->key_len );
-        ssl->session->key_len = ticket->key_len;
-
-        /* store ticket_age_add */
-        ticket->ticket_age_add = ssl->session->ticket_age_add;
-
-#if defined(MBEDTLS_HAVE_TIME)
-        /* store time we received the ticket */
-        ticket->start = ssl->session->ticket_received;
-#endif /* MBEDTLS_HAVE_TIME */
-
-        return( 0 );
-    }
-    else
-    {
-        /* no ticket available */
-        return( 1 );
-    }
-}
-#endif /* MBEDTLS_SSL_NEW_SESSION_TICKET && MBEDTLS_SSL_CLI_C */
-
-void mbedtls_ssl_conf_client_ticket_enable( mbedtls_ssl_context *ssl )
-{
-    mbedtls_ssl_config *conf;
-    if( ssl == NULL ) return;
-    conf = ( mbedtls_ssl_config * ) ssl->conf;
-    if( conf == NULL ) return;
-    conf->resumption_mode = 1; /* enable resumption mode */
-}
-
-void mbedtls_ssl_conf_client_ticket_disable( mbedtls_ssl_context *ssl )
-{
-    mbedtls_ssl_config *conf;
-
-    if( ssl == NULL ) return;
-    conf = ( mbedtls_ssl_config * ) ssl->conf;
-    if( conf == NULL ) return;
-    conf->resumption_mode = 0; /* set full exchange */
-}
-
-#endif /* MBEDTLS_SSL_NEW_SESSION_TICKET */
-
-
-
-
 
 /* Early Data Extension
  *

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -478,7 +478,7 @@ finish_key_share_parsing:
 int mbedtls_ssl_parse_new_session_ticket_server(
     mbedtls_ssl_context *ssl,
     unsigned char *buf,
-    size_t len, mbedtls_ssl_ticket *ticket )
+    size_t len )
 {
     int ret;
     unsigned char *ticket_buffer;
@@ -501,16 +501,18 @@ int mbedtls_ssl_parse_new_session_ticket_server(
      * psk binder value.
      */
     ticket_buffer = mbedtls_calloc( len,1 );
+    
     if( ticket_buffer == NULL )
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "buffer too small" ) );
         return ( MBEDTLS_ERR_SSL_ALLOC_FAILED );
-    } else memcpy( ticket_buffer, buf, len );
+    }
 
-    if( ( ret = ssl->conf->f_ticket_parse( ssl->conf->p_ticket, ticket,
+    memcpy( ticket_buffer, buf, len );
+
+    if( ( ret = ssl->conf->f_ticket_parse( ssl->conf->p_ticket, ssl->session_negotiate,
                                          ticket_buffer, len ) ) != 0 )
     {
-        mbedtls_platform_zeroize( ticket, sizeof( mbedtls_ssl_ticket ) );
         mbedtls_free( ticket_buffer );
         if( ret == MBEDTLS_ERR_SSL_INVALID_MAC )
             MBEDTLS_SSL_DEBUG_MSG( 3, ( "ticket is not authentic" ) );
@@ -540,16 +542,18 @@ int mbedtls_ssl_parse_client_psk_identity_ext(
     int ret = 0;
     unsigned int item_array_length, item_length, sum, length_so_far;
     unsigned char server_computed_binder[MBEDTLS_MD_MAX_SIZE];
-    uint32_t obfuscated_ticket_age;
-    mbedtls_ssl_ticket ticket;
     const unsigned char *psk = NULL;
     unsigned char const * const start = buf;
     size_t psk_len = 0;
-#if defined(MBEDTLS_HAVE_TIME)
+    unsigned char const *end_of_psk_identities;
+
+#if defined(MBEDTLS_SSL_NEW_SESSION_TICKET)
+    uint32_t obfuscated_ticket_age;
+#if defined(MBEDTLS_HAVE_TIME) 
     time_t now;
     int64_t diff;
 #endif /* MBEDTLS_HAVE_TIME */
-    unsigned char const *end_of_psk_identities;
+#endif /* MBEDTLS_SSL_NEW_SESSION_TICKET */
 
     /* Read length of array of identities */
     item_array_length = ( buf[0] << 8 ) | buf[1];
@@ -628,13 +632,13 @@ int mbedtls_ssl_parse_client_psk_identity_ext(
 
                 ret = mbedtls_ssl_parse_new_session_ticket_server( ssl,
                                              ssl->session_negotiate->ticket,
-                                             item_length, &ticket );
+                                             item_length );
                 if( ret == 0 )
                 {
                     /* found a match in the ticket cache; everything is OK */
                     ssl->handshake->resume = 1;
 
-                    /* We put the resumption_master_secret into the handshake->psk
+                    /* We put the resumption key into the handshake->psk.
                      *
                      * Note: The key in the ticket is already the final PSK,
                      *       i.e., the HKDF-Expand-Label( resumption_master_secret,
@@ -643,15 +647,17 @@ int mbedtls_ssl_parse_client_psk_identity_ext(
                      *                                    Hash.length )
                      *       function has already been applied.
                      */
-                    mbedtls_ssl_set_hs_psk( ssl, ticket.key, ticket.key_len );
-                    MBEDTLS_SSL_DEBUG_BUF( 5, "ticket: key", ticket.key,
-                                           ticket.key_len );
+                    mbedtls_ssl_set_hs_psk( ssl, ssl->session_negotiate->key,
+                                            ssl->session_negotiate->resumption_key_len );
+                    MBEDTLS_SSL_DEBUG_BUF( 5, "Ticket-resumed PSK:", ssl->session_negotiate->key,
+                                           ssl->session_negotiate->resumption_key_len );
 
                     /* obfuscated ticket age follows the identity field, which is
                      * item_length long, containing the ticket */
                     memcpy( &obfuscated_ticket_age, buf+item_length, 4 );
-                    MBEDTLS_SSL_DEBUG_BUF( 5, "ticket: obfuscated_ticket_age",
-                                   (const unsigned char *) &obfuscated_ticket_age, 4 );
+
+                    MBEDTLS_SSL_DEBUG_MSG( 5, ( "ticket: obfuscated_ticket_age: %u",
+                                                obfuscated_ticket_age ) );
                     /*
                      * A server MUST validate that the ticket age for the selected PSK identity
                      * is within a small tolerance of the time since the ticket was issued.
@@ -664,11 +670,11 @@ int mbedtls_ssl_parse_client_psk_identity_ext(
                      *   Is the time when the ticket was issued later than now?
                      */
 
-                    if( now < ticket.start )
+                    if( now < ssl->session_negotiate->start )
                     {
                         MBEDTLS_SSL_DEBUG_MSG( 3,
                                ( "Ticket expired: now=%d, ticket.start=%d",
-                                 now, ticket.start ) );
+                                 now, ssl->session_negotiate->start ) );
                         ret = MBEDTLS_ERR_SSL_SESSION_TICKET_EXPIRED;
                     }
 
@@ -676,12 +682,14 @@ int mbedtls_ssl_parse_client_psk_identity_ext(
                      *   Is the ticket expired already?
                      */
 
-                    if( now - ticket.start > ticket.ticket_lifetime )
+                    if( now - ssl->session_negotiate->start > ssl->session_negotiate->ticket_lifetime )
                     {
                         MBEDTLS_SSL_DEBUG_MSG( 3,
                                ( "Ticket expired ( now - ticket.start=%d, "\
                                  "ticket.ticket_lifetime=%d",
-                                 now - ticket.start, ticket.ticket_lifetime ) );
+                                 now - ssl->session_negotiate->start,
+                                 ssl->session_negotiate->ticket_lifetime ) );
+
                         ret = MBEDTLS_ERR_SSL_SESSION_TICKET_EXPIRED;
                     }
 
@@ -693,8 +701,8 @@ int mbedtls_ssl_parse_client_psk_identity_ext(
                      *   ticket was issued?
                      */
 
-                    diff = ( now - ticket.start ) -
-                        ( obfuscated_ticket_age - ticket.ticket_age_add );
+                    diff = ( now - ssl->session_negotiate->start ) -
+                        ( obfuscated_ticket_age -ssl->session_negotiate->ticket_age_add );
 
                     if( diff > MBEDTLS_SSL_TICKET_AGE_TOLERANCE )
                     {
@@ -1270,8 +1278,8 @@ static int ssl_parse_supported_versions_ext( mbedtls_ssl_context *ssl,
         mbedtls_ssl_read_version( &major_ver, &minor_ver, ssl->conf->transport, buf );
 
         /* In this implementation we only support TLS 1.3 and DTLS 1.3. */
-        if( major_ver == ( int )0x03 &&
-            minor_ver == ( int )0x04 )
+        if( major_ver == MBEDTLS_SSL_MAJOR_VERSION_3 &&
+            minor_ver == MBEDTLS_SSL_MINOR_VERSION_4 )
         {
             /* we found a supported version */
             goto found_version;
@@ -1301,6 +1309,11 @@ found_version:
     ssl->minor_ver = minor_ver;
     ssl->handshake->max_major_ver = ssl->major_ver;
     ssl->handshake->max_minor_ver = ssl->minor_ver;
+
+#if defined(MBEDTLS_SSL_NEW_SESSION_TICKET)
+    /* Store minor version for later use with ticket serialization. */
+    ssl->session_negotiate->minor_ver = ssl->minor_ver;
+#endif /* MBEDTLS_SSL_NEW_SESSION_TICKET */
 
     return( 0 );
 }
@@ -1374,6 +1387,7 @@ static int ssl_parse_alpn_ext( mbedtls_ssl_context *ssl,
  * STATE HANDLING: NewSessionTicket message
  *
  */
+#if defined(MBEDTLS_SSL_NEW_SESSION_TICKET)
 
 /* Main state-handling entry point; orchestrates the other functions. */
 static int ssl_write_new_session_ticket_process( mbedtls_ssl_context* ssl );
@@ -1451,7 +1465,6 @@ cleanup:
     return( ret );
 }
 
-#if defined(MBEDTLS_SSL_NEW_SESSION_TICKET)
 static int ssl_write_new_session_ticket_coordinate( mbedtls_ssl_context* ssl )
 {
     /* Check whether the use of session tickets is enabled */
@@ -1462,12 +1475,7 @@ static int ssl_write_new_session_ticket_coordinate( mbedtls_ssl_context* ssl )
 
     return( SSL_NEW_SESSION_TICKET_WRITE );
 }
-#else /* MBEDTLS_SSL_NEW_SESSION_TICKET */
-static int ssl_write_new_session_ticket_coordinate( mbedtls_ssl_context* ssl )
-{
-    return( SSL_NEW_SESSION_TICKET_SKIP );
-}
-#endif /* MBEDTLS_SSL_NEW_SESSION_TICKET */
+
 
 static int ssl_write_new_session_ticket_postprocess( mbedtls_ssl_context* ssl )
 {
@@ -1475,10 +1483,7 @@ static int ssl_write_new_session_ticket_postprocess( mbedtls_ssl_context* ssl )
     return( 0 );
 }
 
-/* This function creates a NewSessionTicket message in the following format.
- * The ticket inside the NewSessionTicket is an encrypted container carrying
- * the necessary information so that the server is later able to restore the
- * required parameters.
+/* This function creates a NewSessionTicket message in the following format:
  *
  * struct {
  *    uint32 ticket_lifetime;
@@ -1487,8 +1492,13 @@ static int ssl_write_new_session_ticket_postprocess( mbedtls_ssl_context* ssl )
  *    opaque ticket<1..2^16-1>;
  *    Extension extensions<0..2^16-2>;
  * } NewSessionTicket;
+ * 
+ * The ticket inside the NewSessionTicket message is an encrypted container
+ * carrying the necessary information so that the server is later able to 
+ * re-start the communication.
  *
- * The following fields are populated in the ticket:
+ * The following fields are placed inside the ticket by the 
+ * f_ticket_write() function:
  *
  *  - creation time (start)
  *  - flags (flags)
@@ -1512,8 +1522,7 @@ static int ssl_write_new_session_ticket_write( mbedtls_ssl_context* ssl,
     unsigned char *end = buf + buflen;
     mbedtls_ssl_ciphersuite_t *suite_info;
     int hash_length;
-    mbedtls_ssl_ticket ticket;
-    mbedtls_ssl_ticket_context *ctx = ssl->conf->p_ticket;
+    unsigned char *ticket_lifetime_ptr;
 
 #if defined(MBEDTLS_SSL_USE_MPS)
     size_t const total_length = 12 + MBEDTLS_SSL_TICKET_NONCE_LENGTH;
@@ -1533,65 +1542,41 @@ static int ssl_write_new_session_ticket_write( mbedtls_ssl_context* ssl,
     }
 
     suite_info = (mbedtls_ssl_ciphersuite_t *) ssl->handshake->ciphersuite_info;
+
     hash_length = mbedtls_hash_size_for_ciphersuite( suite_info );
+    
     if( hash_length == -1 )
         return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
 
-#if defined(MBEDTLS_HAVE_TIME)
-    /* Store time when ticket was created. */
-    ticket.start = time( NULL );
-#endif /* MBEDTLS_HAVE_TIME */
-
-    ticket.flags = ctx->flags;
-    ticket.ticket_lifetime = ctx->ticket_lifetime;
     /* In this code the psk key length equals the length of the hash */
-    ticket.key_len = hash_length;
-    ticket.ciphersuite = ssl->handshake->ciphersuite_info->id;
+    ssl->session->resumption_key_len = hash_length;
+    ssl->session->ciphersuite = ssl->handshake->ciphersuite_info->id;
 
-#if defined(MBEDTLS_X509_CRT_PARSE_C)
-    /* Check whether the client provided a certificate during the exchange */
-    if( ssl->session->peer_cert != NULL )
-        ticket.peer_cert = ssl->session->peer_cert;
-    else
-        ticket.peer_cert = NULL;
-#endif /* MBEDTLS_X509_CRT_PARSE_C */
+    /* Ticket Lifetime 
+     * (write it later) 
+     */
+    ticket_lifetime_ptr = p;
+    p+=4;
 
     /* Ticket Age Add */
-
     if( ( ret = ssl->conf->f_rng( ssl->conf->p_rng,
-                                  (unsigned char*) &ticket.ticket_age_add,
-                                  sizeof( ticket.ticket_age_add ) ) ) != 0 )
+                                  (unsigned char*) &ssl->session->ticket_age_add,
+                                  sizeof( ssl->session->ticket_age_add ) ) != 0 ) )
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "Failed to generate ticket" ) );
         return( ret );
     }
 
-    /* Ticket Lifetime */
-    *(p++) = ( ticket.ticket_lifetime >> 24 ) & 0xFF;
-    *(p++) = ( ticket.ticket_lifetime >> 16 ) & 0xFF;
-    *(p++) = ( ticket.ticket_lifetime >>  8 ) & 0xFF;
-    *(p++) = ( ticket.ticket_lifetime >>  0 ) & 0xFF;
+    *(p++) = ( ssl->session->ticket_age_add >> 24 ) & 0xFF;
+    *(p++) = ( ssl->session->ticket_age_add >> 16 ) & 0xFF;
+    *(p++) = ( ssl->session->ticket_age_add >>  8 ) & 0xFF;
+    *(p++) = ( ssl->session->ticket_age_add >>  0 ) & 0xFF;
 
-    MBEDTLS_SSL_DEBUG_MSG( 3, ( "ticket->ticket_lifetime: %d",
-                                ticket.ticket_lifetime ) );
+    MBEDTLS_SSL_DEBUG_MSG( 3, ( "ticket->ticket_age_add: %u", ssl->session->ticket_age_add ) );
 
-    *(p++) = ( ticket.ticket_age_add >> 24 ) & 0xFF;
-    *(p++) = ( ticket.ticket_age_add >> 16 ) & 0xFF;
-    *(p++) = ( ticket.ticket_age_add >>  8 ) & 0xFF;
-    *(p++) = ( ticket.ticket_age_add >>  0 ) & 0xFF;
-
-    MBEDTLS_SSL_DEBUG_BUF( 3, "ticket->ticket_age_add:",
-                           (const unsigned char *) &ticket.ticket_age_add, 4 );
-
-    /* Nonce Length */
+    /* Ticket Nonce */
     *(p++) = MBEDTLS_SSL_TICKET_NONCE_LENGTH;
 
-    /*
-     *  HKDF-Expand-Label( resumption_master_secret,
-     *                    "resumption", ticket_nonce, Hash.length )
-     */
-
-    /* Compute and write nonce */
     ret = ssl->conf->f_rng( ssl->conf->p_rng, p,
                             MBEDTLS_SSL_TICKET_NONCE_LENGTH );
     if( ret != 0 )
@@ -1604,13 +1589,20 @@ static int ssl_write_new_session_ticket_write( mbedtls_ssl_context* ssl,
                            ssl->session->resumption_master_secret,
                            hash_length );
 
+    /* Computer resumption key
+     * 
+     *  HKDF-Expand-Label( resumption_master_secret,
+     *                    "resumption", ticket_nonce, Hash.length )
+     */
     ret = mbedtls_ssl_tls1_3_hkdf_expand_label( suite_info->mac,
                ssl->session->resumption_master_secret,
                hash_length,
                MBEDTLS_SSL_TLS1_3_LBL_WITH_LEN( resumption ),
                (const unsigned char *) p,
                MBEDTLS_SSL_TICKET_NONCE_LENGTH,
-               ticket.key, hash_length );
+               ssl->session->key,
+               hash_length );
+
     if( ret != 0 )
     {
         MBEDTLS_SSL_DEBUG_RET( 2, "Creating the ticket-resumed PSK failed", ret );
@@ -1619,21 +1611,31 @@ static int ssl_write_new_session_ticket_write( mbedtls_ssl_context* ssl,
 
     p += MBEDTLS_SSL_TICKET_NONCE_LENGTH;
 
-    MBEDTLS_SSL_DEBUG_BUF( 3, "Ticket-resumed PSK",
-                           ticket.key, ticket.key_len );
-    MBEDTLS_SSL_DEBUG_MSG( 3, ( "ticket->key_len: %d", ticket.key_len ) );
+    ssl->session->resumption_key_len = hash_length;
 
+    MBEDTLS_SSL_DEBUG_BUF( 3, "Ticket-resumed PSK",
+                           ssl->session->key, hash_length );
+
+    /* Ticket */
     ret = ssl->conf->f_ticket_write( ssl->conf->p_ticket,
-                                     &ticket,
+                                     ssl->session,
                                      p + 2, end,
                                      &tlen,
-                                     &ticket.ticket_lifetime,
-                                     &ticket.flags );
+                                     &ssl->session->ticket_lifetime);
     if( ret != 0 )
     {
         MBEDTLS_SSL_DEBUG_RET( 1, "f_ticket_write", ret );
         return( ret );
     }
+
+    /* Ticket lifetime */
+    *(ticket_lifetime_ptr++) = ( ssl->session->ticket_lifetime >> 24 ) & 0xFF;
+    *(ticket_lifetime_ptr++) = ( ssl->session->ticket_lifetime >> 16 ) & 0xFF;
+    *(ticket_lifetime_ptr++) = ( ssl->session->ticket_lifetime >>  8 ) & 0xFF;
+    *(ticket_lifetime_ptr++) = ( ssl->session->ticket_lifetime >>  0 ) & 0xFF;
+
+    MBEDTLS_SSL_DEBUG_MSG( 3, ( "ticket->ticket_lifetime: %d",
+                               ssl->session->ticket_lifetime ) );
 
     /* Ticket Length */
     p[0] = (unsigned char)( ( tlen >> 8 ) & 0xFF );
@@ -1641,18 +1643,27 @@ static int ssl_write_new_session_ticket_write( mbedtls_ssl_context* ssl,
 
     p += 2 + tlen;
 
-    /* no extensions for now -> set length to zero */
+    /* Ticket Extensions
+     *
+     * Note: We currently don't have any extensions.
+     * Set length to zero.
+     */
     *(p++) = ( ext_len >> 8 ) & 0xFF;
     *(p++) = ( ext_len >> 0 ) & 0xFF;
 
+    MBEDTLS_SSL_DEBUG_MSG( 3, ( "NewSessionTicket (extension_length): %d", ext_len ) );
+
+    MBEDTLS_SSL_DEBUG_MSG( 3, ( "NewSessionTicket (ticket length): %d", tlen ) );
+
     *olen = p - buf;
 
-    MBEDTLS_SSL_DEBUG_MSG( 3, ( "NewSessionTicket (extension_length): %d", ext_len ) );
-    MBEDTLS_SSL_DEBUG_MSG( 3, ( "NewSessionTicket (ticket length): %d", tlen ) );
+    MBEDTLS_SSL_DEBUG_BUF( 5, "ticket", buf, *olen );
+
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "<= write new session ticket" ) );
 
     return( ret );
 }
+#endif /* MBEDTLS_SSL_NEW_SESSION_TICKET */
 
 /*
  *
@@ -2087,8 +2098,8 @@ static int ssl_client_hello_postprocess( mbedtls_ssl_context* ssl,
 static int ssl_client_hello_process( mbedtls_ssl_context* ssl )
 {
 
-    int ret;
-    int hrr_required;
+    int ret = 0;
+    int hrr_required = SSL_CLIENT_HELLO_OK;
     unsigned char* buf = NULL;
     size_t buflen = 0;
 #if defined(MBEDTLS_SSL_USE_MPS)
@@ -2122,7 +2133,7 @@ static int ssl_client_hello_process( mbedtls_ssl_context* ssl )
 #else /* MBEDTLS_SSL_USE_MPS */
 
     MBEDTLS_SSL_PROC_CHK( ssl_client_hello_fetch( ssl, &buf, &buflen ) );
-    MBEDTLS_SSL_PROC_CHK( ssl_client_hello_parse( ssl, buf, buflen ) );
+    MBEDTLS_SSL_PROC_CHK_NEG( ssl_client_hello_parse( ssl, buf, buflen ) );
     hrr_required = ret;
 
 #endif /* MBEDTLS_SSL_USE_MPS */
@@ -4664,6 +4675,11 @@ int mbedtls_ssl_handshake_server_step( mbedtls_ssl_context *ssl )
             }
 #endif /* MBEDTLS_CID && MBEDTLS_SSL_PROTO_DTLS */
 
+#if defined(MBEDTLS_SSL_NEW_SESSION_TICKET)
+            ssl->session_negotiate->minor_ver = ssl->minor_ver;
+            ssl->session_negotiate->endpoint = ssl->conf->endpoint;
+#endif /* MBEDTLS_SSL_NEW_SESSION_TICKET */
+
             ret = ssl_client_hello_process( ssl );
             if( ret != 0 )
                 MBEDTLS_SSL_DEBUG_RET( 1, "ssl_client_hello_process", ret );
@@ -4905,12 +4921,16 @@ int mbedtls_ssl_handshake_server_step( mbedtls_ssl_context *ssl )
 
         case MBEDTLS_SSL_SERVER_NEW_SESSION_TICKET:
 
+#if defined(MBEDTLS_SSL_NEW_SESSION_TICKET)
+
             ret = ssl_write_new_session_ticket_process( ssl );
             if( ret != 0 )
             {
                 MBEDTLS_SSL_DEBUG_RET( 1, "ssl_write_new_session_ticket ", ret );
                 return( ret );
             }
+#endif /* MBEDTLS_SSL_NEW_SESSION_TICKET */
+
             break;
 
         default:

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -2745,7 +2745,7 @@ int main( int argc, char *argv[] )
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
     // Configure key exchange mode
-    mbedtls_ssl_conf_ke( &conf, opt.key_exchange_modes );
+    mbedtls_ssl_conf_tls13_key_exchange( &conf, opt.key_exchange_modes );
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 
 #if defined(MBEDTLS_DHM_C)
@@ -3794,9 +3794,10 @@ reconnect:
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
         // Configure key exchange mode to use PSK-ECDHE
-        if( ( ret = mbedtls_ssl_conf_ke( &conf, MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_DHE_KE ) )  != 0 )
+        if( ( ret = mbedtls_ssl_conf_tls13_key_exchange( &conf,
+                            MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_DHE_KE ) )  != 0 )
         {
-            mbedtls_printf( " failed\n  ! mbedtls_ssl_conf_ke returned -0x%x\n\n",
+            mbedtls_printf( " failed\n  ! mbedtls_ssl_conf_tls13_key_exchange returned -0x%x\n\n",
                             (unsigned int) -ret );
             goto exit;
         }

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -3916,7 +3916,7 @@ int main( int argc, char *argv[] )
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
     /* Configure supported TLS 1.3 key exchange modes. */
-    mbedtls_ssl_conf_ke(&conf, opt.key_exchange_modes);
+    mbedtls_ssl_conf_tls13_key_exchange( &conf, opt.key_exchange_modes );
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 
 #if defined(MBEDTLS_DHM_C)

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -2144,7 +2144,9 @@ int main( int argc, char *argv[] )
     opt.async_private_error = DFL_ASYNC_PRIVATE_ERROR;
     opt.psk                 = DFL_PSK;
     opt.key_exchange_modes = DFL_KEY_EXCHANGE_MODES;
+#if defined(MBEDTLS_SSL_NEW_SESSION_TICKET)
     opt.ticket_flags        = DFL_TICKET_FLAGS;
+#endif /* MBEDTLS_SSL_NEW_SESSION_TICKET */
     opt.early_data          = DFL_EARLY_DATA;
     opt.sig_algs            = DFL_SIG_ALGS;
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
@@ -3570,28 +3572,7 @@ int main( int argc, char *argv[] )
                                    mbedtls_ssl_cache_get,
                                    mbedtls_ssl_cache_set );
 #endif
-
-#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
-#if defined(MBEDTLS_SSL_NEW_SESSION_TICKET)
-    if( opt.tickets == MBEDTLS_SSL_SESSION_TICKETS_ENABLED )
-    {
-        if( ( ret = mbedtls_ssl_ticket_setup( &ticket_ctx,
-                        mbedtls_ctr_drbg_random, &ctr_drbg,
-                        MBEDTLS_CIPHER_AES_256_GCM,
-                        opt.ticket_timeout, opt.ticket_flags ) ) != 0 )
-        {
-            mbedtls_printf( " failed\n  ! mbedtls_ssl_ticket_setup returned %d\n\n", ret );
-            goto exit;
-        }
-
-        mbedtls_ssl_conf_session_tickets_cb( &conf,
-                mbedtls_ssl_ticket_write,
-                mbedtls_ssl_ticket_parse,
-                &ticket_ctx, opt.tickets );
-    }
-#endif /* MBEDTLS_SSL_NEW_SESSION_TICKET */
-#else
-#if defined(MBEDTLS_SSL_SESSION_TICKETS)
+#if defined(MBEDTLS_SSL_SESSION_TICKETS) || defined(MBEDTLS_SSL_NEW_SESSION_TICKET)
     if( opt.tickets == MBEDTLS_SSL_SESSION_TICKETS_ENABLED )
     {
         if( ( ret = mbedtls_ssl_ticket_setup( &ticket_ctx,
@@ -3607,9 +3588,15 @@ int main( int argc, char *argv[] )
                 mbedtls_ssl_ticket_write,
                 mbedtls_ssl_ticket_parse,
                 &ticket_ctx );
+
+#if defined(MBEDTLS_SSL_NEW_SESSION_TICKET)
+        /* Enable use of tickets */
+        mbedtls_ssl_conf_session_tickets( &conf, opt.tickets );
+#endif /* MBEDTLS_SSL_NEW_SESSION_TICKET */
+
     }
-#endif /* MBEDTLS_SSL_SESSION_TICKETS */
-#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
+
+#endif /* MBEDTLS_SSL_SESSION_TICKETS || MBEDTLS_SSL_NEW_SESSION_TICKET */
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
 #if defined(MBEDTLS_SSL_COOKIE_C)
@@ -3929,7 +3916,7 @@ int main( int argc, char *argv[] )
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
     /* Configure supported TLS 1.3 key exchange modes. */
-    mbedtls_ssl_conf_tls13_key_exchange(&conf, opt.key_exchange_modes);
+    mbedtls_ssl_conf_ke(&conf, opt.key_exchange_modes);
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 
 #if defined(MBEDTLS_DHM_C)


### PR DESCRIPTION
This PR aims to replace PR#68 - https://github.com/hannestschofenig/mbedtls/pull/68

The description of PR 68 applies to this PR. In addition, C preprocessor directives have been included to allow excluding ticket handling in implementations that do not use it.