### PR TITLE
Fix mps compiler error of -Wreturn-type and -Wsometimes-uninitialized

### DIFF
--- a/library/mps/layer1.c
+++ b/library/mps/layer1.c
@@ -1160,6 +1160,7 @@ int mps_l1_fetch( mps_l1 *ctx, unsigned char **buf,
     MBEDTLS_MPS_ELSE_IF_DTLS( mode )
         return( l1_fetch_dgram( &ctx->raw.dgram.rd, buf, desired ) );
 #endif /* MBEDTLS_MPS_PROTO_DTLS */
+    RETURN( MBEDTLS_ERR_MPS_INTERNAL_ERROR );
 }
 
 int mps_l1_consume( mps_l1 *ctx )
@@ -1175,6 +1176,7 @@ int mps_l1_consume( mps_l1 *ctx )
     MBEDTLS_MPS_ELSE_IF_DTLS( mode )
         return( l1_consume_dgram( &ctx->raw.dgram.rd ) );
 #endif /* MBEDTLS_MPS_PROTO_DTLS */
+    RETURN( MBEDTLS_ERR_MPS_INTERNAL_ERROR );
 }
 
 int mps_l1_write( mps_l1 *ctx, unsigned char **buf,
@@ -1191,6 +1193,7 @@ int mps_l1_write( mps_l1 *ctx, unsigned char **buf,
     MBEDTLS_MPS_ELSE_IF_DTLS( mode )
         return( l1_write_dgram( &ctx->raw.dgram.wr, buf, buflen ) );
 #endif /* MBEDTLS_MPS_PROTO_DTLS */
+    RETURN( MBEDTLS_ERR_MPS_INTERNAL_ERROR );
 }
 
 int mps_l1_dispatch( mps_l1 *ctx,
@@ -1208,6 +1211,7 @@ int mps_l1_dispatch( mps_l1 *ctx,
     MBEDTLS_MPS_ELSE_IF_DTLS( mode )
         return( l1_dispatch_dgram( &ctx->raw.dgram.wr, len, pending ) );
 #endif /* MBEDTLS_MPS_PROTO_DTLS */
+    RETURN( MBEDTLS_ERR_MPS_INTERNAL_ERROR );
 }
 
 int mps_l1_flush( mps_l1 *ctx )
@@ -1223,6 +1227,7 @@ int mps_l1_flush( mps_l1 *ctx )
     MBEDTLS_MPS_ELSE_IF_DTLS( mode )
         return( l1_flush_dgram( &ctx->raw.dgram.wr ) );
 #endif /* MBEDTLS_MPS_PROTO_DTLS */
+    RETURN( MBEDTLS_ERR_MPS_INTERNAL_ERROR );
 }
 
 /* TODO: Will we need this at some point? */
@@ -1240,6 +1245,7 @@ int mps_l1_read_dependency( mps_l1 *ctx )
     MBEDTLS_MPS_ELSE_IF_DTLS( mode )
         return( l1_read_dependency_dgram( &ctx->raw.dgram.rd ) );
 #endif /* MBEDTLS_MPS_PROTO_DTLS */
+    RETURN( MBEDTLS_ERR_MPS_INTERNAL_ERROR );
 }
 
 /* TODO: Will we need this at some point? */
@@ -1257,6 +1263,7 @@ int mps_l1_write_dependency( mps_l1 *ctx )
     MBEDTLS_MPS_ELSE_IF_DTLS( mode )
         return( l1_write_dependency_dgram( &ctx->raw.dgram.wr ) );
 #endif /* MBEDTLS_MPS_PROTO_DTLS */
+    RETURN( MBEDTLS_ERR_MPS_INTERNAL_ERROR );
 }
 
 #if defined(MBEDTLS_MPS_PROTO_DTLS)

--- a/library/mps/layer2.c
+++ b/library/mps/layer2.c
@@ -1857,6 +1857,7 @@ int l2_in_fetch_protected_record( mbedtls_mps_l2 *ctx, mps_rec *rec )
         RETURN( l2_in_fetch_protected_record_dtls12( ctx, rec ) );
     }
 #endif /* MBEDTLS_MPS_PROTO_DTLS */
+    RETURN( MBEDTLS_ERR_MPS_INTERNAL_ERROR );
 }
 
 MBEDTLS_MPS_STATIC
@@ -1904,6 +1905,7 @@ mbedtls_mps_size_t l2_get_header_len( mbedtls_mps_l2 *ctx,
 #else
     ((void) ctx);
 #endif /* MBEDTLS_MPS_PROTO_DTLS */
+    RETURN( 0 );
 }
 
 #if defined(MBEDTLS_MPS_PROTO_TLS)
@@ -2195,16 +2197,24 @@ int l2_out_get_and_update_rec_seq( mbedtls_mps_l2 *ctx,
 
 #if defined(MBEDTLS_MPS_PROTO_TLS)
     MBEDTLS_MPS_IF_TLS( mode )
+    {
         src_ctr = epoch->stats.tls.out_ctr;
+        dst_ctr[0] = src_ctr[0];
+        dst_ctr[1] = src_ctr[1];
+        return( l2_increment_counter( src_ctr ) );
+    }
 #endif /* MBEDTLS_MPS_PROTO_TLS */
 #if defined(MBEDTLS_MPS_PROTO_DTLS)
     MBEDTLS_MPS_ELSE_IF_DTLS( mode )
+    {
         src_ctr = epoch->stats.dtls.out_ctr;
+        dst_ctr[0] = src_ctr[0];
+        dst_ctr[1] = src_ctr[1];
+        return( l2_increment_counter( src_ctr ) );
+    }
 #endif /* MBEDTLS_MPS_PROTO_DTLS */
+    RETURN( MBEDTLS_ERR_MPS_INTERNAL_ERROR );
 
-    dst_ctr[0] = src_ctr[0];
-    dst_ctr[1] = src_ctr[1];
-    return( l2_increment_counter( src_ctr ) );
 }
 
 #if defined(MBEDTLS_MPS_PROTO_DTLS)

--- a/library/mps/layer3.c
+++ b/library/mps/layer3.c
@@ -933,7 +933,7 @@ MBEDTLS_MPS_STATIC int l3_check_write_hs_hdr( mps_l3 *l3 )
 int mps_l3_write_handshake( mps_l3 *l3, mps_l3_handshake_out *out )
 {
     int res;
-    int32_t len;
+    int32_t len = MBEDTLS_MPS_SIZE_UNKNOWN;
     mbedtls_mps_l2* const l2 = mbedtls_mps_l3_get_l2( l3 );
     mbedtls_mps_transport_type const mode =
         mbedtls_mps_l3_conf_get_mode( &l3->conf );


### PR DESCRIPTION
Summary:
Found some compiler error when build with -Wreturn-type and
-Wsometimes-uninitialized
```
/home/lhuang04/upstream/library/mps/layer1.c:1163:1: error: control may reach end of non-void function [-Werror,-Wreturn-type]
}
^
/home/lhuang04/upstream/library/mps/layer1.c:1178:1: error: control may reach end of non-void function [-Werror,-Wreturn-type]
}
^
/home/lhuang04/upstream/library/mps/layer1.c:1194:1: error: control may reach end of non-void function [-Werror,-Wreturn-type]
}
^
/home/lhuang04/upstream/library/mps/layer1.c:1211:1: error: control may reach end of non-void function [-Werror,-Wreturn-type]
}
^
/home/lhuang04/upstream/library/mps/layer1.c:1226:1: error: control may reach end of non-void function [-Werror,-Wreturn-type]
}
^
/home/lhuang04/upstream/library/mps/layer1.c:1243:1: error: control may reach end of non-void function [-Werror,-Wreturn-type]
}
^
/home/lhuang04/upstream/library/mps/layer1.c:1260:1: error: control may reach end of non-void function [-Werror,-Wreturn-type]
}
^
7 errors generated.
make[2]: *** [library/CMakeFiles/mbedtls.dir/mps/layer1.c.o] Error 1
make[2]: *** Waiting for unfinished jobs....
/home/lhuang04/upstream/library/mps/layer3.c:1097:5: error: variable 'len' is used uninitialized whenever 'if' condition is false [-Werror,-Wsometimes-uninitialized]
    MBEDTLS_MPS_ELSE_IF_DTLS( mode )
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/lhuang04/upstream/include/mbedtls/mps/common.h:405:14: note: expanded from macro 'MBEDTLS_MPS_ELSE_IF_DTLS'
    else if( ( mode ) == ( mode ) )
             ^~~~~~~~~~~~~~~~~~~~
/home/lhuang04/upstream/library/mps/layer3.c:1103:34: note: uninitialized use occurs here
                                 len != MBEDTLS_MPS_SIZE_UNKNOWN
                                 ^~~
/home/lhuang04/upstream/library/mps/layer3.c:1097:5: note: remove the 'if' if its condition is always true
    MBEDTLS_MPS_ELSE_IF_DTLS( mode )
    ^
/home/lhuang04/upstream/include/mbedtls/mps/common.h:405:10: note: expanded from macro 'MBEDTLS_MPS_ELSE_IF_DTLS'
    else if( ( mode ) == ( mode ) )
         ^
/home/lhuang04/upstream/library/mps/layer3.c:936:16: note: initialize the variable 'len' to silence this warning
    int32_t len;
               ^
                = 0
1 error generated.
make[2]: *** [library/CMakeFiles/mbedtls.dir/mps/layer3.c.o] Error 1
/home/lhuang04/upstream/library/mps/layer2.c:1860:1: error: control may reach end of non-void function [-Werror,-Wreturn-type]
}
^
/home/lhuang04/upstream/library/mps/layer2.c:1907:1: error: control may reach end of non-void function [-Werror,-Wreturn-type]
}
^
/home/lhuang04/upstream/library/mps/layer2.c:2201:5: error: variable 'src_ctr' is used uninitialized whenever 'if' condition is false [-Werror,-Wsometimes-uninitialized]
    MBEDTLS_MPS_ELSE_IF_DTLS( mode )
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/lhuang04/upstream/include/mbedtls/mps/common.h:405:14: note: expanded from macro 'MBEDTLS_MPS_ELSE_IF_DTLS'
    else if( ( mode ) == ( mode ) )
             ^~~~~~~~~~~~~~~~~~~~
/home/lhuang04/upstream/library/mps/layer2.c:2205:18: note: uninitialized use occurs here
    dst_ctr[0] = src_ctr[0];
                 ^~~~~~~
/home/lhuang04/upstream/library/mps/layer2.c:2201:5: note: remove the 'if' if its condition is always true
    MBEDTLS_MPS_ELSE_IF_DTLS( mode )
    ^
/home/lhuang04/upstream/include/mbedtls/mps/common.h:405:10: note: expanded from macro 'MBEDTLS_MPS_ELSE_IF_DTLS'
    else if( ( mode ) == ( mode ) )
         ^
/home/lhuang04/upstream/library/mps/layer2.c:2192:22: note: initialize the variable 'src_ctr' to silence this warning
    uint32_t *src_ctr;
                     ^
                      = NULL
3 errors generated.
make[2]: *** [library/CMakeFiles/mbedtls.dir/mps/layer2.c.o] Error 1

```

Test Plan:
```
rm -rf build/; mkdir build; cd build; CC="/bin/clang" CFLAGS="-g -Wunused-variable -Wsometimes-uninitialized -Wreturn-type" cmake ..; make -j;
```

Reviewers:

Subscribers:

Tasks:

Tags: