### PR TITLE
Prepare mbedtls_ssl_tls13_populate_transform() for upstreaming

### DIFF
--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -1416,9 +1416,11 @@ int mbedtls_ssl_handshake_key_derivation( mbedtls_ssl_context* ssl,
 int mbedtls_ssl_read_certificate_verify_process(mbedtls_ssl_context* ssl);
 int mbedtls_ssl_certificate_verify_process(mbedtls_ssl_context* ssl);
 
-int mbedtls_ssl_tls13_build_transform( mbedtls_ssl_context* ssl,
-                             mbedtls_ssl_key_set* traffic_keys,
-                             mbedtls_ssl_transform* transform );
+int mbedtls_ssl_tls13_populate_transform( mbedtls_ssl_transform *transform,
+                                          int endpoint,
+                                          int ciphersuite,
+                                          mbedtls_ssl_key_set const *traffic_keys,
+                                          mbedtls_ssl_context *ssl /* DEBUG ONLY */ );
 
 #if defined(MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED)
 int mbedtls_ssl_create_binder( mbedtls_ssl_context *ssl,

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -226,8 +226,12 @@ static int ssl_write_early_data_prepare( mbedtls_ssl_context* ssl )
         if( transform_earlydata == NULL )
             return( MBEDTLS_ERR_SSL_ALLOC_FAILED );
 
-        ret = mbedtls_ssl_tls13_build_transform( ssl, &traffic_keys,
-                                                 transform_earlydata );
+        ret = mbedtls_ssl_tls13_populate_transform(
+                              transform_earlydata,
+                              ssl->conf->endpoint,
+                              ssl->session_negotiate->ciphersuite,
+                              &traffic_keys,
+                              ssl );
 
         /* Register transform with MPS. */
         ret = mbedtls_mps_add_key_material( &ssl->mps.l4,
@@ -245,11 +249,15 @@ static int ssl_write_early_data_prepare( mbedtls_ssl_context* ssl )
 
 #else /* MBEDTLS_SSL_USE_MPS */
 
-    ret = mbedtls_ssl_tls13_build_transform( ssl, &traffic_keys,
-                                             ssl->transform_earlydata );
+    ret = mbedtls_ssl_tls13_populate_transform(
+                              ssl->transform_earlydata,
+                              ssl->conf->endpoint,
+                              ssl->session_negotiate->ciphersuite,
+                              &traffic_keys,
+                              ssl );
     if( ret != 0 )
     {
-        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_tls13_build_transform", ret );
+        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_tls13_populate_transform", ret );
         return( ret );
     }
 
@@ -3527,11 +3535,15 @@ static int ssl_server_hello_postprocess( mbedtls_ssl_context* ssl )
         return( ret );
     }
 
-    ret = mbedtls_ssl_tls13_build_transform( ssl, &traffic_keys,
-                                             ssl->transform_handshake );
+    ret = mbedtls_ssl_tls13_populate_transform(
+                              ssl->transform_handshake,
+                              ssl->conf->endpoint,
+                              ssl->session_negotiate->ciphersuite,
+                              &traffic_keys,
+                              ssl );
     if( ret != 0 )
     {
-        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_tls13_build_transform", ret );
+        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_tls13_populate_transform", ret );
         return( ret );
     }
 
@@ -3545,8 +3557,12 @@ static int ssl_server_hello_postprocess( mbedtls_ssl_context* ssl )
         if( transform_handshake == NULL )
             return( MBEDTLS_ERR_SSL_ALLOC_FAILED );
 
-        ret = mbedtls_ssl_tls13_build_transform( ssl, &traffic_keys,
-                                                 transform_handshake );
+        ret = mbedtls_ssl_tls13_populate_transform(
+                              transform_handshake,
+                              ssl->conf->endpoint,
+                              ssl->session_negotiate->ciphersuite,
+                              &traffic_keys,
+                              ssl );
 
         /* Register transform with MPS. */
         ret = mbedtls_mps_add_key_material( &ssl->mps.l4,

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -3229,11 +3229,14 @@ static int ssl_client_hello_postprocess( mbedtls_ssl_context* ssl,
             return( ret );
         }
 
-        ret = mbedtls_ssl_tls13_build_transform( ssl, &traffic_keys,
-                                                 ssl->transform_earlydata );
+        ret = mbedtls_ssl_tls13_populate_transform( ssl->transform_earlydata,
+                                                    ssl->conf->endpoint,
+                                                    ssl->session_negotiate->ciphersuite,
+                                                    &traffic_keys,
+                                                    ssl );
         if( ret != 0 )
         {
-            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_tls13_build_transform", ret );
+            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_tls13_populate_transform", ret );
             return( ret );
         }
 
@@ -3244,8 +3247,12 @@ static int ssl_client_hello_postprocess( mbedtls_ssl_context* ssl,
             if( transform_earlydata == NULL )
                 return( MBEDTLS_ERR_SSL_ALLOC_FAILED );
 
-            ret = mbedtls_ssl_tls13_build_transform( ssl, &traffic_keys,
-                                                     transform_earlydata );
+            ret = mbedtls_ssl_tls13_populate_transform(
+                                  transform_earlydata,
+                                  ssl->conf->endpoint,
+                                  ssl->session_negotiate->ciphersuite,
+                                  &traffic_keys,
+                                  ssl );
 
             /* Register transform with MPS. */
             ret = mbedtls_mps_add_key_material( &ssl->mps.l4,
@@ -3470,11 +3477,15 @@ static int ssl_encrypted_extensions_prepare( mbedtls_ssl_context* ssl )
     }
 
     /* Setup transform from handshake key material */
-    ret = mbedtls_ssl_tls13_build_transform( ssl, &traffic_keys,
-                                             ssl->transform_handshake );
+    ret = mbedtls_ssl_tls13_populate_transform(
+                               ssl->transform_handshake,
+                               ssl->conf->endpoint,
+                               ssl->session_negotiate->ciphersuite,
+                               &traffic_keys,
+                               ssl );
     if( ret != 0 )
     {
-        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_tls13_build_transform", ret );
+        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_tls13_populate_transform", ret );
         return( ret );
     }
     mbedtls_ssl_set_outbound_transform( ssl, ssl->transform_handshake );
@@ -3489,8 +3500,12 @@ static int ssl_encrypted_extensions_prepare( mbedtls_ssl_context* ssl )
         if( transform_handshake == NULL )
             return( MBEDTLS_ERR_SSL_ALLOC_FAILED );
 
-        ret = mbedtls_ssl_tls13_build_transform( ssl, &traffic_keys,
-                                                 transform_handshake );
+        ret = mbedtls_ssl_tls13_populate_transform(
+                                transform_handshake,
+                                ssl->conf->endpoint,
+                                ssl->session_negotiate->ciphersuite,
+                                &traffic_keys,
+                                ssl );
 
         /* Register transform with MPS. */
         ret = mbedtls_mps_add_key_material( &ssl->mps.l4,


### PR DESCRIPTION
This PR makes changes to `mbedtls_ssl_tls13_build_transform()` which prepare it to be upstreamed to Mbed TLS. Specifically:
* ~DTLS 1.3 specific code is removed - this is the subject of the PR #166 in which this one builds.~ (merged)
* The function is renamed to `mbedtls_ssl_tls13_populate_transform()` in line with the existing TLS <= 1.2 specific function `ssl_populate_transform()`
* In line with the existing `ssl_populate_transform()`, context parameters relevant for the creation of the transform structure are added as explicit parameters. The SSL context remains a parameter solely for debugging purposes.