### PR TITLE
Move ecdh and ecp tls13 specific functions from crypto to tls library

### DIFF
--- a/include/mbedtls/ecdh.h
+++ b/include/mbedtls/ecdh.h
@@ -285,32 +285,6 @@ int mbedtls_ecdh_make_params( mbedtls_ecdh_context *ctx, size_t *olen,
                       void *p_rng );
 
 /**
- * \brief           This function generates an EC key pair and exports its
- *                  in the format used in a TLS 1.3 KeyShare extension.
- *
- * \see             ecp.h
- *
- * \param ctx       The ECDH context to use. This must be initialized
- *                  and bound to a group, for example via mbedtls_ecdh_setup().
- * \param olen      The address at which to store the number of Bytes written.
- * \param buf       The destination buffer. This must be a writable buffer of
- *                  length \p blen Bytes.
- * \param blen      The length of the destination buffer \p buf in Bytes.
- * \param f_rng     The RNG function to use. This must not be \c NULL.
- * \param p_rng     The RNG context to be passed to \p f_rng. This may be
- *                  \c NULL in case \p f_rng doesn't need a context argument.
- *
- * \return          \c 0 on success.
- * \return          #MBEDTLS_ERR_ECP_IN_PROGRESS if maximum number of
- *                  operations was reached: see \c mbedtls_ecp_set_max_ops().
- * \return          Another \c MBEDTLS_ERR_ECP_XXX error code on failure.
- */
-int mbedtls_ecdh_make_tls_13_params( mbedtls_ecdh_context *ctx, size_t *olen,
-                      unsigned char *buf, size_t blen,
-                      int (*f_rng)(void *, unsigned char *, size_t),
-                      void *p_rng );
-
-/**
  * \brief           This function parses the ECDHE parameters in a
  *                  TLS ServerKeyExchange handshake message.
  *
@@ -335,30 +309,6 @@ int mbedtls_ecdh_make_tls_13_params( mbedtls_ecdh_context *ctx, size_t *olen,
  *
  */
 int mbedtls_ecdh_read_params( mbedtls_ecdh_context *ctx,
-                              const unsigned char **buf,
-                              const unsigned char *end );
-
-/**
- * \brief           This function parses the ECDHE parameters in a
- *                  TLS 1.3 KeyShare extension.
- *
- * \see             ecp.h
- *
- * \param ctx       The ECDHE context to use. This must be initialized.
- * \param buf       On input, \c *buf must be the start of the input buffer.
- *                  On output, \c *buf is updated to point to the end of the
- *                  data that has been read. On success, this is the first byte
- *                  past the end of the ServerKeyExchange parameters.
- *                  On error, this is the point at which an error has been
- *                  detected, which is usually not useful except to debug
- *                  failures.
- * \param end       The end of the input buffer.
- *
- * \return          \c 0 on success.
- * \return          An \c MBEDTLS_ERR_ECP_XXX error code on failure.
- *
- */
-int mbedtls_ecdh_read_tls_13_params( mbedtls_ecdh_context *ctx,
                               const unsigned char **buf,
                               const unsigned char *end );
 
@@ -417,34 +367,6 @@ int mbedtls_ecdh_make_public( mbedtls_ecdh_context *ctx, size_t *olen,
                       void *p_rng );
 
 /**
- * \brief           This function generates a public key and exports it
- *                  as a TLS 1.3 KeyShare payload.
- *
- * \see             ecp.h
- *
- * \param ctx       The ECDH context to use. This must be initialized
- *                  and bound to a group, the latter usually by
- *                  mbedtls_ecdh_read_params().
- * \param olen      The address at which to store the number of Bytes written.
- *                  This must not be \c NULL.
- * \param buf       The destination buffer. This must be a writable buffer
- *                  of length \p blen Bytes.
- * \param blen      The size of the destination buffer \p buf in Bytes.
- * \param f_rng     The RNG function to use. This must not be \c NULL.
- * \param p_rng     The RNG context to be passed to \p f_rng. This may be
- *                  \c NULL in case \p f_rng doesn't need a context argument.
- *
- * \return          \c 0 on success.
- * \return          #MBEDTLS_ERR_ECP_IN_PROGRESS if maximum number of
- *                  operations was reached: see \c mbedtls_ecp_set_max_ops().
- * \return          Another \c MBEDTLS_ERR_ECP_XXX error code on failure.
- */
-int mbedtls_ecdh_make_tls_13_public( mbedtls_ecdh_context *ctx, size_t *olen,
-                      unsigned char *buf, size_t blen,
-                      int (*f_rng)(void *, unsigned char *, size_t),
-                      void *p_rng );
-
-/**
  * \brief       This function parses and processes the ECDHE payload of a
  *              TLS ClientKeyExchange message.
  *
@@ -464,24 +386,6 @@ int mbedtls_ecdh_make_tls_13_public( mbedtls_ecdh_context *ctx, size_t *olen,
  * \return      An \c MBEDTLS_ERR_ECP_XXX error code on failure.
  */
 int mbedtls_ecdh_read_public( mbedtls_ecdh_context *ctx,
-                              const unsigned char *buf, size_t blen );
-
-/**
- * \brief       This function parses and processes the ECDHE payload of a
- *              TLS 1.3 KeyShare extension.
- *
- * \see         ecp.h
- *
- * \param ctx   The ECDH context to use. This must be initialized
- *              and bound to a group, for example via mbedtls_ecdh_setup().
- * \param buf   The pointer to the ClientKeyExchange payload. This must
- *              be a readable buffer of length \p blen Bytes.
- * \param blen  The length of the input buffer \p buf in Bytes.
- *
- * \return      \c 0 on success.
- * \return      An \c MBEDTLS_ERR_ECP_XXX error code on failure.
- */
-int mbedtls_ecdh_read_tls_13_public( mbedtls_ecdh_context *ctx,
                               const unsigned char *buf, size_t blen );
 
 /**

--- a/include/mbedtls/ecp.h
+++ b/include/mbedtls/ecp.h
@@ -755,28 +755,6 @@ int mbedtls_ecp_tls_read_point( const mbedtls_ecp_group *grp,
                                 const unsigned char **buf, size_t len );
 
 /**
- * \brief           This function imports a point from a TLS ECPoint record.
- *
- * \note            On function return, \p *buf is updated to point immediately
- *                  after the ECPoint record.
- *
- * \param grp       The ECP group to use.
- *                  This must be initialized and have group parameters
- *                  set, for example through mbedtls_ecp_group_load().
- * \param pt        The destination point.
- * \param buf       The address of the pointer to the start of the input buffer.
- * \param len       The length of the buffer.
- *
- * \return          \c 0 on success.
- * \return          An \c MBEDTLS_ERR_MPI_XXX error code on initialization
- *                  failure.
- * \return          #MBEDTLS_ERR_ECP_BAD_INPUT_DATA if input is invalid.
- */
-int mbedtls_ecp_tls_13_read_point( const mbedtls_ecp_group *grp,
-                                mbedtls_ecp_point *pt,
-                                const unsigned char **buf, size_t len );
-
-/**
  * \brief           This function exports a point as a TLS ECPoint record
  *                  defined in RFC 4492, Section 5.4.
  *
@@ -802,33 +780,6 @@ int mbedtls_ecp_tls_write_point( const mbedtls_ecp_group *grp,
                                  const mbedtls_ecp_point *pt,
                                  int format, size_t *olen,
                                  unsigned char *buf, size_t blen );
-
-/**
- * \brief           This function exports a point as defined in TLS 1.3.
- *
- * \param grp       The ECP group to use.
- *                  This must be initialized and have group parameters
- *                  set, for example through mbedtls_ecp_group_load().
- * \param pt        The point to be exported. This must be initialized.
- * \param format    The point format to use. This must be either
- *                  #MBEDTLS_ECP_PF_COMPRESSED or #MBEDTLS_ECP_PF_UNCOMPRESSED.
- * \param olen      The address at which to store the length in Bytes
- *                  of the data written.
- * \param buf       The target buffer. This must be a writable buffer of
- *                  length \p blen Bytes.
- * \param blen      The length of the target buffer \p buf in Bytes.
- *
- * \return          \c 0 on success.
- * \return          #MBEDTLS_ERR_ECP_BAD_INPUT_DATA if the input is invalid.
- * \return          #MBEDTLS_ERR_ECP_BUFFER_TOO_SMALL if the target buffer
- *                  is too small to hold the exported point.
- * \return          Another negative error code on other kinds of failure.
- */
-int mbedtls_ecp_tls_13_write_point( const mbedtls_ecp_group *grp,
-                                 const mbedtls_ecp_point *pt,
-                                 int format, size_t *olen,
-                                 unsigned char *buf, size_t blen );
-
 
 /**
  * \brief           This function sets up an ECP group context
@@ -890,31 +841,6 @@ int mbedtls_ecp_tls_read_group( mbedtls_ecp_group *grp,
 int mbedtls_ecp_tls_read_group_id( mbedtls_ecp_group_id *grp,
                                    const unsigned char **buf,
                                    size_t len );
-
-
-/**
- * \brief           This function extracts an elliptic curve group ID from a
- *                  TLS ECParameters record as defined in TLS 1.3.
- *
- * \note            The read pointer \p buf is updated to point right after
- *                  the ECParameters record on exit.
- *
- * \param grp       The address at which to store the group id.
- *                  This must not be \c NULL.
- * \param buf       The address of the pointer to the start of the input buffer.
- * \param len       The length of the input buffer \c *buf in Bytes.
- *
- * \return          \c 0 on success.
- * \return          #MBEDTLS_ERR_ECP_BAD_INPUT_DATA if input is invalid.
- * \return          #MBEDTLS_ERR_ECP_FEATURE_UNAVAILABLE if the group is not
- *                  recognized.
- * \return          Another negative error code on other kinds of failure.
- */
-int mbedtls_ecp_tls_13_read_group_id( mbedtls_ecp_group_id *grp,
-                                   const unsigned char **buf,
-                                   size_t len );
-
-
 /**
  * \brief           This function exports an elliptic curve as a TLS
  *                  ECParameters record as defined in RFC 4492, Section 5.4.
@@ -936,29 +862,6 @@ int mbedtls_ecp_tls_13_read_group_id( mbedtls_ecp_group_id *grp,
 int mbedtls_ecp_tls_write_group( const mbedtls_ecp_group *grp,
                                  size_t *olen,
                                  unsigned char *buf, size_t blen );
-
-/**
- * \brief           This function exports an elliptic curve as a TLS
- *                  ECParameters record as defined in TLS 1.3.
- *
- * \param grp       The ECP group to be exported.
- *                  This must be initialized and have group parameters
- *                  set, for example through mbedtls_ecp_group_load().
- * \param olen      The address at which to store the number of Bytes written.
- *                  This must not be \c NULL.
- * \param buf       The buffer to write to. This must be a writable buffer
- *                  of length \p blen Bytes.
- * \param blen      The length of the output buffer \p buf in Bytes.
- *
- * \return          \c 0 on success.
- * \return          #MBEDTLS_ERR_ECP_BUFFER_TOO_SMALL if the output
- *                  buffer is too small to hold the exported group.
- * \return          Another negative error code on other kinds of failure.
- */
-int mbedtls_ecp_tls_13_write_group( const mbedtls_ecp_group *grp,
-                                 size_t *olen,
-                                 unsigned char *buf, size_t blen );
-
 
 /**
  * \brief           This function performs a scalar multiplication of a point

--- a/library/ecp.c
+++ b/library/ecp.c
@@ -1030,38 +1030,6 @@ int mbedtls_ecp_tls_read_point( const mbedtls_ecp_group *grp,
     return( mbedtls_ecp_point_read_binary( grp, pt, buf_start, data_len ) );
 }
 
-#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && defined(MBEDTLS_ECDH_C)
-int mbedtls_ecp_tls_13_read_point( const mbedtls_ecp_group *grp,
-                                mbedtls_ecp_point *pt,
-                                const unsigned char **buf, size_t buf_len )
-{
-    unsigned char data_len;
-    const unsigned char *buf_start;
-    ECP_VALIDATE_RET( grp != NULL );
-    ECP_VALIDATE_RET( pt  != NULL );
-    ECP_VALIDATE_RET( buf != NULL );
-    ECP_VALIDATE_RET( *buf != NULL );
-
-    if( buf_len < 3 )
-        return( MBEDTLS_ERR_ECP_BAD_INPUT_DATA );
-
-    data_len = ( *( *buf ) << 8 ) | *( *buf+1 );
-    *buf += 2;
-
-    if( data_len < 1 || data_len > buf_len - 2 )
-        return( MBEDTLS_ERR_ECP_BAD_INPUT_DATA );
-
-    /*
-     * Save buffer start for read_binary and update buf
-     */
-    buf_start = *buf;
-    *buf += data_len;
-
-    return( mbedtls_ecp_point_read_binary( grp, pt, buf_start, data_len ) );
-}
-#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL && MBEDTLS_ECDH_C */
-
-
 /*
  * Export a point as a TLS ECPoint record (RFC 4492)
  *      struct {
@@ -1098,35 +1066,6 @@ int mbedtls_ecp_tls_write_point( const mbedtls_ecp_group *grp, const mbedtls_ecp
 
     return( 0 );
 }
-
-#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && defined(MBEDTLS_ECDH_C)
-int mbedtls_ecp_tls_13_write_point( const mbedtls_ecp_group *grp, const mbedtls_ecp_point *pt,
-                         int format, size_t *olen,
-                         unsigned char *buf, size_t blen )
-{
-    int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
-    ECP_VALIDATE_RET( grp  != NULL );
-    ECP_VALIDATE_RET( pt   != NULL );
-    ECP_VALIDATE_RET( olen != NULL );
-    ECP_VALIDATE_RET( buf  != NULL );
-    ECP_VALIDATE_RET( format == MBEDTLS_ECP_PF_UNCOMPRESSED ||
-                      format == MBEDTLS_ECP_PF_COMPRESSED );
-
-    if( blen < 2 )
-        return( MBEDTLS_ERR_ECP_BAD_INPUT_DATA );
-
-    if( ( ret = mbedtls_ecp_point_write_binary( grp, pt, format,
-                    olen, buf + 2, blen - 2) ) != 0 )
-        return( ret );
-
-    // Length
-    *buf++ = (unsigned char)( ( *olen >> 8 ) & 0xFF );
-    *buf++ = (unsigned char)( ( *olen ) & 0xFF );
-    *olen += 2;
-
-    return( 0 );
-}
-#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL && MBEDTLS_ECDH_C */
 
 /*
  * Set a group from an ECParameters record (RFC 4492)
@@ -1220,65 +1159,6 @@ int mbedtls_ecp_tls_write_group( const mbedtls_ecp_group *grp, size_t *olen,
 
     return( 0 );
 }
-
-#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
-/*
- * Read a group id from an ECParameters record (TLS 1.3) and convert it to
- * mbedtls_ecp_group_id.
- */
-int mbedtls_ecp_tls_13_read_group_id( mbedtls_ecp_group_id *grp,
-                                   const unsigned char **buf, size_t len )
-{
-    uint16_t tls_id;
-    const mbedtls_ecp_curve_info *curve_info;
-    ECP_VALIDATE_RET( grp  != NULL );
-    ECP_VALIDATE_RET( buf  != NULL );
-    ECP_VALIDATE_RET( *buf != NULL );
-
-    if( len < 2 )
-        return( MBEDTLS_ERR_ECP_BAD_INPUT_DATA );
-
-    /*
-     * Next two bytes are the namedcurve value
-     */
-    tls_id = *(*buf)++;
-    tls_id <<= 8;
-    tls_id |= *(*buf)++;
-
-    if( ( curve_info = mbedtls_ecp_curve_info_from_tls_id( tls_id ) ) == NULL )
-        return( MBEDTLS_ERR_ECP_FEATURE_UNAVAILABLE );
-
-    *grp = curve_info->grp_id;
-
-    return( 0 );
-}
-
-/*
- * Write the ECParameters record corresponding to a group (TLS 1.3)
- */
-int mbedtls_ecp_tls_13_write_group( const mbedtls_ecp_group *grp, size_t *olen,
-                         unsigned char *buf, size_t blen )
-{
-    const mbedtls_ecp_curve_info *curve_info;
-    ECP_VALIDATE_RET( grp  != NULL );
-    ECP_VALIDATE_RET( buf  != NULL );
-    ECP_VALIDATE_RET( olen != NULL );
-
-    if( ( curve_info = mbedtls_ecp_curve_info_from_grp_id( grp->id ) ) == NULL )
-        return( MBEDTLS_ERR_ECP_BAD_INPUT_DATA );
-
-    *olen = 2;
-    if( blen < *olen )
-        return( MBEDTLS_ERR_ECP_BUFFER_TOO_SMALL );
-
-    // Two bytes for named curve
-    buf[0] = curve_info->tls_id >> 8;
-    buf[1] = curve_info->tls_id & 0xFF;
-
-    return( 0 );
-}
-#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
-
 
 /*
  * Wrapper around fast quasi-modp functions, with fall-back to mbedtls_mpi_mod_mpi.


### PR DESCRIPTION
Summary:
Move the following functions from crypto library (`ecdh.c`, and `ecp.c`) to tls library(`ssl_tls13_generic.c`):

* mbedtls_ecdh_make_tls_13_params
* mbedtls_ecdh_read_tls_13_params
* mbedtls_ecdh_make_tls_13_public
* mbedtls_ecdh_read_tls_13_public
* mbedtls_ecp_tls_13_read_point
* mbedtls_ecp_tls_13_write_point
* mbedtls_ecp_tls_13_read_group_id
* mbedtls_ecp_tls_13_write_group

It would help us to be sync with development in terms of crypto library. We could upstream them separately to development branch.

Test Plan:
```
tests/ssl-opt.sh
```

Reviewers:

Subscribers:

Tasks:

Tags: