### PR TITLE
ssl_new_session_ticket_parse can't handle 2nd new session ticket

### DIFF
--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -4967,16 +4967,6 @@ static int ssl_new_session_ticket_parse( mbedtls_ssl_context* ssl,
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "ticket->ticket_age_add: %u", ssl->session->ticket_age_add ) );
 
     /* Ticket Nonce */
-    ssl->session->ticket_nonce_len = buf[8];
-
-    used += ssl->session->ticket_nonce_len;
-
-    if( used > buflen )
-    {
-         MBEDTLS_SSL_DEBUG_MSG( 1, ( "bad new session ticket message" ) );
-         return( MBEDTLS_ERR_SSL_BAD_HS_NEW_SESSION_TICKET );
-    }
-
     /* Check if we previously received a ticket already. If we did, then we should
      * re-use already allocated nonce-space.
      */
@@ -4985,6 +4975,16 @@ static int ssl_new_session_ticket_parse( mbedtls_ssl_context* ssl,
         mbedtls_free( ssl->session->ticket_nonce );
         ssl->session->ticket_nonce = NULL;
         ssl->session->ticket_nonce_len = 0;
+    }
+
+    ssl->session->ticket_nonce_len = buf[8];
+
+    used += ssl->session->ticket_nonce_len;
+
+    if( used > buflen )
+    {
+         MBEDTLS_SSL_DEBUG_MSG( 1, ( "bad new session ticket message" ) );
+         return( MBEDTLS_ERR_SSL_BAD_HS_NEW_SESSION_TICKET );
     }
 
     if( ssl->session->ticket_nonce_len > 0 )


### PR DESCRIPTION
Summary:
We [check if we previously received a ticket already](https://github.com/hannestschofenig/mbedtls/blob/tls13-prototype/library/ssl_tls13_generic.c#L4994-L4998) after we assign [ssl->session->ticket_nonce_len to a new value](https://github.com/hannestschofenig/mbedtls/blob/tls13-prototype/library/ssl_tls13_generic.c#L4984). 

This causes error in processing of the 2nd nst(new session ticket).

The change is to move the overwritten code before the [new assignment](https://github.com/hannestschofenig/mbedtls/blob/tls13-prototype/library/ssl_tls13_generic.c#L4970) of
`ssl->session->ticket_nonce_len`.

The original logic is ok as it used local variable, [ticket_nonce_len](https://github.com/hannestschofenig/mbedtls/pull/152/files#diff-f60739d09b65e7b43187688f40e19d5c9825972f8690c0f6f9611431f2cf738eL5017).

Test Plan:
Test with openssl s_server that supports tls13.
```
~/openssl/apps/openssl s_server -state -cert srv_cert.pem -key srv_privkey.pem -CAfile ca_cert.pem -port 5433 -WWW
```
```
programs/ssl/ssl_client2 server_addr=::1 server_port=5433 debug_level=5 force_version=tls1_3 auth_mode=none
```

You may need turn on `MBEDTLS_SSL_TLS13_COMPATIBILITY_MODE` (and disable
    `MBEDTLS_SSL_USE_MPS`)

```
ssl_tls13_generic.c:4949: |2| => parse new session ticket
ssl_tls13_generic.c:5049: |3| ticket->lifetime: 7200
ssl_tls13_generic.c:5058: |3| ticket->ticket_age_add: 1187978059
ssl_tls13_generic.c:5109: |3| ticket->length: 0
ssl_tls13_generic.c:5119: |1| bad new session ticket message
ssl_tls13_generic.c:4979: |2| <= parse new session ticket
ssl_tls13_client.c:4896: |1| mbedtls_ssl_new_session_ticket_process()
  returned -28160 (-0x6e00)
  ssl_tls.c:6812: |2| <= handshake
  ssl_msg.c:6186: |1| mbedtls_ssl_handshake() returned -28160 (-0x6e00)
   mbedtls_ssl_read returned -0x6e00
   Last error was: -0x6E00 - SSL - Processing of the NewSessionTicket
   handshake message failed
```

Reviewers:

Subscribers:

Tasks:

Tags: