### PR TITLE
Remove DTLS 1.3 specific code and fields related to handling of SSL transforms

### DIFF
--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -1428,8 +1428,7 @@ int mbedtls_ssl_certificate_verify_process(mbedtls_ssl_context* ssl);
 
 int mbedtls_ssl_tls13_build_transform( mbedtls_ssl_context* ssl,
                              mbedtls_ssl_key_set* traffic_keys,
-                             mbedtls_ssl_transform* transform,
-                             int mode );
+                             mbedtls_ssl_transform* transform );
 
 #if defined(MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED)
 int mbedtls_ssl_create_binder( mbedtls_ssl_context *ssl,

--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -989,11 +989,6 @@ struct mbedtls_ssl_transform
     size_t taglen;                      /*!<  TAG(AEAD) len           */
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
-    mbedtls_ssl_key_set traffic_keys;
-#if defined(MBEDTLS_SSL_PROTO_DTLS)
-    mbedtls_ssl_key_set traffic_keys_previous;
-#endif /* MBEDTL_SSL_PROTO_DTLS */
-
     unsigned char sequence_number_dec[12]; /* sequence number for incoming (decrypting) traffic */
     unsigned char sequence_number_enc[12]; /* sequence number for outgoing (encrypting) traffic */
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */

--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -988,11 +988,6 @@ struct mbedtls_ssl_transform
     size_t maclen;                      /*!<  MAC(CBC) len            */
     size_t taglen;                      /*!<  TAG(AEAD) len           */
 
-#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
-    unsigned char sequence_number_dec[12]; /* sequence number for incoming (decrypting) traffic */
-    unsigned char sequence_number_enc[12]; /* sequence number for outgoing (encrypting) traffic */
-#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
-
     unsigned char iv_enc[ MBEDTLS_MAX_IV_LENGTH ];           /*!<  IV (encryption)         */
     unsigned char iv_dec[ MBEDTLS_MAX_IV_LENGTH ];           /*!<  IV (decryption)         */
 #if defined(MBEDTLS_SSL_SOME_MODES_USE_MAC)

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -227,7 +227,7 @@ static int ssl_write_early_data_prepare( mbedtls_ssl_context* ssl )
             return( MBEDTLS_ERR_SSL_ALLOC_FAILED );
 
         ret = mbedtls_ssl_tls13_build_transform( ssl, &traffic_keys,
-                                                 transform_earlydata, 0 );
+                                                 transform_earlydata );
 
         /* Register transform with MPS. */
         ret = mbedtls_mps_add_key_material( &ssl->mps.l4,
@@ -245,7 +245,8 @@ static int ssl_write_early_data_prepare( mbedtls_ssl_context* ssl )
 
 #else /* MBEDTLS_SSL_USE_MPS */
 
-    ret = mbedtls_ssl_tls13_build_transform( ssl, &traffic_keys, ssl->transform_earlydata, 0 );
+    ret = mbedtls_ssl_tls13_build_transform( ssl, &traffic_keys,
+                                             ssl->transform_earlydata );
     if( ret != 0 )
     {
         MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_tls13_build_transform", ret );
@@ -3526,7 +3527,8 @@ static int ssl_server_hello_postprocess( mbedtls_ssl_context* ssl )
         return( ret );
     }
 
-    ret = mbedtls_ssl_tls13_build_transform( ssl, &traffic_keys, ssl->transform_handshake, 0 );
+    ret = mbedtls_ssl_tls13_build_transform( ssl, &traffic_keys,
+                                             ssl->transform_handshake );
     if( ret != 0 )
     {
         MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_tls13_build_transform", ret );
@@ -3544,7 +3546,7 @@ static int ssl_server_hello_postprocess( mbedtls_ssl_context* ssl )
             return( MBEDTLS_ERR_SSL_ALLOC_FAILED );
 
         ret = mbedtls_ssl_tls13_build_transform( ssl, &traffic_keys,
-                                                 transform_handshake, 0 );
+                                                 transform_handshake );
 
         /* Register transform with MPS. */
         ret = mbedtls_mps_add_key_material( &ssl->mps.l4,

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -3794,14 +3794,6 @@ int mbedtls_ssl_tls13_build_transform( mbedtls_ssl_context *ssl,
     }
 
     /*
-     * Store new traffic_keys in transform
-     *
-     * TODO: Why do we do that in TLS? We're not using the
-     * raw key material anymore after this routine.
-     */
-    transform->traffic_keys = *traffic_keys;
-
-    /*
      * Setup cipher contexts in target transform
      */
 

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -3870,12 +3870,6 @@ int mbedtls_ssl_tls13_build_transform( mbedtls_ssl_context *ssl,
     transform->minlen      = transform->taglen + 1;
     transform->minor_ver   = MBEDTLS_SSL_MINOR_VERSION_4;
 
-    /*
-     * In case of DTLS, setup sequence number protection keys.
-     */
-#if defined(MBEDTLS_SSL_PROTO_DTLS)
-    ssl_setup_seq_protection_keys( ssl, transform );
-#endif
     return ( 0 );
 }
 

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -3772,15 +3772,10 @@ static void ssl_setup_seq_protection_keys( mbedtls_ssl_context *ssl,
 /* mbedtls_ssl_tls13_build_transform() activates keys and IVs for
  * the negotiated ciphersuite for use with encryption/decryption.
  * The sequence numbers are also set to zero.
- *
- * backup_old_keys (only relevant in DTLS)
- *   - Do not backup old keys       -- use 1
- *   - Backup old keys in transform -- use 0
  */
 int mbedtls_ssl_tls13_build_transform( mbedtls_ssl_context *ssl,
                              mbedtls_ssl_key_set *traffic_keys,
-                             mbedtls_ssl_transform *transform,
-                             int remove_old_keys )
+                             mbedtls_ssl_transform *transform )
 {
     int ret;
     mbedtls_cipher_info_t const *cipher_info;
@@ -3797,21 +3792,6 @@ int mbedtls_ssl_tls13_build_transform( mbedtls_ssl_context *ssl,
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "should never happen" ) );
         return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
     }
-
-    /*
-     * Before we change anything, backup keys for DTLS
-     */
-
-#if defined(MBEDTLS_SSL_PROTO_DTLS)
-    if( ssl->conf->transport == MBEDTLS_SSL_TRANSPORT_DATAGRAM &&
-        remove_old_keys == 1 )
-    {
-        /* Copy current traffic_key structure to previous */
-        transform->traffic_keys_previous = transform->traffic_keys;
-    }
-#else
-    ((void) remove_old_keys);
-#endif /* MBEDTLS_SSL_PROTO_DTLS */
 
     /*
      * Store new traffic_keys in transform
@@ -4401,8 +4381,7 @@ static int ssl_finished_out_postprocess( mbedtls_ssl_context* ssl )
         }
 
         ret = mbedtls_ssl_tls13_build_transform( ssl, &traffic_keys,
-                                                 ssl->transform_application,
-                                                 0 );
+                                                 ssl->transform_application );
         if( ret != 0 )
         {
             MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_tls13_build_transform", ret );
@@ -4417,7 +4396,7 @@ static int ssl_finished_out_postprocess( mbedtls_ssl_context* ssl )
                 return( MBEDTLS_ERR_SSL_ALLOC_FAILED );
 
             ret = mbedtls_ssl_tls13_build_transform( ssl, &traffic_keys,
-                                                     transform_application, 0 );
+                                                     transform_application );
 
             /* Register transform with MPS. */
             ret = mbedtls_mps_add_key_material( &ssl->mps.l4,
@@ -4753,7 +4732,7 @@ static int ssl_finished_in_postprocess_cli( mbedtls_ssl_context *ssl )
     }
 
     ret = mbedtls_ssl_tls13_build_transform( ssl, &traffic_keys,
-                                             ssl->transform_application, 0 );
+                                             ssl->transform_application );
     if( ret != 0 )
     {
         MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_tls13_build_transform", ret );
@@ -4768,7 +4747,7 @@ static int ssl_finished_in_postprocess_cli( mbedtls_ssl_context *ssl )
             return( MBEDTLS_ERR_SSL_ALLOC_FAILED );
 
         ret = mbedtls_ssl_tls13_build_transform( ssl, &traffic_keys,
-                                                 transform_application, 0 );
+                                                 transform_application );
 
         /* Register transform with MPS. */
         ret = mbedtls_mps_add_key_material( &ssl->mps.l4,

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -3859,10 +3859,6 @@ int mbedtls_ssl_tls13_build_transform( mbedtls_ssl_context *ssl,
      * Setup other fields in SSL transform
      */
 
-    /* Reset sequence numbers */
-    memset( transform->sequence_number_dec, 0x0, 12 );
-    memset( transform->sequence_number_enc, 0x0, 12 );
-
     if( ( suite_info->flags & MBEDTLS_CIPHERSUITE_SHORT_TAG ) != 0 )
         transform->taglen  = 8;
     else

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -3229,7 +3229,8 @@ static int ssl_client_hello_postprocess( mbedtls_ssl_context* ssl,
             return( ret );
         }
 
-        ret = mbedtls_ssl_tls13_build_transform( ssl, &traffic_keys, ssl->transform_earlydata, 0 );
+        ret = mbedtls_ssl_tls13_build_transform( ssl, &traffic_keys,
+                                                 ssl->transform_earlydata );
         if( ret != 0 )
         {
             MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_tls13_build_transform", ret );
@@ -3244,7 +3245,7 @@ static int ssl_client_hello_postprocess( mbedtls_ssl_context* ssl,
                 return( MBEDTLS_ERR_SSL_ALLOC_FAILED );
 
             ret = mbedtls_ssl_tls13_build_transform( ssl, &traffic_keys,
-                                                     transform_earlydata, 0 );
+                                                     transform_earlydata );
 
             /* Register transform with MPS. */
             ret = mbedtls_mps_add_key_material( &ssl->mps.l4,
@@ -3469,7 +3470,8 @@ static int ssl_encrypted_extensions_prepare( mbedtls_ssl_context* ssl )
     }
 
     /* Setup transform from handshake key material */
-    ret = mbedtls_ssl_tls13_build_transform( ssl, &traffic_keys, ssl->transform_handshake, 0 );
+    ret = mbedtls_ssl_tls13_build_transform( ssl, &traffic_keys,
+                                             ssl->transform_handshake );
     if( ret != 0 )
     {
         MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_tls13_build_transform", ret );
@@ -3488,7 +3490,7 @@ static int ssl_encrypted_extensions_prepare( mbedtls_ssl_context* ssl )
             return( MBEDTLS_ERR_SSL_ALLOC_FAILED );
 
         ret = mbedtls_ssl_tls13_build_transform( ssl, &traffic_keys,
-                                                 transform_handshake, 0 );
+                                                 transform_handshake );
 
         /* Register transform with MPS. */
         ret = mbedtls_mps_add_key_material( &ssl->mps.l4,

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -3563,13 +3563,6 @@ static int ssl_encrypted_extensions_prepare( mbedtls_ssl_context* ssl )
         }
     }
 #endif
-#if defined(MBEDTLS_SSL_PROTO_DTLS)
-    /* epoch value ( 2 ) is used for messages protected
-     * using keys derived from the handshake_traffic_secret.
-     */
-    ssl->in_epoch = 2;
-    ssl->out_epoch = 2;
-#endif /* MBEDTLS_SSL_PROTO_DTLS */
 
     return( 0 );
 }

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -3553,9 +3553,6 @@ static int ssl_encrypted_extensions_prepare( mbedtls_ssl_context* ssl )
         memset( ssl->out_ctr, 0, 8 );
     }
 
-    /* Set sequence number used at the handshake header to zero */
-    memset( ssl->transform_out->sequence_number_enc, 0x0, 12 );
-
 #if defined(MBEDTLS_SSL_HW_RECORD_ACCEL)
     if( mbedtls_ssl_hw_record_activate != NULL )
     {


### PR DESCRIPTION
__What:__ This PR removes DTLS 1.3 specific code and fields around `mbedtls_ssl_transform`, esp. the transform builder `mbedtls_ssl_tls13_build_transform()`. 

__Why:__ As discussed internally, we don't aim to maintain the DTLS 1.3 specific code in the prototype branch for now, as it hasn't been tested for a long time and impedes the upstreaming of the TLS 1.3 code, which is the primary focus for now. DTLS 1.3 support will be revisited on the basis of MPS once upstreaming of TLS 1.3 support is completed.