### PR TITLE
Minor MPS fixes and graceful handling of illegitimate compiler warnings

### DIFF
--- a/include/mbedtls/mps/common.h
+++ b/include/mbedtls/mps/common.h
@@ -384,7 +384,7 @@ typedef uint8_t mbedtls_mps_transport_type;
 #else
 /* Define `1` in a roundabout way using `mode` to avoid unused
  * variable warnings. */
-#define MBEDTLS_MPS_IS_TLS( mode ) ( ( mode ) == ( mode ) )
+#define MBEDTLS_MPS_IS_TLS( mode ) ( ((void) mode), 1 )
 #endif /* MBEDTLS_MPS_PROTO_BOTH */
 
 #define MBEDTLS_MPS_IF_TLS( mode ) if( MBEDTLS_MPS_IS_TLS( mode ) )
@@ -399,14 +399,12 @@ typedef uint8_t mbedtls_mps_transport_type;
 #if defined(MBEDTLS_MPS_PROTO_BOTH)
 #define MBEDTLS_MPS_IS_DTLS( mode )               \
     ( (mode) == MBEDTLS_MPS_MODE_DATAGRAM )
-/* Define `1` in a roundabout way using `mode` to avoid unused
- * variable warnings. */
 #define MBEDTLS_MPS_ELSE_IF_DTLS( mode )         \
-    else if( ( mode ) == ( mode ) )
+    else if( ((void)mode), 1 )
 #else
 /* Define `1` in a roundabout way using `mode` to avoid unused
  * variable warnings. */
-#define MBEDTLS_MPS_IS_DTLS( mode ) ( ( mode ) == ( mode ) )
+#define MBEDTLS_MPS_IS_DTLS( mode ) ( ((void) mode), 1 )
 #define MBEDTLS_MPS_ELSE_IF_DTLS( mode )        \
     if( MBEDTLS_MPS_IS_DTLS( mode ) )
 #endif /* MBEDTLS_MPS_PROTO_BOTH */

--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -1282,7 +1282,10 @@ int mbedtls_ssl_read_record( mbedtls_ssl_context *ssl,
 
 int mbedtls_ssl_fetch_input(mbedtls_ssl_context* ssl, size_t nb_want);
 int mbedtls_ssl_flush_output(mbedtls_ssl_context* ssl);
+
+#if !defined(MBEDTLS_SSL_US_EMPS)
 int mbedtls_ssl_write_record( mbedtls_ssl_context *ssl, uint8_t force_flush );
+#endif /* MBEDTLS_SSL_USE_MPS */
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
 int mbedtls_ssl_read_certificate_process(mbedtls_ssl_context* ssl);

--- a/library/mps/layer2.c
+++ b/library/mps/layer2.c
@@ -1907,8 +1907,6 @@ mbedtls_mps_size_t l2_get_header_len( mbedtls_mps_l2 *ctx,
          * which have a uniform and simple record header. */
         RETURN( dtls12_rec_hdr_len );
     }
-#else
-    ((void) ctx);
 #endif /* MBEDTLS_MPS_PROTO_DTLS */
 }
 

--- a/library/mps/layer2.c
+++ b/library/mps/layer2.c
@@ -723,11 +723,17 @@ int l2_out_dispatch_record( mbedtls_mps_l2 *ctx )
         if( ret != 0 )
             RETURN( ret );
 
+#if defined(MBEDTLS_MPS_PROTO_TLS)
         MBEDTLS_MPS_ASSERT_RAW(
            ctx->io.out.state == MBEDTLS_MPS_L2_WRITER_STATE_UNSET ||
            ( ctx->io.out.state == MBEDTLS_MPS_L2_WRITER_STATE_QUEUEING &&
              MBEDTLS_MPS_IS_TLS( mbedtls_mps_l2_conf_get_mode( &ctx->conf ) ) ),
            "Unexpected writer state at the end of l2_out_dispatch_record()" );
+#else
+        MBEDTLS_MPS_ASSERT_RAW(
+            ctx->io.out.state == MBEDTLS_MPS_L2_WRITER_STATE_UNSET,
+            "Unexpected writer state at the end of l2_out_dispatch_record()" );
+#endif /* MBEDTLS_MPS_PROTO_TLS */
 
 #if defined(MBEDTLS_MPS_PROTO_TLS)
         if( ctx->io.out.state == MBEDTLS_MPS_L2_WRITER_STATE_UNSET )

--- a/library/mps/layer2.c
+++ b/library/mps/layer2.c
@@ -2053,6 +2053,25 @@ int l2_in_fetch_protected_record_tls( mbedtls_mps_l2 *ctx, mps_rec *rec )
         RETURN( ret );
 
     /*
+     * Check if the record should be silently ignored.
+     */
+
+    /*
+     * Check if we should ignore the record.
+     */
+    if( l2_type_ignore( ctx, type ) == 1 )
+    {
+        TRACE( trace_comment, "Silently ignore record of type %u",
+               (unsigned) type );
+
+        ret = l2_in_release_record( ctx );
+        if( ret != 0 )
+            RETURN( ret );
+
+        RETURN( MBEDTLS_ERR_MPS_RETRY );
+    }
+
+    /*
      * Write target record structure
      */
 
@@ -2537,6 +2556,19 @@ int l2_type_empty_allowed( mbedtls_mps_l2 *ctx, mbedtls_mps_msg_type_t type )
     uint32_t const mask = ((uint32_t) 1u) << type;
     uint32_t const flag =
         mbedtls_mps_l2_conf_get_empty_flag( &ctx->conf );
+    return( ( flag & mask ) != 0 );
+}
+
+/* Check if records of a valid record content type should be
+ * silently ignored.
+ * This assumes that the provided type is at least valid,
+ * and in particular smaller than 64. */
+MBEDTLS_MPS_STATIC
+int l2_type_ignore( mbedtls_mps_l2 *ctx, mbedtls_mps_msg_type_t type )
+{
+    uint32_t const mask = ((uint32_t) 1u) << type;
+    uint32_t const flag =
+        mbedtls_mps_l2_conf_get_ignore_flag( &ctx->conf );
     return( ( flag & mask ) != 0 );
 }
 

--- a/library/mps/layer2_internal.h
+++ b/library/mps/layer2_internal.h
@@ -182,6 +182,8 @@ MBEDTLS_MPS_STATIC int l2_type_is_valid( mbedtls_mps_l2 *ctx,
                              mbedtls_mps_msg_type_t type );
 MBEDTLS_MPS_STATIC int l2_type_empty_allowed( mbedtls_mps_l2 *ctx,
                                   mbedtls_mps_msg_type_t type );
+MBEDTLS_MPS_STATIC int l2_type_ignore( mbedtls_mps_l2 *ctx,
+                                       mbedtls_mps_msg_type_t type );
 
 /*
  * Epoch handling

--- a/library/mps/layer3.c
+++ b/library/mps/layer3.c
@@ -155,7 +155,7 @@ int mps_l3_read( mps_l3 *l3 )
      * For now, just force the initialization.
      */
     {
-        mps_l2_in l2_in_zero = { 0 };
+        mps_l2_in l2_in_zero = { .type = 0, .epoch = 0, .rd = NULL };
         in = l2_in_zero;
     }
 

--- a/library/mps/mps.c
+++ b/library/mps/mps.c
@@ -1549,8 +1549,11 @@ int mbedtls_mps_write_handshake( mbedtls_mps *mps,
          * like the zero-initialization below, or some attribute, or we remove
          * the duplication of the modes altogether -- which would ultimately
          * be the best solution. */
-
-        mps_l3_handshake_out hs_l3 = { 0 };
+        /* Use per-field initialization to silence annoying compiler warning
+         * when using the _compliant_ `struct foo bar = { 0 }` zero-initialization... */
+        mps_l3_handshake_out hs_l3 = { .epoch = 0, .type = 0, .seq_nr = 0,
+                                       .len = 0, .frag_len = 0, .frag_offset = 0,
+                                       .wr_ext = NULL };
 
         /* Retransmission isn't needed in TLS. */
         ((void) cb);
@@ -3242,7 +3245,11 @@ int mbedtls_mps_retransmission_handle_incoming_fragment( mbedtls_mps *mps )
      * At the moment, each layer has its own configuration, and in particular
      * its own `mode` identifier, and if L4 and L3 mode get out of sync,
      * we'd use parts of `hs_l3` uninitialized below. */
-    mps_l3_handshake_in hs_l3 = { 0 };
+    /* Use per-field initialization to silence annoying compiler warning
+     * when using the _compliant_ `struct foo bar = { 0 }` zero-initialization... */
+    mps_l3_handshake_in hs_l3 = { .epoch = 0, .type = 0, .len = 0,
+                                  .frag_len = 0, .frag_offset = 0, .seq_nr = 0,
+                                  .rd_ext = NULL };
     mps_l3* const l3 = mbedtls_mps_l4_get_l3( mps );
     TRACE_INIT( "mps_retransmission_handle_incoming_fragment" );
 

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -2705,6 +2705,7 @@ void mbedtls_ssl_send_flight_completed( mbedtls_ssl_context *ssl )
  * Handshake layer functions
  */
 
+#if !defined(MBEDTLS_SSL_USE_MPS)
 /*
  * Write (DTLS: or queue) current handshake (including CCS) message.
  *
@@ -2903,10 +2904,6 @@ int mbedtls_ssl_write_record( mbedtls_ssl_context *ssl, uint8_t force_flush )
 
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> write record" ) );
 
-#if defined(MBEDTLS_SSL_USE_MPS)
-    return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
-#endif
-
 #if defined(MBEDTLS_ZLIB_SUPPORT)
     if( ssl->transform_out != NULL &&
         ssl->session_out->compression == MBEDTLS_SSL_COMPRESS_DEFLATE )
@@ -3080,6 +3077,7 @@ int mbedtls_ssl_write_record( mbedtls_ssl_context *ssl, uint8_t force_flush )
 
     return( 0 );
 }
+#endif /* MBEDTLS_SSL_USE_MPS */
 
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
 

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -4333,28 +4333,34 @@ static int ssl_mps_init( mbedtls_ssl_context *ssl )
     ret = mps_l2_config_add_type( &ssl->mps.l2, MBEDTLS_MPS_MSG_HS,
                                   MBEDTLS_MPS_SPLIT_ENABLED,
                                   MBEDTLS_MPS_PACK_ENABLED,
-                                  MBEDTLS_MPS_EMPTY_FORBIDDEN );
+                                  MBEDTLS_MPS_EMPTY_FORBIDDEN,
+                                  MBEDTLS_MPS_IGNORE_KEEP );
     if( ret != 0 )
         goto exit;
 
     ret = mps_l2_config_add_type( &ssl->mps.l2, MBEDTLS_MPS_MSG_ALERT,
                                   MBEDTLS_MPS_SPLIT_DISABLED,
                                   MBEDTLS_MPS_PACK_DISABLED,
-                                  MBEDTLS_MPS_EMPTY_FORBIDDEN );
+                                  MBEDTLS_MPS_EMPTY_FORBIDDEN,
+                                  MBEDTLS_MPS_IGNORE_KEEP );
     if( ret != 0 )
         goto exit;
 
+#if defined(MBEDTLS_SSL_TLS13_COMPATIBILITY_MODE)
     ret = mps_l2_config_add_type( &ssl->mps.l2, MBEDTLS_MPS_MSG_CCS,
                                   MBEDTLS_MPS_SPLIT_DISABLED,
                                   MBEDTLS_MPS_PACK_DISABLED,
-                                  MBEDTLS_MPS_EMPTY_FORBIDDEN );
+                                  MBEDTLS_MPS_EMPTY_FORBIDDEN,
+                                  MBEDTLS_MPS_IGNORE_DROP );
     if( ret != 0 )
         goto exit;
+#endif /* MBEDTLS_SSL_TLS13_COMPATIBILITY_MODE */
 
     ret = mps_l2_config_add_type( &ssl->mps.l2, MBEDTLS_MPS_MSG_APP,
                                   MBEDTLS_MPS_SPLIT_ENABLED,
                                   MBEDTLS_MPS_PACK_ENABLED,
-                                  MBEDTLS_MPS_EMPTY_ALLOWED );
+                                  MBEDTLS_MPS_EMPTY_ALLOWED,
+                                  MBEDTLS_MPS_IGNORE_KEEP );
     if( ret != 0 )
         goto exit;
 

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -805,10 +805,13 @@ int mbedtls_ssl_write_change_cipher_spec_process( mbedtls_ssl_context* ssl );
 #define SSL_WRITE_CCS_NEEDED     0
 #define SSL_WRITE_CCS_SKIP       1
 static int ssl_write_change_cipher_spec_coordinate( mbedtls_ssl_context* ssl );
+
+#if !defined(MBEDTLS_SSL_USE_MPS)
 static int ssl_write_change_cipher_spec_write( mbedtls_ssl_context* ssl,
     unsigned char* buf,
     size_t buflen,
     size_t* olen );
+#endif /* !MBEDTLS_SSL_USE_MPS */
 static int ssl_write_change_cipher_spec_postprocess( mbedtls_ssl_context* ssl );
 
 
@@ -826,6 +829,13 @@ int mbedtls_ssl_write_change_cipher_spec_process( mbedtls_ssl_context* ssl )
 
     if( ret == SSL_WRITE_CCS_NEEDED )
     {
+#if defined(MBEDTLS_SSL_USE_MPS)
+
+        MBEDTLS_SSL_PROC_CHK( mbedtls_mps_flush( &ssl->mps.l4 ) );
+        MBEDTLS_SSL_PROC_CHK( mbedtls_mps_write_ccs( &ssl->mps.l4 ) );
+        MBEDTLS_SSL_PROC_CHK( mbedtls_mps_dispatch( &ssl->mps.l4 ) );
+
+#else /* MBEDTLS_SSL_USE_MPS */
         /* Make sure we can write a new message. */
         MBEDTLS_SSL_PROC_CHK( mbedtls_ssl_flush_output( ssl ) );
 
@@ -838,6 +848,8 @@ int mbedtls_ssl_write_change_cipher_spec_process( mbedtls_ssl_context* ssl )
 
         /* Dispatch message */
         MBEDTLS_SSL_PROC_CHK( mbedtls_ssl_write_record( ssl, SSL_FORCE_FLUSH ) );
+
+#endif /* MBEDTLS_SSL_USE_MPS */
 
         /* Update state */
         MBEDTLS_SSL_PROC_CHK( ssl_write_change_cipher_spec_postprocess( ssl ) );
@@ -876,6 +888,7 @@ static int ssl_write_change_cipher_spec_coordinate( mbedtls_ssl_context* ssl )
     return( ret );
 }
 
+#if !defined(MBEDTLS_SSL_USE_MPS)
 static int ssl_write_change_cipher_spec_write( mbedtls_ssl_context* ssl,
                                                unsigned char* buf,
                                                size_t buflen,
@@ -893,6 +906,7 @@ static int ssl_write_change_cipher_spec_write( mbedtls_ssl_context* ssl,
     *olen = 1;
     return( 0 );
 }
+#endif /* !MBEDTLS_SSL_USE_MPS */
 
 static int ssl_write_change_cipher_spec_postprocess( mbedtls_ssl_context* ssl )
 {
@@ -1171,7 +1185,7 @@ int mbedtls_ssl_parse_signature_algorithms_ext( mbedtls_ssl_context *ssl,
         for( md_cur = ssl->conf->sig_hashes; *md_cur != SIGNATURE_NONE; md_cur++ )
             num_supported_hashes++;
     }
-    
+
     /* Clear previously allocated memory */
     if( ssl->handshake->received_signature_schemes_list != NULL )
         mbedtls_free( ssl->handshake->received_signature_schemes_list );
@@ -4998,13 +5012,13 @@ static int ssl_new_session_ticket_parse( mbedtls_ssl_context* ssl,
 
         memcpy( ssl->session->ticket_nonce, &buf[9], ssl->session->ticket_nonce_len );
 
-        MBEDTLS_SSL_DEBUG_BUF( 3, "ticket->nonce:", (unsigned char*)&buf[9], 
+        MBEDTLS_SSL_DEBUG_BUF( 3, "ticket->nonce:", (unsigned char*)&buf[9],
         ssl->session->ticket_nonce_len );
 
     }
 
     /* Ticket */
-    ticket_len = ( buf[9 + ssl->session->ticket_nonce_len] << 8 ) | 
+    ticket_len = ( buf[9 + ssl->session->ticket_nonce_len] << 8 ) |
                  ( buf[10 + ssl->session->ticket_nonce_len] );
 
     used += ticket_len;
@@ -5070,7 +5084,7 @@ static int ssl_new_session_ticket_parse( mbedtls_ssl_context* ssl,
     }
 
     hash_length = mbedtls_hash_size_for_ciphersuite( suite_info );
-    
+
     if( hash_length == -1 )
         return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
 
@@ -5079,7 +5093,7 @@ static int ssl_new_session_ticket_parse( mbedtls_ssl_context* ssl,
                            hash_length );
 
     /* Computer resumption key
-     * 
+     *
      *  HKDF-Expand-Label( resumption_master_secret,
      *                    "resumption", ticket_nonce, Hash.length )
      */
@@ -5100,7 +5114,7 @@ static int ssl_new_session_ticket_parse( mbedtls_ssl_context* ssl,
 
     ssl->session->resumption_key_len = mbedtls_hash_size_for_ciphersuite( suite_info );
 
-    MBEDTLS_SSL_DEBUG_BUF( 3, "Ticket-resumed PSK", ssl->session->key, 
+    MBEDTLS_SSL_DEBUG_BUF( 3, "Ticket-resumed PSK", ssl->session->key,
                            ssl->session->resumption_key_len );
 
 #if defined(MBEDTLS_HAVE_TIME)

--- a/tests/suites/test_suite_mps.function
+++ b/tests/suites/test_suite_mps.function
@@ -4136,19 +4136,23 @@ void mbedtls_mps_l2_basic( int mode,
     TEST_ASSERT( mps_l2_config_add_type( &cli_l2, ty_A,
                                          MBEDTLS_MPS_SPLIT_DISABLED,
                                          MBEDTLS_MPS_PACK_ENABLED,
-                                         MBEDTLS_MPS_EMPTY_ALLOWED ) == 0 );
+                                         MBEDTLS_MPS_EMPTY_ALLOWED,
+                                         MBEDTLS_MPS_IGNORE_KEEP ) == 0 );
     TEST_ASSERT( mps_l2_config_add_type( &cli_l2, ty_B,
                                          MBEDTLS_MPS_SPLIT_DISABLED,
                                          MBEDTLS_MPS_PACK_ENABLED,
-                                         MBEDTLS_MPS_EMPTY_ALLOWED ) == 0 );
+                                         MBEDTLS_MPS_EMPTY_ALLOWED,
+                                         MBEDTLS_MPS_IGNORE_KEEP ) == 0 );
     TEST_ASSERT( mps_l2_config_add_type( &srv_l2, ty_A,
                                          MBEDTLS_MPS_SPLIT_DISABLED,
                                          MBEDTLS_MPS_PACK_ENABLED,
-                                         MBEDTLS_MPS_EMPTY_ALLOWED ) == 0 );
+                                         MBEDTLS_MPS_EMPTY_ALLOWED,
+                                         MBEDTLS_MPS_IGNORE_KEEP ) == 0 );
     TEST_ASSERT( mps_l2_config_add_type( &srv_l2, ty_B,
                                          MBEDTLS_MPS_SPLIT_DISABLED,
                                          MBEDTLS_MPS_PACK_ENABLED,
-                                         MBEDTLS_MPS_EMPTY_ALLOWED ) == 0 );
+                                         MBEDTLS_MPS_EMPTY_ALLOWED,
+                                         MBEDTLS_MPS_IGNORE_KEEP ) == 0 );
     TEST_ASSERT( mps_l2_epoch_add( &cli_l2, dummy_c, &epoch_init ) == 0 );
     TEST_ASSERT( mps_l2_epoch_usage( &cli_l2, epoch_init,
                                      0, MPS_EPOCH_USAGE_WRITE( 0 ) ) == 0 );
@@ -4282,11 +4286,13 @@ void mbedtls_mps_l2_non_packable_type( int mode,
     TEST_ASSERT( mps_l2_config_add_type( &cli_l2, ty_A,
                                          MBEDTLS_MPS_SPLIT_DISABLED,
                                          MBEDTLS_MPS_PACK_ENABLED,
-                                         MBEDTLS_MPS_EMPTY_ALLOWED ) == 0 );
+                                         MBEDTLS_MPS_EMPTY_ALLOWED,
+                                         MBEDTLS_MPS_IGNORE_KEEP ) == 0 );
     TEST_ASSERT( mps_l2_config_add_type( &srv_l2, ty_A,
                                          MBEDTLS_MPS_SPLIT_DISABLED,
                                          MBEDTLS_MPS_PACK_DISABLED,
-                                         MBEDTLS_MPS_EMPTY_ALLOWED ) == 0 );
+                                         MBEDTLS_MPS_EMPTY_ALLOWED,
+                                         MBEDTLS_MPS_IGNORE_KEEP ) == 0 );
     TEST_ASSERT( mps_l2_epoch_add( &cli_l2, dummy_c, &epoch_init ) == 0 );
     TEST_ASSERT( mps_l2_epoch_usage( &cli_l2, epoch_init, 0,
                                      MPS_EPOCH_USAGE_READ( 0 ) | MPS_EPOCH_USAGE_WRITE( 0 ) ) == 0 );
@@ -4450,8 +4456,8 @@ void mbedtls_mps_l2_bad_record( int mode,
     TEST_ASSUME( mode == MBEDTLS_MPS_MODE_STREAM );
 #endif
 
-    TEST_ASSERT( mps_l2_config_add_type( &cli_l2, ty_A, 0, 1, 1 ) == 0 );
-    TEST_ASSERT( mps_l2_config_add_type( &srv_l2, ty_A, 0, 1, 1 ) == 0 );
+    TEST_ASSERT( mps_l2_config_add_type( &cli_l2, ty_A, 0, 1, 1, 0 ) == 0 );
+    TEST_ASSERT( mps_l2_config_add_type( &srv_l2, ty_A, 0, 1, 1, 0 ) == 0 );
     TEST_ASSERT( mps_l2_epoch_add( &cli_l2, dummy_c, &epoch_init ) == 0 );
     TEST_ASSERT( mps_l2_epoch_usage( &cli_l2, epoch_init,
                                      0, MPS_EPOCH_USAGE_WRITE( 0 ) ) == 0 );
@@ -4700,8 +4706,8 @@ void mbedtls_mps_l2_anti_replay( int variant )
     mps_test_config.mode = MBEDTLS_MPS_MODE_DATAGRAM;
     TEST_ASSERT( init_mps_layers() == 0 );
 
-    TEST_ASSERT( mps_l2_config_add_type( &cli_l2, ty_A, 0, 1, 1 ) == 0 );
-    TEST_ASSERT( mps_l2_config_add_type( &srv_l2, ty_A, 0, 1, 1 ) == 0 );
+    TEST_ASSERT( mps_l2_config_add_type( &cli_l2, ty_A, 0, 1, 1, 0 ) == 0 );
+    TEST_ASSERT( mps_l2_config_add_type( &srv_l2, ty_A, 0, 1, 1, 0 ) == 0 );
     TEST_ASSERT( mps_l2_epoch_add( &cli_l2, dummy_c, &epoch_init ) == 0 );
     TEST_ASSERT( mps_l2_epoch_usage( &cli_l2, epoch_init,
                                      0, MPS_EPOCH_USAGE_WRITE( 0 ) ) == 0 );
@@ -4984,21 +4990,25 @@ void mbedtls_mps_l2_pausing( int accumulator_too_small,
     TEST_ASSERT( mps_l2_config_add_type( &cli_l2, ty_A,
                                          MBEDTLS_MPS_SPLIT_ENABLED,
                                          MBEDTLS_MPS_PACK_ENABLED,
-                                         MBEDTLS_MPS_EMPTY_ALLOWED ) == 0 );
+                                         MBEDTLS_MPS_EMPTY_ALLOWED,
+                                         MBEDTLS_MPS_IGNORE_KEEP ) == 0 );
     TEST_ASSERT( mps_l2_config_add_type( &cli_l2, ty_B,
                                          MBEDTLS_MPS_SPLIT_DISABLED,
                                          MBEDTLS_MPS_PACK_ENABLED,
-                                         MBEDTLS_MPS_EMPTY_ALLOWED ) == 0 );
+                                         MBEDTLS_MPS_EMPTY_ALLOWED,
+                                         MBEDTLS_MPS_IGNORE_KEEP ) == 0 );
     TEST_ASSERT( mps_l2_config_add_type( &srv_l2, ty_A,
                                          pausable_for_receiver == 1 ?
                                          MBEDTLS_MPS_SPLIT_ENABLED :
                                          MBEDTLS_MPS_SPLIT_DISABLED,
                                          MBEDTLS_MPS_PACK_ENABLED,
-                                         MBEDTLS_MPS_EMPTY_ALLOWED ) == 0 );
+                                         MBEDTLS_MPS_EMPTY_ALLOWED,
+                                         MBEDTLS_MPS_IGNORE_KEEP ) == 0 );
     TEST_ASSERT( mps_l2_config_add_type( &srv_l2, ty_B,
                                          MBEDTLS_MPS_SPLIT_DISABLED,
                                          MBEDTLS_MPS_PACK_ENABLED,
-                                         MBEDTLS_MPS_EMPTY_ALLOWED ) == 0 );
+                                         MBEDTLS_MPS_EMPTY_ALLOWED,
+                                         MBEDTLS_MPS_IGNORE_KEEP ) == 0 );
 
     TEST_ASSERT( mps_l2_epoch_add( &cli_l2, dummy_c, &epoch_init ) == 0 );
     TEST_ASSERT( mps_l2_epoch_usage( &cli_l2, epoch_init,
@@ -5213,19 +5223,23 @@ void mbedtls_mps_l2_switch_epoch( int mode,
     TEST_ASSERT( mps_l2_config_add_type( &cli_l2, ty_A,
                                          MBEDTLS_MPS_SPLIT_DISABLED,
                                          MBEDTLS_MPS_PACK_ENABLED,
-                                         MBEDTLS_MPS_EMPTY_ALLOWED ) == 0 );
+                                         MBEDTLS_MPS_EMPTY_ALLOWED,
+                                         MBEDTLS_MPS_IGNORE_KEEP ) == 0 );
     TEST_ASSERT( mps_l2_config_add_type( &cli_l2, ty_B,
                                          MBEDTLS_MPS_SPLIT_DISABLED,
                                          MBEDTLS_MPS_PACK_ENABLED,
-                                         MBEDTLS_MPS_EMPTY_ALLOWED ) == 0 );
+                                         MBEDTLS_MPS_EMPTY_ALLOWED,
+                                         MBEDTLS_MPS_IGNORE_KEEP ) == 0 );
     TEST_ASSERT( mps_l2_config_add_type( &srv_l2, ty_A,
                                          MBEDTLS_MPS_SPLIT_DISABLED,
                                          MBEDTLS_MPS_PACK_ENABLED,
-                                         MBEDTLS_MPS_EMPTY_ALLOWED ) == 0 );
+                                         MBEDTLS_MPS_EMPTY_ALLOWED,
+                                         MBEDTLS_MPS_IGNORE_KEEP ) == 0 );
     TEST_ASSERT( mps_l2_config_add_type( &srv_l2, ty_B,
                                          MBEDTLS_MPS_SPLIT_DISABLED,
                                          MBEDTLS_MPS_PACK_ENABLED,
-                                         MBEDTLS_MPS_EMPTY_ALLOWED ) == 0 );
+                                         MBEDTLS_MPS_EMPTY_ALLOWED,
+                                         MBEDTLS_MPS_IGNORE_KEEP ) == 0 );
 
     TEST_ASSERT( mps_l2_epoch_add( &cli_l2,  epoch0_c, &epoch_init ) == 0 );
     TEST_ASSERT( mps_l2_epoch_add( &srv_l2,  epoch0_s, &epoch_init ) == 0 );
@@ -5366,8 +5380,8 @@ void mbedtls_mps_l2_queueing( int allocator_buffer_sz,
     TEST_ASSERT( init_mps_layers() == 0 );
 
     TEST_ASSERT( mps_l2_config_add_type( &cli_l2, ty_A, pausable_for_sender == 1,
-                                         1, 0 ) == 0 );
-    TEST_ASSERT( mps_l2_config_add_type( &srv_l2, ty_A, 0, 1, 0 ) == 0 );
+                                         1, 0, 0 ) == 0 );
+    TEST_ASSERT( mps_l2_config_add_type( &srv_l2, ty_A, 0, 1, 0, 0 ) == 0 );
 
     TEST_ASSERT( mps_l2_epoch_add( &cli_l2, dummy_c, &epoch_init ) == 0 );
     TEST_ASSERT( mps_l2_epoch_usage( &cli_l2, epoch_init,
@@ -5505,19 +5519,23 @@ void mbedtls_mps_l2_many_epochs( int mode,
     TEST_ASSERT( mps_l2_config_add_type( &cli_l2, ty_A,
                                          MBEDTLS_MPS_SPLIT_DISABLED,
                                          MBEDTLS_MPS_PACK_ENABLED,
-                                         MBEDTLS_MPS_EMPTY_ALLOWED ) == 0 );
+                                         MBEDTLS_MPS_EMPTY_ALLOWED,
+                                         MBEDTLS_MPS_IGNORE_KEEP ) == 0 );
     TEST_ASSERT( mps_l2_config_add_type( &cli_l2, ty_B,
                                          MBEDTLS_MPS_SPLIT_DISABLED,
                                          MBEDTLS_MPS_PACK_ENABLED,
-                                         MBEDTLS_MPS_EMPTY_ALLOWED ) == 0 );
+                                         MBEDTLS_MPS_EMPTY_ALLOWED,
+                                         MBEDTLS_MPS_IGNORE_KEEP ) == 0 );
     TEST_ASSERT( mps_l2_config_add_type( &srv_l2, ty_A,
                                          MBEDTLS_MPS_SPLIT_DISABLED,
                                          MBEDTLS_MPS_PACK_ENABLED,
-                                         MBEDTLS_MPS_EMPTY_ALLOWED ) == 0 );
+                                         MBEDTLS_MPS_EMPTY_ALLOWED,
+                                         MBEDTLS_MPS_IGNORE_KEEP ) == 0 );
     TEST_ASSERT( mps_l2_config_add_type( &srv_l2, ty_B,
                                          MBEDTLS_MPS_SPLIT_DISABLED,
                                          MBEDTLS_MPS_PACK_ENABLED,
-                                         MBEDTLS_MPS_EMPTY_ALLOWED ) == 0 );
+                                         MBEDTLS_MPS_EMPTY_ALLOWED,
+                                         MBEDTLS_MPS_IGNORE_KEEP ) == 0 );
 
     TEST_ASSERT( mps_l2_epoch_add( &cli_l2, epochs_c[0], &next_cli_epoch ) == 0 );
     TEST_ASSERT( mps_l2_epoch_add( &srv_l2, epochs_s[0], &next_srv_epoch ) == 0 );
@@ -5741,11 +5759,13 @@ void mbedtls_mps_l2_piggyback_data( int mode,
     TEST_ASSERT( mps_l2_config_add_type( &cli_l2, ty_A,
                                          MBEDTLS_MPS_SPLIT_DISABLED,
                                          MBEDTLS_MPS_PACK_ENABLED,
-                                         MBEDTLS_MPS_EMPTY_ALLOWED ) == 0 );
+                                         MBEDTLS_MPS_EMPTY_ALLOWED,
+                                         MBEDTLS_MPS_IGNORE_KEEP ) == 0 );
     TEST_ASSERT( mps_l2_config_add_type( &srv_l2, ty_A,
                                          MBEDTLS_MPS_SPLIT_DISABLED,
                                          MBEDTLS_MPS_PACK_ENABLED,
-                                         MBEDTLS_MPS_EMPTY_ALLOWED ) == 0 );
+                                         MBEDTLS_MPS_EMPTY_ALLOWED,
+                                         MBEDTLS_MPS_IGNORE_KEEP ) == 0 );
 
     TEST_ASSERT( mps_l2_epoch_add( &cli_l2,  epoch0_c, &epoch_init ) == 0 );
     TEST_ASSERT( mps_l2_epoch_add( &srv_l2,  epoch0_s, &epoch_init ) == 0 );
@@ -5913,11 +5933,13 @@ void mbedtls_mps_l2_random( int allocator_buffer_sz,
         TEST_ASSERT( mps_l2_config_add_type( endpoint[0], ty,
                                              MBEDTLS_MPS_SPLIT_ENABLED,
                                              MBEDTLS_MPS_PACK_ENABLED,
-                                             MBEDTLS_MPS_EMPTY_FORBIDDEN ) == 0 );
+                                             MBEDTLS_MPS_EMPTY_FORBIDDEN,
+                                             MBEDTLS_MPS_IGNORE_KEEP ) == 0 );
         TEST_ASSERT( mps_l2_config_add_type( endpoint[1], ty,
                                              MBEDTLS_MPS_SPLIT_ENABLED,
                                              MBEDTLS_MPS_PACK_ENABLED,
-                                             MBEDTLS_MPS_EMPTY_FORBIDDEN ) == 0 );
+                                             MBEDTLS_MPS_EMPTY_FORBIDDEN,
+                                             MBEDTLS_MPS_IGNORE_KEEP ) == 0 );
     }
 
     TEST_ASSERT( mps_l2_epoch_add( endpoint[0], epochs[0][0],
@@ -6343,11 +6365,13 @@ void mbedtls_mps_l3_basic_handshake(
     TEST_ASSERT( mps_l2_config_add_type( &cli_l2, MBEDTLS_MPS_MSG_HS,
                                          MBEDTLS_MPS_SPLIT_DISABLED,
                                          MBEDTLS_MPS_PACK_ENABLED,
-                                         MBEDTLS_MPS_EMPTY_ALLOWED ) == 0 );
+                                         MBEDTLS_MPS_EMPTY_ALLOWED,
+                                         MBEDTLS_MPS_IGNORE_KEEP ) == 0 );
     TEST_ASSERT( mps_l2_config_add_type( &srv_l2, MBEDTLS_MPS_MSG_HS,
                                          MBEDTLS_MPS_SPLIT_DISABLED,
                                          MBEDTLS_MPS_PACK_ENABLED,
-                                         MBEDTLS_MPS_EMPTY_ALLOWED ) == 0 );
+                                         MBEDTLS_MPS_EMPTY_ALLOWED,
+                                         MBEDTLS_MPS_IGNORE_KEEP ) == 0 );
 
     TEST_ASSERT( mps_l3_epoch_add( &cli_l3, dummy_c, &cli_epoch ) == 0 );
     TEST_ASSERT( mps_l3_epoch_usage( &cli_l3, cli_epoch,
@@ -6623,27 +6647,33 @@ void mbedtls_mps_l3_bad_msg( int variant )
     TEST_ASSERT( mps_l2_config_add_type( &cli_l2, MBEDTLS_MPS_MSG_HS,
                                          MBEDTLS_MPS_SPLIT_DISABLED,
                                          MBEDTLS_MPS_PACK_ENABLED,
-                                         MBEDTLS_MPS_EMPTY_ALLOWED ) == 0 );
+                                         MBEDTLS_MPS_EMPTY_ALLOWED,
+                                         MBEDTLS_MPS_IGNORE_KEEP ) == 0 );
     TEST_ASSERT( mps_l2_config_add_type( &srv_l2, MBEDTLS_MPS_MSG_HS,
                                          MBEDTLS_MPS_SPLIT_DISABLED,
                                          MBEDTLS_MPS_PACK_ENABLED,
-                                         MBEDTLS_MPS_EMPTY_ALLOWED ) == 0 );
+                                         MBEDTLS_MPS_EMPTY_ALLOWED,
+                                         MBEDTLS_MPS_IGNORE_KEEP ) == 0 );
     TEST_ASSERT( mps_l2_config_add_type( &cli_l2, MBEDTLS_MPS_MSG_ALERT,
                                          MBEDTLS_MPS_SPLIT_DISABLED,
                                          MBEDTLS_MPS_PACK_ENABLED,
-                                         MBEDTLS_MPS_EMPTY_ALLOWED ) == 0 );
+                                         MBEDTLS_MPS_EMPTY_ALLOWED,
+                                         MBEDTLS_MPS_IGNORE_KEEP ) == 0 );
     TEST_ASSERT( mps_l2_config_add_type( &srv_l2, MBEDTLS_MPS_MSG_ALERT,
                                          MBEDTLS_MPS_SPLIT_DISABLED,
                                          MBEDTLS_MPS_PACK_ENABLED,
-                                         MBEDTLS_MPS_EMPTY_ALLOWED ) == 0 );
+                                         MBEDTLS_MPS_EMPTY_ALLOWED,
+                                         MBEDTLS_MPS_IGNORE_KEEP ) == 0 );
     TEST_ASSERT( mps_l2_config_add_type( &cli_l2, MBEDTLS_MPS_MSG_CCS,
                                          MBEDTLS_MPS_SPLIT_DISABLED,
                                          MBEDTLS_MPS_PACK_ENABLED,
-                                         MBEDTLS_MPS_EMPTY_ALLOWED ) == 0 );
+                                         MBEDTLS_MPS_EMPTY_ALLOWED,
+                                         MBEDTLS_MPS_IGNORE_KEEP ) == 0 );
     TEST_ASSERT( mps_l2_config_add_type( &srv_l2, MBEDTLS_MPS_MSG_CCS,
                                          MBEDTLS_MPS_SPLIT_DISABLED,
                                          MBEDTLS_MPS_PACK_ENABLED,
-                                         MBEDTLS_MPS_EMPTY_ALLOWED ) == 0 );
+                                         MBEDTLS_MPS_EMPTY_ALLOWED,
+                                         MBEDTLS_MPS_IGNORE_KEEP ) == 0 );
 
     TEST_ASSERT( mps_l3_epoch_add( &cli_l3, dummy_c, &cli_epoch ) == 0 );
     TEST_ASSERT( mps_l3_epoch_usage( &cli_l3, cli_epoch,
@@ -6795,9 +6825,9 @@ void mbedtls_mps_l3_handshake_gradual( int max_out,
 
 
     TEST_ASSERT( mps_l2_config_add_type( &cli_l2, MBEDTLS_MPS_MSG_HS,
-                                         1, 1, 0 ) == 0 );
+                                         1, 1, 0, 0 ) == 0 );
     TEST_ASSERT( mps_l2_config_add_type( &srv_l2, MBEDTLS_MPS_MSG_HS,
-                                         1, 1, 0 ) == 0 );
+                                         1, 1, 0, 0 ) == 0 );
 
     TEST_ASSERT( mps_l3_epoch_add( &cli_l3, dummy_c, &cli_epoch ) == 0 );
     TEST_ASSERT( mps_l3_epoch_usage( &cli_l3, cli_epoch,
@@ -7134,9 +7164,9 @@ void mbedtls_mps_l3_basic_application( int mode,
 #endif
 
     TEST_ASSERT( mps_l2_config_add_type( &cli_l2, MBEDTLS_MPS_MSG_APP,
-                                         1, 0, 1) == 0 );
+                                         1, 0, 1, 0 ) == 0 );
     TEST_ASSERT( mps_l2_config_add_type( &srv_l2, MBEDTLS_MPS_MSG_APP,
-                                         0, 1, 1 ) == 0 );
+                                         0, 1, 1, 0 ) == 0 );
 
     TEST_ASSERT( mps_l3_epoch_add( &cli_l3, dummy_c, &cli_epoch ) == 0 );
     TEST_ASSERT( mps_l3_epoch_usage( &cli_l3, cli_epoch,
@@ -7248,7 +7278,8 @@ void mbedtls_mps_l3_basic_alert( int mode,
                                          alert_merging ?
                                            MBEDTLS_MPS_PACK_ENABLED :
                                            MBEDTLS_MPS_PACK_DISABLED,
-                                         MBEDTLS_MPS_EMPTY_FORBIDDEN ) == 0 );
+                                         MBEDTLS_MPS_EMPTY_FORBIDDEN,
+                                         MBEDTLS_MPS_IGNORE_KEEP ) == 0 );
     TEST_ASSERT( mps_l2_config_add_type( &srv_l2, MBEDTLS_MPS_MSG_ALERT,
                                          handle_fragmentation ?
                                            MBEDTLS_MPS_SPLIT_ENABLED :
@@ -7256,7 +7287,8 @@ void mbedtls_mps_l3_basic_alert( int mode,
                                          alert_merging ?
                                            MBEDTLS_MPS_PACK_ENABLED :
                                            MBEDTLS_MPS_PACK_DISABLED,
-                                         MBEDTLS_MPS_EMPTY_FORBIDDEN ) == 0 );
+                                         MBEDTLS_MPS_EMPTY_FORBIDDEN,
+                                         MBEDTLS_MPS_IGNORE_KEEP ) == 0 );
 
     TEST_ASSERT( mps_l3_epoch_add( &cli_l3, dummy_c, &cli_epoch ) == 0 );
     TEST_ASSERT( mps_l3_epoch_usage( &cli_l3, cli_epoch,
@@ -7373,9 +7405,9 @@ void mbedtls_mps_l3_basic_ccs( int allocator_buffer_sz,
     TEST_ASSERT( init_mps_layers() == 0 );
 
     TEST_ASSERT( mps_l2_config_add_type( &cli_l2, MBEDTLS_MPS_MSG_CCS,
-                                         1, ccs_merging != 0, 0 ) == 0 );
+                                         1, ccs_merging != 0, 0, 0 ) == 0 );
     TEST_ASSERT( mps_l2_config_add_type( &srv_l2, MBEDTLS_MPS_MSG_CCS,
-                                         1, ccs_merging != 0, 0 ) == 0 );
+                                         1, ccs_merging != 0, 0, 0 ) == 0 );
 
     TEST_ASSERT( mps_l3_epoch_add( &cli_l3, dummy_c, &cli_epoch ) == 0 );
     TEST_ASSERT( mps_l3_epoch_usage( &cli_l3, cli_epoch,
@@ -7508,15 +7540,15 @@ void mbedtls_mps_l3_handshake_alert_interleaved( int allocator_buffer_sz,
     TEST_ASSERT( init_mps_layers() == 0 );
 
     TEST_ASSERT( mps_l2_config_add_type( &cli_l2, MBEDTLS_MPS_MSG_HS,
-                                         1, 1, 0 ) == 0 );
+                                         1, 1, 0, 0 ) == 0 );
     TEST_ASSERT( mps_l2_config_add_type( &cli_l2, MBEDTLS_MPS_MSG_ALERT,
                                          treat_alert_as_pausable == 1,
-                                         1, 1 ) == 0 );
-    TEST_ASSERT( mps_l2_config_add_type( &srv_l2, MBEDTLS_MPS_MSG_HS,
                                          1, 1, 0 ) == 0 );
+    TEST_ASSERT( mps_l2_config_add_type( &srv_l2, MBEDTLS_MPS_MSG_HS,
+                                         1, 1, 0, 0 ) == 0 );
     TEST_ASSERT( mps_l2_config_add_type( &srv_l2, MBEDTLS_MPS_MSG_ALERT,
                                          treat_alert_as_pausable == 1,
-                                         1, 1 ) == 0 );
+                                         1, 1, 0 ) == 0 );
 
     TEST_ASSERT( mps_l3_epoch_add( &cli_l3, dummy_c, &cli_epoch ) == 0 );
     TEST_ASSERT( mps_l3_epoch_usage( &cli_l3, cli_epoch,
@@ -7982,21 +8014,21 @@ void mbedtls_mps_l3_random( int allocator_buffer_sz,
     TEST_ASSERT( init_mps_layers() == 0 );
 
     TEST_ASSERT( mps_l2_config_add_type( &cli_l2, MBEDTLS_MPS_MSG_HS,
-                                         1, 1, 0 ) == 0 );
+                                         1, 1, 0, 0 ) == 0 );
     TEST_ASSERT( mps_l2_config_add_type( &srv_l2, MBEDTLS_MPS_MSG_HS,
-                                         1, 1, 0 ) == 0 );
+                                         1, 1, 0, 0 ) == 0 );
     TEST_ASSERT( mps_l2_config_add_type( &cli_l2, MBEDTLS_MPS_MSG_ALERT,
-                                         1, 1, 0 ) == 0 );
+                                         1, 1, 0, 0 ) == 0 );
     TEST_ASSERT( mps_l2_config_add_type( &srv_l2, MBEDTLS_MPS_MSG_ALERT,
-                                         1, 1, 0 ) == 0 );
+                                         1, 1, 0, 0 ) == 0 );
     TEST_ASSERT( mps_l2_config_add_type( &cli_l2, MBEDTLS_MPS_MSG_APP,
-                                         0, 1, 1 ) == 0 );
+                                         0, 1, 1, 0 ) == 0 );
     TEST_ASSERT( mps_l2_config_add_type( &srv_l2, MBEDTLS_MPS_MSG_APP,
-                                         0, 1, 1 ) == 0 );
+                                         0, 1, 1, 0 ) == 0 );
     TEST_ASSERT( mps_l2_config_add_type( &cli_l2, MBEDTLS_MPS_MSG_CCS,
-                                         0, 0, 0 ) == 0 );
+                                         0, 0, 0, 0 ) == 0 );
     TEST_ASSERT( mps_l2_config_add_type( &srv_l2, MBEDTLS_MPS_MSG_CCS,
-                                         0, 0, 0 ) == 0 );
+                                         0, 0, 0, 0 ) == 0 );
 
     TEST_ASSERT( mps_l3_epoch_add( endpoint[0], epochs[0][0],
                                    &latest_epoch[0] ) == 0 );
@@ -8568,9 +8600,9 @@ void mbedtls_mps_l4_basic_handshake(
 #endif
 
     TEST_ASSERT( mps_l2_config_add_type( &cli_l2, MBEDTLS_MPS_MSG_HS,
-                                         1, 1, 0 ) == 0 );
+                                         1, 1, 0, 0 ) == 0 );
     TEST_ASSERT( mps_l2_config_add_type( &srv_l2, MBEDTLS_MPS_MSG_HS,
-                                         1, 1, 0 ) == 0 );
+                                         1, 1, 0, 0 ) == 0 );
 
     TEST_ASSERT( mbedtls_mps_add_key_material( &cli_l4, dummy_c,
                                                &cli_epoch ) == 0 );
@@ -8713,9 +8745,9 @@ void mbedtls_mps_l4_warning( int mode,
 #endif
 
     TEST_ASSERT( mps_l2_config_add_type( &cli_l2, MBEDTLS_MPS_MSG_ALERT,
-                                         1, 1, 0 ) == 0 );
+                                         1, 1, 0, 0 ) == 0 );
     TEST_ASSERT( mps_l2_config_add_type( &srv_l2, MBEDTLS_MPS_MSG_ALERT,
-                                         1, 1, 0 ) == 0 );
+                                         1, 1, 0, 0 ) == 0 );
 
     TEST_ASSERT( mbedtls_mps_add_key_material( &cli_l4, dummy_c[0],
                                                &cli_epoch[0] ) == 0 );
@@ -8837,9 +8869,9 @@ void mbedtls_mps_l4_ccs( int mode,
 #endif
 
     TEST_ASSERT( mps_l2_config_add_type( &cli_l2, MBEDTLS_MPS_MSG_CCS,
-                                         1, 1, 0 ) == 0 );
+                                         1, 1, 0, 0 ) == 0 );
     TEST_ASSERT( mps_l2_config_add_type( &srv_l2, MBEDTLS_MPS_MSG_CCS,
-                                         1, 1, 0 ) == 0 );
+                                         1, 1, 0, 0 ) == 0 );
 
     TEST_ASSERT( mbedtls_mps_add_key_material( &cli_l4, dummy_c[0],
                                                &cli_epoch[0] ) == 0 );
@@ -8971,9 +9003,9 @@ void mbedtls_mps_l4_hs_inconsistent_continuation( int variant )
     TEST_ASSERT( init_mps_layers() == 0 );
 
     TEST_ASSERT( mps_l2_config_add_type( &cli_l2, MBEDTLS_MPS_MSG_HS,
-                                         1, 1, 0 ) == 0 );
+                                         1, 1, 0, 0 ) == 0 );
     TEST_ASSERT( mps_l2_config_add_type( &srv_l2, MBEDTLS_MPS_MSG_HS,
-                                         1, 1, 0 ) == 0 );
+                                         1, 1, 0, 0 ) == 0 );
 
     /* Add key material.  */
 
@@ -9212,13 +9244,13 @@ void mbedtls_mps_l4_disruption( int mode,
 #endif
 
     TEST_ASSERT( mps_l2_config_add_type( &cli_l2, MBEDTLS_MPS_MSG_HS,
-                                         1, 1, 0 ) == 0 );
+                                         1, 1, 0, 0 ) == 0 );
     TEST_ASSERT( mps_l2_config_add_type( &cli_l2, MBEDTLS_MPS_MSG_ALERT,
-                                         1, 1, 0 ) == 0 );
+                                         1, 1, 0, 0 ) == 0 );
     TEST_ASSERT( mps_l2_config_add_type( &srv_l2, MBEDTLS_MPS_MSG_HS,
-                                         1, 1, 0 ) == 0 );
+                                         1, 1, 0, 0 ) == 0 );
     TEST_ASSERT( mps_l2_config_add_type( &srv_l2, MBEDTLS_MPS_MSG_ALERT,
-                                         1, 1, 0 ) == 0 );
+                                         1, 1, 0, 0 ) == 0 );
 
     TEST_ASSERT( mbedtls_mps_add_key_material( &cli_l4, dummy_c,
                                                &cli_epoch ) == 0 );
@@ -9438,13 +9470,13 @@ void mbedtls_mps_l4_dtls_fragmentation( int allocator_buffer_sz,
     TEST_ASSERT( init_mps_layers() == 0 );
 
     TEST_ASSERT( mps_l2_config_add_type( &cli_l2, MBEDTLS_MPS_MSG_HS,
-                                         1, 1, 0 ) == 0 );
+                                         1, 1, 0, 0 ) == 0 );
     TEST_ASSERT( mps_l2_config_add_type( &cli_l2, MBEDTLS_MPS_MSG_ALERT,
-                                         1, 1, 0 ) == 0 );
+                                         1, 1, 0, 0 ) == 0 );
     TEST_ASSERT( mps_l2_config_add_type( &srv_l2, MBEDTLS_MPS_MSG_HS,
-                                         1, 1, 0 ) == 0 );
+                                         1, 1, 0, 0 ) == 0 );
     TEST_ASSERT( mps_l2_config_add_type( &srv_l2, MBEDTLS_MPS_MSG_ALERT,
-                                         1, 1, 0 ) == 0 );
+                                         1, 1, 0, 0 ) == 0 );
 
     TEST_ASSERT( mbedtls_mps_add_key_material( &cli_l4, dummy_c,
                                                &cli_epoch ) == 0 );
@@ -9588,13 +9620,13 @@ void mbedtls_mps_l4_dtls_reassembly( int allocator_buffer_sz,
     TEST_ASSERT( init_mps_layers() == 0 );
 
     TEST_ASSERT( mps_l2_config_add_type( &cli_l2, MBEDTLS_MPS_MSG_HS,
-                                         1, 1, 0 ) == 0 );
+                                         1, 1, 0, 0 ) == 0 );
     TEST_ASSERT( mps_l2_config_add_type( &cli_l2, MBEDTLS_MPS_MSG_ALERT,
-                                         1, 1, 0 ) == 0 );
+                                         1, 1, 0, 0 ) == 0 );
     TEST_ASSERT( mps_l2_config_add_type( &srv_l2, MBEDTLS_MPS_MSG_HS,
-                                         1, 1, 0 ) == 0 );
+                                         1, 1, 0, 0 ) == 0 );
     TEST_ASSERT( mps_l2_config_add_type( &srv_l2, MBEDTLS_MPS_MSG_ALERT,
-                                         1, 1, 0 ) == 0 );
+                                         1, 1, 0, 0 ) == 0 );
 
     TEST_ASSERT( mbedtls_mps_add_key_material( &cli_l4, dummy_c,
                                                &cli_epoch ) == 0 );
@@ -9876,13 +9908,13 @@ void mbedtls_mps_l4_flight_exchange( int mode,
 #endif
 
     TEST_ASSERT( mps_l2_config_add_type( &cli_l2, MBEDTLS_MPS_MSG_HS,
-                                         1, 1, 0 ) == 0 );
+                                         1, 1, 0, 0 ) == 0 );
     TEST_ASSERT( mps_l2_config_add_type( &cli_l2, MBEDTLS_MPS_MSG_CCS,
-                                         1, 1, 0 ) == 0 );
+                                         1, 1, 0, 0 ) == 0 );
     TEST_ASSERT( mps_l2_config_add_type( &srv_l2, MBEDTLS_MPS_MSG_HS,
-                                         1, 1, 0 ) == 0 );
+                                         1, 1, 0, 0 ) == 0 );
     TEST_ASSERT( mps_l2_config_add_type( &srv_l2, MBEDTLS_MPS_MSG_CCS,
-                                         1, 1, 0 ) == 0 );
+                                         1, 1, 0, 0 ) == 0 );
 
     if( multiple_epochs == 0 || multiple_epochs == 2 )
     {
@@ -10120,9 +10152,9 @@ void mbedtls_mps_l4_flight_exchange( int mode,
             TEST_ASSERT( mps_l2_config_version( &srv_l2,
                                                 MBEDTLS_SSL_MINOR_VERSION_3 ) == 0 );
             TEST_ASSERT( mps_l2_config_add_type( &srv_l2, MBEDTLS_MPS_MSG_HS,
-                                                 1, 1, 0 ) == 0 );
+                                                 1, 1, 0, 0 ) == 0 );
             TEST_ASSERT( mps_l2_config_add_type( &srv_l2, MBEDTLS_MPS_MSG_ALERT,
-                                                 1, 1, 0 ) == 0 );
+                                                 1, 1, 0, 0 ) == 0 );
             TEST_ASSERT( mps_l3_init( &srv_l3, &srv_l2, MBEDTLS_MPS_MODE_DATAGRAM ) == 0 );
             TEST_ASSERT( mbedtls_mps_init( &srv_l4, &srv_l3,
                                            MBEDTLS_MPS_MODE_DATAGRAM,


### PR DESCRIPTION
This PR fixes some compiler warnings around MPS, some legit, some not. Subsumes #154 

Also, add support for CCS compatibility mode when using MPS.

@lhuang04 Could you please take a look whether this fixes the issues underlying #154 for you?