### PR TITLE
Fix mismatched macro guard between c and header file

### DIFF
--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -5844,7 +5844,8 @@ int mbedtls_ssl_get_session( const mbedtls_ssl_context *ssl,
 }
 #endif /* MBEDTLS_SSL_CLI_C */
 
-#if defined(MBEDTLS_SSL_SESSION_TICKETS) || defined(MBEDTLS_SSL_NEW_SESSION_TICKET)
+#if defined(MBEDTLS_SSL_PROTO_TLS1_2) || defined(MBEDTLS_SSL_PROTO_TLS1_1) || \
+    defined(MBEDTLS_SSL_PROTO_TLS1) || defined(MBEDTLS_SSL_NEW_SESSION_TICKET)
 const mbedtls_ssl_session *mbedtls_ssl_get_session_pointer( const mbedtls_ssl_context *ssl )
 {
     if( ssl == NULL )
@@ -5852,7 +5853,8 @@ const mbedtls_ssl_session *mbedtls_ssl_get_session_pointer( const mbedtls_ssl_co
 
     return( ssl->session );
 }
-#endif /* MBEDTLS_SSL_SESSION_TICKETS || defined(MBEDTLS_SSL_NEW_SESSION_TICKET */
+#endif /* MBEDTLS_SSL_PROTO_TLS1_2 || MBEDTLS_SSL_PROTO_TLS1_1 || MBEDTLS_SSL_PROTO_TLS1 ||
+          MBEDTLS_SSL_NEW_SESSION_TICKET */
 
 /*
  * Define ticket header determining Mbed TLS version
@@ -5924,7 +5926,8 @@ const mbedtls_ssl_session *mbedtls_ssl_get_session_pointer( const mbedtls_ssl_co
         ( SSL_SERIALIZED_SESSION_CONFIG_ETM           << SSL_SERIALIZED_SESSION_CONFIG_ETM_BIT           ) | \
         ( SSL_SERIALIZED_SESSION_CONFIG_TICKET        << SSL_SERIALIZED_SESSION_CONFIG_TICKET_BIT        ) ) )
 
-#if defined(MBEDTLS_SSL_SESSION_TICKETS) || defined(MBEDTLS_SSL_NEW_SESSION_TICKET)
+#if defined(MBEDTLS_SSL_PROTO_TLS1_2) || defined(MBEDTLS_SSL_PROTO_TLS1_1) || \
+    defined(MBEDTLS_SSL_PROTO_TLS1) || defined(MBEDTLS_SSL_NEW_SESSION_TICKET)
 static unsigned char ssl_serialized_session_header[] = {
     MBEDTLS_VERSION_MAJOR,
     MBEDTLS_VERSION_MINOR,
@@ -5932,9 +5935,7 @@ static unsigned char ssl_serialized_session_header[] = {
     ( SSL_SERIALIZED_SESSION_CONFIG_BITFLAG >> 8 ) & 0xFF,
     ( SSL_SERIALIZED_SESSION_CONFIG_BITFLAG >> 0 ) & 0xFF,
 };
-#endif /* MBEDTLS_SSL_SESSION_TICKETS || defined(MBEDTLS_SSL_NEW_SESSION_TICKET */
 
-#if defined(MBEDTLS_SSL_SESSION_TICKETS) || ( defined(MBEDTLS_SSL_NEW_SESSION_TICKET) && defined(MBEDTLS_SSL_SRV_C) )
 /*
  * Serialize a session in the following format:
  * (in the presentation language of TLS, RFC 8446 section 3)
@@ -6681,7 +6682,8 @@ int mbedtls_ssl_session_load( mbedtls_ssl_session *session,
 
     return( ret );
 }
-#endif /* MBEDTLS_SSL_SESSION_TICKETS || ( MBEDTLS_SSL_NEW_SESSION_TICKET && MBEDTLS_SSL_SRV_C ) */
+#endif /* MBEDTLS_SSL_PROTO_TLS1_2 || MBEDTLS_SSL_PROTO_TLS1_1 || MBEDTLS_SSL_PROTO_TLS1 ||
+          MBEDTLS_SSL_NEW_SESSION_TICKET */
 
 #if defined(MBEDTLS_SSL_USE_MPS)
 int mbedtls_ssl_mps_remap_error( int ret )


### PR DESCRIPTION
Summary:
The following functions are under different macro guard between [c file](https://github.com/hannestschofenig/mbedtls/blob/tls13-prototype/library/ssl_tls.c#L5937) and [header file](https://github.com/hannestschofenig/mbedtls/blob/tls13-prototype/include/mbedtls/ssl.h#L2950-L2951)

* mbedtls_ssl_set_session
* mbedtls_ssl_session_save
* mbedtls_ssl_session_load
* mbedtls_ssl_get_session_pointer

[https://github.com/hannestschofenig/mbedtls/blob/tls13-prototype/programs/ssl/ssl_client2.c#L3488](https://github.com/hannestschofenig/mbedtls/blob/tls13-prototype/programs/ssl/ssl_client2.c#L3488)
is used in client, so the
[MBEDTLS_SSL_SRV_C](https://github.com/hannestschofenig/mbedtls/blob/tls13-prototype/library/ssl_tls.c#L5937) macro in C file seems incorrect.
Change the macro in c file to match the header file.

Also move `ssl_serialized_session_header` [inside](https://github.com/hannestschofenig/mbedtls/blob/tls13-prototype/library/ssl_tls.c#L5937) as it is only used in
the block, and don't need different macro guard

Test Plan:

Undefine MBEDTLS_SSL_SRV_C, and make
```
git diff
diff --git a/include/mbedtls/config.h b/include/mbedtls/config.h
index 80a632613..1a4370ef5 100644
--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -3386,7 +3386,7 @@
  *
    * This module is required for SSL/TLS server support.
      */
      -#define MBEDTLS_SSL_SRV_C
      +//#define MBEDTLS_SSL_SRV_C

       /**
           * \def MBEDTLS_SSL_TLS_C
```

The following compiler error should be fixed.
```
/home/lhuang04/upstream/library/ssl_tls.c:5928:22: error:
‘ssl_serialized_session_header’ defined but not used
[-Werror=unused-variable]
 static unsigned char ssl_serialized_session_header[] = {
                       ^
                       cc1: all warnings being treated as errors
                       make[2]: ***
                       [library/CMakeFiles/mbedtls.dir/ssl_tls.c.o]
                       Error 1
                       make[2]: *** Waiting for unfinished jobs....
                       [ 34%] Built target cert_write
                       make[1]: *** [library/CMakeFiles/mbedtls.dir/all]
                       Error 2
                       make: *** [all] Error 2

```

Reviewers:

Subscribers:

Tasks:

Tags: