### PR TITLE
Remove extra empty line in cipher_wrap.c

### DIFF
--- a/library/cipher_wrap.c
+++ b/library/cipher_wrap.c
@@ -647,7 +647,6 @@ static const mbedtls_cipher_info_t aes_256_ccm_info = {
     16,
     &ccm_aes_info
 };
-
 #endif /* MBEDTLS_CCM_C */
 
 #endif /* MBEDTLS_AES_C */


### PR DESCRIPTION
Summary:
This is one of crypto library related [difference](https://github.com/ARMmbed/mbedtls/compare/development...hannestschofenig:tls13-prototype) between tls13-prototype branch and development branch.
Remove the extra empty line to match [the development](https://github.com/ARMmbed/mbedtls/blob/development/library/cipher_wrap.c#L649-L650).

Test Plan:
`make test`

Reviewers:

Subscribers:

Tasks:

Tags: