### PR TITLE
Remove legacy messaging layer if MPS is enabled

### DIFF
--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -1607,6 +1607,7 @@ struct mbedtls_ssl_context
     mbedtls_ssl_set_timer_t *f_set_timer;       /*!< set timer callback */
     mbedtls_ssl_get_timer_t *f_get_timer;       /*!< get timer callback */
 
+#if !defined(MBEDTLS_SSL_USE_MPS)
     /*
      * Record layer (incoming data)
      */
@@ -1652,7 +1653,7 @@ struct mbedtls_ssl_context
     size_t in_hslen;            /*!< current handshake message length,
                                      including the handshake header   */
     int nb_zero;                /*!< # of 0-length encrypted messages */
-
+#endif /* !MBEDTLS_SSL_USE_MPS */
 
     /* The following two variables indicate if and, if yes,
      * what kind of alert or warning is pending to be sent.
@@ -1678,6 +1679,7 @@ struct mbedtls_ssl_context
                                         *   within a single datagram.  */
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
 
+#if !defined(MBEDTLS_SSL_USE_MPS)
     /*
      * Record layer (outgoing data)
      */
@@ -1704,9 +1706,6 @@ struct mbedtls_ssl_context
 
     unsigned char cur_out_ctr[8]; /*!<  Outgoing record sequence  number. */
 
-#if defined(MBEDTLS_SSL_PROTO_DTLS)
-    uint16_t mtu;               /*!< path mtu, used to fragment outgoing messages */
-#endif /* MBEDTLS_SSL_PROTO_DTLS */
 
 #if defined(MBEDTLS_ZLIB_SUPPORT)
     unsigned char *compress_buf;        /*!<  zlib data buffer        */
@@ -1714,6 +1713,11 @@ struct mbedtls_ssl_context
 #if defined(MBEDTLS_SSL_CBC_RECORD_SPLITTING)
     signed char split_done;     /*!< current record already splitted? */
 #endif /* MBEDTLS_SSL_CBC_RECORD_SPLITTING */
+#endif /* !MBEDTLS_SSL_USE_MPS */
+
+#if defined(MBEDTLS_SSL_PROTO_DTLS)
+    uint16_t mtu;               /*!< path mtu, used to fragment outgoing messages */
+#endif /* MBEDTLS_SSL_PROTO_DTLS */
 
     /*
      * PKI layer
@@ -1946,7 +1950,7 @@ void mbedtls_ssl_conf_transport( mbedtls_ssl_config *conf, int transport );
  * the right time(s), which may not be obvious, while REQUIRED always perform
  * the verification as soon as possible. For example, REQUIRED was protecting
  * against the "triple handshake" attack even before it was found.
- * 
+ *
  * \note In any mode, the signatures of the certificates in CertificateVerify
  * messages are always verified.
  */

--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -1734,7 +1734,12 @@ static inline size_t mbedtls_ssl_in_hdr_len( const mbedtls_ssl_context *ssl )
 
 static inline size_t mbedtls_ssl_out_hdr_len( const mbedtls_ssl_context *ssl )
 {
+#if !defined(MBEDTLS_SSL_USE_MPS)
     return( (size_t) ( ssl->out_iv - ssl->out_hdr ) );
+#else
+    ((void) ssl);
+    return( 5 );
+#endif /* MBEDTLS_SSL_USE_MPS */
 }
 
 static inline size_t mbedtls_ssl_hs_hdr_len( const mbedtls_ssl_context *ssl )

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -1232,6 +1232,7 @@ int mbedtls_ssl_parse_signature_algorithms_ext( mbedtls_ssl_context *ssl,
 }
 #endif /* MBEDTLS_KEY_EXCHANGE_WITH_CERT_ENABLED */
 
+#if !defined(MBEDTLS_SSL_USE_MPS)
 void mbedtls_ssl_set_inbound_transform( mbedtls_ssl_context *ssl,
                                        mbedtls_ssl_transform *transform )
 {
@@ -1253,6 +1254,7 @@ void mbedtls_ssl_set_outbound_transform( mbedtls_ssl_context *ssl,
     ssl->transform_out = transform;
     memset( ssl->cur_out_ctr, 0, 8 );
 }
+#endif /* !MBEDTLS_SSL_USE_MPS */
 
 /* mbedtls_ssl_generate_handshake_traffic_keys() generates keys necessary for
  * protecting the handshake messages, as described in Section 7 of TLS 1.3. */
@@ -2689,7 +2691,6 @@ static int ssl_write_certificate_coordinate( mbedtls_ssl_context* ssl )
     {
         MBEDTLS_SSL_DEBUG_MSG( 1,
                   ( "Switch to handshake traffic keys for outbound traffic" ) );
-        mbedtls_ssl_set_outbound_transform( ssl, ssl->transform_handshake );
 
 #if defined(MBEDTLS_SSL_USE_MPS)
         {
@@ -2701,6 +2702,8 @@ static int ssl_write_certificate_coordinate( mbedtls_ssl_context* ssl )
             if( ret != 0 )
                 return( ret );
         }
+#else
+        mbedtls_ssl_set_outbound_transform( ssl, ssl->transform_handshake );
 #endif /* MBEDTLS_SSL_USE_MPS */
     }
 #endif /* MBEDTLS_SSL_CLI_C */
@@ -3046,7 +3049,6 @@ static int ssl_read_certificate_coordinate( mbedtls_ssl_context* ssl )
     if( ssl->conf->endpoint == MBEDTLS_SSL_IS_SERVER )
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "Switch to handshake keys for inbound traffic" ) );
-        mbedtls_ssl_set_inbound_transform( ssl, ssl->transform_handshake );
 
 #if defined(MBEDTLS_SSL_USE_MPS)
         {
@@ -3056,6 +3058,8 @@ static int ssl_read_certificate_coordinate( mbedtls_ssl_context* ssl )
             if( ret != 0 )
                 return( ret );
         }
+#else
+        mbedtls_ssl_set_inbound_transform( ssl, ssl->transform_handshake );
 #endif /* MBEDTLS_SSL_USE_MPS */
     }
 #endif /* MBEDTLS_SSL_SRV_C */
@@ -4116,11 +4120,13 @@ int mbedtls_ssl_handshake_key_derivation( mbedtls_ssl_context *ssl, mbedtls_ssl_
         return( ret );
     }
 
+#if !defined(MBEDTLS_SSL_USE_MPS)
     /*
      * Set the in_msg pointer to the correct location based on IV length
      * For TLS 1.3 the record layer header has changed and hence we need to accomodate for it.
      */
     ssl->in_msg = ssl->in_iv;
+#endif /* MBEDTLS_SSL_USE_MPS */
 
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "<= mbedtls_ssl_handshake_key_derivation" ) );
     return( 0 );
@@ -4257,9 +4263,11 @@ static int ssl_finished_out_prepare( mbedtls_ssl_context* ssl )
     /*
      * Set the out_msg pointer to the correct location based on IV length
      */
+#if !defined(MBEDTLS_SSL_USE_MPS)
 #if !defined(MBEDTLS_SSL_PROTO_DTLS)
     ssl->out_msg = ssl->out_iv;
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
+#endif /* !MBEDTLS_SSL_USE_MPS */
 
     /* Compute transcript of handshake up to now. */
     ret = ssl->handshake->calc_finished( ssl,


### PR DESCRIPTION
This PR adds guards around the old Mbed TLS messaging layer by, disabling it when MPS (the new messaging layer) is enabled.