### PR TITLE
Address compiler error when turn on MBEDTLS_SSL_ALPN

### DIFF
--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -1604,6 +1604,19 @@ run_test    "TLS 1.3, TLS_AES_128_GCM_SHA256, RSA-certificate, OpenSSL server" \
             0 \
             -c "Certificate Verify: using RSA"
 
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL
+requires_config_enabled MBEDTLS_DEBUG_C
+requires_config_enabled MBEDTLS_SSL_ALPN
+run_test    "TLS 1.3, ALPN" \
+            "$P_SRV debug_level=5 force_version=tls1_3 psk=010203 psk_identity=0a0b0c key_exchange_modes=psk alpn=abc,1234" \
+            "$P_CLI debug_level=5 force_version=tls1_3 psk=010203 psk_identity=0a0b0c key_exchange_modes=psk alpn=1234" \
+            0 \
+            -s "Protocol is TLSv1.3" \
+            -s "found alpn extension" \
+            -c "found alpn extension" \
+            -c "Application Layer Protocol is 1234" \
+            -s "Application Layer Protocol is 1234"
+
 #
 # TLS 1.2 specific tests
 #


### PR DESCRIPTION
Summary:
After turn on MBEDTLS_SSL_ALPN in `configure.h`. Found the following compiler error.
[ssl_write_alpn_ext](https://github.com/hannestschofenig/mbedtls/blob/tls13-prototype/library/ssl_tls13_server.c#L3305-L3307) is not matched with its [call site](https://github.com/hannestschofenig/mbedtls/blob/tls13-prototype/library/ssl_tls13_server.c#L3617).
```
mbedtls/library/ssl_tls13_server.c:3313:9: error: void function 'ssl_write_alpn_ext' should not return a value
      [-Wreturn-type]
        return( 0 );
        ^     ~~~~~
/Users/junqiw/github/mbedtls/library/ssl_tls13_server.c:3617:48: error: too many arguments to function call, expected 3, have 4
    ret = ssl_write_alpn_ext( ssl, p, end - p, &n );
          ~~~~~~~~~~~~~~~~~~                   ^~
/Users/junqiw/github/mbedtls/library/ssl_tls13_server.c:3305:1: note: 'ssl_write_alpn_ext' declared here
static void ssl_write_alpn_ext( mbedtls_ssl_context *ssl,
```

Fix by updating `ssl_write_alpn_ext`.

Test Plan:
build with both MBEDTLS_SSL_ALPN and MBEDTLS_SSL_SRV_C on
```
rm -rf build/; mkdir build; cd build; CFLAGS="-std=c99 -g" cmake ..; make -j;
```
run new test case
```
tests/ssl-opt.sh  -s -f "TLS 1.3, ALPN"
```

Reviewers:

Subscribers:

Tasks:

Tags: