### PR TITLE
Synchronize MPS reader with upstreamed version

### DIFF
--- a/include/mbedtls/mps/common.h
+++ b/include/mbedtls/mps/common.h
@@ -27,8 +27,8 @@
 #define MBEDTLS_MPS_ERR_BASE    ( 1 << 10 )
 #endif
 
-#ifndef MBEDTLS_READER_ERR_BASE
-#define MBEDTLS_READER_ERR_BASE ( 1 << 11 )
+#ifndef MBEDTLS_MPS_READER_ERR_BASE
+#define MBEDTLS_MPS_READER_ERR_BASE ( 1 << 11 )
 #endif
 
 #ifndef MBEDTLS_WRITER_ERR_BASE
@@ -38,8 +38,8 @@
 #define MBEDTLS_MPS_MAKE_ERROR(code) \
     ( -( MBEDTLS_MPS_ERR_BASE | (code) ) )
 
-#define MBEDTLS_READER_MAKE_ERROR(code) \
-    ( -( MBEDTLS_READER_ERR_BASE | (code) ) )
+#define MBEDTLS_MPS_READER_MAKE_ERROR(code) \
+    ( -( MBEDTLS_MPS_READER_ERR_BASE | (code) ) )
 
 #define MBEDTLS_WRITER_MAKE_ERROR(code) \
     ( -( MBEDTLS_WRITER_ERR_BASE | (code) ) )
@@ -235,7 +235,7 @@ typedef uint8_t mbedtls_mps_epoch_offset_t;
     {                                                            \
         if( !(cond) )                                            \
         {                                                        \
-            TRACE( trace_error, string );                        \
+            MBEDTLS_MPS_TRACE( trace_error, string );                        \
             MPS_CHK( MBEDTLS_ERR_MPS_OPERATION_UNEXPECTED );     \
         }                                                        \
     } while( 0 )
@@ -245,8 +245,8 @@ typedef uint8_t mbedtls_mps_epoch_offset_t;
     {                                                            \
         if( !(cond) )                                            \
         {                                                        \
-            TRACE( trace_error, string );                        \
-            RETURN( MBEDTLS_ERR_MPS_OPERATION_UNEXPECTED );      \
+            MBEDTLS_MPS_TRACE( trace_error, string );                        \
+            MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_OPERATION_UNEXPECTED );      \
         }                                                        \
     } while( 0 )
 
@@ -273,7 +273,7 @@ typedef uint8_t mbedtls_mps_epoch_offset_t;
     {                                                            \
         if( !(cond) )                                            \
         {                                                        \
-            TRACE( trace_error, string );                        \
+            MBEDTLS_MPS_TRACE( trace_error, string );                        \
             MPS_CHK( MBEDTLS_ERR_MPS_INTERNAL_ERROR );           \
         }                                                        \
     } while( 0 )
@@ -283,8 +283,8 @@ typedef uint8_t mbedtls_mps_epoch_offset_t;
     {                                                            \
         if( !(cond) )                                            \
         {                                                        \
-            TRACE( trace_error, string );                        \
-            RETURN( MBEDTLS_ERR_MPS_INTERNAL_ERROR );            \
+            MBEDTLS_MPS_TRACE( trace_error, string );                        \
+            MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_INTERNAL_ERROR );            \
         }                                                        \
     } while( 0 )
 

--- a/include/mbedtls/mps/common.h
+++ b/include/mbedtls/mps/common.h
@@ -235,7 +235,7 @@ typedef uint8_t mbedtls_mps_epoch_offset_t;
     {                                                            \
         if( !(cond) )                                            \
         {                                                        \
-            MBEDTLS_MPS_TRACE( trace_error, string );                        \
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR, string );                        \
             MPS_CHK( MBEDTLS_ERR_MPS_OPERATION_UNEXPECTED );     \
         }                                                        \
     } while( 0 )
@@ -245,7 +245,7 @@ typedef uint8_t mbedtls_mps_epoch_offset_t;
     {                                                            \
         if( !(cond) )                                            \
         {                                                        \
-            MBEDTLS_MPS_TRACE( trace_error, string );                        \
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR, string );                        \
             MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_OPERATION_UNEXPECTED );      \
         }                                                        \
     } while( 0 )
@@ -273,7 +273,7 @@ typedef uint8_t mbedtls_mps_epoch_offset_t;
     {                                                            \
         if( !(cond) )                                            \
         {                                                        \
-            MBEDTLS_MPS_TRACE( trace_error, string );                        \
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR, string );                        \
             MPS_CHK( MBEDTLS_ERR_MPS_INTERNAL_ERROR );           \
         }                                                        \
     } while( 0 )
@@ -283,7 +283,7 @@ typedef uint8_t mbedtls_mps_epoch_offset_t;
     {                                                            \
         if( !(cond) )                                            \
         {                                                        \
-            MBEDTLS_MPS_TRACE( trace_error, string );                        \
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR, string );                        \
             MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_INTERNAL_ERROR );            \
         }                                                        \
     } while( 0 )

--- a/include/mbedtls/mps/layer2.h
+++ b/include/mbedtls/mps/layer2.h
@@ -111,7 +111,7 @@ typedef struct
     mbedtls_mps_stored_msg_type_t type;
     /*!< The epoch through which the incoming data is protected. */
     mbedtls_mps_stored_epoch_id epoch;
-    mbedtls_reader *rd;           /*!< The reader providing access to the
+    mbedtls_mps_reader *rd;           /*!< The reader providing access to the
                                    *   incoming data.                        */
 } mps_l2_in;
 
@@ -192,7 +192,7 @@ struct mbedtls_mps_l2_in_internal
     /*! The epoch through which the data is secured. */
     mbedtls_mps_stored_epoch_id epoch;
     /*! The reader managing the incoming data after decryption. */
-    mbedtls_reader rd;
+    mbedtls_mps_reader rd;
 };
 typedef struct mbedtls_mps_l2_in_internal mbedtls_mps_l2_in_internal;
 

--- a/include/mbedtls/mps/layer3.h
+++ b/include/mbedtls/mps/layer3.h
@@ -207,7 +207,7 @@ struct mps_l3_handshake_in
 
     /*!< The extended reader giving access to the message contents, and
      *   keeping track of message bounds. */
-    mbedtls_reader_ext *rd_ext;
+    mbedtls_mps_reader_ext *rd_ext;
 };
 
 /**
@@ -265,7 +265,7 @@ struct mps_l3_app_in
 {
     /*! The epoch used to protect the application data. */
     mbedtls_mps_stored_epoch_id epoch;
-    mbedtls_reader *rd;
+    mbedtls_mps_reader *rd;
 };
 
 struct mps_l3_app_out
@@ -339,7 +339,7 @@ struct mps_l3_hs_in_internal
     /*!< The handshake sequence number. */
     mbedtls_mps_stored_hs_seq_nr_t seq_nr;
 
-    mbedtls_reader_ext rd_ext;  /*!< The extended reader giving access to
+    mbedtls_mps_reader_ext rd_ext;  /*!< The extended reader giving access to
                                  *   the message contents, but also keeping
                                  *   track of message bounds.                */
 };
@@ -448,7 +448,7 @@ struct mps_l3
 
             /*! Epoch of current incoming message.  */
             mbedtls_mps_stored_epoch_id epoch;
-            mbedtls_reader *raw_in; /*!< Reader providing raw access to incoming
+            mbedtls_mps_reader *raw_in; /*!< Reader providing raw access to incoming
                                      *   data of the type indicated by \c state
                                      *   (including headers in case of handshake
                                      *    messages).                             */

--- a/include/mbedtls/mps/mps.h
+++ b/include/mbedtls/mps/mps.h
@@ -856,7 +856,7 @@ struct mbedtls_mps
         union
         {
             mbedtls_mps_alert_t alert;
-            mbedtls_reader*     app;
+            mbedtls_mps_reader*     app;
             mps_l3_handshake_in hs;
         } data;
 
@@ -1053,8 +1053,8 @@ struct mbedtls_mps
                      *
                      *  TODO: Document in which states this is valid.
                      */
-                    mbedtls_reader         rd;
-                    mbedtls_reader_ext rd_ext;
+                    mbedtls_mps_reader         rd;
+                    mbedtls_mps_reader_ext rd_ext;
 
                     /*! The array of structures representing future and/or
                      *  partially received handshake messages. */
@@ -1099,7 +1099,7 @@ struct mbedtls_mps
                             /*! The extended reader owned by Layer 3 giving rise to the
                              *  contents of the handshake message. This is valid if and
                              *  only if \c status is #MPS_REASSEMBLY_NO_FRAGMENTATION */
-                            mbedtls_reader_ext *rd_ext_l3;
+                            mbedtls_mps_reader_ext *rd_ext_l3;
 
                             /*! The reassembly buffer holding the partially received
                              *  handshake message. This is valid if and only if
@@ -1300,7 +1300,7 @@ typedef struct
 {
     uint8_t   type;             /*!< Type of handshake message           */
     size_t  length;             /*!< Length of entire handshake message  */
-    mbedtls_reader_ext *handle; /*!< Reader to retrieve message contents */
+    mbedtls_mps_reader_ext *handle; /*!< Reader to retrieve message contents */
 
     uint8_t add[8];             /*!< Opaque, additional data to be used for
                                  *   checksum calculations. */
@@ -1377,7 +1377,7 @@ int mbedtls_mps_read_handshake( mbedtls_mps *mps,
  *              will silently fail.
  */
 int mbedtls_mps_read_application( mbedtls_mps *mps,
-                                  mbedtls_reader **rd );
+                                  mbedtls_mps_reader **rd );
 
 /**
  * \brief       Get the type of a pending alert message.
@@ -1415,7 +1415,7 @@ int mbedtls_mps_read_set_flags( mbedtls_mps *mps, mbedtls_mps_msg_flags flags );
  * \brief          Pause the reading of an incoming handshake message.
  *
  *                 When a handshake message has been received, the user of the
- *                 MPS can query its contents through mbedtls_reader_get_ext(),
+ *                 MPS can query its contents through mbedtls_mps_reader_get_ext(),
  *                 using the reader returned from mbedtls_mps_read_handshake().
  *                 If the handshake message is only partially available - for
  *                 example, because it was fragments on the TLS record layer -

--- a/include/mbedtls/mps/trace.h
+++ b/include/mbedtls/mps/trace.h
@@ -1,9 +1,5 @@
-/**
- * \file trace.h
- *
- * \brief Debugging module for MPS
- *
- *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
+/*
+ *  Copyright The Mbed TLS Contributors
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -20,141 +16,158 @@
  *
  *  This file is part of mbed TLS (https://tls.mbed.org)
  */
+
+/**
+ * \file mps_trace.h
+ *
+ * \brief Tracing module for MPS
+ */
+
 #ifndef MBEDTLS_MPS_TRACE_H
 #define MBEDTLS_MPS_TRACE_H
 
 #include "common.h"
+#include "trace.h"
 
-#if defined(MBEDTLS_MPS_TRACE)
+#if defined(MBEDTLS_PLATFORM_C)
+#include "mbedtls/platform.h"
+#else
+#include <stdio.h>
+#define mbedtls_printf    printf
+#define mbedtls_vsnprintf vsnprintf
+#endif /* MBEDTLS_PLATFORM_C */
+
+#if defined(MBEDTLS_MPS_ENABLE_TRACE)
 
 /*
  * Adapt this to enable/disable tracing output
  * from the various layers of the MPS.
  */
 
-#define TRACE_ENABLE_LAYER_1
-#define TRACE_ENABLE_LAYER_2
-#define TRACE_ENABLE_LAYER_3
-#define TRACE_ENABLE_LAYER_4
-#define TRACE_ENABLE_READER
-#define TRACE_ENABLE_WRITER
+#define MBEDTLS_MPS_TRACE_ENABLE_LAYER_1
+#define MBEDTLS_MPS_TRACE_ENABLE_LAYER_2
+#define MBEDTLS_MPS_TRACE_ENABLE_LAYER_3
+#define MBEDTLS_MPS_TRACE_ENABLE_LAYER_4
+#define MBEDTLS_MPS_TRACE_ENABLE_READER
+#define MBEDTLS_MPS_TRACE_ENABLE_WRITER
 
 /*
  * To use the existing trace module, only change
- * TRACE_ENABLE_XXX above, but don't modify the
+ * MBEDTLS_MPS_TRACE_ENABLE_XXX above, but don't modify the
  * rest of this file.
  */
 
-__attribute__((unused)) static int trace_id;
-
 typedef enum
 {
-    trace_comment,
-    trace_call,
-    trace_error,
-    trace_return
-} trace_type;
+    MBEDTLS_MPS_TRACE_TYPE_COMMENT,
+    MBEDTLS_MPS_TRACE_TYPE_CALL,
+    MBEDTLS_MPS_TRACE_TYPE_ERROR,
+    MBEDTLS_MPS_TRACE_TYPE_RETURN
+} mbedtls_mps_trace_type;
 
-#define TRACE_BIT_LAYER_1 1
-#define TRACE_BIT_LAYER_2 2
-#define TRACE_BIT_LAYER_3 3
-#define TRACE_BIT_LAYER_4 4
-#define TRACE_BIT_WRITER  5
-#define TRACE_BIT_READER  6
+#define MBEDTLS_MPS_TRACE_BIT_LAYER_1 1
+#define MBEDTLS_MPS_TRACE_BIT_LAYER_2 2
+#define MBEDTLS_MPS_TRACE_BIT_LAYER_3 3
+#define MBEDTLS_MPS_TRACE_BIT_LAYER_4 4
+#define MBEDTLS_MPS_TRACE_BIT_WRITER  5
+#define MBEDTLS_MPS_TRACE_BIT_READER  6
 
-#if defined(TRACE_ENABLE_LAYER_1)
-#define TRACE_MASK_LAYER_1 (1u << TRACE_BIT_LAYER_1 )
+#if defined(MBEDTLS_MPS_TRACE_ENABLE_LAYER_1)
+#define MBEDTLS_MPS_TRACE_MASK_LAYER_1 (1u << MBEDTLS_MPS_TRACE_BIT_LAYER_1 )
 #else
-#define TRACE_MASK_LAYER_1 0
+#define MBEDTLS_MPS_TRACE_MASK_LAYER_1 0
 #endif
 
-#if defined(TRACE_ENABLE_LAYER_2)
-#define TRACE_MASK_LAYER_2 (1u << TRACE_BIT_LAYER_2 )
+#if defined(MBEDTLS_MPS_TRACE_ENABLE_LAYER_2)
+#define MBEDTLS_MPS_TRACE_MASK_LAYER_2 (1u << MBEDTLS_MPS_TRACE_BIT_LAYER_2 )
 #else
-#define TRACE_MASK_LAYER_2 0
+#define MBEDTLS_MPS_TRACE_MASK_LAYER_2 0
 #endif
 
-#if defined(TRACE_ENABLE_LAYER_3)
-#define TRACE_MASK_LAYER_3 (1u << TRACE_BIT_LAYER_3 )
+#if defined(MBEDTLS_MPS_TRACE_ENABLE_LAYER_3)
+#define MBEDTLS_MPS_TRACE_MASK_LAYER_3 (1u << MBEDTLS_MPS_TRACE_BIT_LAYER_3 )
 #else
-#define TRACE_MASK_LAYER_3 0
+#define MBEDTLS_MPS_TRACE_MASK_LAYER_3 0
 #endif
 
-#if defined(TRACE_ENABLE_LAYER_4)
-#define TRACE_MASK_LAYER_4 (1u << TRACE_BIT_LAYER_4 )
+#if defined(MBEDTLS_MPS_TRACE_ENABLE_LAYER_4)
+#define MBEDTLS_MPS_TRACE_MASK_LAYER_4 (1u << MBEDTLS_MPS_TRACE_BIT_LAYER_4 )
 #else
-#define TRACE_MASK_LAYER_4 0
+#define MBEDTLS_MPS_TRACE_MASK_LAYER_4 0
 #endif
 
-#if defined(TRACE_ENABLE_READER)
-#define TRACE_MASK_READER (1u << TRACE_BIT_READER )
+#if defined(MBEDTLS_MPS_TRACE_ENABLE_READER)
+#define MBEDTLS_MPS_TRACE_MASK_READER (1u << MBEDTLS_MPS_TRACE_BIT_READER )
 #else
-#define TRACE_MASK_READER 0
+#define MBEDTLS_MPS_TRACE_MASK_READER 0
 #endif
 
-#if defined(TRACE_ENABLE_WRITER)
-#define TRACE_MASK_WRITER (1u << TRACE_BIT_WRITER )
+#if defined(MBEDTLS_MPS_TRACE_ENABLE_WRITER)
+#define MBEDTLS_MPS_TRACE_MASK_WRITER (1u << MBEDTLS_MPS_TRACE_BIT_WRITER )
 #else
-#define TRACE_MASK_WRITER 0
+#define MBEDTLS_MPS_TRACE_MASK_WRITER 0
 #endif
 
-#define TRACE_MASK ( TRACE_MASK_LAYER_1 |           \
-                     TRACE_MASK_LAYER_2 |           \
-                     TRACE_MASK_LAYER_3 |           \
-                     TRACE_MASK_LAYER_4 |           \
-                     TRACE_MASK_READER  |           \
-                     TRACE_MASK_WRITER )
+#define MBEDTLS_MPS_TRACE_MASK ( MBEDTLS_MPS_TRACE_MASK_LAYER_1 |       \
+                                 MBEDTLS_MPS_TRACE_MASK_LAYER_2 |       \
+                                 MBEDTLS_MPS_TRACE_MASK_LAYER_3 |       \
+                                 MBEDTLS_MPS_TRACE_MASK_LAYER_4 |       \
+                                 MBEDTLS_MPS_TRACE_MASK_READER  |       \
+                                 MBEDTLS_MPS_TRACE_MASK_WRITER )
 
 /* We have to avoid globals because E-ACSL chokes on them...
  * Wrap everything in stub functions. */
-int get_trace_depth( void );
-void inc_trace_depth( void );
-void dec_trace_depth( void );
+int  mbedtls_mps_trace_get_depth( void );
+void mbedtls_mps_trace_inc_depth( void );
+void mbedtls_mps_trace_dec_depth( void );
 
-void trace_color( int id );
-void trace_indent( int level, trace_type ty );
+void mbedtls_mps_trace_color( int id );
+void mbedtls_mps_trace_indent( int level, mbedtls_mps_trace_type ty );
 
-#define TRACE( type, fmt, ... )                                         \
-    do {                                                                \
-        if( ! ( TRACE_MASK & ( 1u << trace_id ) ) )                     \
-            break;                                                      \
-        trace_indent( get_trace_depth(), type );                        \
-        trace_color( trace_id );                                        \
-        printf( "[%d|L%d]: " fmt "\n", trace_id, __LINE__, ##__VA_ARGS__); \
-        trace_color( 0 );                                               \
+void mbedtls_mps_trace_print_msg( int id, int line, const char *format, ... );
+
+#define MBEDTLS_MPS_TRACE( type, ... )                                              \
+    do {                                                                            \
+        if( ! ( MBEDTLS_MPS_TRACE_MASK & ( 1u << mbedtls_mps_trace_id ) ) )         \
+            break;                                                                  \
+        mbedtls_mps_trace_indent( mbedtls_mps_trace_get_depth(), type );            \
+        mbedtls_mps_trace_color( mbedtls_mps_trace_id );                            \
+        mbedtls_mps_trace_print_msg( mbedtls_mps_trace_id, __LINE__, __VA_ARGS__ ); \
+        mbedtls_mps_trace_color( 0 );                                               \
     } while( 0 )
 
-#define TRACE_INIT( fmt, ... )                                          \
-    do {                                                                \
-        if( ! ( TRACE_MASK & ( 1u << trace_id ) ) )                     \
-            break;                                                      \
-        TRACE( trace_call, fmt, ##__VA_ARGS__ );                        \
-        inc_trace_depth();                                              \
+#define MBEDTLS_MPS_TRACE_INIT( ... )                                         \
+    do {                                                                      \
+        if( ! ( MBEDTLS_MPS_TRACE_MASK & ( 1u << mbedtls_mps_trace_id ) ) )   \
+            break;                                                            \
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_CALL, __VA_ARGS__ );        \
+        mbedtls_mps_trace_inc_depth();                                        \
     } while( 0 )
 
-#define TRACE_END( val )                                                \
-    do {                                                                \
-        if( ! ( TRACE_MASK & ( 1u << trace_id ) ) )                     \
-            break;                                                      \
-        TRACE( trace_return, "%d (-%#04x)",                             \
-               (int) (val), -((unsigned)(val)) );                       \
-        dec_trace_depth();                                              \
+#define MBEDTLS_MPS_TRACE_END( val )                                        \
+    do {                                                                    \
+        if( ! ( MBEDTLS_MPS_TRACE_MASK & ( 1u << mbedtls_mps_trace_id ) ) ) \
+            break;                                                          \
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_RETURN, "%d (-%#04x)",    \
+               (int) (val), -((unsigned)(val)) );                           \
+        mbedtls_mps_trace_dec_depth();                                      \
     } while( 0 )
 
-#define RETURN( val )                           \
+#define MBEDTLS_MPS_TRACE_RETURN( val )         \
     do {                                        \
         /* Breaks tail recursion. */            \
         int ret__ = val;                        \
-        TRACE_END( ret__ );                     \
+        MBEDTLS_MPS_TRACE_END( ret__ );         \
         return( ret__ );                        \
     } while( 0 )
 
 #else /* MBEDTLS_MPS_TRACE */
 
-#define TRACE( type, fmt, ... ) do { } while( 0 )
-#define TRACE_INIT( fmt, ... )  do { } while( 0 )
-#define TRACE_END               do { } while( 0 )
-#define RETURN( val ) return( val )
+#define MBEDTLS_MPS_TRACE( type, ... ) do { } while( 0 )
+#define MBEDTLS_MPS_TRACE_INIT( ... )  do { } while( 0 )
+#define MBEDTLS_MPS_TRACE_END          do { } while( 0 )
+
+#define MBEDTLS_MPS_TRACE_RETURN( val ) return( val );
 
 #endif /* MBEDTLS_MPS_TRACE */
 

--- a/library/mps/layer1.c
+++ b/library/mps/layer1.c
@@ -268,11 +268,11 @@ int l1_fetch_stream( mps_l1_stream_read *p,
     read_ptr += br;
     while( data_need > 0 )
     {
-        MBEDTLS_MPS_TRACE( trace_comment, "attempt to receive %u", (unsigned) data_need );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "attempt to receive %u", (unsigned) data_need );
         ret = recv( recv_ctx, read_ptr, data_need );
         if( ret < 0 )
             break;
-        MBEDTLS_MPS_TRACE( trace_comment, "got %u", (unsigned) ret );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "got %u", (unsigned) ret );
 
         /* TODO: FIX! */
 #if( MAX_INT > SIZE_MAX )
@@ -395,7 +395,7 @@ int l1_flush_stream( mps_l1_stream_write *p )
         ret = send( send_ctx, buf, data_remaining );
         if( ret <= 0 )
         {
-            MBEDTLS_MPS_TRACE( trace_comment, "send failed with %d", ret );
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "send failed with %d", ret );
             /* The underlying transport's send callback should return
              * WANT_WRITE instead of 0 if no data can currently be sent.
              * Fail with a fatal internal error if this spec is not obeyed. */
@@ -542,12 +542,12 @@ int l1_check_flush_stream( mps_l1_stream_write *p )
      */
     if( br > 0 && br >= 4 * bl / 5 )
     {
-        MBEDTLS_MPS_TRACE( trace_comment, "L1 check flush -- flush" );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "L1 check flush -- flush" );
         p->status = MPS_L1_STREAM_STATUS_FLUSH;
         MBEDTLS_MPS_TRACE_RETURN( 0 );
     }
 
-    MBEDTLS_MPS_TRACE( trace_comment, "L1 check flush -- no flush" );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "L1 check flush -- no flush" );
     MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
@@ -572,7 +572,7 @@ int l1_dispatch_stream( mps_l1_stream_write *p,
     data_remaining = br - bl;
     if( len > data_remaining )
     {
-        MBEDTLS_MPS_TRACE( trace_comment, "out of bounds %u > %u",
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "out of bounds %u > %u",
                (unsigned) len, (unsigned) data_remaining );
         MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_REQUEST_OUT_OF_BOUNDS );
     }
@@ -761,7 +761,7 @@ int l1_ensure_in_dgram( mps_l1_dgram_read *p )
     ml = p->msg_len;
     if( ml == 0 )
     {
-        MBEDTLS_MPS_TRACE( trace_comment, "Request datagram from underlying transport." );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Request datagram from underlying transport." );
         /* Q: Will the underlying transport error out
          *    if the receive buffer is not large enough
          *    to hold the entire datagram? */
@@ -784,7 +784,7 @@ int l1_ensure_in_dgram( mps_l1_dgram_read *p )
         if( ml > bl )
             MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_BAD_TRANSPORT );
 
-        MBEDTLS_MPS_TRACE( trace_comment, "Obtained datagram of size %u", (unsigned) ml );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Obtained datagram of size %u", (unsigned) ml );
         p->msg_len = ml;
     }
 
@@ -809,9 +809,9 @@ int l1_fetch_dgram( mps_l1_dgram_read *p,
     if( ret != 0 )
         MBEDTLS_MPS_TRACE_RETURN( ret );
 
-    MBEDTLS_MPS_TRACE( trace_comment, "* Datagram length: %u", (unsigned) p->msg_len     );
-    MBEDTLS_MPS_TRACE( trace_comment, "* Window base:     %u", (unsigned) p->window_base );
-    MBEDTLS_MPS_TRACE( trace_comment, "* Window length:   %u", (unsigned) p->window_len  );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* Datagram length: %u", (unsigned) p->msg_len     );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* Window base:     %u", (unsigned) p->window_base );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* Window length:   %u", (unsigned) p->window_len  );
 
     wb = p->window_base;
     wl = p->window_len;
@@ -830,7 +830,7 @@ int l1_fetch_dgram( mps_l1_dgram_read *p,
     data_avail = ml - ( wb + wl );
     if( data_need > data_avail )
     {
-        MBEDTLS_MPS_TRACE( trace_error, "Read request goes beyond the datagram boundary - requested %u, available %u",
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR, "Read request goes beyond the datagram boundary - requested %u, available %u",
                (unsigned) data_need, (unsigned) data_avail );
         MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_REQUEST_OUT_OF_BOUNDS );
     }
@@ -860,7 +860,7 @@ int l1_consume_dgram( mps_l1_dgram_read *p )
 
     if( wb + wl == ml )
     {
-        MBEDTLS_MPS_TRACE( trace_comment, "Reached the end of the datagram." );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Reached the end of the datagram." );
 
         /*
          * Releasing the buffer as soon as a datagram
@@ -886,7 +886,7 @@ int l1_consume_dgram( mps_l1_dgram_read *p )
     }
     else
     {
-        MBEDTLS_MPS_TRACE( trace_comment, "More data left in the current datagram." );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "More data left in the current datagram." );
         p->window_base = wb + wl;
         p->window_len  = 0;
     }
@@ -930,11 +930,11 @@ int l1_write_dgram( mps_l1_dgram_write *p,
     flush = p->flush;
     if( flush )
     {
-        MBEDTLS_MPS_TRACE( trace_comment, "Need to flush first" );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Need to flush first" );
         ret = l1_flush_dgram( p );
         if( ret != 0 )
         {
-            MBEDTLS_MPS_TRACE( trace_error, "Flush failed with %d", ret );
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR, "Flush failed with %d", ret );
             MBEDTLS_MPS_TRACE_RETURN( ret );
         }
     }
@@ -992,12 +992,12 @@ int l1_check_flush_dgram( mps_l1_dgram_write *p )
      * data is available. */
     if( br > 0 && br >= 4 * bl / 5 )
     {
-        MBEDTLS_MPS_TRACE( trace_comment, "L1 check flush -- flush" );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "L1 check flush -- flush" );
         p->flush = 1;
         MBEDTLS_MPS_TRACE_RETURN( 0 );
     }
 
-    MBEDTLS_MPS_TRACE( trace_comment, "L1 check flush -- no flush" );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "L1 check flush -- no flush" );
     MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
@@ -1015,11 +1015,11 @@ int l1_flush_dgram( mps_l1_dgram_write *p )
     buf = p->buf;
     if( buf == NULL )
     {
-        MBEDTLS_MPS_TRACE( trace_error, "No outgoing datagram open." );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR, "No outgoing datagram open." );
         MBEDTLS_MPS_TRACE_RETURN( 0 );
     }
 
-    MBEDTLS_MPS_TRACE( trace_comment, "Datagram size: %u", (unsigned) p->bytes_ready );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Datagram size: %u", (unsigned) p->bytes_ready );
 
     br = p->bytes_ready;
 
@@ -1028,7 +1028,7 @@ int l1_flush_dgram( mps_l1_dgram_write *p )
     ret = send( send_ctx, buf, br );
     if( ret <= 0 )
     {
-        MBEDTLS_MPS_TRACE( trace_comment, "send failed with %d", ret );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "send failed with %d", ret );
         /* The underlying transport's send callback should return
          * WANT_WRITE instead of 0 if no data can currently be sent.
          * Fail with a fatal internal error if this spec is not obeyed. */

--- a/library/mps/layer1.c
+++ b/library/mps/layer1.c
@@ -27,9 +27,9 @@
 
 #include "layer1_internal.h"
 
-#if defined(MBEDTLS_MPS_TRACE)
-static int trace_id = TRACE_BIT_LAYER_1;
-#endif /* MBEDTLS_MPS_TRACE */
+#if defined(MBEDTLS_MPS_ENABLE_TRACE)
+static int mbedtls_mps_trace_id = MBEDTLS_MPS_TRACE_BIT_LAYER_1;
+#endif /* MBEDTLS_MPS_ENABLE_TRACE */
 
 #include <string.h>
 
@@ -238,7 +238,7 @@ int l1_fetch_stream( mps_l1_stream_read *p,
     unsigned char *read_ptr;
     void *recv_ctx;
     mps_l0_recv_t *recv;
-    TRACE_INIT( "l1_fetch_stream, desired %u", (unsigned) len );
+    MBEDTLS_MPS_TRACE_INIT( "l1_fetch_stream, desired %u", (unsigned) len );
 
     /* OPTIMIZATION:
      * This refers to the potential removal of `buf` from
@@ -253,12 +253,12 @@ int l1_fetch_stream( mps_l1_stream_read *p,
     ret = l1_acquire_if_unset( &p->buf, &p->buf_len,
                                p->alloc, MPS_ALLOC_L1_IN );
     if( ret != 0 )
-        RETURN( ret );
+        MBEDTLS_MPS_TRACE_RETURN( ret );
 
     read_ptr = p->buf;
     bl = p->buf_len;
     if( len > bl )
-        RETURN( MBEDTLS_ERR_MPS_BUFFER_TOO_SMALL );
+        MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_BUFFER_TOO_SMALL );
 
     br = p->bytes_read;
     data_need = br <= len ? len - br : 0;
@@ -268,16 +268,16 @@ int l1_fetch_stream( mps_l1_stream_read *p,
     read_ptr += br;
     while( data_need > 0 )
     {
-        TRACE( trace_comment, "attempt to receive %u", (unsigned) data_need );
+        MBEDTLS_MPS_TRACE( trace_comment, "attempt to receive %u", (unsigned) data_need );
         ret = recv( recv_ctx, read_ptr, data_need );
         if( ret < 0 )
             break;
-        TRACE( trace_comment, "got %u", (unsigned) ret );
+        MBEDTLS_MPS_TRACE( trace_comment, "got %u", (unsigned) ret );
 
         /* TODO: FIX! */
 #if( MAX_INT > SIZE_MAX )
         if( ret > (int) SIZE_MAX )
-            RETURN( MBEDTLS_ERR_MPS_BAD_TRANSPORT );
+            MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_BAD_TRANSPORT );
 #endif
 
         /* Now we know that we can safely cast. */
@@ -287,7 +287,7 @@ int l1_fetch_stream( mps_l1_stream_read *p,
         /* Double-check that the external Layer 0 obeys its spec;
          * if it doesn't, we'd otherwise underflow data_need. */
         if( data_fetched > data_need )
-            RETURN( MBEDTLS_ERR_MPS_BAD_TRANSPORT );
+            MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_BAD_TRANSPORT );
 
         data_need -= data_fetched;
         read_ptr  += data_fetched;
@@ -303,7 +303,7 @@ int l1_fetch_stream( mps_l1_stream_read *p,
     else
         p->bytes_fetched = 0;
 
-    RETURN( ret );
+    MBEDTLS_MPS_TRACE_RETURN( ret );
 }
 
 /*@
@@ -315,7 +315,7 @@ int l1_consume_stream( mps_l1_stream_read *p )
 {
     unsigned char *buf;
     mbedtls_mps_size_t bf, br, not_yet_fetched;
-    TRACE_INIT( "l1_consume_stream" );
+    MBEDTLS_MPS_TRACE_INIT( "l1_consume_stream" );
 
     bf = p->bytes_fetched;
     br = p->bytes_read;
@@ -342,7 +342,7 @@ int l1_consume_stream( mps_l1_stream_read *p )
         p->buf_len = 0;
     }
 
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
 /*@
@@ -358,7 +358,7 @@ int l1_flush_stream( mps_l1_stream_write *p )
     mps_l1_stream_state status;
     mps_l0_send_t *send;
     void *send_ctx;
-    TRACE_INIT( "L1 flush stream" );
+    MBEDTLS_MPS_TRACE_INIT( "L1 flush stream" );
 
     /* Flush is called in the following situations:
      * (1) By the user, after data has been dispatched
@@ -395,7 +395,7 @@ int l1_flush_stream( mps_l1_stream_write *p )
         ret = send( send_ctx, buf, data_remaining );
         if( ret <= 0 )
         {
-            TRACE( trace_comment, "send failed with %d", ret );
+            MBEDTLS_MPS_TRACE( trace_comment, "send failed with %d", ret );
             /* The underlying transport's send callback should return
              * WANT_WRITE instead of 0 if no data can currently be sent.
              * Fail with a fatal internal error if this spec is not obeyed. */
@@ -407,7 +407,7 @@ int l1_flush_stream( mps_l1_stream_write *p )
         /* TODO: FIX */
 #if( MAX_INT > SIZE_MAX )
         if( ret > (int) SIZE_MAX )
-            RETURN( MBEDTLS_ERR_MPS_BAD_TRANSPORT );
+            MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_BAD_TRANSPORT );
 #endif
 
         /* Now we know that we can safely cast. */
@@ -417,7 +417,7 @@ int l1_flush_stream( mps_l1_stream_write *p )
         /* Double-check that the external Layer 0 obeys its
          * spec to prevent an underflow in data_remaining. */
         if( data_written > data_remaining )
-            RETURN( MBEDTLS_ERR_MPS_BAD_TRANSPORT );
+            MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_BAD_TRANSPORT );
 
         data_remaining -= data_written;
         buf += data_written;
@@ -433,7 +433,7 @@ int l1_flush_stream( mps_l1_stream_write *p )
     else
         p->bytes_written = bw;
 
-    RETURN( ret );
+    MBEDTLS_MPS_TRACE_RETURN( ret );
 }
 
 /*@
@@ -449,7 +449,7 @@ int l1_write_stream( mps_l1_stream_write *p,
     mps_l1_stream_state status;
     mbedtls_mps_size_t bl, br, data_remaining;
     unsigned char* buf;
-    TRACE_INIT( "l1_write_stream" );
+    MBEDTLS_MPS_TRACE_INIT( "l1_write_stream" );
 
     status = p->status;
 
@@ -461,7 +461,7 @@ int l1_write_stream( mps_l1_stream_write *p,
     {
         ret = l1_flush_stream( p );
         if( ret != 0 )
-            RETURN( ret );
+            MBEDTLS_MPS_TRACE_RETURN( ret );
     }
 
     /* The flush call either succeeded and reset the state
@@ -476,7 +476,7 @@ int l1_write_stream( mps_l1_stream_write *p,
     ret = l1_acquire_if_unset( &p->buf, &p->buf_len,
                                p->alloc, MPS_ALLOC_L1_OUT );
     if( ret != 0 )
-        RETURN( ret );
+        MBEDTLS_MPS_TRACE_RETURN( ret );
 
     br = p->bytes_ready;
     bl = p->buf_len;
@@ -493,7 +493,7 @@ int l1_write_stream( mps_l1_stream_write *p,
     *dst = buf;
     *buflen = data_remaining;
     p->status = MPS_L1_STREAM_STATUS_WRITE;
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
 MBEDTLS_MPS_INLINE int l1_write_dependency_stream( mps_l1_stream_write *p )
@@ -528,7 +528,7 @@ int l1_check_flush_stream( mps_l1_stream_write *p )
     mbedtls_mps_size_t bl, br;
     br = p->bytes_ready;
     bl = p->buf_len;
-    TRACE_INIT( "l1_check_flush_stream:  %u / %u bytes written",
+    MBEDTLS_MPS_TRACE_INIT( "l1_check_flush_stream:  %u / %u bytes written",
            (unsigned) br, (unsigned) bl );
 
     /* Several heuristics for flushing are conceivable,
@@ -542,13 +542,13 @@ int l1_check_flush_stream( mps_l1_stream_write *p )
      */
     if( br > 0 && br >= 4 * bl / 5 )
     {
-        TRACE( trace_comment, "L1 check flush -- flush" );
+        MBEDTLS_MPS_TRACE( trace_comment, "L1 check flush -- flush" );
         p->status = MPS_L1_STREAM_STATUS_FLUSH;
-        RETURN( 0 );
+        MBEDTLS_MPS_TRACE_RETURN( 0 );
     }
 
-    TRACE( trace_comment, "L1 check flush -- no flush" );
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE( trace_comment, "L1 check flush -- no flush" );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
 /*@
@@ -562,7 +562,7 @@ int l1_dispatch_stream( mps_l1_stream_write *p,
 {
     mbedtls_mps_size_t bl, br, data_remaining;
     mps_l1_stream_state status = p->status;
-    TRACE_INIT( "L1 dispatch %u", (unsigned) len );
+    MBEDTLS_MPS_TRACE_INIT( "L1 dispatch %u", (unsigned) len );
 
     MBEDTLS_MPS_STATE_VALIDATE_RAW( status == MPS_L1_STREAM_STATUS_WRITE,
                                     "Invalid state in l1_dispatch_stream()" );
@@ -572,9 +572,9 @@ int l1_dispatch_stream( mps_l1_stream_write *p,
     data_remaining = br - bl;
     if( len > data_remaining )
     {
-        TRACE( trace_comment, "out of bounds %u > %u",
+        MBEDTLS_MPS_TRACE( trace_comment, "out of bounds %u > %u",
                (unsigned) len, (unsigned) data_remaining );
-        RETURN( MBEDTLS_ERR_MPS_REQUEST_OUT_OF_BOUNDS );
+        MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_REQUEST_OUT_OF_BOUNDS );
     }
 
     br += len;
@@ -599,7 +599,7 @@ int l1_dispatch_stream( mps_l1_stream_write *p,
      *
      */
 
-    RETURN( l1_check_flush_stream( p ) );
+    MBEDTLS_MPS_TRACE_RETURN( l1_check_flush_stream( p ) );
 }
 
 #endif /* MBEDTLS_MPS_PROTO_TLS */
@@ -746,13 +746,13 @@ int l1_ensure_in_dgram( mps_l1_dgram_read *p )
     void* recv_ctx;
     mps_l0_recv_t *recv;
     int ret;
-    TRACE_INIT( "l1_ensure_in_dgram" );
+    MBEDTLS_MPS_TRACE_INIT( "l1_ensure_in_dgram" );
 
     /* 1. Ensure that a buffer is available to receive data */
     ret = l1_acquire_if_unset( &p->buf, &p->buf_len,
                                p->alloc, MPS_ALLOC_L1_IN );
     if( ret != 0 )
-        RETURN( ret );
+        MBEDTLS_MPS_TRACE_RETURN( ret );
 
     buf = p->buf;
     bl = p->buf_len;
@@ -761,7 +761,7 @@ int l1_ensure_in_dgram( mps_l1_dgram_read *p )
     ml = p->msg_len;
     if( ml == 0 )
     {
-        TRACE( trace_comment, "Request datagram from underlying transport." );
+        MBEDTLS_MPS_TRACE( trace_comment, "Request datagram from underlying transport." );
         /* Q: Will the underlying transport error out
          *    if the receive buffer is not large enough
          *    to hold the entire datagram? */
@@ -769,12 +769,12 @@ int l1_ensure_in_dgram( mps_l1_dgram_read *p )
         recv_ctx = p->recv_ctx;
         ret = recv( recv_ctx, buf, bl );
         if( ret <= 0 )
-            RETURN( ret );
+            MBEDTLS_MPS_TRACE_RETURN( ret );
 
         /* TODO: FIX */
 #if( MAX_INT > SIZE_MAX )
         if( ret > (int) SIZE_MAX )
-            RETURN( MBEDTLS_ERR_MPS_BAD_TRANSPORT );
+            MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_BAD_TRANSPORT );
 #endif
 
         /* Now we know that we can safely cast. */
@@ -782,13 +782,13 @@ int l1_ensure_in_dgram( mps_l1_dgram_read *p )
 
         /* Double-check that the external Layer 0 obeys its spec. */
         if( ml > bl )
-            RETURN( MBEDTLS_ERR_MPS_BAD_TRANSPORT );
+            MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_BAD_TRANSPORT );
 
-        TRACE( trace_comment, "Obtained datagram of size %u", (unsigned) ml );
+        MBEDTLS_MPS_TRACE( trace_comment, "Obtained datagram of size %u", (unsigned) ml );
         p->msg_len = ml;
     }
 
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
 MBEDTLS_MPS_INLINE
@@ -803,15 +803,15 @@ int l1_fetch_dgram( mps_l1_dgram_read *p,
 
     unsigned char *buf;
 
-    TRACE_INIT( "l1_fetch_dgram, len %u", (unsigned) len );
+    MBEDTLS_MPS_TRACE_INIT( "l1_fetch_dgram, len %u", (unsigned) len );
 
     ret = l1_ensure_in_dgram( p );
     if( ret != 0 )
-        RETURN( ret );
+        MBEDTLS_MPS_TRACE_RETURN( ret );
 
-    TRACE( trace_comment, "* Datagram length: %u", (unsigned) p->msg_len     );
-    TRACE( trace_comment, "* Window base:     %u", (unsigned) p->window_base );
-    TRACE( trace_comment, "* Window length:   %u", (unsigned) p->window_len  );
+    MBEDTLS_MPS_TRACE( trace_comment, "* Datagram length: %u", (unsigned) p->msg_len     );
+    MBEDTLS_MPS_TRACE( trace_comment, "* Window base:     %u", (unsigned) p->window_base );
+    MBEDTLS_MPS_TRACE( trace_comment, "* Window length:   %u", (unsigned) p->window_len  );
 
     wb = p->window_base;
     wl = p->window_len;
@@ -830,9 +830,9 @@ int l1_fetch_dgram( mps_l1_dgram_read *p,
     data_avail = ml - ( wb + wl );
     if( data_need > data_avail )
     {
-        TRACE( trace_error, "Read request goes beyond the datagram boundary - requested %u, available %u",
+        MBEDTLS_MPS_TRACE( trace_error, "Read request goes beyond the datagram boundary - requested %u, available %u",
                (unsigned) data_need, (unsigned) data_avail );
-        RETURN( MBEDTLS_ERR_MPS_REQUEST_OUT_OF_BOUNDS );
+        MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_REQUEST_OUT_OF_BOUNDS );
     }
 
     wl += data_need;
@@ -840,7 +840,7 @@ int l1_fetch_dgram( mps_l1_dgram_read *p,
 
     p->window_len = wl;
     *dst = buf + wb;
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
 MBEDTLS_MPS_INLINE
@@ -849,7 +849,7 @@ int l1_consume_dgram( mps_l1_dgram_read *p )
     int ret;
     mbedtls_mps_size_t wl, wb, ml;
 
-    TRACE_INIT( "l1_consume_dgram" );
+    MBEDTLS_MPS_TRACE_INIT( "l1_consume_dgram" );
 
     MBEDTLS_MPS_STATE_VALIDATE_RAW( p->buf != NULL,
                 "l1_consume_dgram() called, but no datagram available" );
@@ -860,7 +860,7 @@ int l1_consume_dgram( mps_l1_dgram_read *p )
 
     if( wb + wl == ml )
     {
-        TRACE( trace_comment, "Reached the end of the datagram." );
+        MBEDTLS_MPS_TRACE( trace_comment, "Reached the end of the datagram." );
 
         /*
          * Releasing the buffer as soon as a datagram
@@ -876,7 +876,7 @@ int l1_consume_dgram( mps_l1_dgram_read *p )
          */
         ret = mps_alloc_release( p->alloc, MPS_ALLOC_L1_IN );
         if( ret != 0 )
-            RETURN( ret );
+            MBEDTLS_MPS_TRACE_RETURN( ret );
 
         p->window_base = 0;
         p->window_len  = 0;
@@ -886,12 +886,12 @@ int l1_consume_dgram( mps_l1_dgram_read *p )
     }
     else
     {
-        TRACE( trace_comment, "More data left in the current datagram." );
+        MBEDTLS_MPS_TRACE( trace_comment, "More data left in the current datagram." );
         p->window_base = wb + wl;
         p->window_len  = 0;
     }
 
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
 MBEDTLS_MPS_INLINE int l1_write_dependency_dgram( mps_l1_dgram_write *p )
@@ -925,17 +925,17 @@ int l1_write_dgram( mps_l1_dgram_write *p,
     unsigned char *buf;
     mbedtls_mps_size_t bl, br;
     uint8_t flush;
-    TRACE_INIT( "l1_write_dgram" );
+    MBEDTLS_MPS_TRACE_INIT( "l1_write_dgram" );
 
     flush = p->flush;
     if( flush )
     {
-        TRACE( trace_comment, "Need to flush first" );
+        MBEDTLS_MPS_TRACE( trace_comment, "Need to flush first" );
         ret = l1_flush_dgram( p );
         if( ret != 0 )
         {
-            TRACE( trace_error, "Flush failed with %d", ret );
-            RETURN( ret );
+            MBEDTLS_MPS_TRACE( trace_error, "Flush failed with %d", ret );
+            MBEDTLS_MPS_TRACE_RETURN( ret );
         }
     }
 
@@ -952,7 +952,7 @@ int l1_write_dgram( mps_l1_dgram_write *p,
 
     *dst    = buf;
     *dstlen = bl - br;
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
 MBEDTLS_MPS_INLINE
@@ -961,7 +961,7 @@ int l1_dispatch_dgram( mps_l1_dgram_write *p,
                        mbedtls_mps_size_t *pending )
 {
     mbedtls_mps_size_t br;
-    TRACE_INIT( "l1_dispatch_dgram, length %u", (unsigned) len );
+    MBEDTLS_MPS_TRACE_INIT( "l1_dispatch_dgram, length %u", (unsigned) len );
 
     MBEDTLS_MPS_STATE_VALIDATE_RAW( p->buf != NULL,
                   "l1_dispatch_dgram() called, but no datagram open" );
@@ -975,7 +975,7 @@ int l1_dispatch_dgram( mps_l1_dgram_write *p,
     if( pending != NULL )
         *pending = br;
 
-    RETURN( l1_check_flush_dgram( p ) );
+    MBEDTLS_MPS_TRACE_RETURN( l1_check_flush_dgram( p ) );
 }
 
 MBEDTLS_MPS_INLINE
@@ -984,7 +984,7 @@ int l1_check_flush_dgram( mps_l1_dgram_write *p )
     mbedtls_mps_size_t bl, br;
     br = p->bytes_ready;
     bl = p->buf_len;
-    TRACE_INIT( "l1_check_flush_dgram:  %u / %u bytes written",
+    MBEDTLS_MPS_TRACE_INIT( "l1_check_flush_dgram:  %u / %u bytes written",
            (unsigned) br, (unsigned) bl );
 
     /* Several heuristics for flushing are conceivable,
@@ -992,13 +992,13 @@ int l1_check_flush_dgram( mps_l1_dgram_write *p )
      * data is available. */
     if( br > 0 && br >= 4 * bl / 5 )
     {
-        TRACE( trace_comment, "L1 check flush -- flush" );
+        MBEDTLS_MPS_TRACE( trace_comment, "L1 check flush -- flush" );
         p->flush = 1;
-        RETURN( 0 );
+        MBEDTLS_MPS_TRACE_RETURN( 0 );
     }
 
-    TRACE( trace_comment, "L1 check flush -- no flush" );
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE( trace_comment, "L1 check flush -- no flush" );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
 MBEDTLS_MPS_INLINE
@@ -1010,16 +1010,16 @@ int l1_flush_dgram( mps_l1_dgram_write *p )
     unsigned char *buf;
     mbedtls_mps_size_t br;
 
-    TRACE_INIT( "l1_flush_dgram" );
+    MBEDTLS_MPS_TRACE_INIT( "l1_flush_dgram" );
 
     buf = p->buf;
     if( buf == NULL )
     {
-        TRACE( trace_error, "No outgoing datagram open." );
-        RETURN( 0 );
+        MBEDTLS_MPS_TRACE( trace_error, "No outgoing datagram open." );
+        MBEDTLS_MPS_TRACE_RETURN( 0 );
     }
 
-    TRACE( trace_comment, "Datagram size: %u", (unsigned) p->bytes_ready );
+    MBEDTLS_MPS_TRACE( trace_comment, "Datagram size: %u", (unsigned) p->bytes_ready );
 
     br = p->bytes_ready;
 
@@ -1028,25 +1028,25 @@ int l1_flush_dgram( mps_l1_dgram_write *p )
     ret = send( send_ctx, buf, br );
     if( ret <= 0 )
     {
-        TRACE( trace_comment, "send failed with %d", ret );
+        MBEDTLS_MPS_TRACE( trace_comment, "send failed with %d", ret );
         /* The underlying transport's send callback should return
          * WANT_WRITE instead of 0 if no data can currently be sent.
          * Fail with a fatal internal error if this spec is not obeyed. */
         if( ret == 0 )
             ret = MBEDTLS_ERR_MPS_BAD_TRANSPORT;
 
-        RETURN( ret );
+        MBEDTLS_MPS_TRACE_RETURN( ret );
     }
 
 #if( MAX_INT > SIZE_MAX )
     if( ret > (int) SIZE_MAX )
-        RETURN( MBEDTLS_ERR_MPS_BAD_TRANSPORT );
+        MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_BAD_TRANSPORT );
 #endif
 
     if( (size_t) ret != br )
     {
         /* Couldn't deliver the datagram to Layer 0 at once. */
-        RETURN( MBEDTLS_ERR_MPS_BAD_TRANSPORT );
+        MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_BAD_TRANSPORT );
     }
 
     l1_release_if_set( &p->buf, p->alloc, MPS_ALLOC_L1_OUT );
@@ -1056,7 +1056,7 @@ int l1_flush_dgram( mps_l1_dgram_write *p )
     p->buf_len     = 0;
 
     p->flush = 0;
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
 #endif /* MBEDTLS_MPS_PROTO_DTLS */
@@ -1076,7 +1076,7 @@ int mps_l1_init( mps_l1 *ctx, uint8_t mode,
                  void *send_ctx, mps_l0_send_t *send,
                  void *recv_ctx, mps_l0_recv_t *recv )
 {
-    TRACE_INIT( "mps_l1_init, mode %u", (unsigned) mode );
+    MBEDTLS_MPS_TRACE_INIT( "mps_l1_init, mode %u", (unsigned) mode );
 
 #if defined(MBEDTLS_MPS_PROTO_TLS)
     MBEDTLS_MPS_IF_TLS( mode )
@@ -1100,7 +1100,7 @@ int mps_l1_init( mps_l1 *ctx, uint8_t mode,
 #else
     ((void) mode);
 #endif /* MBEDTLS_MPS_PROTO_BOTH */
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
 int mps_l1_set_bio( mps_l1 *ctx,
@@ -1109,7 +1109,7 @@ int mps_l1_set_bio( mps_l1 *ctx,
 {
     mbedtls_mps_transport_type const mode =
         mbedtls_mps_l1_get_mode( ctx );
-    TRACE_INIT( "mps_l1_set_bio" );
+    MBEDTLS_MPS_TRACE_INIT( "mps_l1_set_bio" );
 
 #if defined(MBEDTLS_MPS_PROTO_TLS)
     MBEDTLS_MPS_IF_TLS( mode )
@@ -1128,7 +1128,7 @@ int mps_l1_set_bio( mps_l1 *ctx,
     }
 #endif /* MBEDTLS_MPS_PROTO_DTLS */
 
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
 void mps_l1_free( mps_l1 *ctx )
@@ -1264,7 +1264,7 @@ int mps_l1_skip( mps_l1 *ctx )
     mbedtls_mps_transport_type const mode =
         mbedtls_mps_l1_get_mode( ctx );
 
-    TRACE_INIT( "mps_l1_skip" );
+    MBEDTLS_MPS_TRACE_INIT( "mps_l1_skip" );
 
     MBEDTLS_MPS_STATE_VALIDATE_RAW( MBEDTLS_MPS_IS_DTLS( mode ),
                                     "mps_l1_skip() only for DTLS." );
@@ -1277,7 +1277,7 @@ int mps_l1_skip( mps_l1 *ctx )
     p->msg_len     = 0;
     p->buf         = NULL;
     p->buf_len     = 0;
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 #endif /* MBEDTLS_MPS_PROTO_DTLS */
 

--- a/library/mps/layer2.c
+++ b/library/mps/layer2.c
@@ -28,9 +28,9 @@
 
 #include "layer2_internal.h"
 
-#if defined(MBEDTLS_MPS_TRACE)
-static int trace_id = TRACE_BIT_LAYER_2;
-#endif /* MBEDTLS_MPS_TRACE */
+#if defined(MBEDTLS_MPS_ENABLE_TRACE)
+static int mbedtls_mps_trace_id = MBEDTLS_MPS_TRACE_BIT_LAYER_2;
+#endif /* MBEDTLS_MPS_ENABLE_TRACE */
 
 #include <stdlib.h>
 #include <string.h>
@@ -100,7 +100,7 @@ void mps_l2_readers_init( mbedtls_mps_l2 *ctx )
     for( unsigned idx=0; idx < MBEDTLS_MPS_L2_NUM_SLOTS; idx++, cur++ )
     {
         cur->state = MBEDTLS_MPS_L2_READER_STATE_UNSET;
-        mbedtls_reader_init( &cur->rd, NULL, 0 );
+        mbedtls_mps_reader_init( &cur->rd, NULL, 0 );
     }
 }
 
@@ -111,7 +111,7 @@ void mps_l2_readers_free( mbedtls_mps_l2 *ctx )
     for( unsigned idx=0; idx < MBEDTLS_MPS_L2_NUM_SLOTS; idx++, cur++ )
     {
         cur->state = MBEDTLS_MPS_L2_READER_STATE_UNSET;
-        mbedtls_reader_free( &cur->rd );
+        mbedtls_mps_reader_free( &cur->rd );
     }
 }
 
@@ -138,7 +138,7 @@ int mps_l2_readers_close_active( mbedtls_mps_l2 *ctx )
     mbedtls_mps_l2_in_internal *active = mps_l2_readers_get_active( ctx );
     if( active == NULL )
         return( 0 );
-    mbedtls_reader_free( &active->rd );
+    mbedtls_mps_reader_free( &active->rd );
     active->state = MBEDTLS_MPS_L2_READER_STATE_UNSET;
     return( 0 );
 }
@@ -148,12 +148,12 @@ int mps_l2_readers_close_active( mbedtls_mps_l2 *ctx )
 MBEDTLS_MPS_STATIC
 int mps_l2_readers_pause_active( mbedtls_mps_l2 *ctx )
 {
-    TRACE_INIT( "mps_l2_readers_pause_active" );
+    MBEDTLS_MPS_TRACE_INIT( "mps_l2_readers_pause_active" );
     mbedtls_mps_l2_in_internal *active = mps_l2_readers_get_active( ctx );
     if( active == NULL )
-        RETURN( 0 );
+        MBEDTLS_MPS_TRACE_RETURN( 0 );
     active->state = MBEDTLS_MPS_L2_READER_STATE_PAUSED;
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 #endif /* MBEDTLS_MPS_PROTO_TLS */
 
@@ -224,7 +224,7 @@ int mps_l2_find_suitable_slot( mbedtls_mps_l2 *ctx,
 
     mbedtls_mps_l2_in_internal *slot = NULL;
 
-    TRACE_INIT( "mps_l2_find_suitable_slot(), type %u, epoch %u",
+    MBEDTLS_MPS_TRACE_INIT( "mps_l2_find_suitable_slot(), type %u, epoch %u",
                 (unsigned) type, (unsigned) epoch );
 
 #if defined(MBEDTLS_MPS_PROTO_TLS)
@@ -243,7 +243,7 @@ int mps_l2_find_suitable_slot( mbedtls_mps_l2 *ctx,
                           "The paused epoch doesn't match the incoming epoch" );
 
                 *dst = cur;
-                RETURN( 0 );
+                MBEDTLS_MPS_TRACE_RETURN( 0 );
             }
         }
 
@@ -251,7 +251,7 @@ int mps_l2_find_suitable_slot( mbedtls_mps_l2 *ctx,
         {
             if( mps_l2_readers_accumulator_taken( ctx ) == 0 )
             {
-                TRACE( trace_comment, "The accumulator (size %u) is available",
+                MBEDTLS_MPS_TRACE( trace_comment, "The accumulator (size %u) is available",
                        (unsigned) ctx->io.in.acc_len );
                 acc = ctx->io.in.accumulator;
                 acc_len = ctx->io.in.acc_len;
@@ -259,14 +259,14 @@ int mps_l2_find_suitable_slot( mbedtls_mps_l2 *ctx,
             else
 #if !defined(MPS_L2_ALLOW_PAUSABLE_CONTENT_TYPE_WITHOUT_ACCUMULATOR)
             {
-                TRACE( trace_error,
+                MBEDTLS_MPS_TRACE( trace_error,
                        "The accumulator is not available, and don't allow "
                        "to open pausable content types without accumulator." );
-                RETURN( MBEDTLS_ERR_MPS_EXCESS_RECORD_FRAGMENTATION );
+                MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_EXCESS_RECORD_FRAGMENTATION );
             }
 #else
             {
-                TRACE( trace_comment, "No accumulator is available, but open nonetheless." );
+                MBEDTLS_MPS_TRACE( trace_comment, "No accumulator is available, but open nonetheless." );
             }
 #endif /* MPS_L2_ALLOW_PAUSABLE_CONTENT_TYPE_WITHOUT_ACCUMULATOR */
         }
@@ -278,15 +278,15 @@ int mps_l2_find_suitable_slot( mbedtls_mps_l2 *ctx,
     slot = mps_l2_readers_get_unused( ctx );
     if( slot == NULL )
     {
-        TRACE( trace_error, "No free reader available for the incoming record." );
-        RETURN( MBEDTLS_ERR_MPS_OPERATION_UNSUPPORTED );
+        MBEDTLS_MPS_TRACE( trace_error, "No free reader available for the incoming record." );
+        MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_OPERATION_UNSUPPORTED );
     }
 
-    mbedtls_reader_init( &slot->rd, acc, acc_len );
+    mbedtls_mps_reader_init( &slot->rd, acc, acc_len );
     slot->type = type;
     slot->epoch = epoch;
     *dst = slot;
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
 MBEDTLS_MPS_STATIC
@@ -313,18 +313,18 @@ int mps_l2_init( mbedtls_mps_l2 *ctx, mps_l1 *l1,
 #endif /* MBEDTLS_MPS_PROTO_TLS */
 
     mps_l2_bufpair zero_bufpair = { NULL, 0, 0, 0 };
-    TRACE_INIT( "l2_init" );
+    MBEDTLS_MPS_TRACE_INIT( "l2_init" );
 
 #if defined(MBEDTLS_MPS_PROTO_TLS)
     if( max_write > 0 )
     {
-        TRACE( trace_comment, "Allocating L2 writer queue of size %u Bytes",
+        MBEDTLS_MPS_TRACE( trace_comment, "Allocating L2 writer queue of size %u Bytes",
                (unsigned) max_write );
         queue = malloc( max_write );
     }
     if( max_read > 0 )
     {
-        TRACE( trace_comment, "Allocating L2 reader accumulator of size %u Bytes",
+        MBEDTLS_MPS_TRACE( trace_comment, "Allocating L2 reader accumulator of size %u Bytes",
                (unsigned) max_read );
         accumulator = malloc( max_read );
     }
@@ -332,10 +332,10 @@ int mps_l2_init( mbedtls_mps_l2 *ctx, mps_l1 *l1,
     if( ( max_write > 0  && queue       == NULL ) ||
         ( max_read  > 0  && accumulator == NULL ) )
     {
-        TRACE( trace_error, "Failed to allocate queue or accumulator." );
+        MBEDTLS_MPS_TRACE( trace_error, "Failed to allocate queue or accumulator." );
         free( queue );
         free( accumulator );
-        RETURN( MBEDTLS_ERR_MPS_OUT_OF_MEMORY );
+        MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_OUT_OF_MEMORY );
     }
 #else
     ((void) max_read);
@@ -441,14 +441,14 @@ int mps_l2_init( mbedtls_mps_l2 *ctx, mps_l1 *l1,
     }
 #endif /* MBEDTLS_MPS_PROTO_TLS */
 
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
 int mps_l2_free( mbedtls_mps_l2 *ctx )
 {
     mbedtls_mps_size_t offset;
     ((void) ctx);
-    TRACE_INIT( "l2_free" );
+    MBEDTLS_MPS_TRACE_INIT( "l2_free" );
 
     mps_l2_readers_free( ctx );
     mbedtls_writer_free( &ctx->io.out.writer.wr );
@@ -466,19 +466,19 @@ int mps_l2_free( mbedtls_mps_l2 *ctx )
     for( offset = 0; offset < MBEDTLS_MPS_L2_EPOCH_WINDOW_SIZE; offset++ )
         l2_epoch_free( &ctx->epochs.window[offset] );
 
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
 int mps_l2_config_version( mbedtls_mps_l2 *ctx, uint8_t ver )
 {
-    TRACE_INIT( "mps_l2_config_version: %u", (unsigned) ver );
+    MBEDTLS_MPS_TRACE_INIT( "mps_l2_config_version: %u", (unsigned) ver );
 
 #if !defined(MBEDTLS_MPS_CONF_VERSION)
     /* TODO: Add check */
     ctx->conf.version = ver;
 #endif /* !MBEDTLS_MPS_CONF_VERSION */
 
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
 /* Please consult the documentation of mbedtls_mps_l2 for a basic
@@ -511,14 +511,14 @@ int l2_out_prepare_record( mbedtls_mps_l2 *ctx,
 
     mbedtls_mps_l2_epoch_t *epoch;
 
-    TRACE_INIT( "l2_out_prepare, epoch %d", epoch_id );
+    MBEDTLS_MPS_TRACE_INIT( "l2_out_prepare, epoch %d", epoch_id );
 
     /* Request buffer from Layer 1 to hold entire record. */
     ret = mps_l1_write( l1, &rec_buf, &total_sz );
     if( ret != 0 )
     {
-        TRACE( trace_comment, "l1_write failed with %d", ret );
-        RETURN( ret );
+        MBEDTLS_MPS_TRACE( trace_comment, "l1_write failed with %d", ret );
+        MBEDTLS_MPS_TRACE_RETURN( ret );
     }
 
     /* Lookup epoch and get
@@ -531,14 +531,14 @@ int l2_out_prepare_record( mbedtls_mps_l2 *ctx,
 
     ret = l2_epoch_lookup( ctx, epoch_id, &epoch );
     if( ret != 0 )
-        RETURN( ret );
+        MBEDTLS_MPS_TRACE_RETURN( ret );
 
-    TRACE( trace_comment, "Transform expansion:" );
+    MBEDTLS_MPS_TRACE( trace_comment, "Transform expansion:" );
     mbedtls_mps_transform_get_expansion( epoch->transform,
                                          &pre_expansion,
                                          &post_expansion );
-    TRACE( trace_comment, "* Pre:  %u", (unsigned) pre_expansion  );
-    TRACE( trace_comment, "* Post: %u", (unsigned) post_expansion );
+    MBEDTLS_MPS_TRACE( trace_comment, "* Pre:  %u", (unsigned) pre_expansion  );
+    MBEDTLS_MPS_TRACE( trace_comment, "* Post: %u", (unsigned) post_expansion );
 
 #if defined(MBEDTLS_MPS_TRANSFORM_VALIDATION)
     {
@@ -549,9 +549,9 @@ int l2_out_prepare_record( mbedtls_mps_l2 *ctx,
 
         if( sum1 < sum0 || sum2 < sum1 )
         {
-            TRACE( trace_comment, "INTERNAL ERROR on pre- and postexpansion, len %u, pre-expansion %u, post-expansion %u",
+            MBEDTLS_MPS_TRACE( trace_comment, "INTERNAL ERROR on pre- and postexpansion, len %u, pre-expansion %u, post-expansion %u",
                    (unsigned) hdr_len, (unsigned) pre_expansion, (unsigned) post_expansion );
-            RETURN( MBEDTLS_ERR_MPS_BAD_TRANSFORM );
+            MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_BAD_TRANSFORM );
         }
     }
 #endif /* MBEDTLS_MPS_TRANSFORM_VALIDATION */
@@ -561,8 +561,8 @@ int l2_out_prepare_record( mbedtls_mps_l2 *ctx,
     if( hdr_len + pre_expansion + post_expansion >= total_sz )
     {
         mbedtls_mps_size_t bytes_pending;
-        TRACE( trace_comment, "Not enough space for to hold a non-empty record." );
-        TRACE( trace_comment, "Need at least %u ( %u header + %u pre-expansion + "
+        MBEDTLS_MPS_TRACE( trace_comment, "Not enough space for to hold a non-empty record." );
+        MBEDTLS_MPS_TRACE( trace_comment, "Need at least %u ( %u header + %u pre-expansion + "
                               "%u post-expansion + 1 plaintext ) byte, but have only "
                               "%u bytes available.",
                (unsigned)( hdr_len + pre_expansion + post_expansion + 1 ),
@@ -584,7 +584,7 @@ int l2_out_prepare_record( mbedtls_mps_l2 *ctx,
                   "serve a buffer large enough to hold a non-empty record." );
 
         /* We could also return WANT_WRITE here. */
-        RETURN( MBEDTLS_ERR_MPS_RETRY );
+        MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_RETRY );
     }
 
     /* The previous check ensures that the following is >= 1. */
@@ -610,12 +610,12 @@ int l2_out_prepare_record( mbedtls_mps_l2 *ctx,
 
     epoch->usage |= MPS_EPOCH_USAGE_INTERNAL_OUT_RECORD_OPEN;
 
-    TRACE( trace_comment, "New outgoing record successfully prepared." );
-    TRACE( trace_comment, " * Max plaintext size: %u",
+    MBEDTLS_MPS_TRACE( trace_comment, "New outgoing record successfully prepared." );
+    MBEDTLS_MPS_TRACE( trace_comment, " * Max plaintext size: %u",
            (unsigned) ctx->io.out.payload.data_len );
-    TRACE( trace_comment, " * Pre expansion:      %u",
+    MBEDTLS_MPS_TRACE( trace_comment, " * Pre expansion:      %u",
            (unsigned) ctx->io.out.payload.data_offset );
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
 /* Please consult the documentation of mbedtls_mps_l2 for a basic description
@@ -637,15 +637,15 @@ int l2_out_dispatch_record( mbedtls_mps_l2 *ctx )
     mps_rec rec;
     mps_l1* const l1 = mbedtls_mps_l2_get_l1( ctx );
 
-    TRACE_INIT( "l2_out_dispatch_record" );
-    TRACE( trace_comment, "Plaintext length: %u",
+    MBEDTLS_MPS_TRACE_INIT( "l2_out_dispatch_record" );
+    MBEDTLS_MPS_TRACE( trace_comment, "Plaintext length: %u",
            (unsigned) ctx->io.out.payload.data_len );
 
     if( ctx->io.out.payload.data_len == 0 )
     {
-        TRACE( trace_comment, "Attempt to dispatch an empty record %u.",
+        MBEDTLS_MPS_TRACE( trace_comment, "Attempt to dispatch an empty record %u.",
                (unsigned) ctx->io.out.writer.type );
-        TRACE( trace_comment, "Empty records allowed for type %u: %u",
+        MBEDTLS_MPS_TRACE( trace_comment, "Empty records allowed for type %u: %u",
              (unsigned) ctx->io.out.writer.type,
              (unsigned) l2_type_empty_allowed( ctx, ctx->io.out.writer.type ) );
     }
@@ -655,13 +655,13 @@ int l2_out_dispatch_record( mbedtls_mps_l2 *ctx )
     if( ctx->io.out.payload.data_len == 0 &&
         l2_type_empty_allowed( ctx, ctx->io.out.writer.type ) == 0 )
     {
-        TRACE( trace_comment, "Empty records are not allowed for type %u -> ignore request.",
+        MBEDTLS_MPS_TRACE( trace_comment, "Empty records are not allowed for type %u -> ignore request.",
                ctx->io.out.writer.type );
 
         /* dispatch(0) effectively resets the underlying Layer 1. */
         ret = mps_l1_dispatch( l1, 0, NULL );
         if( ret != 0 )
-            RETURN( ret );
+            MBEDTLS_MPS_TRACE_RETURN( ret );
     }
     else
     {
@@ -676,33 +676,33 @@ int l2_out_dispatch_record( mbedtls_mps_l2 *ctx )
         rec.epoch     = (uint16_t) ctx->io.out.writer.epoch;
         rec.type      = ctx->io.out.writer.type;
 
-        TRACE( trace_comment, "Record header fields:" );
-        TRACE( trace_comment, "* Epoch:           %u", (unsigned) rec.epoch );
-        TRACE( trace_comment, "* Type:            %u", (unsigned) rec.type  );
+        MBEDTLS_MPS_TRACE( trace_comment, "Record header fields:" );
+        MBEDTLS_MPS_TRACE( trace_comment, "* Epoch:           %u", (unsigned) rec.epoch );
+        MBEDTLS_MPS_TRACE( trace_comment, "* Type:            %u", (unsigned) rec.type  );
 
         ret = l2_epoch_lookup( ctx, ctx->io.out.writer.epoch, &epoch );
         if( ret != 0 )
         {
-            TRACE( trace_comment, "Epoch lookup failed" );
-            RETURN( ret );
+            MBEDTLS_MPS_TRACE( trace_comment, "Epoch lookup failed" );
+            MBEDTLS_MPS_TRACE_RETURN( ret );
         }
 
         l2_out_get_and_update_rec_seq( ctx, epoch, rec.ctr );
-        TRACE( trace_comment, "* Sequence number: ( %u << 16 ) + %u",
+        MBEDTLS_MPS_TRACE( trace_comment, "* Sequence number: ( %u << 16 ) + %u",
                (unsigned) rec.ctr[0], (unsigned) rec.ctr[1] );
 
         /* Step 2: Apply record payload protection. */
-        TRACE( trace_comment, "Encrypt record. The plaintext offset is %u.",
+        MBEDTLS_MPS_TRACE( trace_comment, "Encrypt record. The plaintext offset is %u.",
                (unsigned) rec.buf.data_offset );
         ret = mbedtls_mps_transform_encrypt( epoch->transform, &rec,
                                              ctx->conf.f_rng,
                                              ctx->conf.p_rng );
         if( ret != 0 )
         {
-            TRACE( trace_comment, "The record encryption failed with %d", ret );
-            RETURN( ret );
+            MBEDTLS_MPS_TRACE( trace_comment, "The record encryption failed with %d", ret );
+            MBEDTLS_MPS_TRACE_RETURN( ret );
         }
-        TRACE( trace_comment, "Record type after encryption: %u",
+        MBEDTLS_MPS_TRACE( trace_comment, "Record type after encryption: %u",
                (unsigned) rec.type );
 
 #if defined(MBEDTLS_MPS_TRANSFORM_VALIDATION)
@@ -712,16 +712,16 @@ int l2_out_dispatch_record( mbedtls_mps_l2 *ctx )
          * This should always be true, but better err on the safe side. */
         if( rec.buf.data_offset != 0 )
         {
-            TRACE( trace_error, "Get non-zero ciphertext offset %u after encryption.",
+            MBEDTLS_MPS_TRACE( trace_error, "Get non-zero ciphertext offset %u after encryption.",
                    (unsigned) rec.buf.data_offset );
-            RETURN( MBEDTLS_ERR_MPS_BAD_TRANSFORM );
+            MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_BAD_TRANSFORM );
         }
 #endif /* MBEDTLS_MPS_TRANSFORM_VALIDATION */
 
         /* Step 3: Write version- and mode-specific header and send record. */
         ret = l2_out_write_protected_record( ctx, &rec );
         if( ret != 0 )
-            RETURN( ret );
+            MBEDTLS_MPS_TRACE_RETURN( ret );
 
 #if defined(MBEDTLS_MPS_PROTO_TLS)
         MBEDTLS_MPS_ASSERT_RAW(
@@ -746,9 +746,9 @@ int l2_out_dispatch_record( mbedtls_mps_l2 *ctx )
     /* Epochs might have been held back because of the pending write. */
     ret = l2_epoch_cleanup( ctx );
     if( ret != 0 )
-        RETURN( ret );
+        MBEDTLS_MPS_TRACE_RETURN( ret );
 
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
 MBEDTLS_MPS_STATIC
@@ -759,7 +759,7 @@ int l2_out_write_protected_record( mbedtls_mps_l2 *ctx, mps_rec *rec )
     mbedtls_mps_transport_type const mode =
         mbedtls_mps_l2_conf_get_mode( &ctx->conf );
 
-    TRACE_INIT( "Write protected record" );
+    MBEDTLS_MPS_TRACE_INIT( "Write protected record" );
 
 #if defined(MBEDTLS_MPS_PROTO_TLS)
     MBEDTLS_MPS_IF_TLS( mode )
@@ -796,7 +796,7 @@ int l2_out_write_protected_record( mbedtls_mps_l2 *ctx, mps_rec *rec )
     ctx->io.out.hdr_len = 0;
     ctx->io.out.payload = zero_bufpair;
 
-    RETURN( ret );
+    MBEDTLS_MPS_TRACE_RETURN( ret );
 }
 
 #if defined(MBEDTLS_MPS_PROTO_TLS)
@@ -815,7 +815,7 @@ int l2_out_write_protected_record_tls( mbedtls_mps_l2 *ctx, mps_rec *rec )
     mbedtls_mps_size_t const tls_rec_len_offset  = 3;
 
     ((void) tls_rec_hdr_len);
-    TRACE_INIT( "l2_write_protected_record_tls" );
+    MBEDTLS_MPS_TRACE_INIT( "l2_write_protected_record_tls" );
 
     /* Double-check that we have calculated the header length
      * correctly when preparing the outgoing record.
@@ -858,9 +858,9 @@ int l2_out_write_protected_record_tls( mbedtls_mps_l2 *ctx, mps_rec *rec )
     /* Write ciphertext length. */
     MPS_WRITE_UINT16_BE( &rec->buf.data_len, hdr + tls_rec_len_offset );
 
-    TRACE( trace_comment, "* Type:    %u", (unsigned) rec->type );
-    TRACE( trace_comment, "* Version: %u", (unsigned) rec->minor_ver );
-    RETURN( mps_l1_dispatch( l1, hdr_len + rec->buf.data_len, NULL ) );
+    MBEDTLS_MPS_TRACE( trace_comment, "* Type:    %u", (unsigned) rec->type );
+    MBEDTLS_MPS_TRACE( trace_comment, "* Version: %u", (unsigned) rec->minor_ver );
+    MBEDTLS_MPS_TRACE_RETURN( mps_l1_dispatch( l1, hdr_len + rec->buf.data_len, NULL ) );
 }
 #endif /* MBEDTLS_MPS_PROTO_TLS */
 
@@ -897,7 +897,7 @@ int l2_out_write_protected_record_dtls12( mbedtls_mps_l2 *ctx,
     mbedtls_mps_size_t const dtls_rec_seq_offset   = 5;
     mbedtls_mps_size_t const dtls_rec_len_offset   = 11;
 
-    TRACE_INIT( "l2_write_protected_record_dtls12" );
+    MBEDTLS_MPS_TRACE_INIT( "l2_write_protected_record_dtls12" );
 
     /* Double-check that we have calculated the header length
      * correctly when preparing the outgoing record.
@@ -925,20 +925,20 @@ int l2_out_write_protected_record_dtls12( mbedtls_mps_l2 *ctx,
     /* Write ciphertext length. */
     MPS_WRITE_UINT16_BE( &rec->buf.data_len, hdr + dtls_rec_len_offset );
 
-    TRACE( trace_comment, "Write protected record -- DISPATCH" );
-    RETURN( mps_l1_dispatch( l1, hdr_len + rec->buf.data_len, NULL ) );
+    MBEDTLS_MPS_TRACE( trace_comment, "Write protected record -- DISPATCH" );
+    MBEDTLS_MPS_TRACE_RETURN( mps_l1_dispatch( l1, hdr_len + rec->buf.data_len, NULL ) );
 }
 #endif /* MBEDTLS_MPS_PROTO_DTLS */
 
 int mps_l2_write_flush( mbedtls_mps_l2 *ctx )
 {
-    TRACE_INIT( "mps_l2_write_flush, state %u", ctx->io.out.state );
+    MBEDTLS_MPS_TRACE_INIT( "mps_l2_write_flush, state %u", ctx->io.out.state );
     MBEDTLS_MPS_STATE_VALIDATE_RAW(
         ctx->io.out.state != MBEDTLS_MPS_L2_WRITER_STATE_EXTERNAL,
         "mps_l2_write_flush() called in unexpected state." );
 
     ctx->io.out.flush = 1;
-    RETURN( l2_out_clear_pending( ctx ) );
+    MBEDTLS_MPS_TRACE_RETURN( l2_out_clear_pending( ctx ) );
 }
 
 /* See the documentation of `clearing` and `flush` in layer2.h
@@ -948,13 +948,13 @@ int l2_out_clear_pending( mbedtls_mps_l2 *ctx )
 {
     int ret;
     mps_l1* const l1 = mbedtls_mps_l2_get_l1( ctx );
-    TRACE_INIT( "l2_out_clear_pending, state %u", (unsigned) ctx->io.out.state );
+    MBEDTLS_MPS_TRACE_INIT( "l2_out_clear_pending, state %u", (unsigned) ctx->io.out.state );
 
     if( ctx->io.out.clearing == 1 )
     {
         ret = mps_l1_flush( l1 );
         if( ret != 0 )
-            RETURN( ret );
+            MBEDTLS_MPS_TRACE_RETURN( ret );
         ctx->io.out.clearing = 0;
     }
 
@@ -966,40 +966,40 @@ int l2_out_clear_pending( mbedtls_mps_l2 *ctx )
         mbedtls_mps_epoch_id queued_epoch;
         queued_epoch = ctx->io.out.writer.epoch;
 
-        TRACE( trace_comment, "Queued data is pending to be dispatched" );
+        MBEDTLS_MPS_TRACE( trace_comment, "Queued data is pending to be dispatched" );
 
         /* Prepare an outgoing record to dispatch the queued data */
         ret = l2_out_prepare_record( ctx, queued_epoch );
         if( ret != 0 )
-            RETURN( ret );
+            MBEDTLS_MPS_TRACE_RETURN( ret );
 
         ret = l2_out_track_record( ctx );
         if( ret == 0 )
             break;
         else if( ret != MBEDTLS_ERR_WRITER_NEED_MORE )
-            RETURN( ret );
+            MBEDTLS_MPS_TRACE_RETURN( ret );
 
-        TRACE( trace_comment, "The prepared record was entirely filled with queued data -> dispatch it" );
+        MBEDTLS_MPS_TRACE( trace_comment, "The prepared record was entirely filled with queued data -> dispatch it" );
 
         /* There's more queued data pending, so just deliver the record. */
         ret = l2_out_dispatch_record( ctx );
         if( ret != 0 )
-            RETURN( ret );
+            MBEDTLS_MPS_TRACE_RETURN( ret );
     }
 #endif /* MBEDTLS_MPS_PROTO_TLS */
 
-    TRACE( trace_comment, "Queue clear" );
+    MBEDTLS_MPS_TRACE( trace_comment, "Queue clear" );
 
     if( ctx->io.out.flush == 1 )
     {
-        TRACE( trace_comment, "A flush was requested requested, state %u",
+        MBEDTLS_MPS_TRACE( trace_comment, "A flush was requested requested, state %u",
                (unsigned) ctx->io.out.state );
         if( ctx->io.out.state == MBEDTLS_MPS_L2_WRITER_STATE_INTERNAL )
         {
             ret = l2_out_release_and_dispatch( ctx,
                                                MBEDTLS_WRITER_RECLAIM_FORCE );
             if( ret != 0 )
-                RETURN( ret );
+                MBEDTLS_MPS_TRACE_RETURN( ret );
 
             /* NOTE:
              * This code is only valid if Layer 1 doesn't attempt partial
@@ -1020,7 +1020,7 @@ int l2_out_clear_pending( mbedtls_mps_l2 *ctx )
             /* Epochs might have been held back because of the pending write. */
             ret = l2_epoch_cleanup( ctx );
             if( ret != 0 )
-                RETURN( ret );
+                MBEDTLS_MPS_TRACE_RETURN( ret );
         }
 
         ctx->io.out.clearing = 1;
@@ -1031,11 +1031,11 @@ int l2_out_clear_pending( mbedtls_mps_l2 *ctx )
     {
         ret = mps_l1_flush( l1 );
         if( ret != 0 )
-            RETURN( ret );
+            MBEDTLS_MPS_TRACE_RETURN( ret );
         ctx->io.out.clearing = 0;
     }
 
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
 int mps_l2_write_start( mbedtls_mps_l2 *ctx, mps_l2_out *out )
@@ -1044,7 +1044,7 @@ int mps_l2_write_start( mbedtls_mps_l2 *ctx, mps_l2_out *out )
     uint8_t desired_type;
     mbedtls_mps_epoch_id desired_epoch;
 
-    TRACE_INIT( "mps_l2_write_start" );
+    MBEDTLS_MPS_TRACE_INIT( "mps_l2_write_start" );
 
     /* We must not attempt to write multiple records simultaneously.
      * If this happens, the layer most likely forgot to dispatch
@@ -1057,15 +1057,15 @@ int mps_l2_write_start( mbedtls_mps_l2 *ctx, mps_l2_out *out )
     desired_type = out->type;
     if( l2_type_is_valid( ctx, desired_type ) == 0 )
     {
-        TRACE( trace_error, "Message type %d is invalid", desired_type );
-        RETURN( MBEDTLS_ERR_MPS_INTERNAL_ERROR );
+        MBEDTLS_MPS_TRACE( trace_error, "Message type %d is invalid", desired_type );
+        MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_INTERNAL_ERROR );
     }
 
     /* Check if the requested epoch is valid for writing. */
     desired_epoch = out->epoch;
     ret = l2_epoch_check( ctx, desired_epoch, MPS_EPOCH_WRITE_MASK );
     if( ret != 0 )
-        RETURN( ret );
+        MBEDTLS_MPS_TRACE_RETURN( ret );
 
     /* Make sure that no data is queueing for dispatching, and that
      * all dispatched data has been delivered by Layer 1 in case
@@ -1074,8 +1074,8 @@ int mps_l2_write_start( mbedtls_mps_l2 *ctx, mps_l2_out *out )
     ret = l2_out_clear_pending( ctx );
     if( ret != 0 )
     {
-        TRACE( trace_comment, "l2_out_clear_pending failed with %d", ret );
-        RETURN( ret );
+        MBEDTLS_MPS_TRACE( trace_comment, "l2_out_clear_pending failed with %d", ret );
+        MBEDTLS_MPS_TRACE_RETURN( ret );
     }
 
     /* If l2_out_clear_pending() succeeds, it guarantees that the
@@ -1094,26 +1094,26 @@ int mps_l2_write_start( mbedtls_mps_l2 *ctx, mps_l2_out *out )
         if( ctx->io.out.writer.type  == desired_type &&
             ctx->io.out.writer.epoch == desired_epoch )
         {
-            TRACE( trace_comment,
+            MBEDTLS_MPS_TRACE( trace_comment,
                    "Type and epoch match currently open record -> attach." );
             ctx->io.out.state = MBEDTLS_MPS_L2_WRITER_STATE_EXTERNAL;
             out->wr = &ctx->io.out.writer.wr;
 
-            TRACE( trace_comment, "* Total size of record buffer: %u Bytes",
+            MBEDTLS_MPS_TRACE( trace_comment, "* Total size of record buffer: %u Bytes",
                    (unsigned) out->wr->out_len );
-            TRACE( trace_comment, "* Committed: %u Bytes",
+            MBEDTLS_MPS_TRACE( trace_comment, "* Committed: %u Bytes",
                    (unsigned) out->wr->committed );
-            TRACE( trace_comment, "* Written: %u Bytes",
+            MBEDTLS_MPS_TRACE( trace_comment, "* Written: %u Bytes",
                    (unsigned) out->wr->end );
-            TRACE( trace_comment, "* Remaining: %u Bytes",
+            MBEDTLS_MPS_TRACE( trace_comment, "* Remaining: %u Bytes",
                    (unsigned) ( out->wr->out_len - out->wr->committed ) );
-            RETURN( 0 );
+            MBEDTLS_MPS_TRACE_RETURN( 0 );
         }
 
-        TRACE( trace_comment, "Type or epoch doesn't match open record." );
+        MBEDTLS_MPS_TRACE( trace_comment, "Type or epoch doesn't match open record." );
         ret = l2_out_release_and_dispatch( ctx, MBEDTLS_WRITER_RECLAIM_FORCE );
         if( ret != 0 )
-            RETURN( ret );
+            MBEDTLS_MPS_TRACE_RETURN( ret );
 
         /* The old record has been dispatched by now, and we fall through
          * to open a new one for the requested type and epoch. */
@@ -1124,7 +1124,7 @@ int mps_l2_write_start( mbedtls_mps_l2 *ctx, mps_l2_out *out )
     /* Prepare raw buffers from Layer 1 to hold the new record. */
     ret = l2_out_prepare_record( ctx, desired_epoch );
     if( ret != 0 )
-        RETURN( ret );
+        MBEDTLS_MPS_TRACE_RETURN( ret );
 
     ctx->io.out.writer.type  = desired_type;
     ctx->io.out.writer.epoch = desired_epoch;
@@ -1132,17 +1132,17 @@ int mps_l2_write_start( mbedtls_mps_l2 *ctx, mps_l2_out *out )
     /* Bind buffers to the writer passed to the user. */
     ret = l2_out_track_record( ctx );
     if( ret != 0 )
-        RETURN( ret );
+        MBEDTLS_MPS_TRACE_RETURN( ret );
 
     ctx->io.out.state = MBEDTLS_MPS_L2_WRITER_STATE_EXTERNAL;
     out->wr = &ctx->io.out.writer.wr;
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
 int mps_l2_write_done( mbedtls_mps_l2 *ctx )
 {
     int ret;
-    TRACE_INIT( "l2_write_done" );
+    MBEDTLS_MPS_TRACE_INIT( "l2_write_done" );
 
     MBEDTLS_MPS_STATE_VALIDATE_RAW(
         ctx->io.out.state == MBEDTLS_MPS_L2_WRITER_STATE_EXTERNAL,
@@ -1152,16 +1152,16 @@ int mps_l2_write_done( mbedtls_mps_l2 *ctx )
 
     ret = l2_out_release_and_dispatch( ctx, MBEDTLS_WRITER_RECLAIM_NO_FORCE );
     if( ret != 0 )
-        RETURN( ret );
+        MBEDTLS_MPS_TRACE_RETURN( ret );
 
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
 MBEDTLS_MPS_STATIC
 int l2_out_track_record( mbedtls_mps_l2 *ctx )
 {
     int ret;
-    TRACE_INIT( "l2_out_track_record" );
+    MBEDTLS_MPS_TRACE_INIT( "l2_out_track_record" );
 
     if( ctx->io.out.state == MBEDTLS_MPS_L2_WRITER_STATE_UNSET )
     {
@@ -1186,12 +1186,12 @@ int l2_out_track_record( mbedtls_mps_l2 *ctx )
                         ctx->io.out.payload.data_len );
     if( ret != 0 )
     {
-        TRACE( trace_error, "mbedtls_writer_feed failed with %d", ret );
-        RETURN( ret );
+        MBEDTLS_MPS_TRACE( trace_error, "mbedtls_writer_feed failed with %d", ret );
+        MBEDTLS_MPS_TRACE_RETURN( ret );
     }
 
     ctx->io.out.state = MBEDTLS_MPS_L2_WRITER_STATE_INTERNAL;
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
 MBEDTLS_MPS_STATIC
@@ -1200,7 +1200,7 @@ int l2_out_release_record( mbedtls_mps_l2 *ctx, uint8_t force )
     int ret;
     mbedtls_mps_size_t bytes_written, bytes_queued;
     mbedtls_mps_msg_type_t type;
-    TRACE_INIT( "l2_out_release_record, force %u, state %u", force,
+    MBEDTLS_MPS_TRACE_INIT( "l2_out_release_record, force %u, state %u", force,
            (unsigned) ctx->io.out.state );
 
     ret = mbedtls_writer_reclaim( &ctx->io.out.writer.wr, &bytes_written,
@@ -1208,7 +1208,7 @@ int l2_out_release_record( mbedtls_mps_l2 *ctx, uint8_t force )
     if( force == MBEDTLS_WRITER_RECLAIM_NO_FORCE &&
         ret   == MBEDTLS_ERR_WRITER_DATA_LEFT )
     {
-        TRACE( trace_comment, "There's space left in the current outgoing record." );
+        MBEDTLS_MPS_TRACE( trace_comment, "There's space left in the current outgoing record." );
         type = ctx->io.out.writer.type;
 
         /* Check if records of the given type may be merged.
@@ -1216,7 +1216,7 @@ int l2_out_release_record( mbedtls_mps_l2 *ctx, uint8_t force )
          * be placed in a single record. */
         if( l2_type_can_be_merged( ctx, type ) == 1 )
         {
-            TRACE( trace_comment, "Multiple messages of type %u can be merged in a single record.", (unsigned) type );
+            MBEDTLS_MPS_TRACE( trace_comment, "Multiple messages of type %u can be merged in a single record.", (unsigned) type );
             /* Here's the place to add a heuristic deciding when to dispatch
              * a record even if space is left in the output buffer. For TLS,
              * in principle we can go on with as little as a single byte, but
@@ -1224,26 +1224,26 @@ int l2_out_release_record( mbedtls_mps_l2 *ctx, uint8_t force )
 
             if( /* HEURISTIC */ 1 )
             {
-                TRACE( trace_comment, "Postpone dispatching to potentially merge further messages into this record." );
-                RETURN( MBEDTLS_ERR_WRITER_DATA_LEFT );
+                MBEDTLS_MPS_TRACE( trace_comment, "Postpone dispatching to potentially merge further messages into this record." );
+                MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_WRITER_DATA_LEFT );
             }
 
-            TRACE( trace_comment, "Not enough space remaining to wait for another message oftype %u - dispatch.", (unsigned) type );
+            MBEDTLS_MPS_TRACE( trace_comment, "Not enough space remaining to wait for another message oftype %u - dispatch.", (unsigned) type );
 
             /* Fall through if heuristic determines that the current record
              * should be dispatched albeit spacing being left: fall through */
         }
         else
-            TRACE( trace_comment, "Multiple messages of type %u cannot be merged in a single record.", (unsigned) type );
+            MBEDTLS_MPS_TRACE( trace_comment, "Multiple messages of type %u cannot be merged in a single record.", (unsigned) type );
 
-        TRACE( trace_comment, "Force reclaim of current record." );
+        MBEDTLS_MPS_TRACE( trace_comment, "Force reclaim of current record." );
         ret = mbedtls_writer_reclaim( &ctx->io.out.writer.wr, NULL, NULL,
                                       MBEDTLS_WRITER_RECLAIM_FORCE );
         if( ret != 0 )
-            RETURN( ret );
+            MBEDTLS_MPS_TRACE_RETURN( ret );
     }
     else if( ret != 0 )
-        RETURN( ret );
+        MBEDTLS_MPS_TRACE_RETURN( ret );
 
     /* Now it's clear that the record should be dispatched */
 
@@ -1251,15 +1251,15 @@ int l2_out_release_record( mbedtls_mps_l2 *ctx, uint8_t force )
     if( bytes_queued > 0 )
     {
         /* The writer has queued data */
-        TRACE( trace_comment, "The writer has %u bytes of queued data.",
+        MBEDTLS_MPS_TRACE( trace_comment, "The writer has %u bytes of queued data.",
                (unsigned) bytes_queued );
 
         /* Double-check that the record content type can indeed be paused. */
         if( l2_type_can_be_paused( ctx, ctx->io.out.writer.type ) == 0 )
         {
-            TRACE( trace_comment, "Content type not pausable -- queue shouldn't"
+            MBEDTLS_MPS_TRACE( trace_comment, "Content type not pausable -- queue shouldn't"
                    " have been passed to the writer in the first place" );
-            RETURN( MBEDTLS_ERR_MPS_INTERNAL_ERROR );
+            MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_INTERNAL_ERROR );
         }
 
         ctx->io.out.state = MBEDTLS_MPS_L2_WRITER_STATE_QUEUEING;
@@ -1268,7 +1268,7 @@ int l2_out_release_record( mbedtls_mps_l2 *ctx, uint8_t force )
 #endif /* MBEDTLS_MPS_PROTO_TLS */
     {
         /* No data has been queued */
-        TRACE( trace_comment, "The writer has no queued data." );
+        MBEDTLS_MPS_TRACE( trace_comment, "The writer has no queued data." );
 
         /* The writer is no longer needed. */
         mbedtls_writer_free( &ctx->io.out.writer.wr );
@@ -1278,14 +1278,14 @@ int l2_out_release_record( mbedtls_mps_l2 *ctx, uint8_t force )
 
     /* Update internal length field and change the writer state. */
     ctx->io.out.payload.data_len = bytes_written;
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
 MBEDTLS_MPS_STATIC
 int l2_out_release_and_dispatch( mbedtls_mps_l2 *ctx, uint8_t force )
 {
     int ret;
-    TRACE_INIT( "l2_out_release_and_dispatch, force %u", force );
+    MBEDTLS_MPS_TRACE_INIT( "l2_out_release_and_dispatch, force %u", force );
 
     MBEDTLS_MPS_ASSERT_RAW( ctx->io.out.state ==
                             MBEDTLS_MPS_L2_WRITER_STATE_INTERNAL,
@@ -1296,23 +1296,23 @@ int l2_out_release_and_dispatch( mbedtls_mps_l2 *ctx, uint8_t force )
      * left in the buffer for more data to be added to the record. */
     ret = l2_out_release_record( ctx, force );
     if( ret != 0 && ret != MBEDTLS_ERR_WRITER_DATA_LEFT )
-        RETURN( ret );
+        MBEDTLS_MPS_TRACE_RETURN( ret );
 
     if( ret == 0 )
     {
         /* The write-buffer is detached from the writer, hence
          * can be dispatched to Layer 1. */
-        TRACE( trace_comment, "Dispatch current outgoing record." );
+        MBEDTLS_MPS_TRACE( trace_comment, "Dispatch current outgoing record." );
         ret = l2_out_dispatch_record( ctx );
         if( ret != 0 )
-            RETURN( ret );
+            MBEDTLS_MPS_TRACE_RETURN( ret );
     }
     else
     {
-        TRACE( trace_comment, "Current record need not yet be dispatched." );
+        MBEDTLS_MPS_TRACE( trace_comment, "Current record need not yet be dispatched." );
     }
 
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
 int mps_l2_read_done( mbedtls_mps_l2 *ctx )
@@ -1323,14 +1323,14 @@ int mps_l2_read_done( mbedtls_mps_l2 *ctx )
 
     mbedtls_mps_l2_in_internal * active;
 #if defined(MBEDTLS_MPS_PROTO_TLS)
-    mbedtls_mps_size_t paused;
-    mbedtls_mps_size_t * const paused_ptr = &paused;
+    int paused;
+    int* const paused_ptr = &paused;
 #else
-    mbedtls_mps_size_t * const paused_ptr = NULL;
+    int* const paused_ptr = NULL;
 #endif /* MBEDTLS_MPS_PROTO_TLS */
 
     ((void) mode);
-    TRACE_INIT( "mps_l2_read_done" );
+    MBEDTLS_MPS_TRACE_INIT( "mps_l2_read_done" );
 
     /* This only makes sense if the active reader is currently
      * on the user-side, i.e. 'external'. Everything else is
@@ -1367,31 +1367,31 @@ int mps_l2_read_done( mbedtls_mps_l2 *ctx )
      */
 
     active = mps_l2_readers_get_active( ctx );
-    ret = mbedtls_reader_reclaim( &active->rd, paused_ptr );
-    if( ret == MBEDTLS_ERR_READER_DATA_LEFT )
+    ret = mbedtls_mps_reader_reclaim( &active->rd, paused_ptr );
+    if( ret == MBEDTLS_ERR_MPS_READER_DATA_LEFT )
     {
         /* 1a */
-        TRACE( trace_comment, "There is data remaining in the current incoming record." );
+        MBEDTLS_MPS_TRACE( trace_comment, "There is data remaining in the current incoming record." );
 
         /* Check if the content type is configured to allow packing of
          * multiple chunks of data in the same record. */
         if( l2_type_can_be_merged( ctx, active->type ) == 0 )
         {
-            TRACE( trace_error,
+            MBEDTLS_MPS_TRACE( trace_error,
                    "Record content type %u does not allow "
                    "multiple reads from the same record.",
                    (unsigned) active->type );
-            RETURN( MBEDTLS_ERR_MPS_INVALID_CONTENT );
+            MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_INVALID_CONTENT );
         }
 
         active->state = MBEDTLS_MPS_L2_READER_STATE_INTERNAL;
-        RETURN( 0 );
+        MBEDTLS_MPS_TRACE_RETURN( 0 );
     }
     else
 #if defined(MBEDTLS_MPS_PROTO_TLS)
     if( MBEDTLS_MPS_IS_TLS( mode ) &&
-        ( ( ret == MBEDTLS_ERR_READER_NEED_ACCUMULATOR ) ||
-          ( ret == MBEDTLS_ERR_READER_ACCUMULATOR_TOO_SMALL ) ) )
+        ( ( ret == MBEDTLS_ERR_MPS_READER_NEED_ACCUMULATOR ) ||
+          ( ret == MBEDTLS_ERR_MPS_READER_ACCUMULATOR_TOO_SMALL ) ) )
     {
         /* 1b */
 
@@ -1399,50 +1399,50 @@ int mps_l2_read_done( mbedtls_mps_l2 *ctx )
         {
             /* The application should know which types have been configured
              * to be pausable, and not attempt to pause a non-pausable type. */
-            RETURN( MBEDTLS_ERR_MPS_INVALID_RECORD_FRAGMENTATION );
+            MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_INVALID_RECORD_FRAGMENTATION );
         }
 
-        if( ret == MBEDTLS_ERR_READER_NEED_ACCUMULATOR )
+        if( ret == MBEDTLS_ERR_MPS_READER_NEED_ACCUMULATOR )
         {
 #if !defined(MPS_L2_ALLOW_PAUSABLE_CONTENT_TYPE_WITHOUT_ACCUMULATOR)
             /* In this configuration, we shouldn't have opened the read
              * port for a pausable record content type in the first
              * place when not also providing an accumulator with it. */
-            RETURN( MBEDTLS_ERR_MPS_INTERNAL_ERROR );
+            MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_INTERNAL_ERROR );
 #else
-            RETURN( MBEDTLS_ERR_MPS_EXCESS_RECORD_FRAGMENTATION );
+            MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_EXCESS_RECORD_FRAGMENTATION );
 #endif /* MPS_L2_ALLOW_PAUSABLE_CONTENT_TYPE_WITHOUT_ACCUMULATOR */
         }
 
-        RETURN( MBEDTLS_ERR_MPS_BUFFER_TOO_SMALL );
+        MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_BUFFER_TOO_SMALL );
     }
     else
 #endif /* MBEDTLS_MPS_PROTO_TLS */
     if( ret != 0 )
-        RETURN( ret );
+        MBEDTLS_MPS_TRACE_RETURN( ret );
 
     /* 2 */
 
-    TRACE( trace_comment,
+    MBEDTLS_MPS_TRACE( trace_comment,
            "Detached record buffer from reader - "
            "release record from Layer 1." );
     ret = l2_in_release_record( ctx );
     if( ret != 0 )
-        RETURN( ret );
+        MBEDTLS_MPS_TRACE_RETURN( ret );
 
 #if defined(MBEDTLS_MPS_PROTO_TLS)
     if( paused == 0 )
 #endif /* MBEDTLS_MPS_PROTO_TLS */
     {
         /* 2.1 */
-        TRACE( trace_comment, "No pausing - close active reader." );
-        RETURN( mps_l2_readers_close_active( ctx ) );
+        MBEDTLS_MPS_TRACE( trace_comment, "No pausing - close active reader." );
+        MBEDTLS_MPS_TRACE_RETURN( mps_l2_readers_close_active( ctx ) );
     }
 
 #if defined(MBEDTLS_MPS_PROTO_TLS)
     /* 2.2 (TLS only) */
-    TRACE( trace_comment, "Pause active reader." );
-    RETURN( mps_l2_readers_pause_active( ctx ) );
+    MBEDTLS_MPS_TRACE( trace_comment, "Pause active reader." );
+    MBEDTLS_MPS_TRACE_RETURN( mps_l2_readers_pause_active( ctx ) );
 #endif /* MBEDTLS_MPS_PROTO_TLS */
 }
 
@@ -1454,31 +1454,31 @@ int l2_handle_invalid_record( mbedtls_mps_l2 *ctx, int ret )
     /* This function assumes that the mode has been checked
      * to be MBEDTLS_MPS_MODE_DATAGRAM and hence omits this check here. */
 
-    TRACE_INIT( "mps_l2_handle_invalid_record" );
+    MBEDTLS_MPS_TRACE_INIT( "mps_l2_handle_invalid_record" );
     if( ret == MBEDTLS_ERR_MPS_INVALID_RECORD )
     {
-        TRACE( trace_error, "Record with invalid header received -- discard" );
+        MBEDTLS_MPS_TRACE( trace_error, "Record with invalid header received -- discard" );
     }
     else if( ret == MBEDTLS_ERR_MPS_REPLAYED_RECORD )
     {
-        TRACE( trace_error, "Record caught by replay protection -- discard" );
+        MBEDTLS_MPS_TRACE( trace_error, "Record caught by replay protection -- discard" );
     }
     else /* ret == MBEDTLS_ERR_MPS_INVALID_MAC */
     {
-        TRACE( trace_error, "Record with invalid MAC received -- discard" );
+        MBEDTLS_MPS_TRACE( trace_error, "Record with invalid MAC received -- discard" );
         ctx->io.in.bad_mac_ctr++;
         if( mbedtls_mps_l2_conf_get_badmac_limit( &ctx->conf ) != 0 &&
             ctx->io.in.bad_mac_ctr >=
             mbedtls_mps_l2_conf_get_badmac_limit( &ctx->conf ) )
         {
-            TRACE( trace_error, "Bad-MAC-limit %u reached.",
+            MBEDTLS_MPS_TRACE( trace_error, "Bad-MAC-limit %u reached.",
                    (unsigned) mbedtls_mps_l2_conf_get_badmac_limit( &ctx->conf ) );
-            RETURN( MBEDTLS_ERR_MPS_INVALID_MAC );
+            MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_INVALID_MAC );
         }
     }
 
     /* Silently discard datagrams containing invalid records. */
-    RETURN( mps_l1_skip( l1 ) );
+    MBEDTLS_MPS_TRACE_RETURN( mps_l1_skip( l1 ) );
 }
 #endif /* MBEDTLS_MPS_PROTO_DTLS */
 
@@ -1491,19 +1491,19 @@ int l2_handle_record_content( mbedtls_mps_l2 *ctx, mps_rec *rec )
         mbedtls_mps_l2_conf_get_mode( &ctx->conf );
     int ret;
 
-    TRACE_INIT( "l2_handle_record_content" );
+    MBEDTLS_MPS_TRACE_INIT( "l2_handle_record_content" );
 
     /* Find a reader to handle the content.
      * This can either be a paused reader matching the record content type
      * and epoch, or a currently unused reader. */
     ret = mps_l2_find_suitable_slot( ctx, rec->type, rec->epoch, &slot );
     if( ret != 0 )
-        RETURN( ret );
+        MBEDTLS_MPS_TRACE_RETURN( ret );
 
     /* Feed record payload into target slot; might be either
      * a fresh or a matching paused slot.
      * See 3.1.1 and 3.2 in mps_l2_read_start(). */
-    ret = mbedtls_reader_feed( &slot->rd,
+    ret = mbedtls_mps_reader_feed( &slot->rd,
                                rec->buf.buf + rec->buf.data_offset,
                                rec->buf.data_len );
 
@@ -1511,12 +1511,12 @@ int l2_handle_record_content( mbedtls_mps_l2 *ctx, mps_rec *rec )
     ((void) mode);
 #else
     if( MBEDTLS_MPS_IS_TLS( mode ) &&
-        ret == MBEDTLS_ERR_READER_NEED_MORE )
+        ret == MBEDTLS_ERR_MPS_READER_NEED_MORE )
     {
         /* 3.1.1.2 */
         ret = l2_in_release_record( ctx );
         if( ret != 0 )
-            RETURN( ret );
+            MBEDTLS_MPS_TRACE_RETURN( ret );
 
         /* As above, it would be ok to return #MBEDTLS_ERR_MPS_WANT_READ here
          * because the present code-path is TLS-only, and in TLS we never
@@ -1529,20 +1529,20 @@ int l2_handle_record_content( mbedtls_mps_l2 *ctx, mps_rec *rec )
          * data than what we asked for, this would need to be reconsidered,
          * so it's safer to return MBEDTLS_ERR_MPS_RETRY.
          */
-        RETURN( MBEDTLS_ERR_MPS_RETRY );
+        MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_RETRY );
     }
     else
 #endif /* MBEDTLS_MPS_PROTO_TLS */
     {
         if( ret != 0 )
-            RETURN( ret );
+            MBEDTLS_MPS_TRACE_RETURN( ret );
     }
 
     /* 3.1.1.1 or 3.2 in mps_l2_read_start(). */
     slot->state = MBEDTLS_MPS_L2_READER_STATE_INTERNAL;
     mps_l2_reader_slots_changed( ctx );
 
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
 int mps_l2_read_start( mbedtls_mps_l2 *ctx, mps_l2_in *in )
@@ -1550,7 +1550,7 @@ int mps_l2_read_start( mbedtls_mps_l2 *ctx, mps_l2_in *in )
     int ret;
     mbedtls_mps_l2_reader_state current_state;
     mbedtls_mps_l2_in_internal *active;
-    TRACE_INIT( "mps_l2_read_start" );
+    MBEDTLS_MPS_TRACE_INIT( "mps_l2_read_start" );
 
     /*
      * Outline:
@@ -1591,7 +1591,7 @@ int mps_l2_read_start( mbedtls_mps_l2 *ctx, mps_l2_in *in )
     /* 2 */
     if( current_state == MBEDTLS_MPS_L2_READER_STATE_INTERNAL )
     {
-        TRACE( trace_comment, "A record is already open for reading." );
+        MBEDTLS_MPS_TRACE( trace_comment, "A record is already open for reading." );
     }
     else
     {
@@ -1613,9 +1613,9 @@ int mps_l2_read_start( mbedtls_mps_l2 *ctx, mps_l2_in *in )
         {
             ret = l2_handle_invalid_record( ctx, ret );
             if( ret != 0 )
-                RETURN( ret );
+                MBEDTLS_MPS_TRACE_RETURN( ret );
 
-            TRACE( trace_comment, "Signal that the processing should be retried." );
+            MBEDTLS_MPS_TRACE( trace_comment, "Signal that the processing should be retried." );
             /* We could return MBEDTLS_ERR_MPS_WANT_READ here, indicating that
              * progress can _only_ be made through additional data on the
              * underlying transport (which is the case here because we have
@@ -1623,7 +1623,7 @@ int mps_l2_read_start( mbedtls_mps_l2 *ctx, mps_l2_in *in )
              * only be made once another datagram is available).
              * However, this non-locally depends on Layer 1 not buffering
              * more than one datagram and is hence slightly fragile. */
-            RETURN( MBEDTLS_ERR_MPS_RETRY );
+            MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_RETRY );
         }
 #else
         ((void) mode);
@@ -1645,7 +1645,7 @@ int mps_l2_read_start( mbedtls_mps_l2 *ctx, mps_l2_in *in )
          */
 
         if( ret != 0 )
-            RETURN( ret );
+            MBEDTLS_MPS_TRACE_RETURN( ret );
 
         /*
          * Update record sequence numbers and replay protection.
@@ -1653,13 +1653,13 @@ int mps_l2_read_start( mbedtls_mps_l2 *ctx, mps_l2_in *in )
 
         ret = l2_in_update_counter( ctx, rec.epoch, rec.ctr[0], rec.ctr[1] );
         if( ret != 0 )
-            RETURN( ret );
+            MBEDTLS_MPS_TRACE_RETURN( ret );
 
         /* Feed record content in a suitable slot. */
         ret = l2_handle_record_content( ctx, &rec );
         if( ret != 0 )
         {
-            RETURN( ret );
+            MBEDTLS_MPS_TRACE_RETURN( ret );
         }
     }
 
@@ -1685,8 +1685,8 @@ int mps_l2_read_start( mbedtls_mps_l2 *ctx, mps_l2_in *in )
 
     if( l2_epoch_check( ctx, active->epoch, MPS_EPOCH_READ_MASK ) != 0 )
     {
-        TRACE( trace_error, "Content piggy-backing in record with old epoch." );
-        RETURN( MBEDTLS_ERR_MPS_INVALID_CONTENT );
+        MBEDTLS_MPS_TRACE( trace_error, "Content piggy-backing in record with old epoch." );
+        MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_INVALID_CONTENT );
     }
 
     in->type  = active->type;
@@ -1694,7 +1694,7 @@ int mps_l2_read_start( mbedtls_mps_l2 *ctx, mps_l2_in *in )
     in->rd    = &active->rd;
 
     active->state = MBEDTLS_MPS_L2_READER_STATE_EXTERNAL;
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
 MBEDTLS_MPS_STATIC
@@ -1702,13 +1702,13 @@ int l2_in_release_record( mbedtls_mps_l2 *ctx )
 {
     int ret;
     mps_l1* const l1 = mbedtls_mps_l2_get_l1( ctx );
-    TRACE_INIT( "l2_in_release_record" );
+    MBEDTLS_MPS_TRACE_INIT( "l2_in_release_record" );
 
     ret = mps_l1_consume( l1 );
     if( ret != 0 )
-        RETURN( ret );
+        MBEDTLS_MPS_TRACE_RETURN( ret );
 
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
 MBEDTLS_MPS_STATIC
@@ -1717,7 +1717,7 @@ int l2_in_fetch_record( mbedtls_mps_l2 *ctx, mps_rec *rec )
     int ret;
     mbedtls_mps_l2_epoch_t *epoch;
 
-    TRACE_INIT( "l2_in_fetch_record" );
+    MBEDTLS_MPS_TRACE_INIT( "l2_in_fetch_record" );
 
     /*
      * Remarks regarding record header parsing
@@ -1763,27 +1763,27 @@ int l2_in_fetch_record( mbedtls_mps_l2 *ctx, mps_rec *rec )
      */
 
     if( ( ret = l2_in_fetch_protected_record( ctx, rec ) ) != 0 )
-        RETURN( ret );
+        MBEDTLS_MPS_TRACE_RETURN( ret );
 
     /*
      * Step 2: Decrypt and authenticate record
      */
 
-    TRACE( trace_comment, "Decrypt and authenticate record for epoch %u",
+    MBEDTLS_MPS_TRACE( trace_comment, "Decrypt and authenticate record for epoch %u",
            (unsigned) rec->epoch );
 
     if( ( ret = l2_epoch_lookup( ctx, rec->epoch,
                                  &epoch ) ) != 0 )
     {
-        TRACE( trace_comment, "Epoch lookup failed with: %d", (int) ret );
-        RETURN( ret );
+        MBEDTLS_MPS_TRACE( trace_comment, "Epoch lookup failed with: %d", (int) ret );
+        MBEDTLS_MPS_TRACE_RETURN( ret );
     }
 
     ret = mbedtls_mps_transform_decrypt( epoch->transform, rec );
     if( ret != 0 )
     {
-        TRACE( trace_comment, "Decryption failed with: %d", (int) ret );
-        RETURN( ret );
+        MBEDTLS_MPS_TRACE( trace_comment, "Decryption failed with: %d", (int) ret );
+        MBEDTLS_MPS_TRACE_RETURN( ret );
     }
 
     /* Validate plaintext length */
@@ -1791,7 +1791,7 @@ int l2_in_fetch_record( mbedtls_mps_l2 *ctx, mps_rec *rec )
         mbedtls_mps_l2_conf_get_max_plain_in( &ctx->conf ) )
     {
         /* TODO: Release the record */
-        RETURN( MBEDTLS_ERR_MPS_INVALID_RECORD );
+        MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_INVALID_RECORD );
     }
 
     /*
@@ -1802,9 +1802,9 @@ int l2_in_fetch_record( mbedtls_mps_l2 *ctx, mps_rec *rec )
      */
     if( l2_type_is_valid( ctx, rec->type ) == 0 )
     {
-        TRACE( trace_error, "Invalid record type received" );
+        MBEDTLS_MPS_TRACE( trace_error, "Invalid record type received" );
         /* TODO: Release the record? */
-        RETURN( MBEDTLS_ERR_MPS_INVALID_RECORD );
+        MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_INVALID_RECORD );
     }
 
     /*
@@ -1815,7 +1815,7 @@ int l2_in_fetch_record( mbedtls_mps_l2 *ctx, mps_rec *rec )
     if( rec->buf.data_len == 0 )
     {
         if( l2_type_empty_allowed( ctx, rec->type ) == 0 )
-            RETURN( MBEDTLS_ERR_MPS_INVALID_RECORD );
+            MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_INVALID_RECORD );
 
         /* TODO: Should we return WANT_READ here? Is there a reason
          * why empty records would be forwarded to the user?
@@ -1824,7 +1824,7 @@ int l2_in_fetch_record( mbedtls_mps_l2 *ctx, mps_rec *rec )
          * Layer 2 boundary. */
     }
 
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
 MBEDTLS_MPS_STATIC
@@ -1833,7 +1833,7 @@ int l2_in_fetch_protected_record( mbedtls_mps_l2 *ctx, mps_rec *rec )
     mbedtls_mps_transport_type const mode =
         mbedtls_mps_l2_conf_get_mode( &ctx->conf );
 
-    TRACE_INIT( "l2_in_fetch_protected_record" );
+    MBEDTLS_MPS_TRACE_INIT( "l2_in_fetch_protected_record" );
 
 #if defined(MBEDTLS_MPS_PROTO_TLS)
     MBEDTLS_MPS_IF_TLS( mode )
@@ -1845,7 +1845,7 @@ int l2_in_fetch_protected_record( mbedtls_mps_l2 *ctx, mps_rec *rec )
          * Note padding is treated entirely separatedly from encryption
          * and authentication, while for the use of CBC in earlier versions,
          * it was part of CBC, and AEAD didn't allow padding at all. */
-        RETURN( l2_in_fetch_protected_record_tls( ctx, rec ) );
+        MBEDTLS_MPS_TRACE_RETURN( l2_in_fetch_protected_record_tls( ctx, rec ) );
     }
 #endif /* MBEDTLS_MPS_PROTO_TLS */
 #if defined(MBEDTLS_MPS_PROTO_DTLS)
@@ -1860,7 +1860,7 @@ int l2_in_fetch_protected_record( mbedtls_mps_l2 *ctx, mps_rec *rec )
 
         /* Only handle DTLS 1.0 and 1.2 for the moment,
          * which have a uniform and simple record header. */
-        RETURN( l2_in_fetch_protected_record_dtls12( ctx, rec ) );
+        MBEDTLS_MPS_TRACE_RETURN( l2_in_fetch_protected_record_dtls12( ctx, rec ) );
     }
 #endif /* MBEDTLS_MPS_PROTO_DTLS */
 }
@@ -1880,12 +1880,12 @@ mbedtls_mps_size_t l2_get_header_len( mbedtls_mps_l2 *ctx,
 #endif /* MBEDTLS_MPS_PROTO_TLS */
 
     ((void) epoch);
-    TRACE_INIT( "l2_get_header_len, %d", epoch );
+    MBEDTLS_MPS_TRACE_INIT( "l2_get_header_len, %d", epoch );
 
 #if defined(MBEDTLS_MPS_PROTO_TLS)
     MBEDTLS_MPS_IF_TLS( mode )
     {
-        RETURN( tls12_rec_hdr_len );
+        MBEDTLS_MPS_TRACE_RETURN( tls12_rec_hdr_len );
     }
 #endif /* MBEDTLS_MPS_PROTO_TLS */
 #if defined(MBEDTLS_MPS_PROTO_DTLS)
@@ -1905,7 +1905,7 @@ mbedtls_mps_size_t l2_get_header_len( mbedtls_mps_l2 *ctx,
 
         /* Only handle DTLS 1.0 and 1.2 for the moment,
          * which have a uniform and simple record header. */
-        RETURN( dtls12_rec_hdr_len );
+        MBEDTLS_MPS_TRACE_RETURN( dtls12_rec_hdr_len );
     }
 #endif /* MBEDTLS_MPS_PROTO_DTLS */
 }
@@ -1981,7 +1981,7 @@ int l2_in_fetch_protected_record_tls( mbedtls_mps_l2 *ctx, mps_rec *rec )
     mbedtls_mps_msg_type_t type;
     uint16_t len;
 
-    TRACE_INIT( "l2_in_fetch_protected_record_tls" );
+    MBEDTLS_MPS_TRACE_INIT( "l2_in_fetch_protected_record_tls" );
 
     /*
      * Fetch TLS record header from Layer 1
@@ -1989,7 +1989,7 @@ int l2_in_fetch_protected_record_tls( mbedtls_mps_l2 *ctx, mps_rec *rec )
 
     ret = mps_l1_fetch( l1, &buf, tls_rec_hdr_len );
     if( ret != 0 )
-        RETURN( ret );
+        MBEDTLS_MPS_TRACE_RETURN( ret );
 
     /*
      * Read header fields
@@ -2012,9 +2012,9 @@ int l2_in_fetch_protected_record_tls( mbedtls_mps_l2 *ctx, mps_rec *rec )
 
     if( major_ver != MBEDTLS_SSL_MAJOR_VERSION_3 )
     {
-        TRACE( trace_error, "Invalid major record version %u received, expected %u",
+        MBEDTLS_MPS_TRACE( trace_error, "Invalid major record version %u received, expected %u",
                (unsigned) major_ver, (unsigned) MBEDTLS_SSL_MAJOR_VERSION_3 );
-        RETURN( MBEDTLS_ERR_MPS_INVALID_RECORD );
+        MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_INVALID_RECORD );
     }
 
     /* Initially, the server doesn't know which TLS version
@@ -2032,10 +2032,10 @@ int l2_in_fetch_protected_record_tls( mbedtls_mps_l2 *ctx, mps_rec *rec )
     if( l2_version_wire_matches_logical( minor_ver,
                   mbedtls_mps_l2_conf_get_version( &ctx->conf ) ) != 1 )
     {
-        TRACE( trace_error, "Invalid minor record version %u received, expected %u",
+        MBEDTLS_MPS_TRACE( trace_error, "Invalid minor record version %u received, expected %u",
                (unsigned) minor_ver,
                mbedtls_mps_l2_conf_get_version( &ctx->conf ) );
-        RETURN( MBEDTLS_ERR_MPS_INVALID_RECORD );
+        MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_INVALID_RECORD );
     }
 
     /* Length */
@@ -2050,7 +2050,7 @@ int l2_in_fetch_protected_record_tls( mbedtls_mps_l2 *ctx, mps_rec *rec )
      */
     ret = mps_l1_fetch( l1, &buf, tls_rec_hdr_len + len );
     if( ret != 0 )
-        RETURN( ret );
+        MBEDTLS_MPS_TRACE_RETURN( ret );
 
     /*
      * Check if the record should be silently ignored.
@@ -2061,14 +2061,14 @@ int l2_in_fetch_protected_record_tls( mbedtls_mps_l2 *ctx, mps_rec *rec )
      */
     if( l2_type_ignore( ctx, type ) == 1 )
     {
-        TRACE( trace_comment, "Silently ignore record of type %u",
+        MBEDTLS_MPS_TRACE( trace_comment, "Silently ignore record of type %u",
                (unsigned) type );
 
         ret = l2_in_release_record( ctx );
         if( ret != 0 )
-            RETURN( ret );
+            MBEDTLS_MPS_TRACE_RETURN( ret );
 
-        RETURN( MBEDTLS_ERR_MPS_RETRY );
+        MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_RETRY );
     }
 
     /*
@@ -2088,10 +2088,10 @@ int l2_in_fetch_protected_record_tls( mbedtls_mps_l2 *ctx, mps_rec *rec )
 
     ret = l2_tls_in_get_epoch_and_counter( ctx, &rec->epoch, rec->ctr );
     if( ret != 0 )
-        RETURN( ret );
+        MBEDTLS_MPS_TRACE_RETURN( ret );
 
-    TRACE( trace_comment, "* Record epoch:  %u", (unsigned) rec->epoch );
-    TRACE( trace_comment, "* Record number: ( %u << 32 ) + %u ",
+    MBEDTLS_MPS_TRACE( trace_comment, "* Record epoch:  %u", (unsigned) rec->epoch );
+    MBEDTLS_MPS_TRACE( trace_comment, "* Record number: ( %u << 32 ) + %u ",
            (unsigned) rec->ctr[0], (unsigned) rec->ctr[1] );
 
     rec->type      = type;
@@ -2103,7 +2103,7 @@ int l2_in_fetch_protected_record_tls( mbedtls_mps_l2 *ctx, mps_rec *rec )
     rec->buf.data_offset = 0;
     rec->buf.data_len    = len;
 
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 #endif /* MBEDTLS_MPS_PROTO_TLS */
 
@@ -2193,17 +2193,17 @@ int l2_tls_in_get_epoch_and_counter( mbedtls_mps_l2 *ctx,
     int ret;
     mbedtls_mps_l2_epoch_t *epoch;
     mbedtls_mps_epoch_id default_in;
-    TRACE_INIT( "l2_tls_in_get_epoch_and_counter" );
+    MBEDTLS_MPS_TRACE_INIT( "l2_tls_in_get_epoch_and_counter" );
 
     default_in = ctx->epochs.default_in;
     ret = l2_epoch_lookup( ctx, default_in, &epoch );
     if( ret != 0 )
-        RETURN( ret );
+        MBEDTLS_MPS_TRACE_RETURN( ret );
 
     dst_ctr[0] = epoch->stats.tls.in_ctr[0];
     dst_ctr[1] = epoch->stats.tls.in_ctr[1];
     *dst_epoch = default_in;
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 #endif /* MBEDTLS_MPS_PROTO_TLS */
 
@@ -2271,7 +2271,7 @@ int l2_in_fetch_protected_record_dtls12( mbedtls_mps_l2 *ctx,
     uint32_t seq_nr[2];
     uint16_t len;
 
-    TRACE_INIT( "l2_in_fetch_protected_record_dtls12" );
+    MBEDTLS_MPS_TRACE_INIT( "l2_in_fetch_protected_record_dtls12" );
 
     /*
      * Fetch DTLS record header from Layer 1
@@ -2279,7 +2279,7 @@ int l2_in_fetch_protected_record_dtls12( mbedtls_mps_l2 *ctx,
 
     ret = mps_l1_fetch( l1, &buf, dtls_rec_hdr_len );
     if( ret != 0 )
-        RETURN( ret );
+        MBEDTLS_MPS_TRACE_RETURN( ret );
 
     /*
      * Read and validate header fields
@@ -2300,8 +2300,8 @@ int l2_in_fetch_protected_record_dtls12( mbedtls_mps_l2 *ctx,
     MPS_READ_UINT8_BE( buf + dtls_rec_type_offset, &type );
     if( l2_type_is_valid( ctx, type ) == 0 )
     {
-        TRACE( trace_error, "Invalid record type received" );
-        RETURN( MBEDTLS_ERR_MPS_INVALID_RECORD );
+        MBEDTLS_MPS_TRACE( trace_error, "Invalid record type received" );
+        MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_INVALID_RECORD );
     }
     rec->type = type;
 
@@ -2310,19 +2310,19 @@ int l2_in_fetch_protected_record_dtls12( mbedtls_mps_l2 *ctx,
                           buf + dtls_rec_ver_offset );
     if( major_ver != MBEDTLS_SSL_MAJOR_VERSION_3 )
     {
-        TRACE( trace_error, "Invalid major record version %u received, expected %u",
+        MBEDTLS_MPS_TRACE( trace_error, "Invalid major record version %u received, expected %u",
                (unsigned) major_ver, (unsigned) MBEDTLS_SSL_MAJOR_VERSION_3 );
-        RETURN( MBEDTLS_ERR_MPS_INVALID_RECORD );
+        MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_INVALID_RECORD );
     }
     if( mbedtls_mps_l2_conf_get_version( &ctx->conf ) !=
           MBEDTLS_MPS_L2_VERSION_UNSPECIFIED &&
         mbedtls_mps_l2_conf_get_version( &ctx->conf ) !=
           minor_ver )
     {
-        TRACE( trace_error, "Invalid minor record version %u received, expected %u",
+        MBEDTLS_MPS_TRACE( trace_error, "Invalid minor record version %u received, expected %u",
                (unsigned) minor_ver,
                (unsigned) mbedtls_mps_l2_conf_get_version( &ctx->conf ) );
-        RETURN( MBEDTLS_ERR_MPS_INVALID_RECORD );
+        MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_INVALID_RECORD );
     }
     rec->major_ver = major_ver;
     rec->minor_ver = minor_ver;
@@ -2333,7 +2333,7 @@ int l2_in_fetch_protected_record_dtls12( mbedtls_mps_l2 *ctx,
     if( ret == MBEDTLS_ERR_MPS_INVALID_EPOCH )
         ret = MBEDTLS_ERR_MPS_INVALID_RECORD;
     if ( ret != 0 )
-        RETURN( ret );
+        MBEDTLS_MPS_TRACE_RETURN( ret );
     rec->epoch = epoch;
 
     /* Record sequence number */
@@ -2342,8 +2342,8 @@ int l2_in_fetch_protected_record_dtls12( mbedtls_mps_l2 *ctx,
 
     if( l2_counter_replay_check( ctx, epoch, seq_nr[0], seq_nr[1] ) != 0 )
     {
-        TRACE( trace_error, "Replayed record -- ignore" );
-        RETURN( MBEDTLS_ERR_MPS_REPLAYED_RECORD );
+        MBEDTLS_MPS_TRACE( trace_error, "Replayed record -- ignore" );
+        MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_REPLAYED_RECORD );
     }
     rec->ctr[0] = seq_nr[0];
     rec->ctr[1] = seq_nr[1];
@@ -2362,21 +2362,21 @@ int l2_in_fetch_protected_record_dtls12( mbedtls_mps_l2 *ctx,
     ret = mps_l1_fetch( l1, &buf, dtls_rec_hdr_len + len );
     if( ret == MBEDTLS_ERR_MPS_REQUEST_OUT_OF_BOUNDS )
     {
-        TRACE( trace_error, "Claimed record length exceeds datagram bounds." );
+        MBEDTLS_MPS_TRACE( trace_error, "Claimed record length exceeds datagram bounds." );
         ret = MBEDTLS_ERR_MPS_INVALID_RECORD;
     }
     if( ret != 0 )
-        RETURN( ret );
+        MBEDTLS_MPS_TRACE_RETURN( ret );
 
     rec->buf.buf         = buf + dtls_rec_hdr_len;
     rec->buf.buf_len     = len;
     rec->buf.data_offset = 0;
     rec->buf.data_len    = len;
 
-    TRACE( trace_comment, "* Record epoch:  %u", (unsigned) rec->epoch );
-    TRACE( trace_comment, "* Record number: ( %u << 32 ) + %u",
+    MBEDTLS_MPS_TRACE( trace_comment, "* Record epoch:  %u", (unsigned) rec->epoch );
+    MBEDTLS_MPS_TRACE( trace_comment, "* Record number: ( %u << 32 ) + %u",
            (unsigned) rec->ctr[0], (unsigned) rec->ctr[1] );
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
 int l2_in_fetch_protected_record_dtls13( mbedtls_mps_l2 *ctx,
@@ -2455,7 +2455,7 @@ int l2_in_fetch_protected_record_dtls13( mbedtls_mps_l2 *ctx,
 
     ((void) dtls_13_stable_hdr_epoch_mask); /* TODO: Implement epoch parsing. */
 
-    TRACE_INIT( "l2_in_fetch_protected_record_dtls12" );
+    MBEDTLS_MPS_TRACE_INIT( "l2_in_fetch_protected_record_dtls12" );
 
     /*
      * Fetch DTLS record header from Layer 1
@@ -2463,14 +2463,14 @@ int l2_in_fetch_protected_record_dtls13( mbedtls_mps_l2 *ctx,
 
     ret = mps_l1_fetch( l1, &buf, dtls_13_stable_hdr_len );
     if( ret != 0 )
-        RETURN( ret );
+        MBEDTLS_MPS_TRACE_RETURN( ret );
 
     stable_hdr_val = *buf;
     if( ( stable_hdr_val & dtls_13_stable_hdr_magic_mask ) !=
         dtls_13_stable_hdr_magic_bits )
     {
         /* Assume a DTLS 1.2 record header. */
-        RETURN( l2_in_fetch_protected_record_dtls13( ctx, rec ) );
+        MBEDTLS_MPS_TRACE_RETURN( l2_in_fetch_protected_record_dtls13( ctx, rec ) );
     }
 
     /* Determine total length of DTLS 1.3 header. */
@@ -2497,7 +2497,7 @@ int l2_in_fetch_protected_record_dtls13( mbedtls_mps_l2 *ctx,
 
     /* TODO: Finish */
 
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
 #endif /* MBEDTLS_MPS_PROTO_DTLS */
@@ -2596,22 +2596,22 @@ int mps_l2_epoch_add( mbedtls_mps_l2 *ctx,
 {
     uint8_t next_offset;
     mbedtls_mps_l2_epoch_t *epoch;
-    TRACE_INIT( "mps_l2_epoch_add" );
+    MBEDTLS_MPS_TRACE_INIT( "mps_l2_epoch_add" );
 
     next_offset = ctx->epochs.next;
 
     if( ctx->epochs.next > MBEDTLS_MPS_EPOCH_MAX )
     {
-        TRACE( trace_error, "Maximum number %u of epochs reached.",
+        MBEDTLS_MPS_TRACE( trace_error, "Maximum number %u of epochs reached.",
                (unsigned) MBEDTLS_MPS_L2_EPOCH_WINDOW_SIZE );
-        RETURN( MBEDTLS_ERR_MPS_TOO_MANY_EPOCHS );
+        MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_TOO_MANY_EPOCHS );
     }
 
     if( next_offset == MBEDTLS_MPS_L2_EPOCH_WINDOW_SIZE )
     {
-        TRACE( trace_error, "The epoch window (size %u) is full.",
+        MBEDTLS_MPS_TRACE( trace_error, "The epoch window (size %u) is full.",
                (unsigned) MBEDTLS_MPS_L2_EPOCH_WINDOW_SIZE );
-        RETURN( MBEDTLS_ERR_MPS_TOO_MANY_LIVE_EPOCHS );
+        MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_TOO_MANY_LIVE_EPOCHS );
     }
     *epoch_id = ctx->epochs.base + next_offset;
 
@@ -2622,8 +2622,8 @@ int mps_l2_epoch_add( mbedtls_mps_l2 *ctx,
 
     ctx->epochs.next++;
 
-    TRACE( trace_comment, "New epoch: %u", (unsigned) *epoch_id );
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE( trace_comment, "New epoch: %u", (unsigned) *epoch_id );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
 int mps_l2_epoch_usage( mbedtls_mps_l2 *ctx,
@@ -2636,10 +2636,10 @@ int mps_l2_epoch_usage( mbedtls_mps_l2 *ctx,
     mbedtls_mps_transport_type const mode =
         mbedtls_mps_l2_conf_get_mode( &ctx->conf );
 
-    TRACE_INIT( "mps_l2_epoch_usage" );
-    TRACE( trace_comment, "* Epoch: %d", epoch_id );
-    TRACE( trace_comment, "* Clear: %u", (unsigned) clear );
-    TRACE( trace_comment, "* Set:   %u", (unsigned) set );
+    MBEDTLS_MPS_TRACE_INIT( "mps_l2_epoch_usage" );
+    MBEDTLS_MPS_TRACE( trace_comment, "* Epoch: %d", epoch_id );
+    MBEDTLS_MPS_TRACE( trace_comment, "* Clear: %u", (unsigned) clear );
+    MBEDTLS_MPS_TRACE( trace_comment, "* Set:   %u", (unsigned) set );
 
     MBEDTLS_MPS_STATE_VALIDATE_RAW(
         ctx->io.out.state != MBEDTLS_MPS_L2_WRITER_STATE_EXTERNAL,
@@ -2655,11 +2655,11 @@ int mps_l2_epoch_usage( mbedtls_mps_l2 *ctx,
 
     /* Silently ignore requests to remove flags for invalid epochs. */
     if( ret == MBEDTLS_ERR_MPS_INVALID_EPOCH && set == 0 )
-        RETURN( 0 );
+        MBEDTLS_MPS_TRACE_RETURN( 0 );
     if( ret != 0 )
-        RETURN( ret );
+        MBEDTLS_MPS_TRACE_RETURN( ret );
 
-    TRACE( trace_comment, "* Old:   %04x", (unsigned) epoch->usage );
+    MBEDTLS_MPS_TRACE( trace_comment, "* Old:   %04x", (unsigned) epoch->usage );
 
 #if defined(MBEDTLS_MPS_PROTO_TLS)
     /* In TLS, there's at most one epoch holding read permissions;
@@ -2669,7 +2669,7 @@ int mps_l2_epoch_usage( mbedtls_mps_l2 *ctx,
         uint8_t offset;
         for( offset = 0; offset < ctx->epochs.next; offset++ )
         {
-            TRACE( trace_comment,
+            MBEDTLS_MPS_TRACE( trace_comment,
                    "Modify epoch %u usage from %#x to %#x",
                    (unsigned) offset + ctx->epochs.base,
                    (unsigned) ctx->epochs.window[offset].usage,
@@ -2690,13 +2690,13 @@ int mps_l2_epoch_usage( mbedtls_mps_l2 *ctx,
 
         if( ( set & MPS_EPOCH_READ_MASK )  != 0 )
         {
-            TRACE( trace_comment, "Epoch %u the new incoming epoch",
+            MBEDTLS_MPS_TRACE( trace_comment, "Epoch %u the new incoming epoch",
                    (unsigned) epoch_id );
             ctx->epochs.default_in = epoch_id;
         }
         if( ( set & MPS_EPOCH_WRITE_MASK ) != 0 )
         {
-            TRACE( trace_comment, "Epoch %u the new outgoing epoch",
+            MBEDTLS_MPS_TRACE( trace_comment, "Epoch %u the new outgoing epoch",
                    (unsigned) epoch_id );
             ctx->epochs.default_out = epoch_id;
         }
@@ -2707,9 +2707,9 @@ int mps_l2_epoch_usage( mbedtls_mps_l2 *ctx,
 
     epoch->usage |= set;
     epoch->usage &= ~clear;
-    TRACE( trace_comment, "* New:   %04x", (unsigned) epoch->usage );
+    MBEDTLS_MPS_TRACE( trace_comment, "* New:   %04x", (unsigned) epoch->usage );
 
-    RETURN( l2_epoch_cleanup( ctx ) );
+    MBEDTLS_MPS_TRACE_RETURN( l2_epoch_cleanup( ctx ) );
 }
 
 /*
@@ -2724,24 +2724,24 @@ int l2_epoch_check( mbedtls_mps_l2 *ctx,
     int ret;
     mbedtls_mps_l2_epoch_t *epoch;
 
-    TRACE_INIT( "l2_epoch_check for epoch %d, purpose %s",
+    MBEDTLS_MPS_TRACE_INIT( "l2_epoch_check for epoch %d, purpose %s",
                 epoch_id,
                 l2_epoch_usage_to_string( purpose ) );
 
     ret = l2_epoch_lookup( ctx, epoch_id, &epoch );
     if( ret != 0 )
-        RETURN( ret );
+        MBEDTLS_MPS_TRACE_RETURN( ret );
 
     if( ( purpose & epoch->usage ) == 0 )
     {
-        TRACE( trace_comment, "Epoch %u has usage %s, but flag from %s is required.",
+        MBEDTLS_MPS_TRACE( trace_comment, "Epoch %u has usage %s, but flag from %s is required.",
                (unsigned) epoch_id,
                l2_epoch_usage_to_string( epoch->usage ),
                l2_epoch_usage_to_string( purpose ) );
-        RETURN( MBEDTLS_ERR_MPS_INVALID_RECORD );
+        MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_INVALID_RECORD );
     }
 
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
 /*
@@ -2761,30 +2761,30 @@ int l2_epoch_cleanup( mbedtls_mps_l2 *ctx )
 MBEDTLS_MPS_STATIC
 void l2_print_usage( unsigned usage )
 {
-#if defined(MBEDTLS_MPS_TRACE)
+#if defined(MBEDTLS_MPS_ENABLE_TRACE)
     if( ( usage & MPS_EPOCH_READ_MASK ) != 0 )
     {
-        TRACE( trace_comment,
+        MBEDTLS_MPS_TRACE( trace_comment,
                "* epoch can be used for reading." );
     }
     if( ( usage & MPS_EPOCH_WRITE_MASK ) != 0 )
     {
-        TRACE( trace_comment,
+        MBEDTLS_MPS_TRACE( trace_comment,
                "* epoch can be used for writing." );
     }
     if( ( usage & MPS_EPOCH_USAGE_INTERNAL_OUT_PROTECTED ) != 0 )
     {
-        TRACE( trace_comment,
+        MBEDTLS_MPS_TRACE( trace_comment,
                "* Epoch has been added but not yet configured." );
     }
     if( ( usage & MPS_EPOCH_USAGE_INTERNAL_OUT_RECORD_OPEN ) != 0 )
     {
-        TRACE( trace_comment,
+        MBEDTLS_MPS_TRACE( trace_comment,
                "* epoch has an outgoing record open." );
     }
 #else
     ((void) usage);
-#endif /* MBEDTLS_MPS_TRACE */
+#endif /* MBEDTLS_MPS_ENABLE_TRACE */
 }
 
 MBEDTLS_MPS_STATIC
@@ -2793,20 +2793,20 @@ int l2_epoch_cleanup( mbedtls_mps_l2 *ctx )
     uint8_t shift = 0, offset;
     mbedtls_mps_epoch_id max_shift;
 
-    TRACE_INIT( "l2_epoch_cleanup" );
+    MBEDTLS_MPS_TRACE_INIT( "l2_epoch_cleanup" );
 
     /* An epoch is in use if its flags are not empty. */
     for( offset = 0; offset < ctx->epochs.next; offset++ )
     {
         unsigned usage = ctx->epochs.window[offset].usage;
 
-        TRACE( trace_comment, "Checking epoch %u at window offset %u, usage %s",
+        MBEDTLS_MPS_TRACE( trace_comment, "Checking epoch %u at window offset %u, usage %s",
                (unsigned)( ctx->epochs.base + offset ), (unsigned) offset,
                l2_epoch_usage_to_string( usage ) );
 
         if( usage == 0 )
         {
-            TRACE( trace_comment, "* no longer needed" );
+            MBEDTLS_MPS_TRACE( trace_comment, "* no longer needed" );
             l2_epoch_free( &ctx->epochs.window[offset] );
         }
         else
@@ -2820,26 +2820,26 @@ int l2_epoch_cleanup( mbedtls_mps_l2 *ctx )
 
     if( shift == 0 )
     {
-        TRACE( trace_comment, "Cannot get rid of any epoch." );
-        RETURN( 0 );
+        MBEDTLS_MPS_TRACE( trace_comment, "Cannot get rid of any epoch." );
+        MBEDTLS_MPS_TRACE_RETURN( 0 );
     }
 
     max_shift = MBEDTLS_MPS_EPOCH_MAX -
         ( ctx->epochs.base + MBEDTLS_MPS_L2_EPOCH_WINDOW_SIZE );
     if( shift >= max_shift )
     {
-        TRACE( trace_comment, "Cannot shift epoch window further." );
+        MBEDTLS_MPS_TRACE( trace_comment, "Cannot shift epoch window further." );
         shift = max_shift;
     }
 
-    TRACE( trace_comment, "Can get rid of the first %u epochs; clearing.",
+    MBEDTLS_MPS_TRACE( trace_comment, "Can get rid of the first %u epochs; clearing.",
            (unsigned) shift );
 
     ctx->epochs.base += shift;
     ctx->epochs.next -= shift;
 
-    TRACE( trace_comment, "* New base: %u", (unsigned) ctx->epochs.base );
-    TRACE( trace_comment, "* New next: %u", (unsigned) ctx->epochs.next );
+    MBEDTLS_MPS_TRACE( trace_comment, "* New base: %u", (unsigned) ctx->epochs.base );
+    MBEDTLS_MPS_TRACE( trace_comment, "* New next: %u", (unsigned) ctx->epochs.next );
 
     /* Shift epochs. */
     for( offset = 0; offset < MBEDTLS_MPS_L2_EPOCH_WINDOW_SIZE; offset++ )
@@ -2850,8 +2850,8 @@ int l2_epoch_cleanup( mbedtls_mps_l2 *ctx )
             l2_epoch_init( &ctx->epochs.window[offset] );
     }
 
-    TRACE( trace_comment, "Epoch cleanup done" );
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE( trace_comment, "Epoch cleanup done" );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 #endif /* MBEDTLS_MPS_L2_EPOCH_WINDOW_SHIFTING */
 
@@ -2861,34 +2861,34 @@ int l2_epoch_lookup( mbedtls_mps_l2 *ctx,
                      mbedtls_mps_l2_epoch_t **epoch )
 {
     uint8_t epoch_offset;
-    TRACE_INIT( "l2_epoch_lookup" );
-    TRACE( trace_comment, "* Epoch:  %d", epoch_id );
+    MBEDTLS_MPS_TRACE_INIT( "l2_epoch_lookup" );
+    MBEDTLS_MPS_TRACE( trace_comment, "* Epoch:  %d", epoch_id );
 
     if( epoch_id == MBEDTLS_MPS_EPOCH_NONE )
     {
-        TRACE( trace_comment, "The epoch is unset." );
-        RETURN( MBEDTLS_ERR_MPS_INVALID_EPOCH );
+        MBEDTLS_MPS_TRACE( trace_comment, "The epoch is unset." );
+        MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_INVALID_EPOCH );
     }
     else if( epoch_id < ctx->epochs.base )
     {
-        TRACE( trace_comment, "The epoch %u is below the epoch base %u.",
+        MBEDTLS_MPS_TRACE( trace_comment, "The epoch %u is below the epoch base %u.",
                (unsigned) epoch_id, (unsigned) ctx->epochs.base );
-        RETURN( MBEDTLS_ERR_MPS_INVALID_EPOCH );
+        MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_INVALID_EPOCH );
     }
 
     epoch_offset = epoch_id - ctx->epochs.base;
-    TRACE( trace_comment, "* Offset: %u", (unsigned) epoch_offset );
+    MBEDTLS_MPS_TRACE( trace_comment, "* Offset: %u", (unsigned) epoch_offset );
 
     if( epoch_offset >= ctx->epochs.next )
     {
-        TRACE( trace_error, "The epoch is outside the epoch window." );
-        RETURN( MBEDTLS_ERR_MPS_INVALID_EPOCH );
+        MBEDTLS_MPS_TRACE( trace_error, "The epoch is outside the epoch window." );
+        MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_INVALID_EPOCH );
     }
 
     if( epoch != NULL )
         *epoch = &ctx->epochs.window[ epoch_offset ];
 
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
 /*
@@ -2910,12 +2910,12 @@ int l2_counter_replay_check( mbedtls_mps_l2 *ctx,
     mbedtls_mps_transport_type const mode =
         mbedtls_mps_l2_conf_get_mode( &ctx->conf );
 
-    TRACE_INIT( "l2_counter_replay_check, epoch %u",
+    MBEDTLS_MPS_TRACE_INIT( "l2_counter_replay_check, epoch %u",
                 (unsigned) epoch_id );
 
 #if defined(MBEDTLS_MPS_PROTO_TLS)
     if( MBEDTLS_MPS_IS_TLS( mode ) )
-        RETURN( 0 );
+        MBEDTLS_MPS_TRACE_RETURN( 0 );
 #else
     ((void) mode);
 #endif /* MBEDTLS_MPS_PROTO_TLS */
@@ -2923,37 +2923,37 @@ int l2_counter_replay_check( mbedtls_mps_l2 *ctx,
     if( mbedtls_mps_l2_conf_get_anti_replay( &ctx->conf )
         == MBEDTLS_MPS_ANTI_REPLAY_DISABLED )
     {
-        RETURN( 0 );
+        MBEDTLS_MPS_TRACE_RETURN( 0 );
     }
 
     ret = l2_epoch_lookup( ctx, epoch_id, &epoch );
     if( ret != 0 )
-        RETURN( ret );
+        MBEDTLS_MPS_TRACE_RETURN( ret );
 
     window_top_hi = epoch->stats.dtls.replay.in_window_top_hi;
     window_top_lo = epoch->stats.dtls.replay.in_window_top_lo;
-    TRACE( trace_comment, "* Window top hi:  %u", window_top_hi );
-    TRACE( trace_comment, "* Window top lo:  %u", window_top_lo );
-    TRACE( trace_comment, "* Counter top hi: %u", ctr_hi );
-    TRACE( trace_comment, "* Counter top lo: %u", ctr_lo );
+    MBEDTLS_MPS_TRACE( trace_comment, "* Window top hi:  %u", window_top_hi );
+    MBEDTLS_MPS_TRACE( trace_comment, "* Window top lo:  %u", window_top_lo );
+    MBEDTLS_MPS_TRACE( trace_comment, "* Counter top hi: %u", ctr_hi );
+    MBEDTLS_MPS_TRACE( trace_comment, "* Counter top lo: %u", ctr_lo );
 
     if( ctr_hi > window_top_hi )
     {
-        TRACE( trace_comment, "Record sequence number larger than everything seen so far." );
-        RETURN( 0 );
+        MBEDTLS_MPS_TRACE( trace_comment, "Record sequence number larger than everything seen so far." );
+        MBEDTLS_MPS_TRACE_RETURN( 0 );
     }
     else if( ctr_hi < window_top_hi )
     {
         /* Don't maintain window across 32-bit boundaries. */
-        TRACE( trace_comment, "Record sequence number too old -- drop" );
-        RETURN( -1 );
+        MBEDTLS_MPS_TRACE( trace_comment, "Record sequence number too old -- drop" );
+        MBEDTLS_MPS_TRACE_RETURN( -1 );
     }
     else if( ctr_lo > window_top_lo )
-        RETURN( 0 );
+        MBEDTLS_MPS_TRACE_RETURN( 0 );
 
     bit = window_top_lo - ctr_lo;
     if( bit >= 32 )
-        RETURN( -1 );
+        MBEDTLS_MPS_TRACE_RETURN( -1 );
 
     /* Bit-reverse the window, so that bits corresponding to fresh
      * sequence numbers are set. */
@@ -2961,10 +2961,10 @@ int l2_counter_replay_check( mbedtls_mps_l2 *ctx,
 
     window >>= bit;
     if( ( window & 0x1 ) == 0 )
-        RETURN( -1 );
+        MBEDTLS_MPS_TRACE_RETURN( -1 );
 
-    TRACE( trace_comment, "Record sequence number within window and not seen so far." );
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE( trace_comment, "Record sequence number within window and not seen so far." );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 #endif /* MBEDTLS_MPS_PROTO_DTLS */
 
@@ -2976,7 +2976,7 @@ int mps_l2_force_next_sequence_number( mbedtls_mps_l2 *ctx,
     int ret;
     mbedtls_mps_l2_epoch_t *epoch;
 
-    TRACE_INIT( "mps_l2_force_next_sequence_number, epoch %u, ctr %u",
+    MBEDTLS_MPS_TRACE_INIT( "mps_l2_force_next_sequence_number, epoch %u, ctr %u",
                 (unsigned) epoch_id, (unsigned) ctr );
 
     MBEDTLS_MPS_STATE_VALIDATE_RAW(
@@ -2985,11 +2985,11 @@ int mps_l2_force_next_sequence_number( mbedtls_mps_l2 *ctx,
 
     ret = l2_epoch_lookup( ctx, epoch_id, &epoch );
     if( ret != 0 )
-        RETURN( ret );
+        MBEDTLS_MPS_TRACE_RETURN( ret );
 
     epoch->stats.dtls.out_ctr[0] = (uint32_t)( ctr >> 32 );
     epoch->stats.dtls.out_ctr[1] = (uint32_t) ctr;
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
 int mps_l2_get_last_sequence_number( mbedtls_mps_l2 *ctx,
@@ -2998,7 +2998,7 @@ int mps_l2_get_last_sequence_number( mbedtls_mps_l2 *ctx,
 {
     int ret;
     mbedtls_mps_l2_epoch_t *epoch;
-    TRACE_INIT( "mps_l2_get_last_sequence_number, epoch %u",
+    MBEDTLS_MPS_TRACE_INIT( "mps_l2_get_last_sequence_number, epoch %u",
                 (unsigned) epoch_id );
 
     MBEDTLS_MPS_STATE_VALIDATE_RAW(
@@ -3007,11 +3007,11 @@ int mps_l2_get_last_sequence_number( mbedtls_mps_l2 *ctx,
 
     ret = l2_epoch_lookup( ctx, epoch_id, &epoch );
     if( ret != 0 )
-        RETURN( ret );
+        MBEDTLS_MPS_TRACE_RETURN( ret );
 
     *ctr  = ((uint64_t) epoch->stats.dtls.last_seen[0]) << 32;
     *ctr |=  (uint64_t) epoch->stats.dtls.last_seen[1];
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 #endif /* MBEDTLS_MPS_PROTO_TLS */
 

--- a/library/mps/layer2.c
+++ b/library/mps/layer2.c
@@ -251,7 +251,7 @@ int mps_l2_find_suitable_slot( mbedtls_mps_l2 *ctx,
         {
             if( mps_l2_readers_accumulator_taken( ctx ) == 0 )
             {
-                MBEDTLS_MPS_TRACE( trace_comment, "The accumulator (size %u) is available",
+                MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "The accumulator (size %u) is available",
                        (unsigned) ctx->io.in.acc_len );
                 acc = ctx->io.in.accumulator;
                 acc_len = ctx->io.in.acc_len;
@@ -259,14 +259,14 @@ int mps_l2_find_suitable_slot( mbedtls_mps_l2 *ctx,
             else
 #if !defined(MPS_L2_ALLOW_PAUSABLE_CONTENT_TYPE_WITHOUT_ACCUMULATOR)
             {
-                MBEDTLS_MPS_TRACE( trace_error,
+                MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR,
                        "The accumulator is not available, and don't allow "
                        "to open pausable content types without accumulator." );
                 MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_EXCESS_RECORD_FRAGMENTATION );
             }
 #else
             {
-                MBEDTLS_MPS_TRACE( trace_comment, "No accumulator is available, but open nonetheless." );
+                MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "No accumulator is available, but open nonetheless." );
             }
 #endif /* MPS_L2_ALLOW_PAUSABLE_CONTENT_TYPE_WITHOUT_ACCUMULATOR */
         }
@@ -278,7 +278,7 @@ int mps_l2_find_suitable_slot( mbedtls_mps_l2 *ctx,
     slot = mps_l2_readers_get_unused( ctx );
     if( slot == NULL )
     {
-        MBEDTLS_MPS_TRACE( trace_error, "No free reader available for the incoming record." );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR, "No free reader available for the incoming record." );
         MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_OPERATION_UNSUPPORTED );
     }
 
@@ -318,13 +318,13 @@ int mps_l2_init( mbedtls_mps_l2 *ctx, mps_l1 *l1,
 #if defined(MBEDTLS_MPS_PROTO_TLS)
     if( max_write > 0 )
     {
-        MBEDTLS_MPS_TRACE( trace_comment, "Allocating L2 writer queue of size %u Bytes",
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Allocating L2 writer queue of size %u Bytes",
                (unsigned) max_write );
         queue = malloc( max_write );
     }
     if( max_read > 0 )
     {
-        MBEDTLS_MPS_TRACE( trace_comment, "Allocating L2 reader accumulator of size %u Bytes",
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Allocating L2 reader accumulator of size %u Bytes",
                (unsigned) max_read );
         accumulator = malloc( max_read );
     }
@@ -332,7 +332,7 @@ int mps_l2_init( mbedtls_mps_l2 *ctx, mps_l1 *l1,
     if( ( max_write > 0  && queue       == NULL ) ||
         ( max_read  > 0  && accumulator == NULL ) )
     {
-        MBEDTLS_MPS_TRACE( trace_error, "Failed to allocate queue or accumulator." );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR, "Failed to allocate queue or accumulator." );
         free( queue );
         free( accumulator );
         MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_OUT_OF_MEMORY );
@@ -517,7 +517,7 @@ int l2_out_prepare_record( mbedtls_mps_l2 *ctx,
     ret = mps_l1_write( l1, &rec_buf, &total_sz );
     if( ret != 0 )
     {
-        MBEDTLS_MPS_TRACE( trace_comment, "l1_write failed with %d", ret );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "l1_write failed with %d", ret );
         MBEDTLS_MPS_TRACE_RETURN( ret );
     }
 
@@ -533,12 +533,12 @@ int l2_out_prepare_record( mbedtls_mps_l2 *ctx,
     if( ret != 0 )
         MBEDTLS_MPS_TRACE_RETURN( ret );
 
-    MBEDTLS_MPS_TRACE( trace_comment, "Transform expansion:" );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Transform expansion:" );
     mbedtls_mps_transform_get_expansion( epoch->transform,
                                          &pre_expansion,
                                          &post_expansion );
-    MBEDTLS_MPS_TRACE( trace_comment, "* Pre:  %u", (unsigned) pre_expansion  );
-    MBEDTLS_MPS_TRACE( trace_comment, "* Post: %u", (unsigned) post_expansion );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* Pre:  %u", (unsigned) pre_expansion  );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* Post: %u", (unsigned) post_expansion );
 
 #if defined(MBEDTLS_MPS_TRANSFORM_VALIDATION)
     {
@@ -549,7 +549,7 @@ int l2_out_prepare_record( mbedtls_mps_l2 *ctx,
 
         if( sum1 < sum0 || sum2 < sum1 )
         {
-            MBEDTLS_MPS_TRACE( trace_comment, "INTERNAL ERROR on pre- and postexpansion, len %u, pre-expansion %u, post-expansion %u",
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "INTERNAL ERROR on pre- and postexpansion, len %u, pre-expansion %u, post-expansion %u",
                    (unsigned) hdr_len, (unsigned) pre_expansion, (unsigned) post_expansion );
             MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_BAD_TRANSFORM );
         }
@@ -561,8 +561,8 @@ int l2_out_prepare_record( mbedtls_mps_l2 *ctx,
     if( hdr_len + pre_expansion + post_expansion >= total_sz )
     {
         mbedtls_mps_size_t bytes_pending;
-        MBEDTLS_MPS_TRACE( trace_comment, "Not enough space for to hold a non-empty record." );
-        MBEDTLS_MPS_TRACE( trace_comment, "Need at least %u ( %u header + %u pre-expansion + "
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Not enough space for to hold a non-empty record." );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Need at least %u ( %u header + %u pre-expansion + "
                               "%u post-expansion + 1 plaintext ) byte, but have only "
                               "%u bytes available.",
                (unsigned)( hdr_len + pre_expansion + post_expansion + 1 ),
@@ -610,10 +610,10 @@ int l2_out_prepare_record( mbedtls_mps_l2 *ctx,
 
     epoch->usage |= MPS_EPOCH_USAGE_INTERNAL_OUT_RECORD_OPEN;
 
-    MBEDTLS_MPS_TRACE( trace_comment, "New outgoing record successfully prepared." );
-    MBEDTLS_MPS_TRACE( trace_comment, " * Max plaintext size: %u",
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "New outgoing record successfully prepared." );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, " * Max plaintext size: %u",
            (unsigned) ctx->io.out.payload.data_len );
-    MBEDTLS_MPS_TRACE( trace_comment, " * Pre expansion:      %u",
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, " * Pre expansion:      %u",
            (unsigned) ctx->io.out.payload.data_offset );
     MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
@@ -638,14 +638,14 @@ int l2_out_dispatch_record( mbedtls_mps_l2 *ctx )
     mps_l1* const l1 = mbedtls_mps_l2_get_l1( ctx );
 
     MBEDTLS_MPS_TRACE_INIT( "l2_out_dispatch_record" );
-    MBEDTLS_MPS_TRACE( trace_comment, "Plaintext length: %u",
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Plaintext length: %u",
            (unsigned) ctx->io.out.payload.data_len );
 
     if( ctx->io.out.payload.data_len == 0 )
     {
-        MBEDTLS_MPS_TRACE( trace_comment, "Attempt to dispatch an empty record %u.",
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Attempt to dispatch an empty record %u.",
                (unsigned) ctx->io.out.writer.type );
-        MBEDTLS_MPS_TRACE( trace_comment, "Empty records allowed for type %u: %u",
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Empty records allowed for type %u: %u",
              (unsigned) ctx->io.out.writer.type,
              (unsigned) l2_type_empty_allowed( ctx, ctx->io.out.writer.type ) );
     }
@@ -655,7 +655,7 @@ int l2_out_dispatch_record( mbedtls_mps_l2 *ctx )
     if( ctx->io.out.payload.data_len == 0 &&
         l2_type_empty_allowed( ctx, ctx->io.out.writer.type ) == 0 )
     {
-        MBEDTLS_MPS_TRACE( trace_comment, "Empty records are not allowed for type %u -> ignore request.",
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Empty records are not allowed for type %u -> ignore request.",
                ctx->io.out.writer.type );
 
         /* dispatch(0) effectively resets the underlying Layer 1. */
@@ -676,33 +676,33 @@ int l2_out_dispatch_record( mbedtls_mps_l2 *ctx )
         rec.epoch     = (uint16_t) ctx->io.out.writer.epoch;
         rec.type      = ctx->io.out.writer.type;
 
-        MBEDTLS_MPS_TRACE( trace_comment, "Record header fields:" );
-        MBEDTLS_MPS_TRACE( trace_comment, "* Epoch:           %u", (unsigned) rec.epoch );
-        MBEDTLS_MPS_TRACE( trace_comment, "* Type:            %u", (unsigned) rec.type  );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Record header fields:" );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* Epoch:           %u", (unsigned) rec.epoch );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* Type:            %u", (unsigned) rec.type  );
 
         ret = l2_epoch_lookup( ctx, ctx->io.out.writer.epoch, &epoch );
         if( ret != 0 )
         {
-            MBEDTLS_MPS_TRACE( trace_comment, "Epoch lookup failed" );
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Epoch lookup failed" );
             MBEDTLS_MPS_TRACE_RETURN( ret );
         }
 
         l2_out_get_and_update_rec_seq( ctx, epoch, rec.ctr );
-        MBEDTLS_MPS_TRACE( trace_comment, "* Sequence number: ( %u << 16 ) + %u",
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* Sequence number: ( %u << 16 ) + %u",
                (unsigned) rec.ctr[0], (unsigned) rec.ctr[1] );
 
         /* Step 2: Apply record payload protection. */
-        MBEDTLS_MPS_TRACE( trace_comment, "Encrypt record. The plaintext offset is %u.",
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Encrypt record. The plaintext offset is %u.",
                (unsigned) rec.buf.data_offset );
         ret = mbedtls_mps_transform_encrypt( epoch->transform, &rec,
                                              ctx->conf.f_rng,
                                              ctx->conf.p_rng );
         if( ret != 0 )
         {
-            MBEDTLS_MPS_TRACE( trace_comment, "The record encryption failed with %d", ret );
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "The record encryption failed with %d", ret );
             MBEDTLS_MPS_TRACE_RETURN( ret );
         }
-        MBEDTLS_MPS_TRACE( trace_comment, "Record type after encryption: %u",
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Record type after encryption: %u",
                (unsigned) rec.type );
 
 #if defined(MBEDTLS_MPS_TRANSFORM_VALIDATION)
@@ -712,7 +712,7 @@ int l2_out_dispatch_record( mbedtls_mps_l2 *ctx )
          * This should always be true, but better err on the safe side. */
         if( rec.buf.data_offset != 0 )
         {
-            MBEDTLS_MPS_TRACE( trace_error, "Get non-zero ciphertext offset %u after encryption.",
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR, "Get non-zero ciphertext offset %u after encryption.",
                    (unsigned) rec.buf.data_offset );
             MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_BAD_TRANSFORM );
         }
@@ -858,8 +858,8 @@ int l2_out_write_protected_record_tls( mbedtls_mps_l2 *ctx, mps_rec *rec )
     /* Write ciphertext length. */
     MPS_WRITE_UINT16_BE( &rec->buf.data_len, hdr + tls_rec_len_offset );
 
-    MBEDTLS_MPS_TRACE( trace_comment, "* Type:    %u", (unsigned) rec->type );
-    MBEDTLS_MPS_TRACE( trace_comment, "* Version: %u", (unsigned) rec->minor_ver );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* Type:    %u", (unsigned) rec->type );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* Version: %u", (unsigned) rec->minor_ver );
     MBEDTLS_MPS_TRACE_RETURN( mps_l1_dispatch( l1, hdr_len + rec->buf.data_len, NULL ) );
 }
 #endif /* MBEDTLS_MPS_PROTO_TLS */
@@ -925,7 +925,7 @@ int l2_out_write_protected_record_dtls12( mbedtls_mps_l2 *ctx,
     /* Write ciphertext length. */
     MPS_WRITE_UINT16_BE( &rec->buf.data_len, hdr + dtls_rec_len_offset );
 
-    MBEDTLS_MPS_TRACE( trace_comment, "Write protected record -- DISPATCH" );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Write protected record -- DISPATCH" );
     MBEDTLS_MPS_TRACE_RETURN( mps_l1_dispatch( l1, hdr_len + rec->buf.data_len, NULL ) );
 }
 #endif /* MBEDTLS_MPS_PROTO_DTLS */
@@ -966,7 +966,7 @@ int l2_out_clear_pending( mbedtls_mps_l2 *ctx )
         mbedtls_mps_epoch_id queued_epoch;
         queued_epoch = ctx->io.out.writer.epoch;
 
-        MBEDTLS_MPS_TRACE( trace_comment, "Queued data is pending to be dispatched" );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Queued data is pending to be dispatched" );
 
         /* Prepare an outgoing record to dispatch the queued data */
         ret = l2_out_prepare_record( ctx, queued_epoch );
@@ -979,7 +979,7 @@ int l2_out_clear_pending( mbedtls_mps_l2 *ctx )
         else if( ret != MBEDTLS_ERR_WRITER_NEED_MORE )
             MBEDTLS_MPS_TRACE_RETURN( ret );
 
-        MBEDTLS_MPS_TRACE( trace_comment, "The prepared record was entirely filled with queued data -> dispatch it" );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "The prepared record was entirely filled with queued data -> dispatch it" );
 
         /* There's more queued data pending, so just deliver the record. */
         ret = l2_out_dispatch_record( ctx );
@@ -988,11 +988,11 @@ int l2_out_clear_pending( mbedtls_mps_l2 *ctx )
     }
 #endif /* MBEDTLS_MPS_PROTO_TLS */
 
-    MBEDTLS_MPS_TRACE( trace_comment, "Queue clear" );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Queue clear" );
 
     if( ctx->io.out.flush == 1 )
     {
-        MBEDTLS_MPS_TRACE( trace_comment, "A flush was requested requested, state %u",
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "A flush was requested requested, state %u",
                (unsigned) ctx->io.out.state );
         if( ctx->io.out.state == MBEDTLS_MPS_L2_WRITER_STATE_INTERNAL )
         {
@@ -1057,7 +1057,7 @@ int mps_l2_write_start( mbedtls_mps_l2 *ctx, mps_l2_out *out )
     desired_type = out->type;
     if( l2_type_is_valid( ctx, desired_type ) == 0 )
     {
-        MBEDTLS_MPS_TRACE( trace_error, "Message type %d is invalid", desired_type );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR, "Message type %d is invalid", desired_type );
         MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_INTERNAL_ERROR );
     }
 
@@ -1074,7 +1074,7 @@ int mps_l2_write_start( mbedtls_mps_l2 *ctx, mps_l2_out *out )
     ret = l2_out_clear_pending( ctx );
     if( ret != 0 )
     {
-        MBEDTLS_MPS_TRACE( trace_comment, "l2_out_clear_pending failed with %d", ret );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "l2_out_clear_pending failed with %d", ret );
         MBEDTLS_MPS_TRACE_RETURN( ret );
     }
 
@@ -1094,23 +1094,23 @@ int mps_l2_write_start( mbedtls_mps_l2 *ctx, mps_l2_out *out )
         if( ctx->io.out.writer.type  == desired_type &&
             ctx->io.out.writer.epoch == desired_epoch )
         {
-            MBEDTLS_MPS_TRACE( trace_comment,
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT,
                    "Type and epoch match currently open record -> attach." );
             ctx->io.out.state = MBEDTLS_MPS_L2_WRITER_STATE_EXTERNAL;
             out->wr = &ctx->io.out.writer.wr;
 
-            MBEDTLS_MPS_TRACE( trace_comment, "* Total size of record buffer: %u Bytes",
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* Total size of record buffer: %u Bytes",
                    (unsigned) out->wr->out_len );
-            MBEDTLS_MPS_TRACE( trace_comment, "* Committed: %u Bytes",
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* Committed: %u Bytes",
                    (unsigned) out->wr->committed );
-            MBEDTLS_MPS_TRACE( trace_comment, "* Written: %u Bytes",
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* Written: %u Bytes",
                    (unsigned) out->wr->end );
-            MBEDTLS_MPS_TRACE( trace_comment, "* Remaining: %u Bytes",
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* Remaining: %u Bytes",
                    (unsigned) ( out->wr->out_len - out->wr->committed ) );
             MBEDTLS_MPS_TRACE_RETURN( 0 );
         }
 
-        MBEDTLS_MPS_TRACE( trace_comment, "Type or epoch doesn't match open record." );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Type or epoch doesn't match open record." );
         ret = l2_out_release_and_dispatch( ctx, MBEDTLS_WRITER_RECLAIM_FORCE );
         if( ret != 0 )
             MBEDTLS_MPS_TRACE_RETURN( ret );
@@ -1186,7 +1186,7 @@ int l2_out_track_record( mbedtls_mps_l2 *ctx )
                         ctx->io.out.payload.data_len );
     if( ret != 0 )
     {
-        MBEDTLS_MPS_TRACE( trace_error, "mbedtls_writer_feed failed with %d", ret );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR, "mbedtls_writer_feed failed with %d", ret );
         MBEDTLS_MPS_TRACE_RETURN( ret );
     }
 
@@ -1208,7 +1208,7 @@ int l2_out_release_record( mbedtls_mps_l2 *ctx, uint8_t force )
     if( force == MBEDTLS_WRITER_RECLAIM_NO_FORCE &&
         ret   == MBEDTLS_ERR_WRITER_DATA_LEFT )
     {
-        MBEDTLS_MPS_TRACE( trace_comment, "There's space left in the current outgoing record." );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "There's space left in the current outgoing record." );
         type = ctx->io.out.writer.type;
 
         /* Check if records of the given type may be merged.
@@ -1216,7 +1216,7 @@ int l2_out_release_record( mbedtls_mps_l2 *ctx, uint8_t force )
          * be placed in a single record. */
         if( l2_type_can_be_merged( ctx, type ) == 1 )
         {
-            MBEDTLS_MPS_TRACE( trace_comment, "Multiple messages of type %u can be merged in a single record.", (unsigned) type );
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Multiple messages of type %u can be merged in a single record.", (unsigned) type );
             /* Here's the place to add a heuristic deciding when to dispatch
              * a record even if space is left in the output buffer. For TLS,
              * in principle we can go on with as little as a single byte, but
@@ -1224,19 +1224,19 @@ int l2_out_release_record( mbedtls_mps_l2 *ctx, uint8_t force )
 
             if( /* HEURISTIC */ 1 )
             {
-                MBEDTLS_MPS_TRACE( trace_comment, "Postpone dispatching to potentially merge further messages into this record." );
+                MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Postpone dispatching to potentially merge further messages into this record." );
                 MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_WRITER_DATA_LEFT );
             }
 
-            MBEDTLS_MPS_TRACE( trace_comment, "Not enough space remaining to wait for another message oftype %u - dispatch.", (unsigned) type );
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Not enough space remaining to wait for another message oftype %u - dispatch.", (unsigned) type );
 
             /* Fall through if heuristic determines that the current record
              * should be dispatched albeit spacing being left: fall through */
         }
         else
-            MBEDTLS_MPS_TRACE( trace_comment, "Multiple messages of type %u cannot be merged in a single record.", (unsigned) type );
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Multiple messages of type %u cannot be merged in a single record.", (unsigned) type );
 
-        MBEDTLS_MPS_TRACE( trace_comment, "Force reclaim of current record." );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Force reclaim of current record." );
         ret = mbedtls_writer_reclaim( &ctx->io.out.writer.wr, NULL, NULL,
                                       MBEDTLS_WRITER_RECLAIM_FORCE );
         if( ret != 0 )
@@ -1251,13 +1251,13 @@ int l2_out_release_record( mbedtls_mps_l2 *ctx, uint8_t force )
     if( bytes_queued > 0 )
     {
         /* The writer has queued data */
-        MBEDTLS_MPS_TRACE( trace_comment, "The writer has %u bytes of queued data.",
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "The writer has %u bytes of queued data.",
                (unsigned) bytes_queued );
 
         /* Double-check that the record content type can indeed be paused. */
         if( l2_type_can_be_paused( ctx, ctx->io.out.writer.type ) == 0 )
         {
-            MBEDTLS_MPS_TRACE( trace_comment, "Content type not pausable -- queue shouldn't"
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Content type not pausable -- queue shouldn't"
                    " have been passed to the writer in the first place" );
             MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_INTERNAL_ERROR );
         }
@@ -1268,7 +1268,7 @@ int l2_out_release_record( mbedtls_mps_l2 *ctx, uint8_t force )
 #endif /* MBEDTLS_MPS_PROTO_TLS */
     {
         /* No data has been queued */
-        MBEDTLS_MPS_TRACE( trace_comment, "The writer has no queued data." );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "The writer has no queued data." );
 
         /* The writer is no longer needed. */
         mbedtls_writer_free( &ctx->io.out.writer.wr );
@@ -1302,14 +1302,14 @@ int l2_out_release_and_dispatch( mbedtls_mps_l2 *ctx, uint8_t force )
     {
         /* The write-buffer is detached from the writer, hence
          * can be dispatched to Layer 1. */
-        MBEDTLS_MPS_TRACE( trace_comment, "Dispatch current outgoing record." );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Dispatch current outgoing record." );
         ret = l2_out_dispatch_record( ctx );
         if( ret != 0 )
             MBEDTLS_MPS_TRACE_RETURN( ret );
     }
     else
     {
-        MBEDTLS_MPS_TRACE( trace_comment, "Current record need not yet be dispatched." );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Current record need not yet be dispatched." );
     }
 
     MBEDTLS_MPS_TRACE_RETURN( 0 );
@@ -1371,13 +1371,13 @@ int mps_l2_read_done( mbedtls_mps_l2 *ctx )
     if( ret == MBEDTLS_ERR_MPS_READER_DATA_LEFT )
     {
         /* 1a */
-        MBEDTLS_MPS_TRACE( trace_comment, "There is data remaining in the current incoming record." );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "There is data remaining in the current incoming record." );
 
         /* Check if the content type is configured to allow packing of
          * multiple chunks of data in the same record. */
         if( l2_type_can_be_merged( ctx, active->type ) == 0 )
         {
-            MBEDTLS_MPS_TRACE( trace_error,
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR,
                    "Record content type %u does not allow "
                    "multiple reads from the same record.",
                    (unsigned) active->type );
@@ -1423,7 +1423,7 @@ int mps_l2_read_done( mbedtls_mps_l2 *ctx )
 
     /* 2 */
 
-    MBEDTLS_MPS_TRACE( trace_comment,
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT,
            "Detached record buffer from reader - "
            "release record from Layer 1." );
     ret = l2_in_release_record( ctx );
@@ -1435,13 +1435,13 @@ int mps_l2_read_done( mbedtls_mps_l2 *ctx )
 #endif /* MBEDTLS_MPS_PROTO_TLS */
     {
         /* 2.1 */
-        MBEDTLS_MPS_TRACE( trace_comment, "No pausing - close active reader." );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "No pausing - close active reader." );
         MBEDTLS_MPS_TRACE_RETURN( mps_l2_readers_close_active( ctx ) );
     }
 
 #if defined(MBEDTLS_MPS_PROTO_TLS)
     /* 2.2 (TLS only) */
-    MBEDTLS_MPS_TRACE( trace_comment, "Pause active reader." );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Pause active reader." );
     MBEDTLS_MPS_TRACE_RETURN( mps_l2_readers_pause_active( ctx ) );
 #endif /* MBEDTLS_MPS_PROTO_TLS */
 }
@@ -1457,21 +1457,21 @@ int l2_handle_invalid_record( mbedtls_mps_l2 *ctx, int ret )
     MBEDTLS_MPS_TRACE_INIT( "mps_l2_handle_invalid_record" );
     if( ret == MBEDTLS_ERR_MPS_INVALID_RECORD )
     {
-        MBEDTLS_MPS_TRACE( trace_error, "Record with invalid header received -- discard" );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR, "Record with invalid header received -- discard" );
     }
     else if( ret == MBEDTLS_ERR_MPS_REPLAYED_RECORD )
     {
-        MBEDTLS_MPS_TRACE( trace_error, "Record caught by replay protection -- discard" );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR, "Record caught by replay protection -- discard" );
     }
     else /* ret == MBEDTLS_ERR_MPS_INVALID_MAC */
     {
-        MBEDTLS_MPS_TRACE( trace_error, "Record with invalid MAC received -- discard" );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR, "Record with invalid MAC received -- discard" );
         ctx->io.in.bad_mac_ctr++;
         if( mbedtls_mps_l2_conf_get_badmac_limit( &ctx->conf ) != 0 &&
             ctx->io.in.bad_mac_ctr >=
             mbedtls_mps_l2_conf_get_badmac_limit( &ctx->conf ) )
         {
-            MBEDTLS_MPS_TRACE( trace_error, "Bad-MAC-limit %u reached.",
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR, "Bad-MAC-limit %u reached.",
                    (unsigned) mbedtls_mps_l2_conf_get_badmac_limit( &ctx->conf ) );
             MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_INVALID_MAC );
         }
@@ -1591,7 +1591,7 @@ int mps_l2_read_start( mbedtls_mps_l2 *ctx, mps_l2_in *in )
     /* 2 */
     if( current_state == MBEDTLS_MPS_L2_READER_STATE_INTERNAL )
     {
-        MBEDTLS_MPS_TRACE( trace_comment, "A record is already open for reading." );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "A record is already open for reading." );
     }
     else
     {
@@ -1615,7 +1615,7 @@ int mps_l2_read_start( mbedtls_mps_l2 *ctx, mps_l2_in *in )
             if( ret != 0 )
                 MBEDTLS_MPS_TRACE_RETURN( ret );
 
-            MBEDTLS_MPS_TRACE( trace_comment, "Signal that the processing should be retried." );
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Signal that the processing should be retried." );
             /* We could return MBEDTLS_ERR_MPS_WANT_READ here, indicating that
              * progress can _only_ be made through additional data on the
              * underlying transport (which is the case here because we have
@@ -1685,7 +1685,7 @@ int mps_l2_read_start( mbedtls_mps_l2 *ctx, mps_l2_in *in )
 
     if( l2_epoch_check( ctx, active->epoch, MPS_EPOCH_READ_MASK ) != 0 )
     {
-        MBEDTLS_MPS_TRACE( trace_error, "Content piggy-backing in record with old epoch." );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR, "Content piggy-backing in record with old epoch." );
         MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_INVALID_CONTENT );
     }
 
@@ -1769,20 +1769,20 @@ int l2_in_fetch_record( mbedtls_mps_l2 *ctx, mps_rec *rec )
      * Step 2: Decrypt and authenticate record
      */
 
-    MBEDTLS_MPS_TRACE( trace_comment, "Decrypt and authenticate record for epoch %u",
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Decrypt and authenticate record for epoch %u",
            (unsigned) rec->epoch );
 
     if( ( ret = l2_epoch_lookup( ctx, rec->epoch,
                                  &epoch ) ) != 0 )
     {
-        MBEDTLS_MPS_TRACE( trace_comment, "Epoch lookup failed with: %d", (int) ret );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Epoch lookup failed with: %d", (int) ret );
         MBEDTLS_MPS_TRACE_RETURN( ret );
     }
 
     ret = mbedtls_mps_transform_decrypt( epoch->transform, rec );
     if( ret != 0 )
     {
-        MBEDTLS_MPS_TRACE( trace_comment, "Decryption failed with: %d", (int) ret );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Decryption failed with: %d", (int) ret );
         MBEDTLS_MPS_TRACE_RETURN( ret );
     }
 
@@ -1802,7 +1802,7 @@ int l2_in_fetch_record( mbedtls_mps_l2 *ctx, mps_rec *rec )
      */
     if( l2_type_is_valid( ctx, rec->type ) == 0 )
     {
-        MBEDTLS_MPS_TRACE( trace_error, "Invalid record type received" );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR, "Invalid record type received" );
         /* TODO: Release the record? */
         MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_INVALID_RECORD );
     }
@@ -2012,7 +2012,7 @@ int l2_in_fetch_protected_record_tls( mbedtls_mps_l2 *ctx, mps_rec *rec )
 
     if( major_ver != MBEDTLS_SSL_MAJOR_VERSION_3 )
     {
-        MBEDTLS_MPS_TRACE( trace_error, "Invalid major record version %u received, expected %u",
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR, "Invalid major record version %u received, expected %u",
                (unsigned) major_ver, (unsigned) MBEDTLS_SSL_MAJOR_VERSION_3 );
         MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_INVALID_RECORD );
     }
@@ -2032,7 +2032,7 @@ int l2_in_fetch_protected_record_tls( mbedtls_mps_l2 *ctx, mps_rec *rec )
     if( l2_version_wire_matches_logical( minor_ver,
                   mbedtls_mps_l2_conf_get_version( &ctx->conf ) ) != 1 )
     {
-        MBEDTLS_MPS_TRACE( trace_error, "Invalid minor record version %u received, expected %u",
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR, "Invalid minor record version %u received, expected %u",
                (unsigned) minor_ver,
                mbedtls_mps_l2_conf_get_version( &ctx->conf ) );
         MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_INVALID_RECORD );
@@ -2061,7 +2061,7 @@ int l2_in_fetch_protected_record_tls( mbedtls_mps_l2 *ctx, mps_rec *rec )
      */
     if( l2_type_ignore( ctx, type ) == 1 )
     {
-        MBEDTLS_MPS_TRACE( trace_comment, "Silently ignore record of type %u",
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Silently ignore record of type %u",
                (unsigned) type );
 
         ret = l2_in_release_record( ctx );
@@ -2090,8 +2090,8 @@ int l2_in_fetch_protected_record_tls( mbedtls_mps_l2 *ctx, mps_rec *rec )
     if( ret != 0 )
         MBEDTLS_MPS_TRACE_RETURN( ret );
 
-    MBEDTLS_MPS_TRACE( trace_comment, "* Record epoch:  %u", (unsigned) rec->epoch );
-    MBEDTLS_MPS_TRACE( trace_comment, "* Record number: ( %u << 32 ) + %u ",
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* Record epoch:  %u", (unsigned) rec->epoch );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* Record number: ( %u << 32 ) + %u ",
            (unsigned) rec->ctr[0], (unsigned) rec->ctr[1] );
 
     rec->type      = type;
@@ -2300,7 +2300,7 @@ int l2_in_fetch_protected_record_dtls12( mbedtls_mps_l2 *ctx,
     MPS_READ_UINT8_BE( buf + dtls_rec_type_offset, &type );
     if( l2_type_is_valid( ctx, type ) == 0 )
     {
-        MBEDTLS_MPS_TRACE( trace_error, "Invalid record type received" );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR, "Invalid record type received" );
         MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_INVALID_RECORD );
     }
     rec->type = type;
@@ -2310,7 +2310,7 @@ int l2_in_fetch_protected_record_dtls12( mbedtls_mps_l2 *ctx,
                           buf + dtls_rec_ver_offset );
     if( major_ver != MBEDTLS_SSL_MAJOR_VERSION_3 )
     {
-        MBEDTLS_MPS_TRACE( trace_error, "Invalid major record version %u received, expected %u",
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR, "Invalid major record version %u received, expected %u",
                (unsigned) major_ver, (unsigned) MBEDTLS_SSL_MAJOR_VERSION_3 );
         MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_INVALID_RECORD );
     }
@@ -2319,7 +2319,7 @@ int l2_in_fetch_protected_record_dtls12( mbedtls_mps_l2 *ctx,
         mbedtls_mps_l2_conf_get_version( &ctx->conf ) !=
           minor_ver )
     {
-        MBEDTLS_MPS_TRACE( trace_error, "Invalid minor record version %u received, expected %u",
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR, "Invalid minor record version %u received, expected %u",
                (unsigned) minor_ver,
                (unsigned) mbedtls_mps_l2_conf_get_version( &ctx->conf ) );
         MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_INVALID_RECORD );
@@ -2342,7 +2342,7 @@ int l2_in_fetch_protected_record_dtls12( mbedtls_mps_l2 *ctx,
 
     if( l2_counter_replay_check( ctx, epoch, seq_nr[0], seq_nr[1] ) != 0 )
     {
-        MBEDTLS_MPS_TRACE( trace_error, "Replayed record -- ignore" );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR, "Replayed record -- ignore" );
         MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_REPLAYED_RECORD );
     }
     rec->ctr[0] = seq_nr[0];
@@ -2362,7 +2362,7 @@ int l2_in_fetch_protected_record_dtls12( mbedtls_mps_l2 *ctx,
     ret = mps_l1_fetch( l1, &buf, dtls_rec_hdr_len + len );
     if( ret == MBEDTLS_ERR_MPS_REQUEST_OUT_OF_BOUNDS )
     {
-        MBEDTLS_MPS_TRACE( trace_error, "Claimed record length exceeds datagram bounds." );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR, "Claimed record length exceeds datagram bounds." );
         ret = MBEDTLS_ERR_MPS_INVALID_RECORD;
     }
     if( ret != 0 )
@@ -2373,8 +2373,8 @@ int l2_in_fetch_protected_record_dtls12( mbedtls_mps_l2 *ctx,
     rec->buf.data_offset = 0;
     rec->buf.data_len    = len;
 
-    MBEDTLS_MPS_TRACE( trace_comment, "* Record epoch:  %u", (unsigned) rec->epoch );
-    MBEDTLS_MPS_TRACE( trace_comment, "* Record number: ( %u << 32 ) + %u",
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* Record epoch:  %u", (unsigned) rec->epoch );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* Record number: ( %u << 32 ) + %u",
            (unsigned) rec->ctr[0], (unsigned) rec->ctr[1] );
     MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
@@ -2602,14 +2602,14 @@ int mps_l2_epoch_add( mbedtls_mps_l2 *ctx,
 
     if( ctx->epochs.next > MBEDTLS_MPS_EPOCH_MAX )
     {
-        MBEDTLS_MPS_TRACE( trace_error, "Maximum number %u of epochs reached.",
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR, "Maximum number %u of epochs reached.",
                (unsigned) MBEDTLS_MPS_L2_EPOCH_WINDOW_SIZE );
         MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_TOO_MANY_EPOCHS );
     }
 
     if( next_offset == MBEDTLS_MPS_L2_EPOCH_WINDOW_SIZE )
     {
-        MBEDTLS_MPS_TRACE( trace_error, "The epoch window (size %u) is full.",
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR, "The epoch window (size %u) is full.",
                (unsigned) MBEDTLS_MPS_L2_EPOCH_WINDOW_SIZE );
         MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_TOO_MANY_LIVE_EPOCHS );
     }
@@ -2622,7 +2622,7 @@ int mps_l2_epoch_add( mbedtls_mps_l2 *ctx,
 
     ctx->epochs.next++;
 
-    MBEDTLS_MPS_TRACE( trace_comment, "New epoch: %u", (unsigned) *epoch_id );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "New epoch: %u", (unsigned) *epoch_id );
     MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
@@ -2637,9 +2637,9 @@ int mps_l2_epoch_usage( mbedtls_mps_l2 *ctx,
         mbedtls_mps_l2_conf_get_mode( &ctx->conf );
 
     MBEDTLS_MPS_TRACE_INIT( "mps_l2_epoch_usage" );
-    MBEDTLS_MPS_TRACE( trace_comment, "* Epoch: %d", epoch_id );
-    MBEDTLS_MPS_TRACE( trace_comment, "* Clear: %u", (unsigned) clear );
-    MBEDTLS_MPS_TRACE( trace_comment, "* Set:   %u", (unsigned) set );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* Epoch: %d", epoch_id );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* Clear: %u", (unsigned) clear );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* Set:   %u", (unsigned) set );
 
     MBEDTLS_MPS_STATE_VALIDATE_RAW(
         ctx->io.out.state != MBEDTLS_MPS_L2_WRITER_STATE_EXTERNAL,
@@ -2659,7 +2659,7 @@ int mps_l2_epoch_usage( mbedtls_mps_l2 *ctx,
     if( ret != 0 )
         MBEDTLS_MPS_TRACE_RETURN( ret );
 
-    MBEDTLS_MPS_TRACE( trace_comment, "* Old:   %04x", (unsigned) epoch->usage );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* Old:   %04x", (unsigned) epoch->usage );
 
 #if defined(MBEDTLS_MPS_PROTO_TLS)
     /* In TLS, there's at most one epoch holding read permissions;
@@ -2669,7 +2669,7 @@ int mps_l2_epoch_usage( mbedtls_mps_l2 *ctx,
         uint8_t offset;
         for( offset = 0; offset < ctx->epochs.next; offset++ )
         {
-            MBEDTLS_MPS_TRACE( trace_comment,
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT,
                    "Modify epoch %u usage from %#x to %#x",
                    (unsigned) offset + ctx->epochs.base,
                    (unsigned) ctx->epochs.window[offset].usage,
@@ -2690,13 +2690,13 @@ int mps_l2_epoch_usage( mbedtls_mps_l2 *ctx,
 
         if( ( set & MPS_EPOCH_READ_MASK )  != 0 )
         {
-            MBEDTLS_MPS_TRACE( trace_comment, "Epoch %u the new incoming epoch",
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Epoch %u the new incoming epoch",
                    (unsigned) epoch_id );
             ctx->epochs.default_in = epoch_id;
         }
         if( ( set & MPS_EPOCH_WRITE_MASK ) != 0 )
         {
-            MBEDTLS_MPS_TRACE( trace_comment, "Epoch %u the new outgoing epoch",
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Epoch %u the new outgoing epoch",
                    (unsigned) epoch_id );
             ctx->epochs.default_out = epoch_id;
         }
@@ -2707,7 +2707,7 @@ int mps_l2_epoch_usage( mbedtls_mps_l2 *ctx,
 
     epoch->usage |= set;
     epoch->usage &= ~clear;
-    MBEDTLS_MPS_TRACE( trace_comment, "* New:   %04x", (unsigned) epoch->usage );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* New:   %04x", (unsigned) epoch->usage );
 
     MBEDTLS_MPS_TRACE_RETURN( l2_epoch_cleanup( ctx ) );
 }
@@ -2734,7 +2734,7 @@ int l2_epoch_check( mbedtls_mps_l2 *ctx,
 
     if( ( purpose & epoch->usage ) == 0 )
     {
-        MBEDTLS_MPS_TRACE( trace_comment, "Epoch %u has usage %s, but flag from %s is required.",
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Epoch %u has usage %s, but flag from %s is required.",
                (unsigned) epoch_id,
                l2_epoch_usage_to_string( epoch->usage ),
                l2_epoch_usage_to_string( purpose ) );
@@ -2764,22 +2764,22 @@ void l2_print_usage( unsigned usage )
 #if defined(MBEDTLS_MPS_ENABLE_TRACE)
     if( ( usage & MPS_EPOCH_READ_MASK ) != 0 )
     {
-        MBEDTLS_MPS_TRACE( trace_comment,
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT,
                "* epoch can be used for reading." );
     }
     if( ( usage & MPS_EPOCH_WRITE_MASK ) != 0 )
     {
-        MBEDTLS_MPS_TRACE( trace_comment,
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT,
                "* epoch can be used for writing." );
     }
     if( ( usage & MPS_EPOCH_USAGE_INTERNAL_OUT_PROTECTED ) != 0 )
     {
-        MBEDTLS_MPS_TRACE( trace_comment,
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT,
                "* Epoch has been added but not yet configured." );
     }
     if( ( usage & MPS_EPOCH_USAGE_INTERNAL_OUT_RECORD_OPEN ) != 0 )
     {
-        MBEDTLS_MPS_TRACE( trace_comment,
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT,
                "* epoch has an outgoing record open." );
     }
 #else
@@ -2800,13 +2800,13 @@ int l2_epoch_cleanup( mbedtls_mps_l2 *ctx )
     {
         unsigned usage = ctx->epochs.window[offset].usage;
 
-        MBEDTLS_MPS_TRACE( trace_comment, "Checking epoch %u at window offset %u, usage %s",
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Checking epoch %u at window offset %u, usage %s",
                (unsigned)( ctx->epochs.base + offset ), (unsigned) offset,
                l2_epoch_usage_to_string( usage ) );
 
         if( usage == 0 )
         {
-            MBEDTLS_MPS_TRACE( trace_comment, "* no longer needed" );
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* no longer needed" );
             l2_epoch_free( &ctx->epochs.window[offset] );
         }
         else
@@ -2820,7 +2820,7 @@ int l2_epoch_cleanup( mbedtls_mps_l2 *ctx )
 
     if( shift == 0 )
     {
-        MBEDTLS_MPS_TRACE( trace_comment, "Cannot get rid of any epoch." );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Cannot get rid of any epoch." );
         MBEDTLS_MPS_TRACE_RETURN( 0 );
     }
 
@@ -2828,18 +2828,18 @@ int l2_epoch_cleanup( mbedtls_mps_l2 *ctx )
         ( ctx->epochs.base + MBEDTLS_MPS_L2_EPOCH_WINDOW_SIZE );
     if( shift >= max_shift )
     {
-        MBEDTLS_MPS_TRACE( trace_comment, "Cannot shift epoch window further." );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Cannot shift epoch window further." );
         shift = max_shift;
     }
 
-    MBEDTLS_MPS_TRACE( trace_comment, "Can get rid of the first %u epochs; clearing.",
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Can get rid of the first %u epochs; clearing.",
            (unsigned) shift );
 
     ctx->epochs.base += shift;
     ctx->epochs.next -= shift;
 
-    MBEDTLS_MPS_TRACE( trace_comment, "* New base: %u", (unsigned) ctx->epochs.base );
-    MBEDTLS_MPS_TRACE( trace_comment, "* New next: %u", (unsigned) ctx->epochs.next );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* New base: %u", (unsigned) ctx->epochs.base );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* New next: %u", (unsigned) ctx->epochs.next );
 
     /* Shift epochs. */
     for( offset = 0; offset < MBEDTLS_MPS_L2_EPOCH_WINDOW_SIZE; offset++ )
@@ -2850,7 +2850,7 @@ int l2_epoch_cleanup( mbedtls_mps_l2 *ctx )
             l2_epoch_init( &ctx->epochs.window[offset] );
     }
 
-    MBEDTLS_MPS_TRACE( trace_comment, "Epoch cleanup done" );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Epoch cleanup done" );
     MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 #endif /* MBEDTLS_MPS_L2_EPOCH_WINDOW_SHIFTING */
@@ -2862,26 +2862,26 @@ int l2_epoch_lookup( mbedtls_mps_l2 *ctx,
 {
     uint8_t epoch_offset;
     MBEDTLS_MPS_TRACE_INIT( "l2_epoch_lookup" );
-    MBEDTLS_MPS_TRACE( trace_comment, "* Epoch:  %d", epoch_id );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* Epoch:  %d", epoch_id );
 
     if( epoch_id == MBEDTLS_MPS_EPOCH_NONE )
     {
-        MBEDTLS_MPS_TRACE( trace_comment, "The epoch is unset." );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "The epoch is unset." );
         MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_INVALID_EPOCH );
     }
     else if( epoch_id < ctx->epochs.base )
     {
-        MBEDTLS_MPS_TRACE( trace_comment, "The epoch %u is below the epoch base %u.",
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "The epoch %u is below the epoch base %u.",
                (unsigned) epoch_id, (unsigned) ctx->epochs.base );
         MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_INVALID_EPOCH );
     }
 
     epoch_offset = epoch_id - ctx->epochs.base;
-    MBEDTLS_MPS_TRACE( trace_comment, "* Offset: %u", (unsigned) epoch_offset );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* Offset: %u", (unsigned) epoch_offset );
 
     if( epoch_offset >= ctx->epochs.next )
     {
-        MBEDTLS_MPS_TRACE( trace_error, "The epoch is outside the epoch window." );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR, "The epoch is outside the epoch window." );
         MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_INVALID_EPOCH );
     }
 
@@ -2932,20 +2932,20 @@ int l2_counter_replay_check( mbedtls_mps_l2 *ctx,
 
     window_top_hi = epoch->stats.dtls.replay.in_window_top_hi;
     window_top_lo = epoch->stats.dtls.replay.in_window_top_lo;
-    MBEDTLS_MPS_TRACE( trace_comment, "* Window top hi:  %u", window_top_hi );
-    MBEDTLS_MPS_TRACE( trace_comment, "* Window top lo:  %u", window_top_lo );
-    MBEDTLS_MPS_TRACE( trace_comment, "* Counter top hi: %u", ctr_hi );
-    MBEDTLS_MPS_TRACE( trace_comment, "* Counter top lo: %u", ctr_lo );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* Window top hi:  %u", window_top_hi );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* Window top lo:  %u", window_top_lo );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* Counter top hi: %u", ctr_hi );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* Counter top lo: %u", ctr_lo );
 
     if( ctr_hi > window_top_hi )
     {
-        MBEDTLS_MPS_TRACE( trace_comment, "Record sequence number larger than everything seen so far." );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Record sequence number larger than everything seen so far." );
         MBEDTLS_MPS_TRACE_RETURN( 0 );
     }
     else if( ctr_hi < window_top_hi )
     {
         /* Don't maintain window across 32-bit boundaries. */
-        MBEDTLS_MPS_TRACE( trace_comment, "Record sequence number too old -- drop" );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Record sequence number too old -- drop" );
         MBEDTLS_MPS_TRACE_RETURN( -1 );
     }
     else if( ctr_lo > window_top_lo )
@@ -2963,7 +2963,7 @@ int l2_counter_replay_check( mbedtls_mps_l2 *ctx,
     if( ( window & 0x1 ) == 0 )
         MBEDTLS_MPS_TRACE_RETURN( -1 );
 
-    MBEDTLS_MPS_TRACE( trace_comment, "Record sequence number within window and not seen so far." );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Record sequence number within window and not seen so far." );
     MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 #endif /* MBEDTLS_MPS_PROTO_DTLS */

--- a/library/mps/layer2_internal.h
+++ b/library/mps/layer2_internal.h
@@ -249,7 +249,7 @@ MBEDTLS_MPS_STATIC int l2_type_ignore( mbedtls_mps_l2 *ctx,
 /* Print human-readable description of epoch usage flags. */
 MBEDTLS_MPS_STATIC void l2_print_usage( unsigned usage );
 
-#if defined(MBEDTLS_MPS_TRACE)
+#if defined(MBEDTLS_MPS_ENABLE_TRACE)
 static inline const char * l2_epoch_usage_to_string(
     mbedtls_mps_epoch_usage usage )
 {
@@ -265,7 +265,7 @@ static inline const char * l2_epoch_usage_to_string(
 
     return( "NONE" );
 }
-#endif /* MBEDTLS_MPS_TRACE */
+#endif /* MBEDTLS_MPS_ENABLE_TRACE */
 
 /* Internal macro used to indicate internal usage of an epoch,
  * e.g. because data it still pending to be dispatched.

--- a/library/mps/layer3.c
+++ b/library/mps/layer3.c
@@ -28,9 +28,9 @@
 
 #include "layer3_internal.h"
 
-#if defined(MBEDTLS_MPS_TRACE)
-static int trace_id = TRACE_BIT_LAYER_3;
-#endif /* MBEDTLS_MPS_TRACE */
+#if defined(MBEDTLS_MPS_ENABLE_TRACE)
+static int mbedtls_mps_trace_id = MBEDTLS_MPS_TRACE_BIT_LAYER_3;
+#endif /* MBEDTLS_MPS_ENABLE_TRACE */
 
 #include <stdlib.h>
 
@@ -54,7 +54,7 @@ static int trace_id = TRACE_BIT_LAYER_3;
 
 int mps_l3_init( mps_l3 *l3, mbedtls_mps_l2 *l2, uint8_t mode )
 {
-    TRACE_INIT( "mps_l3_init" );
+    MBEDTLS_MPS_TRACE_INIT( "mps_l3_init" );
     l3->conf.l2 = l2;
 
 #if !defined(MBEDTLS_MPS_CONF_MODE)
@@ -64,9 +64,9 @@ int mps_l3_init( mps_l3 *l3, mbedtls_mps_l2 *l2, uint8_t mode )
 #if defined(MBEDTLS_MPS_ENABLE_ASSERTIONS)
     if( mode != MBEDTLS_MPS_CONF_MODE )
     {
-        TRACE( trace_error, "Protocol passed to mps_l3_init() doesn't match " \
+        MBEDTLS_MPS_TRACE( trace_error, "Protocol passed to mps_l3_init() doesn't match " \
                "hardcoded protocol." );
-        RETURN( MBEDTLS_ERR_MPS_INTERNAL_ERROR );
+        MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_INTERNAL_ERROR );
     }
 #endif /* MBEDTLS_MPS_ENABLE_ASSERTIONS */
 #endif /* !MBEDTLS_MPS_CONF_MODE */
@@ -85,14 +85,14 @@ int mps_l3_init( mps_l3 *l3, mbedtls_mps_l2 *l2, uint8_t mode )
      * - Configure constraints for merging, pausing,
      *   and empty records.
      */
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
 int mps_l3_free( mps_l3 *l3 )
 {
     ((void) l3);
-    TRACE_INIT( "mps_l3_free" );
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_INIT( "mps_l3_free" );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
 /*
@@ -115,7 +115,7 @@ int mps_l3_read( mps_l3 *l3 )
         mbedtls_mps_l3_conf_get_mode( &l3->conf );
     mbedtls_mps_l2* const l2 = mbedtls_mps_l3_get_l2( l3 );
 
-    TRACE_INIT( "mps_l3_read" );
+    MBEDTLS_MPS_TRACE_INIT( "mps_l3_read" );
 
     /*
      * Outline:
@@ -145,7 +145,7 @@ int mps_l3_read( mps_l3 *l3 )
 
     /* 2 */
     /* Request incoming data from Layer 2 context */
-    TRACE( trace_comment, "Check for incoming data on Layer 2" );
+    MBEDTLS_MPS_TRACE( trace_comment, "Check for incoming data on Layer 2" );
 
     /* TODO: Some compilers complain that `in` could still be
      * uninitialized after the call has succeeded.
@@ -161,21 +161,21 @@ int mps_l3_read( mps_l3 *l3 )
 
     ret = mps_l2_read_start( l2, &in );
     if( ret != 0 )
-        RETURN( ret );
+        MBEDTLS_MPS_TRACE_RETURN( ret );
 
-    TRACE( trace_comment, "Opened incoming datastream" );
-    TRACE( trace_comment, "* Epoch: %u", (unsigned) in.epoch );
-    TRACE( trace_comment, "* Type:  %u", (unsigned) in.type );
+    MBEDTLS_MPS_TRACE( trace_comment, "Opened incoming datastream" );
+    MBEDTLS_MPS_TRACE( trace_comment, "* Epoch: %u", (unsigned) in.epoch );
+    MBEDTLS_MPS_TRACE( trace_comment, "* Type:  %u", (unsigned) in.type );
     switch( in.type )
     {
         /* 3.1 */
 
         case MBEDTLS_MPS_MSG_APP:
-            TRACE( trace_comment, "-> Application data" );
+            MBEDTLS_MPS_TRACE( trace_comment, "-> Application data" );
             break;
 
         case MBEDTLS_MPS_MSG_ALERT:
-            TRACE( trace_comment, "-> Alert message" );
+            MBEDTLS_MPS_TRACE( trace_comment, "-> Alert message" );
 
             /* Attempt to fetch alert.
              *
@@ -189,59 +189,59 @@ int mps_l3_read( mps_l3 *l3 )
              *   is treated as a fatal error.
              */
             ret = l3_parse_alert( in.rd, &l3->io.in.alert );
-            if( ret == MBEDTLS_ERR_READER_OUT_OF_DATA )
+            if( ret == MBEDTLS_ERR_MPS_READER_OUT_OF_DATA )
             {
 #if defined(MBEDTLS_MPS_PROTO_DTLS)
                 if( MBEDTLS_MPS_IS_DTLS( mode ) )
                 {
-                    TRACE( trace_error, "Incomplete alert message found -- abort" );
-                    RETURN( MBEDTLS_ERR_MPS_INVALID_CONTENT );
+                    MBEDTLS_MPS_TRACE( trace_error, "Incomplete alert message found -- abort" );
+                    MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_INVALID_CONTENT );
                 }
 #endif /* MBEDTLS_MPS_PROTO_DTLS */
 
 #if defined(MBEDTLS_MPS_PROTO_TLS)
                 if( MBEDTLS_MPS_IS_TLS( mode ) )
                 {
-                    TRACE( trace_comment, "Not enough data available in record to read alert message" );
+                    MBEDTLS_MPS_TRACE( trace_comment, "Not enough data available in record to read alert message" );
                     ret = mps_l2_read_done( l2 );
                     if( ret != 0 )
-                        RETURN( ret );
+                        MBEDTLS_MPS_TRACE_RETURN( ret );
 
                     /* No records are buffered by Layer 2, so progress depends
                      * on the availability of the underlying transport. We could
                      * hence return MBEDTLS_ERR_MPS_WANT_READ here. However, this would
                      * need to be re-evaluated with any change on Layer 2, so
                      * it's safer to return MBEDTLS_ERR_MPS_RETRY. */
-                    RETURN( MBEDTLS_ERR_MPS_RETRY );
+                    MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_RETRY );
                 }
 #endif /* MBEDTLS_MPS_PROTO_TLS */
             }
             else if( ret != 0 )
-                RETURN( ret );
+                MBEDTLS_MPS_TRACE_RETURN( ret );
 
             break;
 
         case MBEDTLS_MPS_MSG_CCS:
-            TRACE( trace_comment, "-> CCS message" );
+            MBEDTLS_MPS_TRACE( trace_comment, "-> CCS message" );
 
-            /* We don't need to consider #MBEDTLS_ERR_READER_OUT_OF_DATA
+            /* We don't need to consider #MBEDTLS_ERR_MPS_READER_OUT_OF_DATA
              * here because the CCS content type does not allow empty
              * records, and hence malicious length-0 records of type CCS
              * will already have been silently skipped over (DTLS) or
              * lead to failure (TLS) by Layer 2. */
             ret = l3_parse_ccs( in.rd );
             if( ret != 0 )
-                RETURN( ret );
+                MBEDTLS_MPS_TRACE_RETURN( ret );
             break;
 
         case MBEDTLS_MPS_MSG_ACK:
             /* DTLS-1.3-TODO: Implement */
-            RETURN( MBEDTLS_ERR_MPS_INVALID_CONTENT );
+            MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_INVALID_CONTENT );
 
         /* 3.2 */
 
         case MBEDTLS_MPS_MSG_HS:
-            TRACE( trace_comment, "-> Handshake message" );
+            MBEDTLS_MPS_TRACE( trace_comment, "-> Handshake message" );
 
             /*
              * General workings of handshake reading:
@@ -279,7 +279,7 @@ int mps_l3_read( mps_l3 *l3 )
             {
                 /* 3.2.1 */
                 case MPS_L3_HS_NONE:
-                    TRACE( trace_comment, "No handshake message is currently processed" );
+                    MBEDTLS_MPS_TRACE( trace_comment, "No handshake message is currently processed" );
 
                     /* Attempt to fetch and parse handshake header.
                      *
@@ -295,24 +295,24 @@ int mps_l3_read( mps_l3 *l3 )
                     ret = l3_parse_hs_header(
                         mbedtls_mps_l3_conf_get_mode( &l3->conf ), in.rd,
                         &l3->io.in.hs );
-                    if( ret == MBEDTLS_ERR_READER_OUT_OF_DATA )
+                    if( ret == MBEDTLS_ERR_MPS_READER_OUT_OF_DATA )
                     {
 #if defined(MBEDTLS_MPS_PROTO_DTLS)
                         if( MBEDTLS_MPS_IS_DTLS( mode ) )
                         {
-                            TRACE( trace_error, "Incomplete handshake header found -- abort" );
-                            RETURN( MBEDTLS_ERR_MPS_INVALID_CONTENT );
+                            MBEDTLS_MPS_TRACE( trace_error, "Incomplete handshake header found -- abort" );
+                            MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_INVALID_CONTENT );
                         }
 #endif /* MBEDTLS_MPS_PROTO_DTLS */
 
 #if defined(MBEDTLS_MPS_PROTO_TLS)
                         if( MBEDTLS_MPS_IS_TLS( mode ) )
                         {
-                            TRACE( trace_comment, "Incomplete handshake header in current record -- wait for more data." );
+                            MBEDTLS_MPS_TRACE( trace_comment, "Incomplete handshake header in current record -- wait for more data." );
 
                             ret = mps_l2_read_done( l2 );
                             if( ret != 0 )
-                                RETURN( ret );
+                                MBEDTLS_MPS_TRACE_RETURN( ret );
 
                             /* We could return WANT_READ here, because
                              * _currently_ no records are buffered by Layer 2,
@@ -322,30 +322,30 @@ int mps_l3_read( mps_l3 *l3 )
                              * potentially adapted with any change to Layer 2,
                              * so returning MBEDTLS_ERR_MPS_RETRY
                              * is safer. */
-                            RETURN( MBEDTLS_ERR_MPS_RETRY );
+                            MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_RETRY );
                         }
 #endif /* MBEDTLS_MPS_PROTO_TLS */
                     }
                     else if( ret != 0 )
-                        RETURN( ret );
+                        MBEDTLS_MPS_TRACE_RETURN( ret );
 
                     /* Setup the extended reader keeping track of the
                      * global message bounds. */
-                    TRACE( trace_comment, "Setup extended reader for handshake message" );
+                    MBEDTLS_MPS_TRACE( trace_comment, "Setup extended reader for handshake message" );
 
                     /* TODO: Think about storing the frag_len in len for DTLS
                      *       to avoid this distinction. */
 #if defined(MBEDTLS_MPS_PROTO_TLS)
                     if( MBEDTLS_MPS_IS_TLS( mode ) )
                     {
-                        mbedtls_reader_init_ext( &l3->io.in.hs.rd_ext,
+                        mbedtls_mps_reader_init_ext( &l3->io.in.hs.rd_ext,
                                                  l3->io.in.hs.len );
                     }
 #endif /* MBEDTLS_MPS_PROTO_TLS */
 #if defined(MBEDTLS_MPS_PROTO_DTLS)
                     if( MBEDTLS_MPS_IS_DTLS( mode ) )
                     {
-                        mbedtls_reader_init_ext( &l3->io.in.hs.rd_ext,
+                        mbedtls_mps_reader_init_ext( &l3->io.in.hs.rd_ext,
                                                  l3->io.in.hs.frag_len );
                     }
 #endif /* MBEDTLS_MPS_PROTO_DTLS */
@@ -354,15 +354,15 @@ int mps_l3_read( mps_l3 *l3 )
 
                 /* 3.2.2 */
                 case MPS_L3_HS_PAUSED:
-                    TRACE( trace_comment, "A handshake message currently paused" );
+                    MBEDTLS_MPS_TRACE( trace_comment, "A handshake message currently paused" );
 #if defined(MBEDTLS_MPS_ENABLE_ASSERTIONS)
                     if( l3->io.in.hs.epoch != in.epoch )
                     {
                         /* This should never happen, as we don't allow switching
                          * the incoming epoch while pausing the reading of a
                          * handshake message. But double-check nonetheless. */
-                        TRACE( trace_error, "ASSERTION FAILURE!" );
-                        RETURN( MBEDTLS_ERR_MPS_INTERNAL_ERROR );
+                        MBEDTLS_MPS_TRACE( trace_error, "ASSERTION FAILURE!" );
+                        MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_INTERNAL_ERROR );
                     }
 #endif /* MBEDTLS_MPS_ENABLE_ASSERTIONS */
                     break;
@@ -374,8 +374,8 @@ int mps_l3_read( mps_l3 *l3 )
                     /* Should never happen -- if a handshake message
                      * is active, then this must be reflected in the
                      * state variable l3->io.in.state. */
-                    TRACE( trace_error, "ASSERTION FAILURE!" );
-                    RETURN( MBEDTLS_ERR_MPS_INTERNAL_ERROR );
+                    MBEDTLS_MPS_TRACE( trace_error, "ASSERTION FAILURE!" );
+                    MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_INTERNAL_ERROR );
 #else
                     break;
 #endif /* MBEDTLS_MPS_ENABLE_ASSERTIONS */
@@ -383,9 +383,9 @@ int mps_l3_read( mps_l3 *l3 )
 
             /* Bind the raw reader (supplying record contents) to the
              * extended reader (keeping track of global message bounds). */
-            ret = mbedtls_reader_attach( &l3->io.in.hs.rd_ext, in.rd );
+            ret = mbedtls_mps_reader_attach( &l3->io.in.hs.rd_ext, in.rd );
             if( ret != 0 )
-                RETURN( ret );
+                MBEDTLS_MPS_TRACE_RETURN( ret );
 
             /* Make changes to internal structures only now
              * that we know that everything went well. */
@@ -398,8 +398,8 @@ int mps_l3_read( mps_l3 *l3 )
         default:
             /* Should never happen because we configured L2
              * to only accept the above types. */
-            TRACE( trace_error, "ASSERTION FAILURE!" );
-            RETURN( MBEDTLS_ERR_MPS_INTERNAL_ERROR );
+            MBEDTLS_MPS_TRACE( trace_error, "ASSERTION FAILURE!" );
+            MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_INTERNAL_ERROR );
 #endif /* MBEDTLS_MPS_ENABLE_ASSERTIONS */
     }
 
@@ -407,13 +407,13 @@ int mps_l3_read( mps_l3 *l3 )
     l3->io.in.epoch  = in.epoch;
     l3->io.in.state  = in.type;
 
-    TRACE( trace_comment, "New state" );
-    TRACE( trace_comment, "* External state:  %u",
+    MBEDTLS_MPS_TRACE( trace_comment, "New state" );
+    MBEDTLS_MPS_TRACE( trace_comment, "* External state:  %u",
            (unsigned) l3->io.in.state );
-    TRACE( trace_comment, "* Handshake state: %u",
+    MBEDTLS_MPS_TRACE( trace_comment, "* Handshake state: %u",
            (unsigned) l3->io.in.hs.state );
 
-    RETURN( l3->io.in.state );
+    MBEDTLS_MPS_TRACE_RETURN( l3->io.in.state );
 }
 
 /* Mark an incoming message as fully processed. */
@@ -421,12 +421,12 @@ int mps_l3_read_consume( mps_l3 *l3 )
 {
     int res;
     mbedtls_mps_l2* const l2 = mbedtls_mps_l3_get_l2( l3 );
-    TRACE_INIT( "mps_l3_read_consume" );
+    MBEDTLS_MPS_TRACE_INIT( "mps_l3_read_consume" );
 
     switch( l3->io.in.state )
     {
         case MBEDTLS_MPS_MSG_HS:
-            TRACE( trace_comment, "Finishing handshake message" );
+            MBEDTLS_MPS_TRACE( trace_comment, "Finishing handshake message" );
             /* See mps_l3_read for the general description
              * of how the implementation uses extended readers
              * to handle pausing of handshake messages. */
@@ -434,19 +434,19 @@ int mps_l3_read_consume( mps_l3 *l3 )
             /* Attempt to close the extended reader.
              * This in particular checks whether the entire
              * message has been fetched and committed. */
-            if( mbedtls_reader_check_done( &l3->io.in.hs.rd_ext ) != 0 )
+            if( mbedtls_mps_reader_check_done( &l3->io.in.hs.rd_ext ) != 0 )
             {
-                TRACE( trace_error, "Attempting to close a not fully processed handshake message." );
-                RETURN( MBEDTLS_ERR_MPS_UNFINISHED_HS_MSG );
+                MBEDTLS_MPS_TRACE( trace_error, "Attempting to close a not fully processed handshake message." );
+                MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_UNFINISHED_HS_MSG );
             }
 
             /* Remove reference to raw reader from extended reader. */
-            res = mbedtls_reader_detach( &l3->io.in.hs.rd_ext );
+            res = mbedtls_mps_reader_detach( &l3->io.in.hs.rd_ext );
             if( res != 0 )
-                RETURN( res );
+                MBEDTLS_MPS_TRACE_RETURN( res );
 
             /* Reset extended reader. */
-            mbedtls_reader_free_ext( &l3->io.in.hs.rd_ext );
+            mbedtls_mps_reader_free_ext( &l3->io.in.hs.rd_ext );
 
             break;
 
@@ -473,13 +473,13 @@ int mps_l3_read_consume( mps_l3 *l3 )
     /* Signal that incoming data is fully processed. */
     res = mps_l2_read_done( l2 );
     if( res != 0 )
-        RETURN( res );
+        MBEDTLS_MPS_TRACE_RETURN( res );
 
     /* Reset state */
     if( l3->io.in.state == MBEDTLS_MPS_MSG_HS )
         l3->io.in.hs.state = MPS_L3_HS_NONE;
     l3->io.in.state = MBEDTLS_MPS_MSG_NONE;
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
 #if defined(MBEDTLS_MPS_PROTO_TLS)
@@ -488,7 +488,7 @@ int mps_l3_read_pause_handshake( mps_l3 *l3 )
 {
     int res;
     mbedtls_mps_l2* const l2 = mbedtls_mps_l3_get_l2( l3 );
-    TRACE_INIT( "mps_l3_read_pause_handshake" );
+    MBEDTLS_MPS_TRACE_INIT( "mps_l3_read_pause_handshake" );
 
     /* See mps_l3_read() for the general description
      * of how the implementation uses extended readers
@@ -500,9 +500,9 @@ int mps_l3_read_pause_handshake( mps_l3 *l3 )
         "mps_l3_read_pause_handshake() called in unexpected state." );
 
     /* Remove reference to raw reader from extended reader. */
-    res = mbedtls_reader_detach( &l3->io.in.hs.rd_ext );
+    res = mbedtls_mps_reader_detach( &l3->io.in.hs.rd_ext );
     if( res != 0 )
-        RETURN( res );
+        MBEDTLS_MPS_TRACE_RETURN( res );
 
     /* Remove reference to the raw reader borrowed from Layer 2
      * before calling mps_l2_read_done(), which invalidates it. */
@@ -511,12 +511,12 @@ int mps_l3_read_pause_handshake( mps_l3 *l3 )
     /* Signal to Layer 2 that incoming data is fully processed. */
     res = mps_l2_read_done( l2 );
     if( res != 0 )
-        RETURN( res );
+        MBEDTLS_MPS_TRACE_RETURN( res );
 
     /* Switch to paused state. */
     l3->io.in.state    = MBEDTLS_MPS_MSG_NONE;
     l3->io.in.hs.state = MPS_L3_HS_PAUSED;
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 #endif /* MBEDTLS_MPS_PROTO_TLS */
 
@@ -526,7 +526,7 @@ int mps_l3_read_pause_handshake( mps_l3 *l3 )
 
 /* Handshake */
 
-MBEDTLS_MPS_STATIC int l3_parse_hs_header( uint8_t mode, mbedtls_reader *rd,
+MBEDTLS_MPS_STATIC int l3_parse_hs_header( uint8_t mode, mbedtls_mps_reader *rd,
                                mps_l3_hs_in_internal *in )
 {
 #if !defined(MBEDTLS_MPS_PROTO_BOTH)
@@ -547,7 +547,7 @@ MBEDTLS_MPS_STATIC int l3_parse_hs_header( uint8_t mode, mbedtls_reader *rd,
 }
 
 #if defined(MBEDTLS_MPS_PROTO_TLS)
-MBEDTLS_MPS_STATIC int l3_parse_hs_header_tls( mbedtls_reader *rd,
+MBEDTLS_MPS_STATIC int l3_parse_hs_header_tls( mbedtls_mps_reader *rd,
                                    mps_l3_hs_in_internal *in )
 {
     int res;
@@ -585,7 +585,7 @@ MBEDTLS_MPS_STATIC int l3_parse_hs_header_tls( mbedtls_reader *rd,
 
     */
 
-    TRACE_INIT( "l3_parse_hs_header_tls" );
+    MBEDTLS_MPS_TRACE_INIT( "l3_parse_hs_header_tls" );
 
     /* This call might fail for handshake headers spanning
      * multiple records. This will be caught in up in the
@@ -593,26 +593,26 @@ MBEDTLS_MPS_STATIC int l3_parse_hs_header_tls( mbedtls_reader *rd,
      * in this case and ensure it can be satisfied the next
      * time it signals incoming data of handshake content type.
      * We therefore don't need to save state here. */
-    res = mbedtls_reader_get( rd, tls_hs_hdr_len, &tmp, NULL );
+    res = mbedtls_mps_reader_get( rd, tls_hs_hdr_len, &tmp, NULL );
     if( res != 0 )
-        RETURN( res );
+        MBEDTLS_MPS_TRACE_RETURN( res );
 
     MPS_READ_UINT8_BE ( tmp + tls_hs_type_offset, &in->type );
     MPS_READ_UINT24_BE( tmp + tls_hs_length_offset, &in->len );
 
-    res = mbedtls_reader_commit( rd );
+    res = mbedtls_mps_reader_commit( rd );
     if( res != 0 )
-        RETURN( res );
+        MBEDTLS_MPS_TRACE_RETURN( res );
 
-    TRACE( trace_comment, "Parsed handshake header" );
-    TRACE( trace_comment, "* Type:   %u", (unsigned) in->type );
-    TRACE( trace_comment, "* Length: %u", (unsigned) in->len );
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE( trace_comment, "Parsed handshake header" );
+    MBEDTLS_MPS_TRACE( trace_comment, "* Type:   %u", (unsigned) in->type );
+    MBEDTLS_MPS_TRACE( trace_comment, "* Length: %u", (unsigned) in->len );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 #endif /* MBEDTLS_MPS_PROTO_TLS */
 
 #if defined(MBEDTLS_MPS_PROTO_DTLS)
-MBEDTLS_MPS_STATIC int l3_parse_hs_header_dtls( mbedtls_reader *rd,
+MBEDTLS_MPS_STATIC int l3_parse_hs_header_dtls( mbedtls_mps_reader *rd,
                                     mps_l3_hs_in_internal *in )
 {
     int res;
@@ -652,11 +652,11 @@ MBEDTLS_MPS_STATIC int l3_parse_hs_header_dtls( mbedtls_reader *rd,
      *
      */
 
-    TRACE_INIT( "parse_hs_header_dtls" );
+    MBEDTLS_MPS_TRACE_INIT( "parse_hs_header_dtls" );
 
-    res = mbedtls_reader_get( rd, dtls_hs_hdr_len, &tmp, NULL );
+    res = mbedtls_mps_reader_get( rd, dtls_hs_hdr_len, &tmp, NULL );
     if( res != 0 )
-        RETURN( res );
+        MBEDTLS_MPS_TRACE_RETURN( res );
 
     MPS_READ_UINT8_BE ( tmp + dtls_hs_type_offset, &in->type );
     MPS_READ_UINT24_BE( tmp + dtls_hs_len_offset, &in->len );
@@ -664,40 +664,40 @@ MBEDTLS_MPS_STATIC int l3_parse_hs_header_dtls( mbedtls_reader *rd,
     MPS_READ_UINT24_BE( tmp + dtls_hs_frag_off_offset, &in->frag_offset );
     MPS_READ_UINT24_BE( tmp + dtls_hs_frag_len_offset, &in->frag_len );
 
-    res = mbedtls_reader_commit( rd );
+    res = mbedtls_mps_reader_commit( rd );
     if( res != 0 )
-        RETURN( res );
+        MBEDTLS_MPS_TRACE_RETURN( res );
 
     /* frag_offset + frag_len cannot overflow within uint32_t
      * since the summands are 24 bit each. */
     if( in->frag_offset + in->frag_len > in->len )
     {
-        TRACE( trace_error, "Invalid handshake header: frag_offset (%u) + frag_len (%u) > len (%u)",
+        MBEDTLS_MPS_TRACE( trace_error, "Invalid handshake header: frag_offset (%u) + frag_len (%u) > len (%u)",
                (unsigned)in->frag_offset,
                (unsigned)in->frag_len,
                (unsigned)in->len );
-        RETURN( MBEDTLS_ERR_MPS_INVALID_CONTENT );
+        MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_INVALID_CONTENT );
     }
 
-    TRACE( trace_comment, "Parsed DTLS handshake header" );
-    TRACE( trace_comment, "* Type:        %u", (unsigned) in->type        );
-    TRACE( trace_comment, "* Length:      %u", (unsigned) in->len         );
-    TRACE( trace_comment, "* Sequence Nr: %u", (unsigned) in->seq_nr      );
-    TRACE( trace_comment, "* Frag Offset: %u", (unsigned) in->frag_offset );
-    TRACE( trace_comment, "* Frag Length: %u", (unsigned) in->frag_len    );
+    MBEDTLS_MPS_TRACE( trace_comment, "Parsed DTLS handshake header" );
+    MBEDTLS_MPS_TRACE( trace_comment, "* Type:        %u", (unsigned) in->type        );
+    MBEDTLS_MPS_TRACE( trace_comment, "* Length:      %u", (unsigned) in->len         );
+    MBEDTLS_MPS_TRACE( trace_comment, "* Sequence Nr: %u", (unsigned) in->seq_nr      );
+    MBEDTLS_MPS_TRACE( trace_comment, "* Frag Offset: %u", (unsigned) in->frag_offset );
+    MBEDTLS_MPS_TRACE( trace_comment, "* Frag Length: %u", (unsigned) in->frag_len    );
 
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 #endif /* MBEDTLS_MPS_PROTO_DTLS */
 
 /* Alert */
 
-MBEDTLS_MPS_STATIC int l3_parse_alert( mbedtls_reader *rd,
+MBEDTLS_MPS_STATIC int l3_parse_alert( mbedtls_mps_reader *rd,
                            mps_l3_alert_in_internal *alert )
 {
     int res;
     unsigned char *tmp;
-    TRACE_INIT( "l3_parse_alert" );
+    MBEDTLS_MPS_TRACE_INIT( "l3_parse_alert" );
 
     /*
 
@@ -718,39 +718,39 @@ MBEDTLS_MPS_STATIC int l3_parse_alert( mbedtls_reader *rd,
      * in this case and ensure it can be satisfied the next
      * time it signals incoming data of alert content type.
      * We therefore don't need to save state here. */
-    res = mbedtls_reader_get( rd, MPS_TLS_ALERT_SIZE, &tmp, NULL );
+    res = mbedtls_mps_reader_get( rd, MPS_TLS_ALERT_SIZE, &tmp, NULL );
     if( res != 0 )
-        RETURN( res );
+        MBEDTLS_MPS_TRACE_RETURN( res );
 
     MPS_READ_UINT8_BE( tmp + 0, &alert->level );
     MPS_READ_UINT8_BE( tmp + 1, &alert->type );
 
-    res = mbedtls_reader_commit( rd );
+    res = mbedtls_mps_reader_commit( rd );
     if( res != 0 )
-        RETURN( res );
+        MBEDTLS_MPS_TRACE_RETURN( res );
 
-    TRACE( trace_comment, "Parsed alert message" );
-    TRACE( trace_comment, "* Level: %u", (unsigned) alert->level );
-    TRACE( trace_comment, "* Type:  %u", (unsigned) alert->type );
+    MBEDTLS_MPS_TRACE( trace_comment, "Parsed alert message" );
+    MBEDTLS_MPS_TRACE( trace_comment, "* Level: %u", (unsigned) alert->level );
+    MBEDTLS_MPS_TRACE( trace_comment, "* Type:  %u", (unsigned) alert->type );
 
     if( alert->level != MPS_TLS_ALERT_LEVEL_FATAL &&
         alert->level != MPS_TLS_ALERT_LEVEL_WARNING )
     {
-        TRACE( trace_error, "Alert level unknown" );
-        RETURN( MBEDTLS_ERR_MPS_INVALID_CONTENT );
+        MBEDTLS_MPS_TRACE( trace_error, "Alert level unknown" );
+        MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_INVALID_CONTENT );
     }
 
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
 /* CCS */
 
-MBEDTLS_MPS_STATIC int l3_parse_ccs( mbedtls_reader *rd )
+MBEDTLS_MPS_STATIC int l3_parse_ccs( mbedtls_mps_reader *rd )
 {
     int res;
     unsigned char *tmp;
     uint8_t val;
-    TRACE_INIT( "l3_parse_ccs" );
+    MBEDTLS_MPS_TRACE_INIT( "l3_parse_ccs" );
 
     /*
 
@@ -762,25 +762,25 @@ MBEDTLS_MPS_STATIC int l3_parse_ccs( mbedtls_reader *rd )
 
     */
 
-    res = mbedtls_reader_get( rd, MPS_TLS_CCS_SIZE, &tmp, NULL );
+    res = mbedtls_mps_reader_get( rd, MPS_TLS_CCS_SIZE, &tmp, NULL );
     if( res != 0 )
-        RETURN( res );
+        MBEDTLS_MPS_TRACE_RETURN( res );
 
     MPS_READ_UINT8_BE( tmp + 0, &val );
 
-    res = mbedtls_reader_commit( rd );
+    res = mbedtls_mps_reader_commit( rd );
     if( res != 0 )
-        RETURN( res );
+        MBEDTLS_MPS_TRACE_RETURN( res );
 
     if( val != MPS_TLS_CCS_VALUE )
     {
-        TRACE( trace_error, "Bad CCS value %u", (unsigned) val );
-        RETURN( MBEDTLS_ERR_MPS_INVALID_CONTENT );
+        MBEDTLS_MPS_TRACE( trace_error, "Bad CCS value %u", (unsigned) val );
+        MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_INVALID_CONTENT );
     }
 
-    TRACE( trace_comment, "Parsed alert message" );
-    TRACE( trace_comment, " * Value: %u", (unsigned) MPS_TLS_CCS_VALUE );
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE( trace_comment, "Parsed alert message" );
+    MBEDTLS_MPS_TRACE( trace_comment, " * Value: %u", (unsigned) MPS_TLS_CCS_VALUE );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
 /*
@@ -792,7 +792,7 @@ int mps_l3_read_handshake( mps_l3 *l3, mps_l3_handshake_in *hs )
     mbedtls_mps_transport_type const mode =
         mbedtls_mps_l3_conf_get_mode( &l3->conf );
 
-    TRACE_INIT( "mps_l3_read_handshake" );
+    MBEDTLS_MPS_TRACE_INIT( "mps_l3_read_handshake" );
 
     MBEDTLS_MPS_STATE_VALIDATE_RAW(
         l3->io.in.state    == MBEDTLS_MPS_MSG_HS &&
@@ -815,12 +815,12 @@ int mps_l3_read_handshake( mps_l3 *l3, mps_l3_handshake_in *hs )
     ((void) mode);
 #endif /* MBEDTLS_MPS_PROTO_DTLS */
 
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
 int mps_l3_read_app( mps_l3 *l3, mps_l3_app_in *app )
 {
-    TRACE_INIT( "mps_l3_read_app" );
+    MBEDTLS_MPS_TRACE_INIT( "mps_l3_read_app" );
 
     MBEDTLS_MPS_STATE_VALIDATE_RAW(
         l3->io.in.state == MBEDTLS_MPS_MSG_APP,
@@ -828,12 +828,12 @@ int mps_l3_read_app( mps_l3 *l3, mps_l3_app_in *app )
 
     app->epoch = l3->io.in.epoch;
     app->rd = l3->io.in.raw_in;
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
 int mps_l3_read_alert( mps_l3 *l3, mps_l3_alert_in *alert )
 {
-    TRACE_INIT( "mps_l3_read_alert" );
+    MBEDTLS_MPS_TRACE_INIT( "mps_l3_read_alert" );
 
     MBEDTLS_MPS_STATE_VALIDATE_RAW(
         l3->io.in.state == MBEDTLS_MPS_MSG_ALERT,
@@ -842,19 +842,19 @@ int mps_l3_read_alert( mps_l3 *l3, mps_l3_alert_in *alert )
     alert->epoch = l3->io.in.epoch;
     alert->type  = l3->io.in.alert.type;
     alert->level = l3->io.in.alert.level;
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
 int mps_l3_read_ccs( mps_l3 *l3, mps_l3_ccs_in *ccs )
 {
-    TRACE_INIT( "mps_l3_read_ccs" );
+    MBEDTLS_MPS_TRACE_INIT( "mps_l3_read_ccs" );
 
     MBEDTLS_MPS_STATE_VALIDATE_RAW(
         l3->io.in.state == MBEDTLS_MPS_MSG_CCS,
         "mps_l3_read_appccs() called in unexpected state." );
 
     ccs->epoch = l3->io.in.epoch;
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
 /*
@@ -863,9 +863,9 @@ int mps_l3_read_ccs( mps_l3 *l3, mps_l3_ccs_in *ccs )
 
 int mps_l3_flush( mps_l3 *l3 )
 {
-    TRACE_INIT( "mps_l3_flush" );
+    MBEDTLS_MPS_TRACE_INIT( "mps_l3_flush" );
     l3->io.out.clearing = 1;
-    RETURN( l3_check_clear( l3 ) );
+    MBEDTLS_MPS_TRACE_RETURN( l3_check_clear( l3 ) );
 }
 
 #if defined(MBEDTLS_MPS_PROTO_TLS)
@@ -937,14 +937,14 @@ int mps_l3_write_handshake( mps_l3 *l3, mps_l3_handshake_out *out )
     mbedtls_mps_transport_type const mode =
         mbedtls_mps_l3_conf_get_mode( &l3->conf );
 
-    TRACE_INIT( "l3_write_handshake" );
-    TRACE( trace_comment, "Parameters: " );
-    TRACE( trace_comment, "* Seq Nr:   %u", (unsigned) out->seq_nr );
-    TRACE( trace_comment, "* Epoch:    %u", (unsigned) out->epoch );
-    TRACE( trace_comment, "* Type:     %u", (unsigned) out->type );
-    TRACE( trace_comment, "* Length:   %u", (unsigned) out->len );
-    TRACE( trace_comment, "* Frag Off: %u", (unsigned) out->frag_offset );
-    TRACE( trace_comment, "* Frag Len: %u", (unsigned) out->frag_len );
+    MBEDTLS_MPS_TRACE_INIT( "l3_write_handshake" );
+    MBEDTLS_MPS_TRACE( trace_comment, "Parameters: " );
+    MBEDTLS_MPS_TRACE( trace_comment, "* Seq Nr:   %u", (unsigned) out->seq_nr );
+    MBEDTLS_MPS_TRACE( trace_comment, "* Epoch:    %u", (unsigned) out->epoch );
+    MBEDTLS_MPS_TRACE( trace_comment, "* Type:     %u", (unsigned) out->type );
+    MBEDTLS_MPS_TRACE( trace_comment, "* Length:   %u", (unsigned) out->len );
+    MBEDTLS_MPS_TRACE( trace_comment, "* Frag Off: %u", (unsigned) out->frag_offset );
+    MBEDTLS_MPS_TRACE( trace_comment, "* Frag Len: %u", (unsigned) out->frag_len );
 
     /*
      * See the documentation of mps_l3_read() for a description
@@ -959,18 +959,18 @@ int mps_l3_write_handshake( mps_l3 *l3, mps_l3_handshake_out *out )
           l3->io.out.hs.type  != out->type  ||
           l3->io.out.hs.len   != out->len ) )
     {
-        TRACE( trace_error, "Inconsistent parameters on continuation." );
-        RETURN( MBEDTLS_ERR_MPS_INVALID_ARGS );
+        MBEDTLS_MPS_TRACE( trace_error, "Inconsistent parameters on continuation." );
+        MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_INVALID_ARGS );
     }
 #endif /* MBEDTLS_MPS_STATE_VALIDATION */
 
     res = l3_prepare_write( l3, MBEDTLS_MPS_MSG_HS, out->epoch );
     if( res != 0 )
-        RETURN( res );
+        MBEDTLS_MPS_TRACE_RETURN( res );
 
     if( l3->io.out.hs.state == MPS_L3_HS_NONE )
     {
-        TRACE( trace_comment, "No handshake message currently paused" );
+        MBEDTLS_MPS_TRACE( trace_comment, "No handshake message currently paused" );
 
         l3->io.out.hs.epoch = out->epoch;
         l3->io.out.hs.len   = out->len;
@@ -990,8 +990,8 @@ int mps_l3_write_handshake( mps_l3 *l3, mps_l3_handshake_out *out )
                 ( out->frag_offset != 0 ||
                   out->frag_len    != MBEDTLS_MPS_SIZE_UNKNOWN ) )
             {
-                TRACE( trace_error, "ASSERTION FAILURE!" );
-                RETURN( MBEDTLS_ERR_MPS_INTERNAL_ERROR );
+                MBEDTLS_MPS_TRACE( trace_error, "ASSERTION FAILURE!" );
+                MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_INTERNAL_ERROR );
             }
 
             /* Check that fragment doesn't exceed the total message length. */
@@ -1009,8 +1009,8 @@ int mps_l3_write_handshake( mps_l3 *l3, mps_l3_handshake_out *out )
                 if( end_of_fragment < out->frag_offset /* overflow */ ||
                     end_of_fragment > total_len )
                 {
-                    TRACE( trace_error, "ASSERTION FAILURE!" );
-                    RETURN( MBEDTLS_ERR_MPS_INTERNAL_ERROR );
+                    MBEDTLS_MPS_TRACE( trace_error, "ASSERTION FAILURE!" );
+                    MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_INTERNAL_ERROR );
                 }
             }
 #endif /* MBEDTLS_MPS_ENABLE_ASSERTIONS */
@@ -1034,27 +1034,27 @@ int mps_l3_write_handshake( mps_l3 *l3, mps_l3_handshake_out *out )
          * again. */
         if( res == MBEDTLS_ERR_WRITER_OUT_OF_DATA )
         {
-            TRACE( trace_comment, "Not enough space to write handshake header - flush." );
+            MBEDTLS_MPS_TRACE( trace_comment, "Not enough space to write handshake header - flush." );
             /* Remember that we must flush. */
             l3->io.out.clearing = 1;
             l3->io.out.state = MBEDTLS_MPS_MSG_NONE;
             res = mps_l2_write_done( l2 );
             if( res != 0 )
-                RETURN( res );
+                MBEDTLS_MPS_TRACE_RETURN( res );
 
             /* We could return WANT_WRITE here to indicate that
              * progress hinges on the availability of the underlying
              * transport. */
-            RETURN( MBEDTLS_ERR_MPS_RETRY );
+            MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_RETRY );
         }
         else if( res != 0 )
-            RETURN( res );
+            MBEDTLS_MPS_TRACE_RETURN( res );
 
         /* Write the handshake header if we have
          * complete knowledge about the lengths. */
         res = l3_check_write_hs_hdr( l3 );
         if( res != 0 )
-            RETURN( res );
+            MBEDTLS_MPS_TRACE_RETURN( res );
 
         /* Note: Even if we do not know the total handshake length in
          *       advance, we do not yet commit the handshake header.
@@ -1063,7 +1063,7 @@ int mps_l3_write_handshake( mps_l3 *l3, mps_l3_handshake_out *out )
          *       progress, and in this case we should abort the write
          *       instead of writing an empty handshake fragment. */
 
-        TRACE( trace_comment, "Setup extended writer for handshake message" );
+        MBEDTLS_MPS_TRACE( trace_comment, "Setup extended writer for handshake message" );
 
         /* TODO: Think about storing the frag_len in len for DTLS
          *       to avoid this distinction. */
@@ -1084,7 +1084,7 @@ int mps_l3_write_handshake( mps_l3 *l3, mps_l3_handshake_out *out )
         }
 #endif /* MBEDTLS_MPS_PROTO_DTLS */
         if( res != 0 )
-            RETURN( res );
+            MBEDTLS_MPS_TRACE_RETURN( res );
     }
 
 
@@ -1097,31 +1097,31 @@ int mps_l3_write_handshake( mps_l3 *l3, mps_l3_handshake_out *out )
         len = out->frag_len;
 #endif /* MBEDTLS_MPS_PROTO_DTLS */
 
-    TRACE( trace_comment, "Bind raw writer to extended writer" );
+    MBEDTLS_MPS_TRACE( trace_comment, "Bind raw writer to extended writer" );
     res = mbedtls_writer_attach( &l3->io.out.hs.wr_ext, l3->io.out.raw_out,
                                  len != MBEDTLS_MPS_SIZE_UNKNOWN
                                  ? MBEDTLS_WRITER_EXT_PASS
                                  : MBEDTLS_WRITER_EXT_HOLD );
     if( res != 0 )
-        RETURN( res );
+        MBEDTLS_MPS_TRACE_RETURN( res );
 
     l3->io.out.hs.state = MPS_L3_HS_ACTIVE;
     out->wr_ext = &l3->io.out.hs.wr_ext;
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
 int mps_l3_write_app( mps_l3 *l3, mps_l3_app_out *app )
 {
     int res;
     mbedtls_mps_epoch_id epoch = app->epoch;
-    TRACE_INIT( "l3_write_app: epoch %u", (unsigned) epoch );
+    MBEDTLS_MPS_TRACE_INIT( "l3_write_app: epoch %u", (unsigned) epoch );
 
     res = l3_prepare_write( l3, MBEDTLS_MPS_MSG_APP, epoch );
     if( res != 0 )
-        RETURN( res );
+        MBEDTLS_MPS_TRACE_RETURN( res );
 
     app->wr = l3->io.out.raw_out;
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
 int mps_l3_write_alert( mps_l3 *l3, mps_l3_alert_out *alert )
@@ -1130,11 +1130,11 @@ int mps_l3_write_alert( mps_l3 *l3, mps_l3_alert_out *alert )
     unsigned char *tmp;
     mbedtls_mps_epoch_id epoch = alert->epoch;
     mbedtls_mps_l2* const l2 = mbedtls_mps_l3_get_l2( l3 );
-    TRACE_INIT( "l3_write_alert: epoch %u", (unsigned) epoch );
+    MBEDTLS_MPS_TRACE_INIT( "l3_write_alert: epoch %u", (unsigned) epoch );
 
     res = l3_prepare_write( l3, MBEDTLS_MPS_MSG_ALERT, epoch );
     if( res != 0 )
-        RETURN( res );
+        MBEDTLS_MPS_TRACE_RETURN( res );
 
     res = mbedtls_writer_get( l3->io.out.raw_out, 2, &tmp, NULL );
     if( res == MBEDTLS_ERR_WRITER_OUT_OF_DATA )
@@ -1143,19 +1143,19 @@ int mps_l3_write_alert( mps_l3 *l3, mps_l3_alert_out *alert )
         l3->io.out.state = MBEDTLS_MPS_MSG_NONE;
         res = mps_l2_write_done( l2 );
         if( res != 0 )
-            RETURN( res );
+            MBEDTLS_MPS_TRACE_RETURN( res );
 
         /* We could return WANT_WRITE here to indicate that
          * progress hinges on the availability of the underlying
          * transport. */
-        RETURN( MBEDTLS_ERR_MPS_RETRY );
+        MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_RETRY );
     }
     else if( res != 0 )
-        RETURN( res );
+        MBEDTLS_MPS_TRACE_RETURN( res );
 
     alert->level = &tmp[0];
     alert->type  = &tmp[1];
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
 int mps_l3_write_ccs( mps_l3 *l3, mps_l3_ccs_out *ccs )
@@ -1164,11 +1164,11 @@ int mps_l3_write_ccs( mps_l3 *l3, mps_l3_ccs_out *ccs )
     unsigned char *tmp;
     mbedtls_mps_epoch_id epoch = ccs->epoch;
     mbedtls_mps_l2* const l2 = mbedtls_mps_l3_get_l2( l3 );
-    TRACE_INIT( "l3_write_ccs: epoch %u", (unsigned) epoch );
+    MBEDTLS_MPS_TRACE_INIT( "l3_write_ccs: epoch %u", (unsigned) epoch );
 
     res = l3_prepare_write( l3, MBEDTLS_MPS_MSG_CCS, epoch );
     if( res != 0 )
-        RETURN( res );
+        MBEDTLS_MPS_TRACE_RETURN( res );
 
     res = mbedtls_writer_get( l3->io.out.raw_out, 1, &tmp, NULL );
     if( res == MBEDTLS_ERR_WRITER_OUT_OF_DATA )
@@ -1177,18 +1177,18 @@ int mps_l3_write_ccs( mps_l3 *l3, mps_l3_ccs_out *ccs )
         l3->io.out.state = MBEDTLS_MPS_MSG_NONE;
         res = mps_l2_write_done( l2 );
         if( res != 0 )
-            RETURN( res );
+            MBEDTLS_MPS_TRACE_RETURN( res );
 
         /* We could return WANT_WRITE here to indicate that
          * progress hinges on the availability of the underlying
          * transport. */
-        RETURN( MBEDTLS_ERR_MPS_RETRY );
+        MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_RETRY );
     }
     else if( res != 0 )
-        RETURN( res );
+        MBEDTLS_MPS_TRACE_RETURN( res );
 
     *tmp = MPS_TLS_CCS_VALUE;
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
 #if defined(MBEDTLS_MPS_PROTO_TLS)
@@ -1198,7 +1198,7 @@ int mps_l3_pause_handshake( mps_l3 *l3 )
     int res;
     mbedtls_mps_size_t uncommitted;
     mbedtls_mps_l2* const l2 = mbedtls_mps_l3_get_l2( l3 );
-    TRACE_INIT( "mps_l3_pause_handshake" );
+    MBEDTLS_MPS_TRACE_INIT( "mps_l3_pause_handshake" );
 
     /* See mps_l3_read() for the general description
      * of how the implementation uses extended readers to
@@ -1216,7 +1216,7 @@ int mps_l3_pause_handshake( mps_l3 *l3 )
                                  NULL,
                                  &uncommitted );
     if( res != 0 )
-        RETURN( res );
+        MBEDTLS_MPS_TRACE_RETURN( res );
 
     /* We must perform this commit even if commits
      * are passed through, because it might happen
@@ -1226,7 +1226,7 @@ int mps_l3_pause_handshake( mps_l3 *l3 )
     res = mbedtls_writer_commit_partial( l3->io.out.raw_out,
                                          uncommitted );
     if( res != 0 )
-        RETURN( res );
+        MBEDTLS_MPS_TRACE_RETURN( res );
 
     /* Remove reference to the raw writer borrowed from Layer 2
      * before calling mps_l2_write_done(), which invalidates it. */
@@ -1236,12 +1236,12 @@ int mps_l3_pause_handshake( mps_l3 *l3 )
      * writing to the outgoing data buffers. */
     res = mps_l2_write_done( l2 );
     if( res != 0 )
-        RETURN( res );
+        MBEDTLS_MPS_TRACE_RETURN( res );
 
     /* Switch to paused state. */
     l3->io.out.hs.state = MPS_L3_HS_PAUSED;
     l3->io.out.state    = MBEDTLS_MPS_MSG_NONE;
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 #endif /* MBEDTLS_MPS_PROTO_TLS */
 
@@ -1252,7 +1252,7 @@ int UNUSED mps_l3_write_abort_handshake( mps_l3 *l3 )
     int res;
     mbedtls_mps_size_t committed;
     mbedtls_mps_l2* const l2 = mbedtls_mps_l3_get_l2( l3 );
-    TRACE_INIT( "mps_l3_write_abort_handshake" );
+    MBEDTLS_MPS_TRACE_INIT( "mps_l3_write_abort_handshake" );
 
     MBEDTLS_MPS_STATE_VALIDATE_RAW(
         l3->io.out.state    == MBEDTLS_MPS_MSG_HS &&
@@ -1264,7 +1264,7 @@ int UNUSED mps_l3_write_abort_handshake( mps_l3 *l3 )
                                  &committed,
                                  NULL );
     if( res != 0 )
-        RETURN( res );
+        MBEDTLS_MPS_TRACE_RETURN( res );
 
     /* Reset extended writer. */
     mbedtls_writer_free_ext( &l3->io.out.hs.wr_ext );
@@ -1280,11 +1280,11 @@ int UNUSED mps_l3_write_abort_handshake( mps_l3 *l3 )
      * writing to the outgoing data buffers. */
     res = mps_l2_write_done( l2 );
     if( res != 0 )
-        RETURN( res );
+        MBEDTLS_MPS_TRACE_RETURN( res );
 
     l3->io.out.hs.state = MPS_L3_HS_NONE;
     l3->io.out.state    = MBEDTLS_MPS_MSG_NONE;
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
 int mps_l3_dispatch( mps_l3 *l3 )
@@ -1296,33 +1296,33 @@ int mps_l3_dispatch( mps_l3 *l3 )
     mbedtls_mps_transport_type const mode =
         mbedtls_mps_l3_conf_get_mode( &l3->conf );
 
-    TRACE_INIT( "mps_l3_dispatch" );
+    MBEDTLS_MPS_TRACE_INIT( "mps_l3_dispatch" );
 
     switch( l3->io.out.state )
     {
         case MBEDTLS_MPS_MSG_HS:
-            TRACE( trace_comment, "Dispatch handshake message" );
+            MBEDTLS_MPS_TRACE( trace_comment, "Dispatch handshake message" );
 
 #if defined(MBEDTLS_MPS_ENABLE_ASSERTIONS)
             if( l3->io.out.hs.state != MPS_L3_HS_ACTIVE )
             {
-                TRACE( trace_error, "ASSERTION FAILURE!" );
-                RETURN( MBEDTLS_ERR_MPS_INTERNAL_ERROR );
+                MBEDTLS_MPS_TRACE( trace_error, "ASSERTION FAILURE!" );
+                MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_INTERNAL_ERROR );
             }
 #endif /* MBEDTLS_MPS_ENABLE_ASSERTIONS */
 
             res = mbedtls_writer_check_done( &l3->io.out.hs.wr_ext );
             if( res != 0 )
             {
-                TRACE( trace_error, "Attempting to close not yet fully written handshake message." );
-                RETURN( MBEDTLS_ERR_MPS_UNFINISHED_HS_MSG );
+                MBEDTLS_MPS_TRACE( trace_error, "Attempting to close not yet fully written handshake message." );
+                MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_UNFINISHED_HS_MSG );
             }
 
             res = mbedtls_writer_detach( &l3->io.out.hs.wr_ext,
                                          &committed,
                                          &uncommitted );
             if( res != 0 )
-                RETURN( res );
+                MBEDTLS_MPS_TRACE_RETURN( res );
 
             /* Reset extended writer. */
             mbedtls_writer_free_ext( &l3->io.out.hs.wr_ext );
@@ -1354,36 +1354,36 @@ int mps_l3_dispatch( mps_l3 *l3 )
              * Write the header now. */
             res = l3_check_write_hs_hdr( l3 );
             if( res != 0 )
-                RETURN( res );
+                MBEDTLS_MPS_TRACE_RETURN( res );
 
             res = mbedtls_writer_commit_partial( l3->io.out.raw_out,
                                                  uncommitted );
             if( res != 0 )
-                RETURN( res );
+                MBEDTLS_MPS_TRACE_RETURN( res );
 
             l3->io.out.hs.state = MPS_L3_HS_NONE;
             break;
 
         case MBEDTLS_MPS_MSG_ALERT:
-            TRACE( trace_comment, "Dispatch alert message" );
+            MBEDTLS_MPS_TRACE( trace_comment, "Dispatch alert message" );
             res = mbedtls_writer_commit( l3->io.out.raw_out );
             if( res != 0 )
-                RETURN( res );
+                MBEDTLS_MPS_TRACE_RETURN( res );
 
             break;
 
         case MBEDTLS_MPS_MSG_CCS:
-            TRACE( trace_comment, "Dispatch CCS message" );
+            MBEDTLS_MPS_TRACE( trace_comment, "Dispatch CCS message" );
             res = mbedtls_writer_commit( l3->io.out.raw_out );
             if( res != 0 )
-                RETURN( res );
+                MBEDTLS_MPS_TRACE_RETURN( res );
 
             break;
 
         case MBEDTLS_MPS_MSG_APP:
             /* The application data is directly written through
              * the writer. */
-            TRACE( trace_comment, "Dispatch application data" );
+            MBEDTLS_MPS_TRACE( trace_comment, "Dispatch application data" );
             break;
 
         default:
@@ -1404,11 +1404,11 @@ int mps_l3_dispatch( mps_l3 *l3 )
 
     res = mps_l2_write_done( l2 );
     if( res != 0 )
-        RETURN( res );
+        MBEDTLS_MPS_TRACE_RETURN( res );
 
-    TRACE( trace_comment, "Done" );
+    MBEDTLS_MPS_TRACE( trace_comment, "Done" );
     l3->io.out.state = MBEDTLS_MPS_MSG_NONE;
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
 #if defined(MBEDTLS_MPS_PROTO_TLS)
@@ -1449,14 +1449,14 @@ MBEDTLS_MPS_STATIC int l3_write_hs_header_tls( mps_l3_hs_out_internal *hs )
 
     */
 
-    TRACE_INIT( "l3_write_hs_hdr_tls, type %u, len %u",
+    MBEDTLS_MPS_TRACE_INIT( "l3_write_hs_hdr_tls, type %u, len %u",
            (unsigned) hs->type, (unsigned) hs->len );
 
 #if defined(MBEDTLS_MPS_ENABLE_ASSERTIONS)
     if( buf == NULL || hs->hdr_len != tls_hs_hdr_len )
     {
-        TRACE( trace_error, "ASSERTION FAILURE!" );
-        RETURN( MBEDTLS_ERR_MPS_INTERNAL_ERROR );
+        MBEDTLS_MPS_TRACE( trace_error, "ASSERTION FAILURE!" );
+        MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_INTERNAL_ERROR );
     }
 #else
     ((void) tls_hs_hdr_len);
@@ -1465,7 +1465,7 @@ MBEDTLS_MPS_STATIC int l3_write_hs_header_tls( mps_l3_hs_out_internal *hs )
     MPS_WRITE_UINT8_BE ( &hs->type, buf + tls_hs_type_offset   );
     MPS_WRITE_UINT24_BE( &hs->len,  buf + tls_hs_length_offset );
 
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 #endif /* MBEDTLS_MPS_PROTO_TLS */
 
@@ -1509,14 +1509,14 @@ MBEDTLS_MPS_STATIC int l3_write_hs_header_dtls( mps_l3_hs_out_internal *hs )
      *
      */
 
-    TRACE_INIT( "l3_write_hs_hdr_tls, type %u, len %u",
+    MBEDTLS_MPS_TRACE_INIT( "l3_write_hs_hdr_tls, type %u, len %u",
            (unsigned) hs->type, (unsigned) hs->len );
 
 #if defined(MBEDTLS_MPS_ENABLE_ASSERTIONS)
     if( buf == NULL || hs->hdr_len != dtls_hs_hdr_len )
     {
-        TRACE( trace_error, "ASSERTION FAILURE!" );
-        RETURN( MBEDTLS_ERR_MPS_INTERNAL_ERROR );
+        MBEDTLS_MPS_TRACE( trace_error, "ASSERTION FAILURE!" );
+        MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_INTERNAL_ERROR );
     }
 #else
     ((void) dtls_hs_hdr_len);
@@ -1528,14 +1528,14 @@ MBEDTLS_MPS_STATIC int l3_write_hs_header_dtls( mps_l3_hs_out_internal *hs )
     MPS_WRITE_UINT24_BE( &hs->frag_offset, buf + dtls_hs_frag_off_offset );
     MPS_WRITE_UINT24_BE( &hs->frag_len,    buf + dtls_hs_frag_len_offset );
 
-    TRACE( trace_comment, "Wrote DTLS handshake header" );
-    TRACE( trace_comment, "* Type:        %u", (unsigned) hs->type        );
-    TRACE( trace_comment, "* Length:      %u", (unsigned) hs->len         );
-    TRACE( trace_comment, "* Sequence Nr: %u", (unsigned) hs->seq_nr      );
-    TRACE( trace_comment, "* Frag Offset: %u", (unsigned) hs->frag_offset );
-    TRACE( trace_comment, "* Frag Length: %u", (unsigned) hs->frag_len    );
+    MBEDTLS_MPS_TRACE( trace_comment, "Wrote DTLS handshake header" );
+    MBEDTLS_MPS_TRACE( trace_comment, "* Type:        %u", (unsigned) hs->type        );
+    MBEDTLS_MPS_TRACE( trace_comment, "* Length:      %u", (unsigned) hs->len         );
+    MBEDTLS_MPS_TRACE( trace_comment, "* Sequence Nr: %u", (unsigned) hs->seq_nr      );
+    MBEDTLS_MPS_TRACE( trace_comment, "* Frag Offset: %u", (unsigned) hs->frag_offset );
+    MBEDTLS_MPS_TRACE( trace_comment, "* Frag Length: %u", (unsigned) hs->frag_len    );
 
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 #endif /* MBEDTLS_MPS_PROTO_DTLS */
 
@@ -1546,16 +1546,16 @@ MBEDTLS_MPS_STATIC int l3_check_clear( mps_l3 *l3 )
 {
     int res;
     mbedtls_mps_l2* const l2 = mbedtls_mps_l3_get_l2( l3 );
-    TRACE_INIT( "l3_check_clear" );
+    MBEDTLS_MPS_TRACE_INIT( "l3_check_clear" );
     if( l3->io.out.clearing == 0 )
-        RETURN( 0 );
+        MBEDTLS_MPS_TRACE_RETURN( 0 );
 
     res = mps_l2_write_flush( l2 );
     if( res != 0 )
-        RETURN( res );
+        MBEDTLS_MPS_TRACE_RETURN( res );
 
     l3->io.out.clearing = 0;
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
 /*
@@ -1569,9 +1569,9 @@ MBEDTLS_MPS_STATIC int l3_prepare_write( mps_l3 *l3, mbedtls_mps_msg_type_t port
     int res;
     mps_l2_out out;
     mbedtls_mps_l2* const l2 = mbedtls_mps_l3_get_l2( l3 );
-    TRACE_INIT( "l3_prepare_write" );
-    TRACE( trace_comment, "* Type:  %u", (unsigned) port );
-    TRACE( trace_comment, "* Epoch: %u", (unsigned) epoch );
+    MBEDTLS_MPS_TRACE_INIT( "l3_prepare_write" );
+    MBEDTLS_MPS_TRACE( trace_comment, "* Type:  %u", (unsigned) port );
+    MBEDTLS_MPS_TRACE( trace_comment, "* Epoch: %u", (unsigned) epoch );
 
     MBEDTLS_MPS_STATE_VALIDATE_RAW( l3->io.out.state == MBEDTLS_MPS_MSG_NONE,
                       "l3_prepare_write() called in unexpected state." );
@@ -1579,24 +1579,24 @@ MBEDTLS_MPS_STATIC int l3_prepare_write( mps_l3 *l3, mbedtls_mps_msg_type_t port
 #if !defined(MPS_L3_ALLOW_INTERLEAVED_SENDING)
     if( l3->io.out.hs.state == MPS_L3_HS_PAUSED && port != MBEDTLS_MPS_MSG_HS )
     {
-        TRACE( trace_error, "Interleaving of outgoing messages is disabled." );
-        RETURN( MBEDTLS_ERR_MPS_NO_INTERLEAVING );
+        MBEDTLS_MPS_TRACE( trace_error, "Interleaving of outgoing messages is disabled." );
+        MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_NO_INTERLEAVING );
     }
 #endif
 
     res = l3_check_clear( l3 );
     if( res != 0 )
-        RETURN( res );
+        MBEDTLS_MPS_TRACE_RETURN( res );
 
     out.epoch = epoch;
     out.type = port;
     res = mps_l2_write_start( l2, &out );
     if( res != 0 )
-        RETURN( res );
+        MBEDTLS_MPS_TRACE_RETURN( res );
 
     l3->io.out.raw_out = out.wr;
     l3->io.out.state   = port;
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
 int mps_l3_epoch_add( mps_l3 *ctx,

--- a/library/mps/layer3.c
+++ b/library/mps/layer3.c
@@ -64,7 +64,7 @@ int mps_l3_init( mps_l3 *l3, mbedtls_mps_l2 *l2, uint8_t mode )
 #if defined(MBEDTLS_MPS_ENABLE_ASSERTIONS)
     if( mode != MBEDTLS_MPS_CONF_MODE )
     {
-        MBEDTLS_MPS_TRACE( trace_error, "Protocol passed to mps_l3_init() doesn't match " \
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR, "Protocol passed to mps_l3_init() doesn't match " \
                "hardcoded protocol." );
         MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_INTERNAL_ERROR );
     }
@@ -145,7 +145,7 @@ int mps_l3_read( mps_l3 *l3 )
 
     /* 2 */
     /* Request incoming data from Layer 2 context */
-    MBEDTLS_MPS_TRACE( trace_comment, "Check for incoming data on Layer 2" );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Check for incoming data on Layer 2" );
 
     /* TODO: Some compilers complain that `in` could still be
      * uninitialized after the call has succeeded.
@@ -163,19 +163,19 @@ int mps_l3_read( mps_l3 *l3 )
     if( ret != 0 )
         MBEDTLS_MPS_TRACE_RETURN( ret );
 
-    MBEDTLS_MPS_TRACE( trace_comment, "Opened incoming datastream" );
-    MBEDTLS_MPS_TRACE( trace_comment, "* Epoch: %u", (unsigned) in.epoch );
-    MBEDTLS_MPS_TRACE( trace_comment, "* Type:  %u", (unsigned) in.type );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Opened incoming datastream" );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* Epoch: %u", (unsigned) in.epoch );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* Type:  %u", (unsigned) in.type );
     switch( in.type )
     {
         /* 3.1 */
 
         case MBEDTLS_MPS_MSG_APP:
-            MBEDTLS_MPS_TRACE( trace_comment, "-> Application data" );
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "-> Application data" );
             break;
 
         case MBEDTLS_MPS_MSG_ALERT:
-            MBEDTLS_MPS_TRACE( trace_comment, "-> Alert message" );
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "-> Alert message" );
 
             /* Attempt to fetch alert.
              *
@@ -194,7 +194,7 @@ int mps_l3_read( mps_l3 *l3 )
 #if defined(MBEDTLS_MPS_PROTO_DTLS)
                 if( MBEDTLS_MPS_IS_DTLS( mode ) )
                 {
-                    MBEDTLS_MPS_TRACE( trace_error, "Incomplete alert message found -- abort" );
+                    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR, "Incomplete alert message found -- abort" );
                     MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_INVALID_CONTENT );
                 }
 #endif /* MBEDTLS_MPS_PROTO_DTLS */
@@ -202,7 +202,7 @@ int mps_l3_read( mps_l3 *l3 )
 #if defined(MBEDTLS_MPS_PROTO_TLS)
                 if( MBEDTLS_MPS_IS_TLS( mode ) )
                 {
-                    MBEDTLS_MPS_TRACE( trace_comment, "Not enough data available in record to read alert message" );
+                    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Not enough data available in record to read alert message" );
                     ret = mps_l2_read_done( l2 );
                     if( ret != 0 )
                         MBEDTLS_MPS_TRACE_RETURN( ret );
@@ -222,7 +222,7 @@ int mps_l3_read( mps_l3 *l3 )
             break;
 
         case MBEDTLS_MPS_MSG_CCS:
-            MBEDTLS_MPS_TRACE( trace_comment, "-> CCS message" );
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "-> CCS message" );
 
             /* We don't need to consider #MBEDTLS_ERR_MPS_READER_OUT_OF_DATA
              * here because the CCS content type does not allow empty
@@ -241,7 +241,7 @@ int mps_l3_read( mps_l3 *l3 )
         /* 3.2 */
 
         case MBEDTLS_MPS_MSG_HS:
-            MBEDTLS_MPS_TRACE( trace_comment, "-> Handshake message" );
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "-> Handshake message" );
 
             /*
              * General workings of handshake reading:
@@ -279,7 +279,7 @@ int mps_l3_read( mps_l3 *l3 )
             {
                 /* 3.2.1 */
                 case MPS_L3_HS_NONE:
-                    MBEDTLS_MPS_TRACE( trace_comment, "No handshake message is currently processed" );
+                    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "No handshake message is currently processed" );
 
                     /* Attempt to fetch and parse handshake header.
                      *
@@ -300,7 +300,7 @@ int mps_l3_read( mps_l3 *l3 )
 #if defined(MBEDTLS_MPS_PROTO_DTLS)
                         if( MBEDTLS_MPS_IS_DTLS( mode ) )
                         {
-                            MBEDTLS_MPS_TRACE( trace_error, "Incomplete handshake header found -- abort" );
+                            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR, "Incomplete handshake header found -- abort" );
                             MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_INVALID_CONTENT );
                         }
 #endif /* MBEDTLS_MPS_PROTO_DTLS */
@@ -308,7 +308,7 @@ int mps_l3_read( mps_l3 *l3 )
 #if defined(MBEDTLS_MPS_PROTO_TLS)
                         if( MBEDTLS_MPS_IS_TLS( mode ) )
                         {
-                            MBEDTLS_MPS_TRACE( trace_comment, "Incomplete handshake header in current record -- wait for more data." );
+                            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Incomplete handshake header in current record -- wait for more data." );
 
                             ret = mps_l2_read_done( l2 );
                             if( ret != 0 )
@@ -331,7 +331,7 @@ int mps_l3_read( mps_l3 *l3 )
 
                     /* Setup the extended reader keeping track of the
                      * global message bounds. */
-                    MBEDTLS_MPS_TRACE( trace_comment, "Setup extended reader for handshake message" );
+                    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Setup extended reader for handshake message" );
 
                     /* TODO: Think about storing the frag_len in len for DTLS
                      *       to avoid this distinction. */
@@ -354,14 +354,14 @@ int mps_l3_read( mps_l3 *l3 )
 
                 /* 3.2.2 */
                 case MPS_L3_HS_PAUSED:
-                    MBEDTLS_MPS_TRACE( trace_comment, "A handshake message currently paused" );
+                    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "A handshake message currently paused" );
 #if defined(MBEDTLS_MPS_ENABLE_ASSERTIONS)
                     if( l3->io.in.hs.epoch != in.epoch )
                     {
                         /* This should never happen, as we don't allow switching
                          * the incoming epoch while pausing the reading of a
                          * handshake message. But double-check nonetheless. */
-                        MBEDTLS_MPS_TRACE( trace_error, "ASSERTION FAILURE!" );
+                        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR, "ASSERTION FAILURE!" );
                         MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_INTERNAL_ERROR );
                     }
 #endif /* MBEDTLS_MPS_ENABLE_ASSERTIONS */
@@ -374,7 +374,7 @@ int mps_l3_read( mps_l3 *l3 )
                     /* Should never happen -- if a handshake message
                      * is active, then this must be reflected in the
                      * state variable l3->io.in.state. */
-                    MBEDTLS_MPS_TRACE( trace_error, "ASSERTION FAILURE!" );
+                    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR, "ASSERTION FAILURE!" );
                     MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_INTERNAL_ERROR );
 #else
                     break;
@@ -398,7 +398,7 @@ int mps_l3_read( mps_l3 *l3 )
         default:
             /* Should never happen because we configured L2
              * to only accept the above types. */
-            MBEDTLS_MPS_TRACE( trace_error, "ASSERTION FAILURE!" );
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR, "ASSERTION FAILURE!" );
             MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_INTERNAL_ERROR );
 #endif /* MBEDTLS_MPS_ENABLE_ASSERTIONS */
     }
@@ -407,10 +407,10 @@ int mps_l3_read( mps_l3 *l3 )
     l3->io.in.epoch  = in.epoch;
     l3->io.in.state  = in.type;
 
-    MBEDTLS_MPS_TRACE( trace_comment, "New state" );
-    MBEDTLS_MPS_TRACE( trace_comment, "* External state:  %u",
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "New state" );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* External state:  %u",
            (unsigned) l3->io.in.state );
-    MBEDTLS_MPS_TRACE( trace_comment, "* Handshake state: %u",
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* Handshake state: %u",
            (unsigned) l3->io.in.hs.state );
 
     MBEDTLS_MPS_TRACE_RETURN( l3->io.in.state );
@@ -426,7 +426,7 @@ int mps_l3_read_consume( mps_l3 *l3 )
     switch( l3->io.in.state )
     {
         case MBEDTLS_MPS_MSG_HS:
-            MBEDTLS_MPS_TRACE( trace_comment, "Finishing handshake message" );
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Finishing handshake message" );
             /* See mps_l3_read for the general description
              * of how the implementation uses extended readers
              * to handle pausing of handshake messages. */
@@ -436,7 +436,7 @@ int mps_l3_read_consume( mps_l3 *l3 )
              * message has been fetched and committed. */
             if( mbedtls_mps_reader_check_done( &l3->io.in.hs.rd_ext ) != 0 )
             {
-                MBEDTLS_MPS_TRACE( trace_error, "Attempting to close a not fully processed handshake message." );
+                MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR, "Attempting to close a not fully processed handshake message." );
                 MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_UNFINISHED_HS_MSG );
             }
 
@@ -604,9 +604,9 @@ MBEDTLS_MPS_STATIC int l3_parse_hs_header_tls( mbedtls_mps_reader *rd,
     if( res != 0 )
         MBEDTLS_MPS_TRACE_RETURN( res );
 
-    MBEDTLS_MPS_TRACE( trace_comment, "Parsed handshake header" );
-    MBEDTLS_MPS_TRACE( trace_comment, "* Type:   %u", (unsigned) in->type );
-    MBEDTLS_MPS_TRACE( trace_comment, "* Length: %u", (unsigned) in->len );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Parsed handshake header" );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* Type:   %u", (unsigned) in->type );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* Length: %u", (unsigned) in->len );
     MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 #endif /* MBEDTLS_MPS_PROTO_TLS */
@@ -672,19 +672,19 @@ MBEDTLS_MPS_STATIC int l3_parse_hs_header_dtls( mbedtls_mps_reader *rd,
      * since the summands are 24 bit each. */
     if( in->frag_offset + in->frag_len > in->len )
     {
-        MBEDTLS_MPS_TRACE( trace_error, "Invalid handshake header: frag_offset (%u) + frag_len (%u) > len (%u)",
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR, "Invalid handshake header: frag_offset (%u) + frag_len (%u) > len (%u)",
                (unsigned)in->frag_offset,
                (unsigned)in->frag_len,
                (unsigned)in->len );
         MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_INVALID_CONTENT );
     }
 
-    MBEDTLS_MPS_TRACE( trace_comment, "Parsed DTLS handshake header" );
-    MBEDTLS_MPS_TRACE( trace_comment, "* Type:        %u", (unsigned) in->type        );
-    MBEDTLS_MPS_TRACE( trace_comment, "* Length:      %u", (unsigned) in->len         );
-    MBEDTLS_MPS_TRACE( trace_comment, "* Sequence Nr: %u", (unsigned) in->seq_nr      );
-    MBEDTLS_MPS_TRACE( trace_comment, "* Frag Offset: %u", (unsigned) in->frag_offset );
-    MBEDTLS_MPS_TRACE( trace_comment, "* Frag Length: %u", (unsigned) in->frag_len    );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Parsed DTLS handshake header" );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* Type:        %u", (unsigned) in->type        );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* Length:      %u", (unsigned) in->len         );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* Sequence Nr: %u", (unsigned) in->seq_nr      );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* Frag Offset: %u", (unsigned) in->frag_offset );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* Frag Length: %u", (unsigned) in->frag_len    );
 
     MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
@@ -729,14 +729,14 @@ MBEDTLS_MPS_STATIC int l3_parse_alert( mbedtls_mps_reader *rd,
     if( res != 0 )
         MBEDTLS_MPS_TRACE_RETURN( res );
 
-    MBEDTLS_MPS_TRACE( trace_comment, "Parsed alert message" );
-    MBEDTLS_MPS_TRACE( trace_comment, "* Level: %u", (unsigned) alert->level );
-    MBEDTLS_MPS_TRACE( trace_comment, "* Type:  %u", (unsigned) alert->type );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Parsed alert message" );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* Level: %u", (unsigned) alert->level );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* Type:  %u", (unsigned) alert->type );
 
     if( alert->level != MPS_TLS_ALERT_LEVEL_FATAL &&
         alert->level != MPS_TLS_ALERT_LEVEL_WARNING )
     {
-        MBEDTLS_MPS_TRACE( trace_error, "Alert level unknown" );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR, "Alert level unknown" );
         MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_INVALID_CONTENT );
     }
 
@@ -774,12 +774,12 @@ MBEDTLS_MPS_STATIC int l3_parse_ccs( mbedtls_mps_reader *rd )
 
     if( val != MPS_TLS_CCS_VALUE )
     {
-        MBEDTLS_MPS_TRACE( trace_error, "Bad CCS value %u", (unsigned) val );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR, "Bad CCS value %u", (unsigned) val );
         MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_INVALID_CONTENT );
     }
 
-    MBEDTLS_MPS_TRACE( trace_comment, "Parsed alert message" );
-    MBEDTLS_MPS_TRACE( trace_comment, " * Value: %u", (unsigned) MPS_TLS_CCS_VALUE );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Parsed alert message" );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, " * Value: %u", (unsigned) MPS_TLS_CCS_VALUE );
     MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
@@ -938,13 +938,13 @@ int mps_l3_write_handshake( mps_l3 *l3, mps_l3_handshake_out *out )
         mbedtls_mps_l3_conf_get_mode( &l3->conf );
 
     MBEDTLS_MPS_TRACE_INIT( "l3_write_handshake" );
-    MBEDTLS_MPS_TRACE( trace_comment, "Parameters: " );
-    MBEDTLS_MPS_TRACE( trace_comment, "* Seq Nr:   %u", (unsigned) out->seq_nr );
-    MBEDTLS_MPS_TRACE( trace_comment, "* Epoch:    %u", (unsigned) out->epoch );
-    MBEDTLS_MPS_TRACE( trace_comment, "* Type:     %u", (unsigned) out->type );
-    MBEDTLS_MPS_TRACE( trace_comment, "* Length:   %u", (unsigned) out->len );
-    MBEDTLS_MPS_TRACE( trace_comment, "* Frag Off: %u", (unsigned) out->frag_offset );
-    MBEDTLS_MPS_TRACE( trace_comment, "* Frag Len: %u", (unsigned) out->frag_len );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Parameters: " );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* Seq Nr:   %u", (unsigned) out->seq_nr );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* Epoch:    %u", (unsigned) out->epoch );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* Type:     %u", (unsigned) out->type );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* Length:   %u", (unsigned) out->len );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* Frag Off: %u", (unsigned) out->frag_offset );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* Frag Len: %u", (unsigned) out->frag_len );
 
     /*
      * See the documentation of mps_l3_read() for a description
@@ -959,7 +959,7 @@ int mps_l3_write_handshake( mps_l3 *l3, mps_l3_handshake_out *out )
           l3->io.out.hs.type  != out->type  ||
           l3->io.out.hs.len   != out->len ) )
     {
-        MBEDTLS_MPS_TRACE( trace_error, "Inconsistent parameters on continuation." );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR, "Inconsistent parameters on continuation." );
         MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_INVALID_ARGS );
     }
 #endif /* MBEDTLS_MPS_STATE_VALIDATION */
@@ -970,7 +970,7 @@ int mps_l3_write_handshake( mps_l3 *l3, mps_l3_handshake_out *out )
 
     if( l3->io.out.hs.state == MPS_L3_HS_NONE )
     {
-        MBEDTLS_MPS_TRACE( trace_comment, "No handshake message currently paused" );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "No handshake message currently paused" );
 
         l3->io.out.hs.epoch = out->epoch;
         l3->io.out.hs.len   = out->len;
@@ -990,7 +990,7 @@ int mps_l3_write_handshake( mps_l3 *l3, mps_l3_handshake_out *out )
                 ( out->frag_offset != 0 ||
                   out->frag_len    != MBEDTLS_MPS_SIZE_UNKNOWN ) )
             {
-                MBEDTLS_MPS_TRACE( trace_error, "ASSERTION FAILURE!" );
+                MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR, "ASSERTION FAILURE!" );
                 MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_INTERNAL_ERROR );
             }
 
@@ -1009,7 +1009,7 @@ int mps_l3_write_handshake( mps_l3 *l3, mps_l3_handshake_out *out )
                 if( end_of_fragment < out->frag_offset /* overflow */ ||
                     end_of_fragment > total_len )
                 {
-                    MBEDTLS_MPS_TRACE( trace_error, "ASSERTION FAILURE!" );
+                    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR, "ASSERTION FAILURE!" );
                     MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_INTERNAL_ERROR );
                 }
             }
@@ -1034,7 +1034,7 @@ int mps_l3_write_handshake( mps_l3 *l3, mps_l3_handshake_out *out )
          * again. */
         if( res == MBEDTLS_ERR_WRITER_OUT_OF_DATA )
         {
-            MBEDTLS_MPS_TRACE( trace_comment, "Not enough space to write handshake header - flush." );
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Not enough space to write handshake header - flush." );
             /* Remember that we must flush. */
             l3->io.out.clearing = 1;
             l3->io.out.state = MBEDTLS_MPS_MSG_NONE;
@@ -1063,7 +1063,7 @@ int mps_l3_write_handshake( mps_l3 *l3, mps_l3_handshake_out *out )
          *       progress, and in this case we should abort the write
          *       instead of writing an empty handshake fragment. */
 
-        MBEDTLS_MPS_TRACE( trace_comment, "Setup extended writer for handshake message" );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Setup extended writer for handshake message" );
 
         /* TODO: Think about storing the frag_len in len for DTLS
          *       to avoid this distinction. */
@@ -1097,7 +1097,7 @@ int mps_l3_write_handshake( mps_l3 *l3, mps_l3_handshake_out *out )
         len = out->frag_len;
 #endif /* MBEDTLS_MPS_PROTO_DTLS */
 
-    MBEDTLS_MPS_TRACE( trace_comment, "Bind raw writer to extended writer" );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Bind raw writer to extended writer" );
     res = mbedtls_writer_attach( &l3->io.out.hs.wr_ext, l3->io.out.raw_out,
                                  len != MBEDTLS_MPS_SIZE_UNKNOWN
                                  ? MBEDTLS_WRITER_EXT_PASS
@@ -1301,12 +1301,12 @@ int mps_l3_dispatch( mps_l3 *l3 )
     switch( l3->io.out.state )
     {
         case MBEDTLS_MPS_MSG_HS:
-            MBEDTLS_MPS_TRACE( trace_comment, "Dispatch handshake message" );
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Dispatch handshake message" );
 
 #if defined(MBEDTLS_MPS_ENABLE_ASSERTIONS)
             if( l3->io.out.hs.state != MPS_L3_HS_ACTIVE )
             {
-                MBEDTLS_MPS_TRACE( trace_error, "ASSERTION FAILURE!" );
+                MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR, "ASSERTION FAILURE!" );
                 MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_INTERNAL_ERROR );
             }
 #endif /* MBEDTLS_MPS_ENABLE_ASSERTIONS */
@@ -1314,7 +1314,7 @@ int mps_l3_dispatch( mps_l3 *l3 )
             res = mbedtls_writer_check_done( &l3->io.out.hs.wr_ext );
             if( res != 0 )
             {
-                MBEDTLS_MPS_TRACE( trace_error, "Attempting to close not yet fully written handshake message." );
+                MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR, "Attempting to close not yet fully written handshake message." );
                 MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_UNFINISHED_HS_MSG );
             }
 
@@ -1365,7 +1365,7 @@ int mps_l3_dispatch( mps_l3 *l3 )
             break;
 
         case MBEDTLS_MPS_MSG_ALERT:
-            MBEDTLS_MPS_TRACE( trace_comment, "Dispatch alert message" );
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Dispatch alert message" );
             res = mbedtls_writer_commit( l3->io.out.raw_out );
             if( res != 0 )
                 MBEDTLS_MPS_TRACE_RETURN( res );
@@ -1373,7 +1373,7 @@ int mps_l3_dispatch( mps_l3 *l3 )
             break;
 
         case MBEDTLS_MPS_MSG_CCS:
-            MBEDTLS_MPS_TRACE( trace_comment, "Dispatch CCS message" );
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Dispatch CCS message" );
             res = mbedtls_writer_commit( l3->io.out.raw_out );
             if( res != 0 )
                 MBEDTLS_MPS_TRACE_RETURN( res );
@@ -1383,7 +1383,7 @@ int mps_l3_dispatch( mps_l3 *l3 )
         case MBEDTLS_MPS_MSG_APP:
             /* The application data is directly written through
              * the writer. */
-            MBEDTLS_MPS_TRACE( trace_comment, "Dispatch application data" );
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Dispatch application data" );
             break;
 
         default:
@@ -1406,7 +1406,7 @@ int mps_l3_dispatch( mps_l3 *l3 )
     if( res != 0 )
         MBEDTLS_MPS_TRACE_RETURN( res );
 
-    MBEDTLS_MPS_TRACE( trace_comment, "Done" );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Done" );
     l3->io.out.state = MBEDTLS_MPS_MSG_NONE;
     MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
@@ -1455,7 +1455,7 @@ MBEDTLS_MPS_STATIC int l3_write_hs_header_tls( mps_l3_hs_out_internal *hs )
 #if defined(MBEDTLS_MPS_ENABLE_ASSERTIONS)
     if( buf == NULL || hs->hdr_len != tls_hs_hdr_len )
     {
-        MBEDTLS_MPS_TRACE( trace_error, "ASSERTION FAILURE!" );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR, "ASSERTION FAILURE!" );
         MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_INTERNAL_ERROR );
     }
 #else
@@ -1515,7 +1515,7 @@ MBEDTLS_MPS_STATIC int l3_write_hs_header_dtls( mps_l3_hs_out_internal *hs )
 #if defined(MBEDTLS_MPS_ENABLE_ASSERTIONS)
     if( buf == NULL || hs->hdr_len != dtls_hs_hdr_len )
     {
-        MBEDTLS_MPS_TRACE( trace_error, "ASSERTION FAILURE!" );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR, "ASSERTION FAILURE!" );
         MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_INTERNAL_ERROR );
     }
 #else
@@ -1528,12 +1528,12 @@ MBEDTLS_MPS_STATIC int l3_write_hs_header_dtls( mps_l3_hs_out_internal *hs )
     MPS_WRITE_UINT24_BE( &hs->frag_offset, buf + dtls_hs_frag_off_offset );
     MPS_WRITE_UINT24_BE( &hs->frag_len,    buf + dtls_hs_frag_len_offset );
 
-    MBEDTLS_MPS_TRACE( trace_comment, "Wrote DTLS handshake header" );
-    MBEDTLS_MPS_TRACE( trace_comment, "* Type:        %u", (unsigned) hs->type        );
-    MBEDTLS_MPS_TRACE( trace_comment, "* Length:      %u", (unsigned) hs->len         );
-    MBEDTLS_MPS_TRACE( trace_comment, "* Sequence Nr: %u", (unsigned) hs->seq_nr      );
-    MBEDTLS_MPS_TRACE( trace_comment, "* Frag Offset: %u", (unsigned) hs->frag_offset );
-    MBEDTLS_MPS_TRACE( trace_comment, "* Frag Length: %u", (unsigned) hs->frag_len    );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Wrote DTLS handshake header" );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* Type:        %u", (unsigned) hs->type        );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* Length:      %u", (unsigned) hs->len         );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* Sequence Nr: %u", (unsigned) hs->seq_nr      );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* Frag Offset: %u", (unsigned) hs->frag_offset );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* Frag Length: %u", (unsigned) hs->frag_len    );
 
     MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
@@ -1570,8 +1570,8 @@ MBEDTLS_MPS_STATIC int l3_prepare_write( mps_l3 *l3, mbedtls_mps_msg_type_t port
     mps_l2_out out;
     mbedtls_mps_l2* const l2 = mbedtls_mps_l3_get_l2( l3 );
     MBEDTLS_MPS_TRACE_INIT( "l3_prepare_write" );
-    MBEDTLS_MPS_TRACE( trace_comment, "* Type:  %u", (unsigned) port );
-    MBEDTLS_MPS_TRACE( trace_comment, "* Epoch: %u", (unsigned) epoch );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* Type:  %u", (unsigned) port );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* Epoch: %u", (unsigned) epoch );
 
     MBEDTLS_MPS_STATE_VALIDATE_RAW( l3->io.out.state == MBEDTLS_MPS_MSG_NONE,
                       "l3_prepare_write() called in unexpected state." );
@@ -1579,7 +1579,7 @@ MBEDTLS_MPS_STATIC int l3_prepare_write( mps_l3 *l3, mbedtls_mps_msg_type_t port
 #if !defined(MPS_L3_ALLOW_INTERLEAVED_SENDING)
     if( l3->io.out.hs.state == MPS_L3_HS_PAUSED && port != MBEDTLS_MPS_MSG_HS )
     {
-        MBEDTLS_MPS_TRACE( trace_error, "Interleaving of outgoing messages is disabled." );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR, "Interleaving of outgoing messages is disabled." );
         MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_NO_INTERLEAVING );
     }
 #endif

--- a/library/mps/layer3_internal.h
+++ b/library/mps/layer3_internal.h
@@ -37,27 +37,27 @@ MBEDTLS_MPS_STATIC int l3_check_write_hs_hdr_dtls( mps_l3 *l3 );
 MBEDTLS_MPS_STATIC int l3_check_write_hs_hdr( mps_l3 *l3 );
 
 #if defined(MBEDTLS_MPS_PROTO_TLS)
-MBEDTLS_MPS_STATIC int l3_parse_hs_header_tls( mbedtls_reader *rd,
+MBEDTLS_MPS_STATIC int l3_parse_hs_header_tls( mbedtls_mps_reader *rd,
                                                mps_l3_hs_in_internal *in );
 MBEDTLS_MPS_STATIC int l3_write_hs_header_tls( mps_l3_hs_out_internal *hs );
 #endif /* MBEDTLS_MPS_PROTO_TLS */
 
 #if defined(MBEDTLS_MPS_PROTO_DTLS)
-MBEDTLS_MPS_STATIC int l3_parse_hs_header_dtls( mbedtls_reader *rd,
+MBEDTLS_MPS_STATIC int l3_parse_hs_header_dtls( mbedtls_mps_reader *rd,
                                                 mps_l3_hs_in_internal *in );
 MBEDTLS_MPS_STATIC int l3_write_hs_header_dtls( mps_l3_hs_out_internal *hs );
 #endif /* MBEDTLS_MPS_PROTO_DTLS */
 
-MBEDTLS_MPS_STATIC int l3_parse_hs_header( uint8_t mode, mbedtls_reader *rd,
+MBEDTLS_MPS_STATIC int l3_parse_hs_header( uint8_t mode, mbedtls_mps_reader *rd,
                                mps_l3_hs_in_internal *in );
 
 /*
  * Other message types
  */
 
-MBEDTLS_MPS_STATIC int l3_parse_alert( mbedtls_reader *rd,
+MBEDTLS_MPS_STATIC int l3_parse_alert( mbedtls_mps_reader *rd,
                            mps_l3_alert_in_internal *alert );
-MBEDTLS_MPS_STATIC int l3_parse_ccs( mbedtls_reader *rd );
+MBEDTLS_MPS_STATIC int l3_parse_ccs( mbedtls_mps_reader *rd );
 
 /*
  * Miscellanious

--- a/library/mps/mps.c
+++ b/library/mps/mps.c
@@ -48,9 +48,9 @@
 #define mbedtls_free      free
 #endif
 
-#if defined(MBEDTLS_MPS_TRACE)
-static int trace_id = TRACE_BIT_LAYER_4;
-#endif /* MBEDTLS_MPS_TRACE */
+#if defined(MBEDTLS_MPS_ENABLE_TRACE)
+static int mbedtls_mps_trace_id = MBEDTLS_MPS_TRACE_BIT_LAYER_4;
+#endif /* MBEDTLS_MPS_ENABLE_TRACE */
 
 /*
  * Error state handling
@@ -85,7 +85,7 @@ static int trace_id = TRACE_BIT_LAYER_4;
 #define MPS_INTERNAL_FAILURE_HANDLER                    \
     goto exit; /* Silence unused label warnings */      \
     exit:                                               \
-    RETURN( ret );
+    MBEDTLS_MPS_TRACE_RETURN( ret );
 
 /* Convenience macro for the failure handling
  * within functions at MPS-API boundary, which
@@ -94,7 +94,7 @@ static int trace_id = TRACE_BIT_LAYER_4;
     goto exit; /* Silence unused label warnings */      \
     exit:                                               \
     ret = mps_generic_failure_handler( mps, ret );      \
-    RETURN( ret );                                      \
+    MBEDTLS_MPS_TRACE_RETURN( ret );                                      \
 
 /* Check if the MPS will serve read resp. write API calls.
  * It will e.g. reject this if it is blocked after a fatal error,
@@ -472,7 +472,7 @@ MBEDTLS_MPS_STATIC int mps_clear_pending( mbedtls_mps *mps,
         mbedtls_mps_conf_get_mode( &mps->conf );
     mps_l3* const l3 = mbedtls_mps_l4_get_l3( mps );
 
-    TRACE_INIT( "mps_clear_pending, allow_active_hs %u",
+    MBEDTLS_MPS_TRACE_INIT( "mps_clear_pending, allow_active_hs %u",
                 (unsigned) allow_active_hs );
 
 #if defined(MBEDTLS_MPS_PROTO_DTLS)
@@ -497,7 +497,7 @@ MBEDTLS_MPS_STATIC int mps_clear_pending( mbedtls_mps *mps,
 
     if( mps->out.flush == 1 )
     {
-        TRACE( trace_comment, "A flush was requested" );
+        MBEDTLS_MPS_TRACE( trace_comment, "A flush was requested" );
         MPS_CHK( mps_l3_flush( l3 ) );
         mps->out.flush = 0;
     }
@@ -510,12 +510,12 @@ MBEDTLS_MPS_STATIC int mps_prepare_read( mbedtls_mps *mps )
     int ret;
     mbedtls_mps_transport_type const mode =
         mbedtls_mps_conf_get_mode( &mps->conf );
-    TRACE_INIT( "mps_prepare_read" );
+    MBEDTLS_MPS_TRACE_INIT( "mps_prepare_read" );
 
     /* Check that MPS isn't blocked or has its reading side closed. */
     ret = mps_check_read( mps );
     if( ret != 0 )
-        RETURN( ret );
+        MBEDTLS_MPS_TRACE_RETURN( ret );
 
     /* Layer 4 forbids reading while writing. */
     MBEDTLS_MPS_STATE_VALIDATE( mps->out.state == MBEDTLS_MPS_MSG_NONE,
@@ -582,11 +582,11 @@ MBEDTLS_MPS_STATIC int mps_prepare_write( mbedtls_mps *mps,
     int ret = 0;
     mbedtls_mps_transport_type const mode =
         mbedtls_mps_conf_get_mode( &mps->conf );
-    TRACE_INIT( "mps_prepare_write" );
+    MBEDTLS_MPS_TRACE_INIT( "mps_prepare_write" );
 
     ret = mps_check_write( mps );
     if( ret != 0 )
-        RETURN( ret );
+        MBEDTLS_MPS_TRACE_RETURN( ret );
 
     MBEDTLS_MPS_STATE_VALIDATE( mps->out.state == MBEDTLS_MPS_MSG_NONE,
                                 "Write operation already in progress." );
@@ -636,7 +636,7 @@ MBEDTLS_MPS_STATIC int mps_generic_failure_handler( mbedtls_mps *mps, int ret )
     int found = 0;
     const char *error_string = NULL;
 
-#if !defined(MBEDTLS_MPS_TRACE)
+#if !defined(MBEDTLS_MPS_ENABLE_TRACE)
     ((void) error_string);
 #endif
 
@@ -656,7 +656,7 @@ MBEDTLS_MPS_STATIC int mps_generic_failure_handler( mbedtls_mps *mps, int ret )
 
     if( found == 0 )
     {
-        TRACE( trace_error, "Unknown error at MPS boundary: -%#04x",
+        MBEDTLS_MPS_TRACE( trace_error, "Unknown error at MPS boundary: -%#04x",
                (unsigned) -ret );
         ret = MBEDTLS_ERR_MPS_INTERNAL_ERROR;
         goto fatal;
@@ -671,7 +671,7 @@ MBEDTLS_MPS_STATIC int mps_generic_failure_handler( mbedtls_mps *mps, int ret )
         if( MBEDTLS_MPS_IS_DTLS( mode ) &&
             MBEDTLS_MPS_ERROR_IS_TLS_ONLY( flags ) )
         {
-            TRACE( trace_error, "TLS-only error observed in DTLS mode: %s (-%#04x)",
+            MBEDTLS_MPS_TRACE( trace_error, "TLS-only error observed in DTLS mode: %s (-%#04x)",
                    error_string, (unsigned) -ret );
             ret = MBEDTLS_ERR_MPS_INTERNAL_ERROR;
             goto fatal;
@@ -680,7 +680,7 @@ MBEDTLS_MPS_STATIC int mps_generic_failure_handler( mbedtls_mps *mps, int ret )
 
         if( !MBEDTLS_MPS_ERROR_IS_EXTERNAL( flags ) )
         {
-            TRACE( trace_error, "TLS-only error observed in DTLS mode: %s (-%#04x)",
+            MBEDTLS_MPS_TRACE( trace_error, "TLS-only error observed in DTLS mode: %s (-%#04x)",
                    error_string, (unsigned) -ret );
             ret = MBEDTLS_ERR_MPS_INTERNAL_ERROR;
             goto fatal;
@@ -701,7 +701,7 @@ fatal:
     if( mps->state != MBEDTLS_MPS_STATE_BLOCKED )
     {
         /* Remember error and block MPS. */
-        TRACE( trace_error, "Blocking MPS after a fatal error" );
+        MBEDTLS_MPS_TRACE( trace_error, "Blocking MPS after a fatal error" );
         mps->blocking_reason = MBEDTLS_MPS_ERROR_INTERNAL_ERROR;
         mps->blocking_info.err = ret;
         mps_block( mps );
@@ -714,7 +714,7 @@ fatal:
 int mbedtls_mps_send_fatal( mbedtls_mps *mps, mbedtls_mps_alert_t alert_type )
 {
     int ret;
-    TRACE_INIT( "mbedtls_mps_send_fatal, type %d", alert_type );
+    MBEDTLS_MPS_TRACE_INIT( "mbedtls_mps_send_fatal, type %d", alert_type );
 
     MPS_CHK( mps_check_write( mps ) );
 
@@ -727,7 +727,7 @@ int mbedtls_mps_send_fatal( mbedtls_mps *mps, mbedtls_mps_alert_t alert_type )
     mps_block( mps );
 
     /* Attempt to send alert. */
-    TRACE( trace_comment, "Pend fatal alert" );
+    MBEDTLS_MPS_TRACE( trace_comment, "Pend fatal alert" );
     mps->alert_pending = 1;
     MPS_CHK( mbedtls_mps_flush( mps ) );
 
@@ -754,16 +754,16 @@ MBEDTLS_MPS_STATIC void mps_fatal_alert_received( mbedtls_mps *mps,
 /* React to a close notification from the peer. */
 MBEDTLS_MPS_STATIC void mps_close_notification_received( mbedtls_mps *mps )
 {
-    TRACE_INIT( "mps_close_notification_received" );
+    MBEDTLS_MPS_TRACE_INIT( "mps_close_notification_received" );
     switch( mps->state )
     {
         case MBEDTLS_MPS_STATE_OPEN:
-            TRACE( trace_comment, "State transition OPEN -> WRITE-ONLY" );
+            MBEDTLS_MPS_TRACE( trace_comment, "State transition OPEN -> WRITE-ONLY" );
             mps->state = MBEDTLS_MPS_STATE_WRITE_ONLY;
             break;
 
         case MBEDTLS_MPS_STATE_READ_ONLY:
-            TRACE( trace_comment, "State transition READ-ONLY -> CLOSED" );
+            MBEDTLS_MPS_TRACE( trace_comment, "State transition READ-ONLY -> CLOSED" );
             mps->state = MBEDTLS_MPS_STATE_CLOSED;
             break;
     }
@@ -774,12 +774,12 @@ MBEDTLS_MPS_STATIC int mps_handle_pending_alert( mbedtls_mps *mps )
     int ret;
     mps_l3_alert_out alert;
     mps_l3* const l3 = mbedtls_mps_l4_get_l3( mps );
-    TRACE_INIT( "mps_handle_pending_alert" );
+    MBEDTLS_MPS_TRACE_INIT( "mps_handle_pending_alert" );
 
     if( mps->alert_pending == 0 )
     {
-        TRACE( trace_comment, "No alert pending" );
-        RETURN( 0 );
+        MBEDTLS_MPS_TRACE( trace_comment, "No alert pending" );
+        MBEDTLS_MPS_TRACE_RETURN( 0 );
     }
 
     alert.epoch = mps->out_epoch;
@@ -792,14 +792,14 @@ MBEDTLS_MPS_STATIC int mps_handle_pending_alert( mbedtls_mps *mps )
                                      MBEDTLS_MPS_STATE_READ_ONLY,
                                      MBEDTLS_MPS_STATE_CLOSED ) )
     {
-        TRACE( trace_comment, "Report orderly closure of write-side to peer." );
+        MBEDTLS_MPS_TRACE( trace_comment, "Report orderly closure of write-side to peer." );
         *alert.level = MBEDTLS_MPS_ALERT_LEVEL_WARNING;
         *alert.type  = MBEDTLS_MPS_ALERT_MSG_CLOSE_NOTIFY;
     }
     else if( mps->state == MBEDTLS_MPS_STATE_BLOCKED &&
              mps->blocking_reason == MBEDTLS_MPS_ERROR_ALERT_SENT )
     {
-        TRACE( trace_comment, "Report fatal alert to peer." );
+        MBEDTLS_MPS_TRACE( trace_comment, "Report fatal alert to peer." );
         *alert.level = MBEDTLS_MPS_ALERT_LEVEL_FATAL;
         *alert.type  = mps->blocking_info.alert;
     }
@@ -821,18 +821,18 @@ MBEDTLS_MPS_STATIC int mps_handle_pending_alert( mbedtls_mps *mps )
 int mbedtls_mps_close( mbedtls_mps *mps )
 {
     int ret;
-    TRACE_INIT( "mbedtls_mps_close" );
+    MBEDTLS_MPS_TRACE_INIT( "mbedtls_mps_close" );
 
     switch( mps->state )
     {
         case MBEDTLS_MPS_STATE_OPEN:
-            TRACE( trace_comment, "State transition OPEN -> READ-ONLY" );
+            MBEDTLS_MPS_TRACE( trace_comment, "State transition OPEN -> READ-ONLY" );
             mps->state = MBEDTLS_MPS_STATE_READ_ONLY;
             mps->alert_pending = 1;
             break;
 
         case MBEDTLS_MPS_STATE_WRITE_ONLY:
-            TRACE( trace_comment, "State transition WRITE-ONLY -> CLOSED" );
+            MBEDTLS_MPS_TRACE( trace_comment, "State transition WRITE-ONLY -> CLOSED" );
             mps->state = MBEDTLS_MPS_STATE_CLOSED;
             mps->alert_pending = 1;
             break;
@@ -864,31 +864,31 @@ int mbedtls_mps_close( mbedtls_mps *mps )
 /* Check if the MPS can be used for reading. */
 MBEDTLS_MPS_STATIC int mps_check_read( mbedtls_mps const *mps )
 {
-    TRACE_INIT( "mps_check_read, state %d", mps->state );
+    MBEDTLS_MPS_TRACE_INIT( "mps_check_read, state %d", mps->state );
 
     if( MBEDTLS_MPS_STATE_EITHER_OR( mps->state,
                MBEDTLS_MPS_STATE_OPEN, MBEDTLS_MPS_STATE_READ_ONLY ) )
     {
-        RETURN( 0 );
+        MBEDTLS_MPS_TRACE_RETURN( 0 );
     }
 
-    TRACE( trace_error, "Read-side blocked" );
-    RETURN( MBEDTLS_ERR_MPS_BLOCKED );
+    MBEDTLS_MPS_TRACE( trace_error, "Read-side blocked" );
+    MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_BLOCKED );
 }
 
 /* Check if the MPS can be used for writing. */
 MBEDTLS_MPS_STATIC int mps_check_write( mbedtls_mps const *mps )
 {
-    TRACE_INIT( "mps_check_write, state %d", mps->state );
+    MBEDTLS_MPS_TRACE_INIT( "mps_check_write, state %d", mps->state );
 
     if( MBEDTLS_MPS_STATE_EITHER_OR( mps->state,
                 MBEDTLS_MPS_STATE_OPEN, MBEDTLS_MPS_STATE_WRITE_ONLY ) )
     {
-        RETURN( 0 );
+        MBEDTLS_MPS_TRACE_RETURN( 0 );
     }
 
-    TRACE( trace_error, "Write-side blocked" );
-    RETURN( MBEDTLS_ERR_MPS_BLOCKED );
+    MBEDTLS_MPS_TRACE( trace_error, "Write-side blocked" );
+    MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_BLOCKED );
 }
 
 /*
@@ -901,7 +901,7 @@ int mbedtls_mps_init( mbedtls_mps *mps,
                       size_t max_write )
 {
     int ret = 0;
-    TRACE_INIT( "mbedtls_mps_init" );
+    MBEDTLS_MPS_TRACE_INIT( "mbedtls_mps_init" );
 
     mps->conf.l3   = l3;
 
@@ -949,11 +949,11 @@ int mbedtls_mps_init( mbedtls_mps *mps,
     if( max_write > 0 )
     {
         unsigned char *queue = NULL;
-        TRACE( trace_comment, "Alloc L4 %u Byte queue", (unsigned) max_write );
+        MBEDTLS_MPS_TRACE( trace_comment, "Alloc L4 %u Byte queue", (unsigned) max_write );
 
         queue = calloc( 1, max_write );
         if( queue == NULL )
-            RETURN( MBEDTLS_ERR_MPS_OUT_OF_MEMORY );
+            MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_OUT_OF_MEMORY );
 
         mps->dtls.io.out.hs.queue_len = max_write;
         mps->dtls.io.out.hs.queue     = queue;
@@ -989,7 +989,7 @@ int mbedtls_mps_read( mbedtls_mps *mps )
     mbedtls_mps_transport_type const mode =
         mbedtls_mps_conf_get_mode( &mps->conf );
     mps_l3* const l3 = mbedtls_mps_l4_get_l3( mps );
-    TRACE_INIT( "mbedtls_mps_read" );
+    MBEDTLS_MPS_TRACE_INIT( "mbedtls_mps_read" );
 
     /* Take care of numerous checks that need to be performed
      * before we can fetch a new message:
@@ -1012,8 +1012,8 @@ int mbedtls_mps_read( mbedtls_mps *mps )
      * expected message is unambiguous. */
     if( mps->in.state != MBEDTLS_MPS_MSG_NONE )
     {
-        TRACE( trace_comment, "Msg of type %d already open", mps->in.state );
-        RETURN( mps->in.state );
+        MBEDTLS_MPS_TRACE( trace_comment, "Msg of type %d already open", mps->in.state );
+        MBEDTLS_MPS_TRACE_RETURN( mps->in.state );
     }
 
 #if defined(MBEDTLS_MPS_PROTO_DTLS)
@@ -1024,7 +1024,7 @@ int mbedtls_mps_read( mbedtls_mps *mps )
         if( ret != MBEDTLS_ERR_MPS_REASSEMBLY_FEED_NEED_MORE )
         {
             MPS_CHK( ret );
-            RETURN( MBEDTLS_MPS_MSG_HS );
+            MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_MPS_MSG_HS );
         }
     }
 #endif /* MBEDTLS_MPS_PROTO_DTLS */
@@ -1062,7 +1062,7 @@ int mbedtls_mps_read( mbedtls_mps *mps )
         case MBEDTLS_MPS_MSG_CCS:
         {
             mps_l3_ccs_in ccs_l3;
-            TRACE( trace_comment, "CCS message received from L3." );
+            MBEDTLS_MPS_TRACE( trace_comment, "CCS message received from L3." );
 
             MPS_CHK( mps_l3_read_ccs( l3, &ccs_l3 ) );
             MPS_CHK( mps_l3_read_consume( l3 ) );
@@ -1091,14 +1091,14 @@ int mbedtls_mps_read( mbedtls_mps *mps )
 #endif /* MBEDTLS_MPS_PROTO_DTLS */
 
             mps->in.state = MBEDTLS_MPS_MSG_CCS;
-            RETURN( MBEDTLS_MPS_MSG_CCS );
+            MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_MPS_MSG_CCS );
         }
 
         case MBEDTLS_MPS_MSG_ALERT:
         {
             mps_l3_alert_in alert;
 
-            TRACE( trace_comment, "Alert msg received from L3." );
+            MBEDTLS_MPS_TRACE( trace_comment, "Alert msg received from L3." );
             MPS_CHK( mps_l3_read_alert( l3, &alert ) );
 
             /* For DTLS, Layer 3 might be configured to pass through
@@ -1120,14 +1120,14 @@ int mbedtls_mps_read( mbedtls_mps *mps )
             switch( alert.level )
             {
                 case MBEDTLS_MPS_ALERT_LEVEL_FATAL:
-                    TRACE( trace_comment, "Fatal alert, type %d", alert.type );
+                    MBEDTLS_MPS_TRACE( trace_comment, "Fatal alert, type %d", alert.type );
                     mps_fatal_alert_received( mps, alert.type );
                     MPS_CHK( MBEDTLS_ERR_MPS_FATAL_ALERT_RECEIVED );
                     break;
 
                 case MBEDTLS_MPS_ALERT_LEVEL_WARNING:
 
-                    TRACE( trace_comment, "Warning, type %d", alert.type );
+                    MBEDTLS_MPS_TRACE( trace_comment, "Warning, type %d", alert.type );
 
                     if( alert.type == MBEDTLS_MPS_ALERT_MSG_CLOSE_NOTIFY )
                     {
@@ -1137,7 +1137,7 @@ int mbedtls_mps_read( mbedtls_mps *mps )
                     mps->in.data.alert = alert.type;
 
                     mps->in.state = MBEDTLS_MPS_MSG_ALERT;
-                    RETURN( MBEDTLS_MPS_MSG_ALERT );
+                    MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_MPS_MSG_ALERT );
                     break;
 
                 default:
@@ -1159,7 +1159,7 @@ int mbedtls_mps_read( mbedtls_mps *mps )
 
         case MBEDTLS_MPS_MSG_HS:
         {
-            TRACE( trace_comment, "Received HS fragment from L3" );
+            MBEDTLS_MPS_TRACE( trace_comment, "Received HS fragment from L3" );
 
             /* Pass message fragment to retransmission state machine
              * and check if it leads to a handshake message being ready
@@ -1179,7 +1179,7 @@ int mbedtls_mps_read( mbedtls_mps *mps )
             {
                 /* In TLS, we transparently forward the data from Layer 3. */
                 mps->in.state = MBEDTLS_MPS_MSG_HS;
-                RETURN( MBEDTLS_MPS_MSG_HS );
+                MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_MPS_MSG_HS );
             }
 #endif /* MBEDTLS_MPS_PROTO_TLS */
 #if defined(MBEDTLS_MPS_PROTO_DTLS)
@@ -1197,7 +1197,7 @@ int mbedtls_mps_read( mbedtls_mps *mps )
                 MPS_CHK( ret );
 
                 MPS_CHK( mps_reassembly_check_and_load( mps ) );
-                RETURN( MBEDTLS_MPS_MSG_HS );
+                MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_MPS_MSG_HS );
             }
 #endif /* MBEDTLS_MPS_PROTO_DTLS */
             break;
@@ -1226,7 +1226,7 @@ int mbedtls_mps_read( mbedtls_mps *mps )
             mps->in.data.app = app_l3.rd;
 
             mps->in.state = MBEDTLS_MPS_MSG_APP;
-            RETURN( MBEDTLS_MPS_MSG_APP );
+            MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_MPS_MSG_APP );
         }
 
         default:
@@ -1254,11 +1254,11 @@ int mbedtls_mps_read_handshake( mbedtls_mps *mps,
     int ret;
     mbedtls_mps_transport_type const mode =
         mbedtls_mps_conf_get_mode( &mps->conf );
-    TRACE_INIT( "mbedtls_mps_read_handshake" );
+    MBEDTLS_MPS_TRACE_INIT( "mbedtls_mps_read_handshake" );
 
     ret = mps_check_read( mps );
     if( ret != 0 )
-        RETURN( ret );
+        MBEDTLS_MPS_TRACE_RETURN( ret );
 
     MBEDTLS_MPS_STATE_VALIDATE( mps->in.state == MBEDTLS_MPS_MSG_HS,
       "mbedtls_mps_read_handshake() must only be called if HS msg is open." );
@@ -1288,10 +1288,10 @@ int mbedtls_mps_read_handshake( mbedtls_mps *mps,
 }
 
 int mbedtls_mps_read_application( mbedtls_mps *mps,
-                                  mbedtls_reader **rd )
+                                  mbedtls_mps_reader **rd )
 {
     int ret;
-    TRACE_INIT( "mbedtls_mps_read_application" );
+    MBEDTLS_MPS_TRACE_INIT( "mbedtls_mps_read_application" );
 
     ret = mps_check_read( mps );
     if( ret != 0 )
@@ -1309,7 +1309,7 @@ int mbedtls_mps_read_alert( mbedtls_mps *mps,
                             mbedtls_mps_alert_t *alert_type )
 {
     int ret;
-    TRACE_INIT( "mbedtls_mps_read_alert" );
+    MBEDTLS_MPS_TRACE_INIT( "mbedtls_mps_read_alert" );
 
     ret = mps_check_read( mps );
     if( ret != 0 )
@@ -1329,8 +1329,8 @@ int mbedtls_mps_read_set_flags( mbedtls_mps *mps, mbedtls_mps_msg_flags flags )
         mbedtls_mps_conf_get_mode( &mps->conf );
     int ret = 0;
 
-    TRACE_INIT( "mbedtls_mps_write_set_flags" );
-    TRACE( trace_comment, "* Flags: %02x", (unsigned) flags );
+    MBEDTLS_MPS_TRACE_INIT( "mbedtls_mps_write_set_flags" );
+    MBEDTLS_MPS_TRACE( trace_comment, "* Flags: %02x", (unsigned) flags );
 
     MBEDTLS_MPS_STATE_VALIDATE( mps->in.state != MBEDTLS_MPS_MSG_NONE,
            "mbedtls_mps_read_set_flags() must only be called while reading." );
@@ -1392,14 +1392,14 @@ int mbedtls_mps_read_consume( mbedtls_mps *mps )
     mbedtls_mps_transport_type const mode =
         mbedtls_mps_conf_get_mode( &mps->conf );
     mps_l3* const l3 = mbedtls_mps_l4_get_l3( mps );
-    TRACE_INIT( "mbedtls_mps_read_consume" );
+    MBEDTLS_MPS_TRACE_INIT( "mbedtls_mps_read_consume" );
 
     MBEDTLS_MPS_STATE_VALIDATE( mps->in.state != MBEDTLS_MPS_MSG_NONE,
       "mbedtls_mps_read_consume() must only be called if HS msg is open." );
 
     ret = mps_check_read( mps );
     if( ret != 0 )
-        RETURN( ret );
+        MBEDTLS_MPS_TRACE_RETURN( ret );
 
     switch( mps->in.state )
     {
@@ -1449,7 +1449,7 @@ int mbedtls_mps_read_consume( mbedtls_mps *mps )
             break;
     }
 
-    TRACE( trace_comment, "New incoming state: NONE" );
+    MBEDTLS_MPS_TRACE( trace_comment, "New incoming state: NONE" );
     mps->in.state = MBEDTLS_MPS_MSG_NONE;
 
     MPS_API_BOUNDARY_FAILURE_HANDLER
@@ -1480,8 +1480,8 @@ int mbedtls_mps_write_set_flags( mbedtls_mps *mps, mbedtls_mps_msg_flags flags )
         mbedtls_mps_conf_get_mode( &mps->conf );
     int ret = 0;
 
-    TRACE_INIT( "mbedtls_mps_write_set_flags" );
-    TRACE( trace_comment, "* Flags: %02x", (unsigned) flags );
+    MBEDTLS_MPS_TRACE_INIT( "mbedtls_mps_write_set_flags" );
+    MBEDTLS_MPS_TRACE( trace_comment, "* Flags: %02x", (unsigned) flags );
 
     MBEDTLS_MPS_STATE_VALIDATE( mps->out.state != MBEDTLS_MPS_MSG_NONE,
          "mbedtls_mps_write_set_flags() must only be called while writing." );
@@ -1524,7 +1524,7 @@ int mbedtls_mps_write_handshake( mbedtls_mps *mps,
     mbedtls_mps_transport_type const mode =
         mbedtls_mps_conf_get_mode( &mps->conf );
 
-    TRACE_INIT( "mbedtls_mps_write_handshake, type %u, length %u",
+    MBEDTLS_MPS_TRACE_INIT( "mbedtls_mps_write_handshake, type %u, length %u",
                 (unsigned) hs_new->type, (unsigned) hs_new->length );
 
     MPS_CHK( mps_prepare_write( mps, MPS_PAUSED_HS_ALLOWED ) );
@@ -1591,7 +1591,7 @@ int mbedtls_mps_write_handshake( mbedtls_mps *mps,
          */
         if( mps_get_hs_state( mps ) == MBEDTLS_MPS_FLIGHT_FINALIZE )
         {
-            TRACE( trace_comment, "Last flight-exchange complete for us, "
+            MBEDTLS_MPS_TRACE( trace_comment, "Last flight-exchange complete for us, "
                                   "but not necessarily for peer - ignore." );
             MPS_CHK( mps_handshake_state_transition( mps,
                          MBEDTLS_MPS_FLIGHT_FINALIZE,
@@ -1607,7 +1607,7 @@ int mbedtls_mps_write_handshake( mbedtls_mps *mps,
         /* No `else` because we want to fall through. */
         if( mps_get_hs_state( mps ) == MBEDTLS_MPS_FLIGHT_DONE )
         {
-            TRACE( trace_comment,
+            MBEDTLS_MPS_TRACE( trace_comment,
                    "No flight-exchange in progress. Start a new one" );
             mps->dtls.seq_nr = MPS_INITIAL_HS_SEQ_NR;
             MPS_CHK( mps_handshake_state_transition( mps,
@@ -1629,7 +1629,7 @@ int mbedtls_mps_write_handshake( mbedtls_mps *mps,
         if( hs->state == MBEDTLS_MPS_HS_ACTIVE )
         {
             mbedtls_mps_msg_metadata * const metadata = hs->metadata;
-            TRACE( trace_comment, "Handshake message has been paused - continue" );
+            MBEDTLS_MPS_TRACE( trace_comment, "Handshake message has been paused - continue" );
 
             /* Check consistency of parameters and forward to the user. */
             /* OPTIMIZATION: Consider ignoring the metadata passed on
@@ -1637,7 +1637,7 @@ int mbedtls_mps_write_handshake( mbedtls_mps *mps,
             if( metadata->len  != hs_new->length ||
                 metadata->type != hs_new->type )
             {
-                TRACE( trace_error,
+                MBEDTLS_MPS_TRACE( trace_error,
                        "Inconsistent parameters on continuation "
                        "of handshake write." );
                 MPS_CHK( MBEDTLS_ERR_MPS_INVALID_ARGS );
@@ -1650,7 +1650,7 @@ int mbedtls_mps_write_handshake( mbedtls_mps *mps,
             size_t queue_len;
             uint8_t write_mode;
 
-            TRACE( trace_comment,
+            MBEDTLS_MPS_TRACE( trace_comment,
                    "No handshake message paused - start a new one." );
 
             /* No handshake message is paused -- start a new one.
@@ -1709,13 +1709,13 @@ int mbedtls_mps_write_handshake( mbedtls_mps *mps,
                 size_t backup_len;
                 unsigned char *backup_buf;
 
-                TRACE( trace_comment, "Retransmission via raw backup" );
+                MBEDTLS_MPS_TRACE( trace_comment, "Retransmission via raw backup" );
                 handle->handle_type = MBEDTLS_MPS_RETRANSMISSION_HANDLE_HS_RAW;
 
                 /* Infer length for backup buffer. */
                 if( handle->metadata.len != MBEDTLS_MPS_SIZE_UNKNOWN )
                 {
-                    TRACE( trace_comment, "Total handshake length known: %u",
+                    MBEDTLS_MPS_TRACE( trace_comment, "Total handshake length known: %u",
                            (unsigned) hs_new->length );
 
                     MBEDTLS_MPS_ASSERT(
@@ -1726,7 +1726,7 @@ int mbedtls_mps_write_handshake( mbedtls_mps *mps,
                 }
                 else
                 {
-                    TRACE( trace_comment,
+                    MBEDTLS_MPS_TRACE( trace_comment,
                            "Total handshake length unknown, "
                            "puse backup buffer of maximum size %u",
                            (unsigned) MBEDTLS_MPS_MAX_HS_LENGTH );
@@ -1737,7 +1737,7 @@ int mbedtls_mps_write_handshake( mbedtls_mps *mps,
                 backup_buf = mbedtls_calloc( 1, backup_len );
                 if( backup_buf == NULL )
                 {
-                    TRACE( trace_error, "Error allocating backup buffer" );
+                    MBEDTLS_MPS_TRACE( trace_error, "Error allocating backup buffer" );
                     MPS_CHK( MBEDTLS_ERR_MPS_OUT_OF_MEMORY );
                 }
                 handle->handle.raw.buf = backup_buf;
@@ -1750,7 +1750,7 @@ int mbedtls_mps_write_handshake( mbedtls_mps *mps,
             else
             {
                 /* Retransmission via callback. */
-                TRACE( trace_comment, "Retransmission via callback" );
+                MBEDTLS_MPS_TRACE( trace_comment, "Retransmission via callback" );
                 handle->handle_type =
                     MBEDTLS_MPS_RETRANSMISSION_HANDLE_HS_CALLBACK;
 
@@ -1761,7 +1761,7 @@ int mbedtls_mps_write_handshake( mbedtls_mps *mps,
                  * a handshake write (shouldn't be difficult). */
                 if( handle->metadata.len == MBEDTLS_MPS_SIZE_UNKNOWN )
                 {
-                    TRACE( trace_error,
+                    MBEDTLS_MPS_TRACE( trace_error,
                            "Handshake messages with retransmission callback "
                            "and unknown size not supported." );
                     MPS_CHK( MBEDTLS_ERR_MPS_OPERATION_UNSUPPORTED );
@@ -1805,7 +1805,7 @@ int mbedtls_mps_write_application( mbedtls_mps *mps,
     int ret;
     mps_l3_app_out out_l3;
     mps_l3* const l3 = mbedtls_mps_l4_get_l3( mps );
-    TRACE_INIT( "mbedtls_mps_write_application" );
+    MBEDTLS_MPS_TRACE_INIT( "mbedtls_mps_write_application" );
     MPS_CHK( mps_prepare_write( mps, MPS_PAUSED_HS_FORBIDDEN ) );
 
     out_l3.epoch = mps->out_epoch;
@@ -1823,7 +1823,7 @@ int mbedtls_mps_write_alert( mbedtls_mps *mps,
     int ret;
     mps_l3_alert_out alert_l3;
     mps_l3* const l3 = mbedtls_mps_l4_get_l3( mps );
-    TRACE_INIT( "mbedtls_mps_write_alert" );
+    MBEDTLS_MPS_TRACE_INIT( "mbedtls_mps_write_alert" );
     MPS_CHK( mps_prepare_write( mps, MPS_PAUSED_HS_FORBIDDEN ) );
 
     alert_l3.epoch = mps->out_epoch;
@@ -1846,7 +1846,7 @@ int mbedtls_mps_write_ccs( mbedtls_mps *mps )
     mps_l3* const l3 = mbedtls_mps_l4_get_l3( mps );
     ((void) mode);
 
-    TRACE_INIT( "mbedtls_mps_write_ccs" );
+    MBEDTLS_MPS_TRACE_INIT( "mbedtls_mps_write_ccs" );
     MPS_CHK( mps_prepare_write( mps, MPS_PAUSED_HS_FORBIDDEN ) );
 
     ccs_l3.epoch = mps->out_epoch;
@@ -1873,11 +1873,11 @@ int mbedtls_mps_write_pause( mbedtls_mps *mps )
     int ret;
     mbedtls_mps_transport_type const mode =
         mbedtls_mps_conf_get_mode( &mps->conf );
-    TRACE_INIT( "mbedtls_mps_write_pause" );
+    MBEDTLS_MPS_TRACE_INIT( "mbedtls_mps_write_pause" );
 
     ret = mps_check_write( mps );
     if( ret != 0 )
-        RETURN( ret );
+        MBEDTLS_MPS_TRACE_RETURN( ret );
 
 #if defined(MBEDTLS_MPS_PROTO_TLS)
     if( MBEDTLS_MPS_IS_TLS( mode ) )
@@ -1897,7 +1897,7 @@ int mbedtls_mps_write_pause( mbedtls_mps *mps )
         /* Check that the handshake message is not yet fully written. */
         if( mbedtls_writer_check_done( &mps->dtls.io.out.hs.wr_ext ) == 0 )
         {
-            TRACE( trace_error,
+            MBEDTLS_MPS_TRACE( trace_error,
                    "Attempt to pause a fully written handshake message." );
             MPS_CHK( MBEDTLS_ERR_MPS_INTERNAL_ERROR );
         }
@@ -1919,11 +1919,11 @@ int mbedtls_mps_dispatch( mbedtls_mps *mps )
     mbedtls_mps_transport_type const mode =
         mbedtls_mps_conf_get_mode( &mps->conf );
     mps_l3* const l3 = mbedtls_mps_l4_get_l3( mps );
-    TRACE_INIT( "mbedtls_mps_dispatch" );
+    MBEDTLS_MPS_TRACE_INIT( "mbedtls_mps_dispatch" );
 
     ret = mps_check_write( mps );
     if( ret != 0 )
-        RETURN( ret );
+        MBEDTLS_MPS_TRACE_RETURN( ret );
 
 #if defined(MBEDTLS_MPS_PROTO_TLS)
     if( MBEDTLS_MPS_IS_TLS( mode ) )
@@ -1941,7 +1941,7 @@ int mbedtls_mps_dispatch( mbedtls_mps *mps )
 
         if( mps->out.state == MBEDTLS_MPS_MSG_NONE )
         {
-            TRACE( trace_error, "No message open" );
+            MBEDTLS_MPS_TRACE( trace_error, "No message open" );
             MPS_CHK( MBEDTLS_ERR_MPS_INTERNAL_ERROR );
         }
 
@@ -1980,7 +1980,7 @@ int mbedtls_mps_dispatch( mbedtls_mps *mps )
 
             if( flags == MBEDTLS_MPS_FLIGHT_END )
             {
-                TRACE( trace_comment,
+                MBEDTLS_MPS_TRACE( trace_comment,
                        "Message finishes the flight, "
                        "move from SEND to AWAIT state." );
                 MPS_CHK( mps_handshake_state_transition(
@@ -1990,7 +1990,7 @@ int mbedtls_mps_dispatch( mbedtls_mps *mps )
             }
             else
             {
-                TRACE( trace_comment,
+                MBEDTLS_MPS_TRACE( trace_comment,
                        "Message finishes the flight-exchange, "
                        "move from SEND to FINALIZE state." );
                 MPS_CHK( mps_handshake_state_transition(
@@ -2012,7 +2012,7 @@ int mbedtls_mps_dispatch( mbedtls_mps *mps )
 int mbedtls_mps_flush( mbedtls_mps *mps )
 {
     int ret;
-    TRACE_INIT( "mbedtls_mps_flush" );
+    MBEDTLS_MPS_TRACE_INIT( "mbedtls_mps_flush" );
 
     mps->out.flush = 1;
     MPS_CHK( mps_clear_pending( mps, MPS_PAUSED_HS_ALLOWED ) );
@@ -2045,7 +2045,7 @@ int mbedtls_mps_add_key_material( mbedtls_mps *mps,
 {
     int ret;
     mps_l3* const l3 = mbedtls_mps_l4_get_l3( mps );
-    TRACE_INIT( "mbedtls_mps_add_key_material" );
+    MBEDTLS_MPS_TRACE_INIT( "mbedtls_mps_add_key_material" );
     MPS_CHK( mps_l3_epoch_add( l3, params, id ) );
 
     MPS_API_BOUNDARY_FAILURE_HANDLER
@@ -2056,16 +2056,16 @@ int mbedtls_mps_set_incoming_keys( mbedtls_mps *mps,
 {
     int ret = 0;
     mps_l3* const l3 = mbedtls_mps_l4_get_l3( mps );
-    TRACE_INIT( "mbedtls_mps_set_incoming_keys, epoch %d", (int) id );
+    MBEDTLS_MPS_TRACE_INIT( "mbedtls_mps_set_incoming_keys, epoch %d", (int) id );
 
     MBEDTLS_MPS_STATE_VALIDATE( mps->in.state == MBEDTLS_MPS_MSG_NONE,
           "Refuse to change incoming keys while reading a message." );
 
     if( mps->in_epoch == id )
     {
-        TRACE( trace_comment, "Epoch %u is already the current incoming epoch",
+        MBEDTLS_MPS_TRACE( trace_comment, "Epoch %u is already the current incoming epoch",
                (unsigned) id );
-        RETURN( 0 );
+        MBEDTLS_MPS_TRACE_RETURN( 0 );
     }
 
     /* Clear 'active epoch' usage for old epoch and set it for new. */
@@ -2092,16 +2092,16 @@ int mbedtls_mps_set_outgoing_keys( mbedtls_mps *mps,
 {
     int ret = 0;
     mps_l3* const l3 = mbedtls_mps_l4_get_l3( mps );
-    TRACE_INIT( "mbedtls_mps_set_outgoing_keys, epoch %d", (int) id );
+    MBEDTLS_MPS_TRACE_INIT( "mbedtls_mps_set_outgoing_keys, epoch %d", (int) id );
 
     MBEDTLS_MPS_STATE_VALIDATE( mps->in.state == MBEDTLS_MPS_MSG_NONE,
           "Refuse to change outgoing keys while writing a message." );
 
     if( mps->out_epoch == id )
     {
-        TRACE( trace_comment, "Epoch %u is already the current incoming epoch",
+        MBEDTLS_MPS_TRACE( trace_comment, "Epoch %u is already the current incoming epoch",
                (unsigned) id );
-        RETURN( 0 );
+        MBEDTLS_MPS_TRACE_RETURN( 0 );
     }
 
     /* Clear 'active epoch' usage for old epoch and set it for new. */
@@ -2154,13 +2154,13 @@ MBEDTLS_MPS_STATIC int mps_retransmission_timer_increase_timeout( mbedtls_mps *m
 {
     uint32_t new_timeout, cur_timeout, max_timeout;
     uint8_t overflow;
-    TRACE_INIT( "mps_retransmit_timer_increase_timeout" );
+    MBEDTLS_MPS_TRACE_INIT( "mps_retransmit_timer_increase_timeout" );
 
     cur_timeout = mps->dtls.wait.retransmit_timeout;
 
     max_timeout = mbedtls_mps_conf_get_hs_timeout_max( &mps->conf );
     if( cur_timeout >= max_timeout )
-        RETURN( 0 /* -1 */ );
+        MBEDTLS_MPS_TRACE_RETURN( 0 /* -1 */ );
 
     new_timeout = 2 * cur_timeout;
 
@@ -2170,44 +2170,44 @@ MBEDTLS_MPS_STATIC int mps_retransmission_timer_increase_timeout( mbedtls_mps *m
         new_timeout = max_timeout;
 
     mps->dtls.wait.retransmit_timeout = new_timeout;
-    TRACE( trace_comment, "Update timeout value to %u milliseonds",
+    MBEDTLS_MPS_TRACE( trace_comment, "Update timeout value to %u milliseonds",
            (unsigned) new_timeout );
 
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
 MBEDTLS_MPS_STATIC int mps_retransmission_timer_update( mbedtls_mps *mps )
 {
     void*                     const timer_ctx = mps->conf.p_timer;
     mbedtls_mps_set_timer_t * const set_timer = mps->conf.f_set_timer;
-    TRACE_INIT( "mps_retransmission_timer_update" );
+    MBEDTLS_MPS_TRACE_INIT( "mps_retransmission_timer_update" );
 
     if( set_timer == NULL )
     {
-        TRACE( trace_comment, "No timer configured" );
-        RETURN( 0 );
+        MBEDTLS_MPS_TRACE( trace_comment, "No timer configured" );
+        MBEDTLS_MPS_TRACE_RETURN( 0 );
     }
 
     set_timer( timer_ctx, mps->dtls.wait.retransmit_timeout / 4,
                mps->dtls.wait.retransmit_timeout );
 
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
 MBEDTLS_MPS_STATIC int mps_retransmission_timer_stop( mbedtls_mps *mps )
 {
     void*                     const timer_ctx = mps->conf.p_timer;
     mbedtls_mps_set_timer_t * const set_timer = mps->conf.f_set_timer;
-    TRACE_INIT( "mps_retransmission_timer_stop" );
+    MBEDTLS_MPS_TRACE_INIT( "mps_retransmission_timer_stop" );
 
     if( set_timer == NULL )
     {
-        TRACE( trace_comment, "No timer configured" );
-        RETURN( 0 );
+        MBEDTLS_MPS_TRACE( trace_comment, "No timer configured" );
+        MBEDTLS_MPS_TRACE_RETURN( 0 );
     }
 
     set_timer( timer_ctx, 0, 0 );
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
 MBEDTLS_MPS_STATIC int mps_retransmission_timer_check( mbedtls_mps *mps )
@@ -2215,11 +2215,11 @@ MBEDTLS_MPS_STATIC int mps_retransmission_timer_check( mbedtls_mps *mps )
     int ret = 0;
     void*                     const timer_ctx = mps->conf.p_timer;
     mbedtls_mps_get_timer_t * const get_timer = mps->conf.f_get_timer;
-    TRACE_INIT( "mps_retransmission_timer_check" );
+    MBEDTLS_MPS_TRACE_INIT( "mps_retransmission_timer_check" );
 
     if( get_timer != NULL && get_timer( timer_ctx ) == 2 )
     {
-        TRACE( trace_comment, "Retransmission timer fired" );
+        MBEDTLS_MPS_TRACE( trace_comment, "Retransmission timer fired" );
         mps_retransmission_timer_stop( mps );
 
         /* The retransmission timer is used in various states of the
@@ -2230,7 +2230,7 @@ MBEDTLS_MPS_STATIC int mps_retransmission_timer_check( mbedtls_mps *mps )
             /* When waiting for the first message of the next flight
              * from the peer, resend the last outgoing flight. */
             case MBEDTLS_MPS_FLIGHT_AWAIT:
-                TRACE( trace_comment,
+                MBEDTLS_MPS_TRACE( trace_comment,
                        "Trigger retransmission of last outgoing flight." );
                 MPS_CHK( mps_trigger_retransmission( mps ) );
                 break;
@@ -2238,7 +2238,7 @@ MBEDTLS_MPS_STATIC int mps_retransmission_timer_check( mbedtls_mps *mps )
             /* If we have already received some parts of the next
              * flight from the peer, send a retransmission request. */
             case MBEDTLS_MPS_FLIGHT_RECEIVE:
-                TRACE( trace_comment,
+                MBEDTLS_MPS_TRACE( trace_comment,
                        "Trigger sending retransmission request to peer." );
                 MPS_CHK( mps_trigger_retransmission_request( mps ) );
                 break;
@@ -2261,7 +2261,7 @@ MBEDTLS_MPS_STATIC int mps_retransmission_timer_check( mbedtls_mps *mps )
     }
 
 exit:
-    RETURN( ret );
+    MBEDTLS_MPS_TRACE_RETURN( ret );
 }
 
 MBEDTLS_MPS_STATIC int mps_trigger_retransmission( mbedtls_mps *mps )
@@ -2338,14 +2338,14 @@ MBEDTLS_MPS_STATIC int mps_retransmit_in_check( mbedtls_mps *mps,
      * strategy applied here.
      */
 
-    TRACE_INIT( "mps_retransmit_in_check" );
-    TRACE( trace_comment, "Seq Nr: %u", (unsigned) hs->seq_nr );
-    TRACE( trace_comment, "Type:   %u", (unsigned) hs->type   );
-    TRACE( trace_comment, "Length: %u", (unsigned) hs->len    );
+    MBEDTLS_MPS_TRACE_INIT( "mps_retransmit_in_check" );
+    MBEDTLS_MPS_TRACE( trace_comment, "Seq Nr: %u", (unsigned) hs->seq_nr );
+    MBEDTLS_MPS_TRACE( trace_comment, "Type:   %u", (unsigned) hs->type   );
+    MBEDTLS_MPS_TRACE( trace_comment, "Length: %u", (unsigned) hs->len    );
 
     /* We only consider handshake fragments with offset 0. */
     if( hs->frag_offset != 0 )
-        RETURN( 0 );
+        MBEDTLS_MPS_TRACE_RETURN( 0 );
 
     flight_len = mps->dtls.retransmission_detection.flight_len;
     info       = &mps->dtls.retransmission_detection.msgs[0];
@@ -2360,9 +2360,9 @@ MBEDTLS_MPS_STATIC int mps_retransmit_in_check( mbedtls_mps *mps,
     }
 
     if( match_idx == 0xff )
-        RETURN( 0 );
+        MBEDTLS_MPS_TRACE_RETURN( 0 );
 
-    TRACE( trace_comment, "Retransmission of %u-th message detected",
+    MBEDTLS_MPS_TRACE( trace_comment, "Retransmission of %u-th message detected",
            (unsigned) match_idx );
 
     status = &mps->dtls.retransmission_detection.msg_state[match_idx];
@@ -2372,7 +2372,7 @@ MBEDTLS_MPS_STATIC int mps_retransmit_in_check( mbedtls_mps *mps,
         /* Observed a retransmission - move all messages to 'on hold'
          * state to omit triggering multiple retransmissions from a
          * single retransmission of the peer. */
-        TRACE( trace_comment, "Retransmission active for message"
+        MBEDTLS_MPS_TRACE( trace_comment, "Retransmission active for message"
                " - retransmit and put all other messages on hold." );
 
         status = &mps->dtls.retransmission_detection.msg_state[0];
@@ -2384,10 +2384,10 @@ MBEDTLS_MPS_STATIC int mps_retransmit_in_check( mbedtls_mps *mps,
     else
     {
         /* Re-activate retransmission detection for message. */
-        TRACE( trace_comment, "Retransmission currently put on hold "
+        MBEDTLS_MPS_TRACE( trace_comment, "Retransmission currently put on hold "
                "for this messsage - reactivate." );
         *status = MBEDTLS_MPS_RETRANSMISSION_DETECTION_ENABLED;
-        RETURN( 0 );
+        MBEDTLS_MPS_TRACE_RETURN( 0 );
     }
 
     MPS_INTERNAL_FAILURE_HANDLER
@@ -2401,7 +2401,7 @@ MBEDTLS_MPS_STATIC int mps_retransmit_in_remember( mbedtls_mps *mps,
     size_t msg_idx;
     mps_l3* const l3 = mbedtls_mps_l4_get_l3( mps );
     mbedtls_mps_recognition_info *next_info;
-    TRACE_INIT( "mps_retransmit_in_remember" );
+    MBEDTLS_MPS_TRACE_INIT( "mps_retransmit_in_remember" );
 
     /* Currently, we are basing retransmission detection
      * on epoch and sequence number only. */
@@ -2442,15 +2442,15 @@ MBEDTLS_MPS_STATIC int mps_retransmit_in_free( mbedtls_mps *mps )
     uint8_t flight_len, msg_idx;
     mbedtls_mps_recognition_info *info;
     mps_l3* const l3 = mbedtls_mps_l4_get_l3( mps );
-    TRACE_INIT( "mps_retransmit_in_free" );
+    MBEDTLS_MPS_TRACE_INIT( "mps_retransmit_in_free" );
 
     flight_len = mps->dtls.retransmission_detection.flight_len;
     info       = &mps->dtls.retransmission_detection.msgs[0];
 
-    TRACE( trace_comment, "Flight length: %u", (unsigned) flight_len );
+    MBEDTLS_MPS_TRACE( trace_comment, "Flight length: %u", (unsigned) flight_len );
     for( msg_idx=0; msg_idx < flight_len; msg_idx++, info++ )
     {
-        TRACE( trace_comment,
+        MBEDTLS_MPS_TRACE( trace_comment,
                "Epoch %u no longer needed for retransmission detection",
                (unsigned) info->epoch );
 
@@ -2468,7 +2468,7 @@ MBEDTLS_MPS_STATIC int mps_retransmit_in_free( mbedtls_mps *mps )
 MBEDTLS_MPS_STATIC int mps_retransmit_in_forget( mbedtls_mps *mps )
 {
     int ret = 0;
-    TRACE_INIT( "mps_retransmit_in_forget" );
+    MBEDTLS_MPS_TRACE_INIT( "mps_retransmit_in_forget" );
     MPS_CHK( mps_retransmit_in_free( mps ) );
     MPS_CHK( mps_retransmit_in_init( mps ) );
     MPS_INTERNAL_FAILURE_HANDLER
@@ -2527,13 +2527,13 @@ MBEDTLS_MPS_STATIC int mps_reassembly_feed( mbedtls_mps *mps,
     mbedtls_mps_msg_reassembly * reassembly;
     mps_l3* const l3 = mbedtls_mps_l4_get_l3( mps );
 
-    TRACE_INIT( "mps_reassembly_feed" );
-    TRACE( trace_comment, "* Sequence number: %u", (unsigned) hs->seq_nr      );
-    TRACE( trace_comment, "* Type:            %u", (unsigned) hs->type        );
-    TRACE( trace_comment, "* Total length:    %u", (unsigned) hs->len         );
-    TRACE( trace_comment, "* Fragment offset: %u", (unsigned) hs->frag_offset );
-    TRACE( trace_comment, "* Fragment length: %u", (unsigned) hs->frag_len    );
-    TRACE( trace_comment, "Sequence number of next HS message: %u",
+    MBEDTLS_MPS_TRACE_INIT( "mps_reassembly_feed" );
+    MBEDTLS_MPS_TRACE( trace_comment, "* Sequence number: %u", (unsigned) hs->seq_nr      );
+    MBEDTLS_MPS_TRACE( trace_comment, "* Type:            %u", (unsigned) hs->type        );
+    MBEDTLS_MPS_TRACE( trace_comment, "* Total length:    %u", (unsigned) hs->len         );
+    MBEDTLS_MPS_TRACE( trace_comment, "* Fragment offset: %u", (unsigned) hs->frag_offset );
+    MBEDTLS_MPS_TRACE( trace_comment, "* Fragment length: %u", (unsigned) hs->frag_len    );
+    MBEDTLS_MPS_TRACE( trace_comment, "Sequence number of next HS message: %u",
            (unsigned) mps->dtls.seq_nr );
 
     MBEDTLS_MPS_ASSERT(
@@ -2553,16 +2553,16 @@ MBEDTLS_MPS_STATIC int mps_reassembly_feed( mbedtls_mps *mps,
     {
         unsigned char *tmp;
 
-        TRACE( trace_error, "Sequence number %u outside current window [%u,%u]",
+        MBEDTLS_MPS_TRACE( trace_error, "Sequence number %u outside current window [%u,%u]",
           (unsigned) seq_nr, (unsigned) mps->dtls.seq_nr,
           (unsigned) ( mps->dtls.seq_nr + MBEDTLS_MPS_FUTURE_MESSAGE_BUFFERS ) );
 
         /* Layer 3 will error out if we don't fully consume a fragment,
          * so fetch and commit it even if we don't consider the contents. */
         /* TODO: This could be moved to an 'abort' function on Layer 3. */
-        MPS_CHK( mbedtls_reader_get_ext( hs->rd_ext, hs->frag_len,
+        MPS_CHK( mbedtls_mps_reader_get_ext( hs->rd_ext, hs->frag_len,
                                          &tmp, NULL ) );
-        MPS_CHK( mbedtls_reader_commit_ext( hs->rd_ext ) );
+        MPS_CHK( mbedtls_mps_reader_commit_ext( hs->rd_ext ) );
         MPS_CHK( mps_l3_read_consume( l3 ) );
         MPS_CHK( MBEDTLS_ERR_MPS_REASSEMBLY_FEED_NEED_MORE );
     }
@@ -2572,7 +2572,7 @@ MBEDTLS_MPS_STATIC int mps_reassembly_feed( mbedtls_mps *mps,
 
     if( reassembly->status == MBEDTLS_MPS_REASSEMBLY_NO_FRAGMENTATION )
     {
-        TRACE( trace_error,
+        MBEDTLS_MPS_TRACE( trace_error,
                "Attempt to feed a fragment for a message that "
                "has previously been fully received." );
         MPS_CHK( MBEDTLS_ERR_MPS_INTERNAL_ERROR );
@@ -2583,7 +2583,7 @@ MBEDTLS_MPS_STATIC int mps_reassembly_feed( mbedtls_mps *mps,
         uint8_t complete_msg;
 
         /* Sequence number not seen before. */
-        TRACE( trace_comment,
+        MBEDTLS_MPS_TRACE( trace_comment,
            "Sequence number %u not seen before - setup reassembly structure.",
            (unsigned) seq_nr );
 
@@ -2598,18 +2598,18 @@ MBEDTLS_MPS_STATIC int mps_reassembly_feed( mbedtls_mps *mps,
                        ( hs->frag_len    == hs->len );
         if( seq_nr_offset == 0 && complete_msg )
         {
-            TRACE( trace_comment,
+            MBEDTLS_MPS_TRACE( trace_comment,
                    "Received next handshake message in single fragment." );
             reassembly->status = MBEDTLS_MPS_REASSEMBLY_NO_FRAGMENTATION;
             reassembly->data.rd_ext_l3 = hs->rd_ext;
-            RETURN( 0 );
+            MBEDTLS_MPS_TRACE_RETURN( 0 );
         }
         else
         {
             size_t bitmask_len, msg_len;
             unsigned char *bitmask;
             unsigned char *buf;
-            TRACE( trace_comment, "Feed handshake message into reassembler." );
+            MBEDTLS_MPS_TRACE( trace_comment, "Feed handshake message into reassembler." );
 
             /* For proper fragments of the next expected message,
              * or for any fragments (even full ones) belonging
@@ -2643,7 +2643,7 @@ MBEDTLS_MPS_STATIC int mps_reassembly_feed( mbedtls_mps *mps,
             hs->type  != reassembly->type  ||
             hs->len   != reassembly->length )
         {
-            TRACE( trace_error,
+            MBEDTLS_MPS_TRACE( trace_error,
                    "Inconsistent parameters (%u,%u,%u) != (%u,%u,%u) "
                    "for fragments of HS msg of sequence number %u",
                    (unsigned) hs->epoch,        (unsigned) hs->type,
@@ -2663,13 +2663,13 @@ MBEDTLS_MPS_STATIC int mps_reassembly_feed( mbedtls_mps *mps,
     {
         unsigned char* bitmask = reassembly->data.window.bitmask;
         unsigned char *frag_content;
-        TRACE( trace_comment, "Contribute to ongoing reassembly." );
+        MBEDTLS_MPS_TRACE( trace_comment, "Contribute to ongoing reassembly." );
 
-        MPS_CHK( mbedtls_reader_get_ext( hs->rd_ext, hs->frag_len,
+        MPS_CHK( mbedtls_mps_reader_get_ext( hs->rd_ext, hs->frag_len,
                                          &frag_content, NULL ) );
         memcpy( reassembly->data.window.buf + hs->frag_offset,
                 frag_content, hs->frag_len );
-        MPS_CHK( mbedtls_reader_commit_ext( hs->rd_ext ) );
+        MPS_CHK( mbedtls_mps_reader_commit_ext( hs->rd_ext ) );
         MPS_CHK( mps_l3_read_consume( l3 ) );
 
         if( bitmask != NULL )
@@ -2681,13 +2681,13 @@ MBEDTLS_MPS_STATIC int mps_reassembly_feed( mbedtls_mps *mps,
             if( mps_bitmask_check( bitmask, hs->len ) == 0 )
             {
                 /* Free bitmask to indicate that the message is complete. */
-                TRACE( trace_comment, "Message fully reassembled." );
+                MBEDTLS_MPS_TRACE( trace_comment, "Message fully reassembled." );
                 reassembly->data.window.bitmask = NULL;
                 MPS_CHK( mps_reassembly_next_msg_complete( mps ) );
             }
             else
             {
-                TRACE( trace_comment,
+                MBEDTLS_MPS_TRACE( trace_comment,
                        "Reassembly incomplete -- need more fragments." );
                 MPS_CHK( MBEDTLS_ERR_MPS_REASSEMBLY_FEED_NEED_MORE );
             }
@@ -2703,7 +2703,7 @@ MBEDTLS_MPS_STATIC int mps_reassembly_feed( mbedtls_mps *mps,
 MBEDTLS_MPS_STATIC int mps_reassembly_free( mbedtls_mps *mps )
 {
     uint8_t idx;
-    TRACE_INIT( "mps_reassembly_free" );
+    MBEDTLS_MPS_TRACE_INIT( "mps_reassembly_free" );
 
     for( idx = 0; idx < MBEDTLS_MPS_FUTURE_MESSAGE_BUFFERS; idx++ )
     {
@@ -2719,7 +2719,7 @@ MBEDTLS_MPS_STATIC int mps_reassembly_free( mbedtls_mps *mps )
         }
     }
 
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
 MBEDTLS_MPS_STATIC int mps_reassembly_init( mbedtls_mps *mps )
@@ -2738,7 +2738,7 @@ MBEDTLS_MPS_STATIC int mps_reassembly_get_seq( mbedtls_mps *mps,
                                    uint8_t *seq_nr )
 {
     int ret = 0;
-    TRACE_INIT( "mps_reassembly_get_seq" );
+    MBEDTLS_MPS_TRACE_INIT( "mps_reassembly_get_seq" );
 
     MBEDTLS_MPS_ASSERT( MBEDTLS_MPS_FLIGHT_STATE_EITHER_OR(
             mps_get_hs_state( mps ),
@@ -2756,7 +2756,7 @@ MBEDTLS_MPS_STATIC int mps_reassembly_check_and_load( mbedtls_mps *mps )
     mbedtls_mps_msg_reassembly const * reassembly;
     int next_message_complete = 0;
     int ret = 0;
-    TRACE_INIT( "mps_reassembly_check_and_load" );
+    MBEDTLS_MPS_TRACE_INIT( "mps_reassembly_check_and_load" );
 
     if( ! MBEDTLS_MPS_FLIGHT_STATE_EITHER_OR(
             mps_get_hs_state( mps ),
@@ -2785,7 +2785,7 @@ MBEDTLS_MPS_STATIC int mps_reassembly_check_and_load( mbedtls_mps *mps )
     /* Check that message's epoch matches the current incoming epoch. */
     if( reassembly->epoch != mps->in_epoch )
     {
-        TRACE( trace_error, "Reassembled message isn't protected through current incoming epoch." );
+        MBEDTLS_MPS_TRACE( trace_error, "Reassembled message isn't protected through current incoming epoch." );
         MPS_CHK( MBEDTLS_ERR_MPS_INVALID_CONTENT );
     }
 
@@ -2799,7 +2799,7 @@ MBEDTLS_MPS_STATIC int mps_reassembly_read( mbedtls_mps *mps,
     int ret = 0;
     mbedtls_mps_reassembly * const in = &mps->dtls.io.in.incoming;
     mbedtls_mps_msg_reassembly * reassembly = &in->reassembly[0];
-    TRACE_INIT( "mps_reassembly_read" );
+    MBEDTLS_MPS_TRACE_INIT( "mps_reassembly_read" );
 
     MBEDTLS_MPS_ASSERT( MBEDTLS_MPS_FLIGHT_STATE_EITHER_OR(
             mps_get_hs_state( mps ),
@@ -2808,14 +2808,14 @@ MBEDTLS_MPS_STATIC int mps_reassembly_read( mbedtls_mps *mps,
 
     hs->length = reassembly->length;
     hs->type   = reassembly->type;
-    TRACE( trace_comment, "Length: %u", (unsigned) hs->length );
-    TRACE( trace_comment, "Type:   %u", (unsigned) hs->type   );
+    MBEDTLS_MPS_TRACE( trace_comment, "Length: %u", (unsigned) hs->length );
+    MBEDTLS_MPS_TRACE( trace_comment, "Type:   %u", (unsigned) hs->type   );
 
     /* TODO: Add additional data (sequence number). */
 
     if( reassembly->status == MBEDTLS_MPS_REASSEMBLY_NO_FRAGMENTATION )
     {
-        TRACE( trace_comment,
+        MBEDTLS_MPS_TRACE( trace_comment,
                "Handshake message received as single fragment "
                "on Layer 3 - pass on to user." );
         /* The message has been received in a single fragment
@@ -2825,14 +2825,14 @@ MBEDTLS_MPS_STATIC int mps_reassembly_read( mbedtls_mps *mps,
     else if( reassembly->status == MBEDTLS_MPS_REASSEMBLY_WINDOW &&
              reassembly->data.window.bitmask == NULL )
     {
-        TRACE( trace_comment, "Fully reassembled handshake messaged" );
+        MBEDTLS_MPS_TRACE( trace_comment, "Fully reassembled handshake messaged" );
         hs->handle = &in->rd_ext;
     }
     else
     {
         /* We should never call this function unless we know
          * that a message is ready. */
-        TRACE( trace_comment,
+        MBEDTLS_MPS_TRACE( trace_comment,
                "Should never call mps_reassembly_read unless it is "
                "known that a message is ready." );
         MPS_CHK( MBEDTLS_ERR_MPS_INTERNAL_ERROR );
@@ -2848,7 +2848,7 @@ MBEDTLS_MPS_STATIC int mps_reassembly_done( mbedtls_mps *mps )
     mbedtls_mps_reassembly * const in = &mps->dtls.io.in.incoming;
     mbedtls_mps_msg_reassembly * reassembly = &in->reassembly[0];
     mps_l3* const l3 = mbedtls_mps_l4_get_l3( mps );
-    TRACE_INIT( "mps_reassembly_done" );
+    MBEDTLS_MPS_TRACE_INIT( "mps_reassembly_done" );
 
     MBEDTLS_MPS_ASSERT( MBEDTLS_MPS_FLIGHT_STATE_EITHER_OR(
             mps_get_hs_state( mps ),
@@ -2860,9 +2860,9 @@ MBEDTLS_MPS_STATIC int mps_reassembly_done( mbedtls_mps *mps )
         mbedtls_free( reassembly->data.window.buf );
         /* The bitmask is freed as soon as the fragmentation completes. */
 
-        MPS_CHK( mbedtls_reader_check_done( &in->rd_ext ) );
-        mbedtls_reader_free_ext( &in->rd_ext );
-        mbedtls_reader_free    ( &in->rd     );
+        MPS_CHK( mbedtls_mps_reader_check_done( &in->rd_ext ) );
+        mbedtls_mps_reader_free_ext( &in->rd_ext );
+        mbedtls_mps_reader_free    ( &in->rd     );
     }
     else
     {
@@ -2878,7 +2878,7 @@ MBEDTLS_MPS_STATIC int mps_reassembly_done( mbedtls_mps *mps )
 
     if( mps->dtls.seq_nr == MBEDTLS_MPS_LIMIT_SEQUENCE_NUMBER )
     {
-        TRACE( trace_error, "Reached maximum incoming sequence number %u",
+        MBEDTLS_MPS_TRACE( trace_error, "Reached maximum incoming sequence number %u",
                (unsigned) MBEDTLS_MPS_LIMIT_SEQUENCE_NUMBER );
         MPS_CHK( MBEDTLS_ERR_MPS_COUNTER_WRAP );
     }
@@ -2894,7 +2894,7 @@ MBEDTLS_MPS_STATIC int mps_reassembly_next_msg_complete( mbedtls_mps *mps )
     int ret = 0;
     mbedtls_mps_reassembly * const in = &mps->dtls.io.in.incoming;
     mbedtls_mps_msg_reassembly * const reassembly = &in->reassembly[0];
-    TRACE_INIT( "mps_reassembly_next_msg_complete" );
+    MBEDTLS_MPS_TRACE_INIT( "mps_reassembly_next_msg_complete" );
 
     MBEDTLS_MPS_ASSERT( MBEDTLS_MPS_FLIGHT_STATE_EITHER_OR(
             mps_get_hs_state( mps ),
@@ -2904,17 +2904,17 @@ MBEDTLS_MPS_STATIC int mps_reassembly_next_msg_complete( mbedtls_mps *mps )
     if( reassembly->status == MBEDTLS_MPS_REASSEMBLY_WINDOW &&
         reassembly->data.window.bitmask == NULL )
     {
-        TRACE( trace_comment, "Next message already fully available." );
-        mbedtls_reader_init( &in->rd, NULL, 0 );
-        mbedtls_reader_init_ext( &in->rd_ext, reassembly->length );
-        MPS_CHK( mbedtls_reader_attach( &in->rd_ext, &in->rd ) );
-        MPS_CHK( mbedtls_reader_feed( &in->rd,
+        MBEDTLS_MPS_TRACE( trace_comment, "Next message already fully available." );
+        mbedtls_mps_reader_init( &in->rd, NULL, 0 );
+        mbedtls_mps_reader_init_ext( &in->rd_ext, reassembly->length );
+        MPS_CHK( mbedtls_mps_reader_attach( &in->rd_ext, &in->rd ) );
+        MPS_CHK( mbedtls_mps_reader_feed( &in->rd,
                                       reassembly->data.window.buf,
                                       reassembly->data.window.buf_len ) );
     }
     else
     {
-        TRACE( trace_comment, "Next message not yet available." );
+        MBEDTLS_MPS_TRACE( trace_comment, "Next message not yet available." );
     }
 
     MPS_INTERNAL_FAILURE_HANDLER
@@ -2924,7 +2924,7 @@ MBEDTLS_MPS_STATIC int mps_reassembly_pause( mbedtls_mps *mps )
 {
     int ret = 0;
     ((void) mps);
-    TRACE_INIT( "mps_reassembly_pause" );
+    MBEDTLS_MPS_TRACE_INIT( "mps_reassembly_pause" );
 
     MBEDTLS_MPS_ASSERT( MBEDTLS_MPS_FLIGHT_STATE_EITHER_OR(
             mps_get_hs_state( mps ),
@@ -2941,7 +2941,7 @@ MBEDTLS_MPS_STATIC int mps_reassembly_forget( mbedtls_mps *mps )
     uint8_t idx;
     int ret = 0;
     mbedtls_mps_reassembly * const in = &mps->dtls.io.in.incoming;
-    TRACE_INIT( "mps_reassembly_forget" );
+    MBEDTLS_MPS_TRACE_INIT( "mps_reassembly_forget" );
 
     MBEDTLS_MPS_ASSERT( MBEDTLS_MPS_FLIGHT_STATE_EITHER_OR(
             mps_get_hs_state( mps ),
@@ -2978,14 +2978,14 @@ MBEDTLS_MPS_STATIC int mps_retransmit_out( mbedtls_mps *mps )
 MBEDTLS_MPS_ALWAYS_INLINE int mps_out_flight_get_retransmission_handle(
     mbedtls_mps *mps, mbedtls_mps_retransmission_handle **hdl, size_t offset )
 {
-    TRACE_INIT( "mps_get_transmission_handle, index %u",
+    MBEDTLS_MPS_TRACE_INIT( "mps_get_transmission_handle, index %u",
                 (unsigned) offset );
 
     MBEDTLS_MPS_ASSERT_RAW( offset < MBEDTLS_MPS_MAX_FLIGHT_LENGTH,
                             "Invalid retransmission handle index" );
 
     *hdl = &mps->dtls.outgoing.backup[ offset ];
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
 MBEDTLS_MPS_STATIC int mps_retransmit_out_core( mbedtls_mps *mps,
@@ -2994,17 +2994,17 @@ MBEDTLS_MPS_STATIC int mps_retransmit_out_core( mbedtls_mps *mps,
     int ret = 0;
     uint8_t offset;
     mbedtls_mps_retransmission_handle *handle;
-    TRACE_INIT( "mps_retransmit_out" );
+    MBEDTLS_MPS_TRACE_INIT( "mps_retransmit_out" );
 
     if( mps->dtls.wait.resend_offset == 0 )
     {
-        TRACE( trace_comment,
+        MBEDTLS_MPS_TRACE( trace_comment,
                "Start retransmission of last outgoing flight of length %u",
                (unsigned) mps->dtls.outgoing.flight_len );
     }
     else
     {
-        TRACE( trace_comment,
+        MBEDTLS_MPS_TRACE( trace_comment,
                "Continue retransmission of last outgoing flight "
                "of length %u at message %u.",
                (unsigned) mps->dtls.outgoing.flight_len,
@@ -3016,7 +3016,7 @@ MBEDTLS_MPS_STATIC int mps_retransmit_out_core( mbedtls_mps *mps,
 
     while( offset < mps->dtls.outgoing.flight_len )
     {
-        TRACE( trace_comment,
+        MBEDTLS_MPS_TRACE( trace_comment,
                "Retransmitting message %u of last outgoing flight.",
                (unsigned) offset );
 
@@ -3049,7 +3049,7 @@ MBEDTLS_MPS_STATIC int mps_retransmit_out_core( mbedtls_mps *mps,
 
 exit:
     mps->dtls.wait.resend_offset = offset;
-    RETURN( ret );
+    MBEDTLS_MPS_TRACE_RETURN( ret );
 }
 
 /*
@@ -3061,14 +3061,14 @@ exit:
 
 MBEDTLS_MPS_STATIC int mps_request_resend( mbedtls_mps *mps )
 {
-    TRACE_INIT( "mps_request_send" );
+    MBEDTLS_MPS_TRACE_INIT( "mps_request_send" );
     /* TLS-1.3-NOTE: This needs to be handled through ACK's
      *               in DTLS 1.3. */
-    RETURN( mps_retransmit_out_core( mps,
+    MBEDTLS_MPS_TRACE_RETURN( mps_retransmit_out_core( mps,
                                      MPS_RETRANSMIT_ONLY_EMPTY_FRAGMENTS ) );
 }
 
-#if defined(MBEDTLS_MPS_TRACE)
+#if defined(MBEDTLS_MPS_ENABLE_TRACE)
 static inline const char * mps_flight_state_to_string(
     mbedtls_mps_flight_state_t state )
 {
@@ -3092,7 +3092,7 @@ static inline const char * mps_flight_state_to_string(
             return( "UNKNOWN" );
     }
 }
-#endif /* MBEDTLS_MPS_TRACE */
+#endif /* MBEDTLS_MPS_ENABLE_TRACE */
 
 MBEDTLS_MPS_INLINE
 /* Perform a retransmisison state machine transition and
@@ -3107,7 +3107,7 @@ int mps_handshake_state_transition( mbedtls_mps *mps,
                                     mbedtls_mps_flight_state_t new )
 {
     int ret = 0;
-    TRACE_INIT( "mps_handshake_state_transition, old %u (%s), new %u (%s)",
+    MBEDTLS_MPS_TRACE_INIT( "mps_handshake_state_transition, old %u (%s), new %u (%s)",
                 (unsigned) old, mps_flight_state_to_string( old ),
                 (unsigned) new, mps_flight_state_to_string( new ) );
 
@@ -3226,7 +3226,7 @@ int mps_handshake_state_transition( mbedtls_mps *mps,
 
     mps->dtls.state = new;
 
-    TRACE( trace_comment, "State transition from %u to %u done.",
+    MBEDTLS_MPS_TRACE( trace_comment, "State transition from %u to %u done.",
            (unsigned) old, (unsigned) new );
     MPS_INTERNAL_FAILURE_HANDLER
 }
@@ -3251,7 +3251,7 @@ int mbedtls_mps_retransmission_handle_incoming_fragment( mbedtls_mps *mps )
                                   .frag_len = 0, .frag_offset = 0, .seq_nr = 0,
                                   .rd_ext = NULL };
     mps_l3* const l3 = mbedtls_mps_l4_get_l3( mps );
-    TRACE_INIT( "mps_retransmission_handle_incoming_fragment" );
+    MBEDTLS_MPS_TRACE_INIT( "mps_retransmission_handle_incoming_fragment" );
 
     /*
      * When we reach this code-path, the flight state is either
@@ -3298,7 +3298,7 @@ int mbedtls_mps_retransmission_handle_incoming_fragment( mbedtls_mps *mps )
      *   getting out of sync with the actual flight state.
      */
 
-    TRACE( trace_comment, "Fetch new fragment from Layer 3" );
+    MBEDTLS_MPS_TRACE( trace_comment, "Fetch new fragment from Layer 3" );
     MPS_CHK( mps_l3_read_handshake( l3, &hs_l3 ) );
 
     /* 1. Check if the message is recognized as a retransmission
@@ -3307,26 +3307,26 @@ int mbedtls_mps_retransmission_handle_incoming_fragment( mbedtls_mps *mps )
     if( MBEDTLS_MPS_FLIGHT_STATE_EITHER_OR( mps_get_hs_state( mps ),
             MBEDTLS_MPS_FLIGHT_AWAIT, MBEDTLS_MPS_FLIGHT_FINALIZE ) )
     {
-        TRACE( trace_comment,
+        MBEDTLS_MPS_TRACE( trace_comment,
                "Check if the fragment is a retransmission from old flight." );
         ret = mps_retransmit_in_check( mps, &hs_l3 );
 
         if( ret == MBEDTLS_ERR_MPS_FLIGHT_RETRANSMISSION )
         {
-            mbedtls_reader_ext *hs_rd_ext;
+            mbedtls_mps_reader_ext *hs_rd_ext;
             unsigned char *tmp;
 
             /* Message is a retransmission from the last incoming flight. */
-            TRACE( trace_comment,
+            MBEDTLS_MPS_TRACE( trace_comment,
                    "Retransmission detected - retransmit last flight." );
 
             /* Layer 3 will error out if we don't fully consume a fragment,
              * so fetch and commit it even if we don't consider the contents. */
             /* TODO: This could be moved to an 'abort' function on Layer 3. */
             hs_rd_ext = hs_l3.rd_ext;
-            MPS_CHK( mbedtls_reader_get_ext( hs_rd_ext, hs_l3.frag_len,
+            MPS_CHK( mbedtls_mps_reader_get_ext( hs_rd_ext, hs_l3.frag_len,
                                              &tmp, NULL ) );
-            MPS_CHK( mbedtls_reader_commit_ext( hs_rd_ext ) );
+            MPS_CHK( mbedtls_mps_reader_commit_ext( hs_rd_ext ) );
 
             /* Mark handshake fragment as processed before starting
              * the retransmission, which might return WANT_WRITE. */
@@ -3339,7 +3339,7 @@ int mbedtls_mps_retransmission_handle_incoming_fragment( mbedtls_mps *mps )
         else
             MPS_CHK( ret );
 
-        TRACE( trace_comment, "Frag not recognized as a retransmission." );
+        MBEDTLS_MPS_TRACE( trace_comment, "Frag not recognized as a retransmission." );
 
         /* Logically, we should also be able to forget about our last
          * outgoing flight, because we know that our peer has already
@@ -3405,18 +3405,18 @@ int mbedtls_mps_retransmission_handle_incoming_fragment( mbedtls_mps *mps )
          *       This needs to be changed at some point. */
         if( hs_l3.frag_offset != 0 )
         {
-            mbedtls_reader_ext *hs_rd_ext;
+            mbedtls_mps_reader_ext *hs_rd_ext;
             unsigned char *tmp;
 
-            TRACE( trace_comment,
+            MBEDTLS_MPS_TRACE( trace_comment,
                    "Discard non-initial fragments outside of handshake." );
 
             /* Layer 3 will error out if we don't fully consume a fragment,
              * so fetch and commit it even if we don't consider the contents. */
             /* TODO: This could be moved to an 'abort' function on Layer 3. */
             hs_rd_ext = hs_l3.rd_ext;
-            MPS_CHK( mbedtls_reader_get_ext( hs_rd_ext, hs_l3.frag_len, &tmp, NULL ) );
-            MPS_CHK( mbedtls_reader_commit_ext( hs_rd_ext ) );
+            MPS_CHK( mbedtls_mps_reader_get_ext( hs_rd_ext, hs_l3.frag_len, &tmp, NULL ) );
+            MPS_CHK( mbedtls_mps_reader_commit_ext( hs_rd_ext ) );
 
             MPS_CHK( mps_l3_read_consume( l3 ) );
             MPS_CHK( MBEDTLS_ERR_MPS_NO_FORWARD );
@@ -3478,7 +3478,7 @@ int mbedtls_mps_retransmission_handle_incoming_fragment( mbedtls_mps *mps )
      *
      */
 
-    TRACE( trace_comment, "Feed fragment into reassembly module." );
+    MBEDTLS_MPS_TRACE( trace_comment, "Feed fragment into reassembly module." );
     ret = mps_reassembly_feed( mps, &hs_l3 );
     if( ret == MBEDTLS_ERR_MPS_REASSEMBLY_FEED_NEED_MORE )
     {
@@ -3505,7 +3505,7 @@ int mbedtls_mps_retransmission_handle_incoming_fragment( mbedtls_mps *mps )
         MPS_CHK( mps_l3_get_last_sequence_number( l3, hs_l3.epoch,
                                                   &rec_ctr ) );
 
-        TRACE( trace_comment, "Mirror rec seq nr %u", (unsigned) rec_ctr );
+        MBEDTLS_MPS_TRACE( trace_comment, "Mirror rec seq nr %u", (unsigned) rec_ctr );
         MPS_CHK( mps_l3_force_next_sequence_number( l3, hs_l3.epoch,
                                                     rec_ctr ) );
     }
@@ -3518,7 +3518,7 @@ MBEDTLS_MPS_STATIC int mps_retransmission_finish_incoming_message( mbedtls_mps *
     int ret;
     uint8_t flags;
     uint8_t seq_nr;
-    TRACE_INIT( "mps_retransmission_finish_incoming_message" );
+    MBEDTLS_MPS_TRACE_INIT( "mps_retransmission_finish_incoming_message" );
 
     /* Remember parts of message to detect retransmission.
      * Currently, we're only remembering the epoch and the
@@ -3540,19 +3540,19 @@ MBEDTLS_MPS_STATIC int mps_retransmission_finish_incoming_message( mbedtls_mps *
 
     if( flags == MBEDTLS_MPS_FLIGHT_END )
     {
-        TRACE( trace_comment, "Incoming msg ends flight. -> PREPARE" );
+        MBEDTLS_MPS_TRACE( trace_comment, "Incoming msg ends flight. -> PREPARE" );
         MPS_CHK( mps_handshake_state_transition( mps,
                      MBEDTLS_MPS_FLIGHT_RECEIVE, MBEDTLS_MPS_FLIGHT_PREPARE ) );
     }
     else if( flags == MBEDTLS_MPS_FLIGHT_FINISHED )
     {
-        TRACE( trace_comment, "Incoming msg ends exchange. -> DONE" );
+        MBEDTLS_MPS_TRACE( trace_comment, "Incoming msg ends exchange. -> DONE" );
         MPS_CHK( mps_handshake_state_transition( mps,
                      MBEDTLS_MPS_FLIGHT_RECEIVE, MBEDTLS_MPS_FLIGHT_DONE ) );
     }
     else
     {
-        TRACE( trace_comment, "Incoming msg not last in flight. Keep RECEIVE" );
+        MBEDTLS_MPS_TRACE( trace_comment, "Incoming msg not last in flight. Keep RECEIVE" );
     }
 
     mps->in.flags = 0;
@@ -3580,11 +3580,11 @@ MBEDTLS_MPS_STATIC int mps_out_flight_free( mbedtls_mps *mps )
     uint8_t idx, flight_len;
     mbedtls_mps_retransmission_handle *handle;
     mps_l3* const l3 = mbedtls_mps_l4_get_l3( mps );
-    TRACE_INIT( "mps_out_flight_free" );
+    MBEDTLS_MPS_TRACE_INIT( "mps_out_flight_free" );
 
     flight_len =  mps->dtls.outgoing.flight_len;
     handle     = &mps->dtls.outgoing.backup[0];
-    TRACE( trace_comment, "Flight length: %u", (unsigned) flight_len );
+    MBEDTLS_MPS_TRACE( trace_comment, "Flight length: %u", (unsigned) flight_len );
 
     for( idx=0; idx < flight_len; idx++, handle++ )
     {
@@ -3639,7 +3639,7 @@ MBEDTLS_MPS_STATIC int mbedtls_mps_retransmission_handle_resend_empty(
     int ret = 0;
     mps_l3_handshake_out hs_out_l3;
     mps_l3* const l3 = mbedtls_mps_l4_get_l3( mps );
-    TRACE_INIT( "mps_retransmission_handle_resend_empty" );
+    MBEDTLS_MPS_TRACE_INIT( "mps_retransmission_handle_resend_empty" );
 
     hs_out_l3.epoch       = handle->metadata.epoch;
     hs_out_l3.frag_len    = 0;
@@ -3661,7 +3661,7 @@ MBEDTLS_MPS_STATIC int mbedtls_mps_retransmission_handle_resend( mbedtls_mps *mp
     mbedtls_mps_handshake_out_internal * const hs = &mps->dtls.io.out.hs;
     mps_l3* const l3 = mbedtls_mps_l4_get_l3( mps );
 
-    TRACE_INIT( "mps_retransmission_handle_resend" );
+    MBEDTLS_MPS_TRACE_INIT( "mps_retransmission_handle_resend" );
 
     MBEDTLS_MPS_ASSERT(
         handle->handle_type == MBEDTLS_MPS_RETRANSMISSION_HANDLE_HS_RAW      ||
@@ -3676,7 +3676,7 @@ MBEDTLS_MPS_STATIC int mbedtls_mps_retransmission_handle_resend( mbedtls_mps *mp
             unsigned char * backup_buf    = handle->handle.raw.buf;
             mbedtls_mps_size_t backup_len = handle->handle.raw.len;
 
-            TRACE( trace_comment, "Retransmission via raw backup" );
+            MBEDTLS_MPS_TRACE( trace_comment, "Retransmission via raw backup" );
 
             MPS_CHK( mps_clear_pending( mps, MPS_PAUSED_HS_FORBIDDEN ) );
 
@@ -3700,13 +3700,13 @@ MBEDTLS_MPS_STATIC int mbedtls_mps_retransmission_handle_resend( mbedtls_mps *mp
             int cb_unfinished = 0;
             mbedtls_mps_write_cb_t      const cb  = handle->handle.callback.cb;
             mbedtls_mps_write_cb_ctx_t* const ctx = handle->handle.callback.ctx;
-            TRACE( trace_comment, "Retransmission via callback" );
+            MBEDTLS_MPS_TRACE( trace_comment, "Retransmission via callback" );
 
             MPS_CHK( mps_clear_pending( mps, MPS_PAUSED_HS_ALLOWED ) );
 
             if( mps->dtls.io.out.hs.state == MBEDTLS_MPS_HS_NONE )
             {
-                TRACE( trace_comment, "Open new outgoing handshake message." );
+                MBEDTLS_MPS_TRACE( trace_comment, "Open new outgoing handshake message." );
                 MPS_CHK( mps_dtls_frag_out_start( hs,
                                            hs->queue,
                                            hs->queue_len,
@@ -3723,7 +3723,7 @@ MBEDTLS_MPS_STATIC int mbedtls_mps_retransmission_handle_resend( mbedtls_mps *mp
             }
             else
             {
-                TRACE( trace_comment, "Retransmission in progress -- continue." );
+                MBEDTLS_MPS_TRACE( trace_comment, "Retransmission in progress -- continue." );
             }
 
             /* Call retransmission callback. */
@@ -3746,7 +3746,7 @@ MBEDTLS_MPS_STATIC int mbedtls_mps_retransmission_handle_resend( mbedtls_mps *mp
         case MBEDTLS_MPS_RETRANSMISSION_HANDLE_CCS:
         {
             mps_l3_ccs_out ccs_l3;
-            TRACE( trace_comment, "CCS retransmission" );
+            MBEDTLS_MPS_TRACE( trace_comment, "CCS retransmission" );
             MPS_CHK( mps_clear_pending( mps, MPS_PAUSED_HS_FORBIDDEN ) );
 
             ccs_l3.epoch = handle->metadata.epoch;
@@ -3764,12 +3764,12 @@ MBEDTLS_MPS_STATIC int mps_dtls_frag_out_unpause( mbedtls_mps *mps,
                                                   uint8_t allow_active_hs )
 {
     int ret;
-    TRACE_INIT( "mps_dtls_frag_out_unpause" );
+    MBEDTLS_MPS_TRACE_INIT( "mps_dtls_frag_out_unpause" );
 
     if( mps->dtls.io.out.hs.state != MBEDTLS_MPS_HS_PAUSED )
     {
-        TRACE( trace_comment, "No handshake data queueing - skip." );
-        RETURN( 0 );
+        MBEDTLS_MPS_TRACE( trace_comment, "No handshake data queueing - skip." );
+        MBEDTLS_MPS_TRACE_RETURN( 0 );
     }
 
     /* In theory, this could loop indefinitely if we happen to configure Layer 1
@@ -3778,7 +3778,7 @@ MBEDTLS_MPS_STATIC int mps_dtls_frag_out_unpause( mbedtls_mps *mps,
      * be that small. */
     do
     {
-        TRACE( trace_comment, "Fetch frag from L3 to dispatch queued data." );
+        MBEDTLS_MPS_TRACE( trace_comment, "Fetch frag from L3 to dispatch queued data." );
 
         ret = mps_dtls_frag_out_bind( mps );
         if( ret == 0 )
@@ -3787,7 +3787,7 @@ MBEDTLS_MPS_STATIC int mps_dtls_frag_out_unpause( mbedtls_mps *mps,
             MPS_CHK( ret );
 
         MPS_CHK( mps_dtls_frag_out_dispatch( mps ) );
-        TRACE( trace_comment, "More data queueing" );
+        MBEDTLS_MPS_TRACE( trace_comment, "More data queueing" );
 
     } while( mps->dtls.io.out.hs.state == MBEDTLS_MPS_HS_PAUSED );
 
@@ -3797,14 +3797,14 @@ MBEDTLS_MPS_STATIC int mps_dtls_frag_out_unpause( mbedtls_mps *mps,
     /* Check if the handshake message has been fully written. */
     if( mbedtls_writer_check_done( &mps->dtls.io.out.hs.wr_ext ) == 0 )
     {
-        TRACE( trace_comment, "Handshake message fully written." );
+        MBEDTLS_MPS_TRACE( trace_comment, "Handshake message fully written." );
         MPS_CHK( mps_dtls_frag_out_close( mps ) );
         MPS_CHK( mps_dtls_frag_out_dispatch( mps ) );
 
         mbedtls_writer_free( &mps->dtls.io.out.hs.wr );
         mbedtls_writer_free_ext( &mps->dtls.io.out.hs.wr_ext );
 
-        TRACE( trace_comment,
+        MBEDTLS_MPS_TRACE( trace_comment,
                "New outgoing handshake message state: MBEDTLS_MPS_HS_NONE." );
         mps->dtls.io.out.hs.state = MBEDTLS_MPS_HS_NONE;
     }
@@ -3816,7 +3816,7 @@ MBEDTLS_MPS_STATIC int mps_dtls_frag_out_unpause( mbedtls_mps *mps,
         ((void) allow_active_hs);
         MBEDTLS_MPS_ASSERT( allow_active_hs,
                             "Caller doesn't allow active handshake" );
-        TRACE( trace_comment, "HS msg not yet fully written -- keep open" );
+        MBEDTLS_MPS_TRACE( trace_comment, "HS msg not yet fully written -- keep open" );
     }
 
     MPS_INTERNAL_FAILURE_HANDLER
@@ -3832,7 +3832,7 @@ MBEDTLS_MPS_STATIC int mps_dtls_frag_out_bind( mbedtls_mps *mps )
     mbedtls_mps_handshake_out_internal * const hs = &mps->dtls.io.out.hs;
     mbedtls_mps_msg_metadata * const metadata = mps->dtls.io.out.hs.metadata;
 
-    TRACE_INIT( "mps_dtls_frag_out_bind" );
+    MBEDTLS_MPS_TRACE_INIT( "mps_dtls_frag_out_bind" );
 
     /* Request a new handshake fragment from Layer 3. */
     l3_hs.type        = metadata->type;
@@ -3843,7 +3843,7 @@ MBEDTLS_MPS_STATIC int mps_dtls_frag_out_bind( mbedtls_mps *mps )
     l3_hs.frag_len    = MBEDTLS_MPS_SIZE_UNKNOWN;
     MPS_CHK( mps_l3_write_handshake( l3, &l3_hs ) );
 
-    TRACE( trace_comment, "Get max len buffer from L3 and feed to writer." );
+    MBEDTLS_MPS_TRACE( trace_comment, "Get max len buffer from L3 and feed to writer." );
 
     /* Extract buffer for remaining handshake content from
      * reader obtained from Layer 3. */
@@ -3855,14 +3855,14 @@ MBEDTLS_MPS_STATIC int mps_dtls_frag_out_bind( mbedtls_mps *mps )
     MPS_CHK( mbedtls_writer_get_ext( hs->wr_ext_l3, remaining,
                                      &frag, &frag_len ) );
     hs->frag_len = frag_len;
-    TRACE( trace_comment, "Received len %u buf from L3.", (unsigned) frag_len );
+    MBEDTLS_MPS_TRACE( trace_comment, "Received len %u buf from L3.", (unsigned) frag_len );
 
     /* Feed the buffer into the user-facing writer
      * used to write the handshake message. */
     ret = mbedtls_writer_feed( &hs->wr, frag, frag_len );
     if( ret == MBEDTLS_ERR_WRITER_NEED_MORE )
     {
-        TRACE( trace_comment, "L3 buffer too small to dispatch queued data." );
+        MBEDTLS_MPS_TRACE( trace_comment, "L3 buffer too small to dispatch queued data." );
         MPS_CHK( mbedtls_writer_commit_ext( hs->wr_ext_l3 ) );
         MPS_CHK( MBEDTLS_ERR_WRITER_NEED_MORE );
     }
@@ -3877,17 +3877,17 @@ MBEDTLS_MPS_STATIC int mps_dtls_frag_out_close( mbedtls_mps *mps )
     mbedtls_mps_size_t frag_len, bytes_queued, remaining;
     mbedtls_mps_handshake_out_internal * const hs = &mps->dtls.io.out.hs;
     mbedtls_mps_msg_metadata * const metadata = hs->metadata;
-    TRACE_INIT( "mps_dtls_frag_out_close" );
+    MBEDTLS_MPS_TRACE_INIT( "mps_dtls_frag_out_close" );
 
     /* Revoke the Layer 3 fragment buffer from the writer
      * and see how much has been written to it, and how much
      * is potentially still pending. */
     MPS_CHK( mbedtls_writer_reclaim( &hs->wr, &frag_len, &bytes_queued,
                                      MBEDTLS_WRITER_RECLAIM_FORCE ) );
-    TRACE( trace_comment, "* Fragment length: %u", (unsigned) frag_len );
-    TRACE( trace_comment, "* Bytes queued:    %u", (unsigned) bytes_queued );
-    TRACE( trace_comment, "* Total length:    %u", (unsigned) metadata->len );
-    TRACE( trace_comment, "* Fragment offset: %u", (unsigned) hs->offset );
+    MBEDTLS_MPS_TRACE( trace_comment, "* Fragment length: %u", (unsigned) frag_len );
+    MBEDTLS_MPS_TRACE( trace_comment, "* Bytes queued:    %u", (unsigned) bytes_queued );
+    MBEDTLS_MPS_TRACE( trace_comment, "* Total length:    %u", (unsigned) metadata->len );
+    MBEDTLS_MPS_TRACE( trace_comment, "* Fragment offset: %u", (unsigned) hs->offset );
 
     if( hs->wr_ext_l3 != NULL )
     {
@@ -3916,7 +3916,7 @@ MBEDTLS_MPS_STATIC int mps_dtls_frag_out_close( mbedtls_mps *mps )
                             (unsigned) metadata->len == bytes_queued,
               "Mismatch between HS msg size and amount of data written" );
 
-        TRACE( trace_comment, "Total HS len: %u", (unsigned) bytes_queued );
+        MBEDTLS_MPS_TRACE( trace_comment, "Total HS len: %u", (unsigned) bytes_queued );
 
         metadata->len = bytes_queued;
         hs->state  = MBEDTLS_MPS_HS_PAUSED;
@@ -3933,14 +3933,14 @@ MBEDTLS_MPS_STATIC int mps_dtls_frag_out_dispatch( mbedtls_mps *mps )
     mps_l3* const l3 = mbedtls_mps_l4_get_l3( mps );
     ((void) metadata);
 
-    TRACE_INIT( "mps_dtls_frag_out_dispatch" );
+    MBEDTLS_MPS_TRACE_INIT( "mps_dtls_frag_out_dispatch" );
 
     if( mps->dtls.io.out.hs.wr_ext_l3 != NULL )
     {
-        TRACE( trace_comment, " * Seq: %u", (unsigned) metadata->seq_nr );
-        TRACE( trace_comment, " * Frag off: %u", (unsigned) hs->offset );
-        TRACE( trace_comment, " * Frag len: %u", (unsigned) hs->frag_len );
-        TRACE( trace_comment, " * Total len: %u", (unsigned) metadata->len );
+        MBEDTLS_MPS_TRACE( trace_comment, " * Seq: %u", (unsigned) metadata->seq_nr );
+        MBEDTLS_MPS_TRACE( trace_comment, " * Frag off: %u", (unsigned) hs->offset );
+        MBEDTLS_MPS_TRACE( trace_comment, " * Frag len: %u", (unsigned) hs->frag_len );
+        MBEDTLS_MPS_TRACE( trace_comment, " * Total len: %u", (unsigned) metadata->len );
 
         MPS_CHK( mps_l3_dispatch( l3 ) );
 
@@ -3960,7 +3960,7 @@ MBEDTLS_MPS_STATIC int mps_dtls_frag_out_start( mbedtls_mps_handshake_out_intern
 {
     int ret = 0;
     mbedtls_mps_size_t msg_len;
-    TRACE_INIT( "mps_dtls_frag_out_start, type %u, length %u",
+    MBEDTLS_MPS_TRACE_INIT( "mps_dtls_frag_out_start, type %u, length %u",
                 (unsigned) metadata->type, (unsigned) metadata->len );
 
     MBEDTLS_MPS_ASSERT( hs->state == MBEDTLS_MPS_HS_NONE,
@@ -4001,15 +4001,15 @@ MBEDTLS_MPS_STATIC int mps_out_flight_msg_start( mbedtls_mps *mps,
     int ret = 0;
     uint8_t cur_flight_len;
     mbedtls_mps_retransmission_handle *hdl;
-    TRACE_INIT( "mps_out_flight_msg_start" );
+    MBEDTLS_MPS_TRACE_INIT( "mps_out_flight_msg_start" );
 
-    TRACE( trace_comment, "Add msg to flight, seq nr %u",
+    MBEDTLS_MPS_TRACE( trace_comment, "Add msg to flight, seq nr %u",
            (unsigned) mps->dtls.seq_nr );
 
     cur_flight_len = mps->dtls.outgoing.flight_len;
     if( cur_flight_len == MBEDTLS_MPS_MAX_FLIGHT_LENGTH )
     {
-        TRACE( trace_error, "Outgoing flight reached max len %u",
+        MBEDTLS_MPS_TRACE( trace_error, "Outgoing flight reached max len %u",
                (unsigned) MBEDTLS_MPS_MAX_FLIGHT_LENGTH );
         MPS_CHK( MBEDTLS_ERR_MPS_FLIGHT_TOO_LONG );
     }
@@ -4035,7 +4035,7 @@ MBEDTLS_MPS_STATIC int mps_out_flight_msg_done( mbedtls_mps *mps )
     mps_l3* const l3 = mbedtls_mps_l4_get_l3( mps );
 
     mbedtls_mps_retransmission_handle *hdl;
-    TRACE_INIT( "mps_out_flight_msg_done" );
+    MBEDTLS_MPS_TRACE_INIT( "mps_out_flight_msg_done" );
 
     MPS_CHK( mps_l3_epoch_usage( l3, mps->out_epoch,
                                  /* No removal of usage flags. */
@@ -4057,7 +4057,7 @@ MBEDTLS_MPS_STATIC int mps_out_flight_msg_done( mbedtls_mps *mps )
         cur_seq_nr = mps->dtls.seq_nr;
         if( cur_seq_nr == MBEDTLS_MPS_LIMIT_SEQUENCE_NUMBER )
         {
-            TRACE( trace_error, "Reached max seq nr %u",
+            MBEDTLS_MPS_TRACE( trace_error, "Reached max seq nr %u",
                    (unsigned) MBEDTLS_MPS_LIMIT_SEQUENCE_NUMBER );
             MPS_CHK( MBEDTLS_ERR_MPS_COUNTER_WRAP );
         }

--- a/library/mps/mps.c
+++ b/library/mps/mps.c
@@ -497,7 +497,7 @@ MBEDTLS_MPS_STATIC int mps_clear_pending( mbedtls_mps *mps,
 
     if( mps->out.flush == 1 )
     {
-        MBEDTLS_MPS_TRACE( trace_comment, "A flush was requested" );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "A flush was requested" );
         MPS_CHK( mps_l3_flush( l3 ) );
         mps->out.flush = 0;
     }
@@ -656,7 +656,7 @@ MBEDTLS_MPS_STATIC int mps_generic_failure_handler( mbedtls_mps *mps, int ret )
 
     if( found == 0 )
     {
-        MBEDTLS_MPS_TRACE( trace_error, "Unknown error at MPS boundary: -%#04x",
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR, "Unknown error at MPS boundary: -%#04x",
                (unsigned) -ret );
         ret = MBEDTLS_ERR_MPS_INTERNAL_ERROR;
         goto fatal;
@@ -671,7 +671,7 @@ MBEDTLS_MPS_STATIC int mps_generic_failure_handler( mbedtls_mps *mps, int ret )
         if( MBEDTLS_MPS_IS_DTLS( mode ) &&
             MBEDTLS_MPS_ERROR_IS_TLS_ONLY( flags ) )
         {
-            MBEDTLS_MPS_TRACE( trace_error, "TLS-only error observed in DTLS mode: %s (-%#04x)",
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR, "TLS-only error observed in DTLS mode: %s (-%#04x)",
                    error_string, (unsigned) -ret );
             ret = MBEDTLS_ERR_MPS_INTERNAL_ERROR;
             goto fatal;
@@ -680,7 +680,7 @@ MBEDTLS_MPS_STATIC int mps_generic_failure_handler( mbedtls_mps *mps, int ret )
 
         if( !MBEDTLS_MPS_ERROR_IS_EXTERNAL( flags ) )
         {
-            MBEDTLS_MPS_TRACE( trace_error, "TLS-only error observed in DTLS mode: %s (-%#04x)",
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR, "TLS-only error observed in DTLS mode: %s (-%#04x)",
                    error_string, (unsigned) -ret );
             ret = MBEDTLS_ERR_MPS_INTERNAL_ERROR;
             goto fatal;
@@ -701,7 +701,7 @@ fatal:
     if( mps->state != MBEDTLS_MPS_STATE_BLOCKED )
     {
         /* Remember error and block MPS. */
-        MBEDTLS_MPS_TRACE( trace_error, "Blocking MPS after a fatal error" );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR, "Blocking MPS after a fatal error" );
         mps->blocking_reason = MBEDTLS_MPS_ERROR_INTERNAL_ERROR;
         mps->blocking_info.err = ret;
         mps_block( mps );
@@ -727,7 +727,7 @@ int mbedtls_mps_send_fatal( mbedtls_mps *mps, mbedtls_mps_alert_t alert_type )
     mps_block( mps );
 
     /* Attempt to send alert. */
-    MBEDTLS_MPS_TRACE( trace_comment, "Pend fatal alert" );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Pend fatal alert" );
     mps->alert_pending = 1;
     MPS_CHK( mbedtls_mps_flush( mps ) );
 
@@ -758,12 +758,12 @@ MBEDTLS_MPS_STATIC void mps_close_notification_received( mbedtls_mps *mps )
     switch( mps->state )
     {
         case MBEDTLS_MPS_STATE_OPEN:
-            MBEDTLS_MPS_TRACE( trace_comment, "State transition OPEN -> WRITE-ONLY" );
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "State transition OPEN -> WRITE-ONLY" );
             mps->state = MBEDTLS_MPS_STATE_WRITE_ONLY;
             break;
 
         case MBEDTLS_MPS_STATE_READ_ONLY:
-            MBEDTLS_MPS_TRACE( trace_comment, "State transition READ-ONLY -> CLOSED" );
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "State transition READ-ONLY -> CLOSED" );
             mps->state = MBEDTLS_MPS_STATE_CLOSED;
             break;
     }
@@ -778,7 +778,7 @@ MBEDTLS_MPS_STATIC int mps_handle_pending_alert( mbedtls_mps *mps )
 
     if( mps->alert_pending == 0 )
     {
-        MBEDTLS_MPS_TRACE( trace_comment, "No alert pending" );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "No alert pending" );
         MBEDTLS_MPS_TRACE_RETURN( 0 );
     }
 
@@ -792,14 +792,14 @@ MBEDTLS_MPS_STATIC int mps_handle_pending_alert( mbedtls_mps *mps )
                                      MBEDTLS_MPS_STATE_READ_ONLY,
                                      MBEDTLS_MPS_STATE_CLOSED ) )
     {
-        MBEDTLS_MPS_TRACE( trace_comment, "Report orderly closure of write-side to peer." );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Report orderly closure of write-side to peer." );
         *alert.level = MBEDTLS_MPS_ALERT_LEVEL_WARNING;
         *alert.type  = MBEDTLS_MPS_ALERT_MSG_CLOSE_NOTIFY;
     }
     else if( mps->state == MBEDTLS_MPS_STATE_BLOCKED &&
              mps->blocking_reason == MBEDTLS_MPS_ERROR_ALERT_SENT )
     {
-        MBEDTLS_MPS_TRACE( trace_comment, "Report fatal alert to peer." );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Report fatal alert to peer." );
         *alert.level = MBEDTLS_MPS_ALERT_LEVEL_FATAL;
         *alert.type  = mps->blocking_info.alert;
     }
@@ -826,13 +826,13 @@ int mbedtls_mps_close( mbedtls_mps *mps )
     switch( mps->state )
     {
         case MBEDTLS_MPS_STATE_OPEN:
-            MBEDTLS_MPS_TRACE( trace_comment, "State transition OPEN -> READ-ONLY" );
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "State transition OPEN -> READ-ONLY" );
             mps->state = MBEDTLS_MPS_STATE_READ_ONLY;
             mps->alert_pending = 1;
             break;
 
         case MBEDTLS_MPS_STATE_WRITE_ONLY:
-            MBEDTLS_MPS_TRACE( trace_comment, "State transition WRITE-ONLY -> CLOSED" );
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "State transition WRITE-ONLY -> CLOSED" );
             mps->state = MBEDTLS_MPS_STATE_CLOSED;
             mps->alert_pending = 1;
             break;
@@ -872,7 +872,7 @@ MBEDTLS_MPS_STATIC int mps_check_read( mbedtls_mps const *mps )
         MBEDTLS_MPS_TRACE_RETURN( 0 );
     }
 
-    MBEDTLS_MPS_TRACE( trace_error, "Read-side blocked" );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR, "Read-side blocked" );
     MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_BLOCKED );
 }
 
@@ -887,7 +887,7 @@ MBEDTLS_MPS_STATIC int mps_check_write( mbedtls_mps const *mps )
         MBEDTLS_MPS_TRACE_RETURN( 0 );
     }
 
-    MBEDTLS_MPS_TRACE( trace_error, "Write-side blocked" );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR, "Write-side blocked" );
     MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_BLOCKED );
 }
 
@@ -949,7 +949,7 @@ int mbedtls_mps_init( mbedtls_mps *mps,
     if( max_write > 0 )
     {
         unsigned char *queue = NULL;
-        MBEDTLS_MPS_TRACE( trace_comment, "Alloc L4 %u Byte queue", (unsigned) max_write );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Alloc L4 %u Byte queue", (unsigned) max_write );
 
         queue = calloc( 1, max_write );
         if( queue == NULL )
@@ -1012,7 +1012,7 @@ int mbedtls_mps_read( mbedtls_mps *mps )
      * expected message is unambiguous. */
     if( mps->in.state != MBEDTLS_MPS_MSG_NONE )
     {
-        MBEDTLS_MPS_TRACE( trace_comment, "Msg of type %d already open", mps->in.state );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Msg of type %d already open", mps->in.state );
         MBEDTLS_MPS_TRACE_RETURN( mps->in.state );
     }
 
@@ -1062,7 +1062,7 @@ int mbedtls_mps_read( mbedtls_mps *mps )
         case MBEDTLS_MPS_MSG_CCS:
         {
             mps_l3_ccs_in ccs_l3;
-            MBEDTLS_MPS_TRACE( trace_comment, "CCS message received from L3." );
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "CCS message received from L3." );
 
             MPS_CHK( mps_l3_read_ccs( l3, &ccs_l3 ) );
             MPS_CHK( mps_l3_read_consume( l3 ) );
@@ -1098,7 +1098,7 @@ int mbedtls_mps_read( mbedtls_mps *mps )
         {
             mps_l3_alert_in alert;
 
-            MBEDTLS_MPS_TRACE( trace_comment, "Alert msg received from L3." );
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Alert msg received from L3." );
             MPS_CHK( mps_l3_read_alert( l3, &alert ) );
 
             /* For DTLS, Layer 3 might be configured to pass through
@@ -1120,14 +1120,14 @@ int mbedtls_mps_read( mbedtls_mps *mps )
             switch( alert.level )
             {
                 case MBEDTLS_MPS_ALERT_LEVEL_FATAL:
-                    MBEDTLS_MPS_TRACE( trace_comment, "Fatal alert, type %d", alert.type );
+                    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Fatal alert, type %d", alert.type );
                     mps_fatal_alert_received( mps, alert.type );
                     MPS_CHK( MBEDTLS_ERR_MPS_FATAL_ALERT_RECEIVED );
                     break;
 
                 case MBEDTLS_MPS_ALERT_LEVEL_WARNING:
 
-                    MBEDTLS_MPS_TRACE( trace_comment, "Warning, type %d", alert.type );
+                    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Warning, type %d", alert.type );
 
                     if( alert.type == MBEDTLS_MPS_ALERT_MSG_CLOSE_NOTIFY )
                     {
@@ -1159,7 +1159,7 @@ int mbedtls_mps_read( mbedtls_mps *mps )
 
         case MBEDTLS_MPS_MSG_HS:
         {
-            MBEDTLS_MPS_TRACE( trace_comment, "Received HS fragment from L3" );
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Received HS fragment from L3" );
 
             /* Pass message fragment to retransmission state machine
              * and check if it leads to a handshake message being ready
@@ -1330,7 +1330,7 @@ int mbedtls_mps_read_set_flags( mbedtls_mps *mps, mbedtls_mps_msg_flags flags )
     int ret = 0;
 
     MBEDTLS_MPS_TRACE_INIT( "mbedtls_mps_write_set_flags" );
-    MBEDTLS_MPS_TRACE( trace_comment, "* Flags: %02x", (unsigned) flags );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* Flags: %02x", (unsigned) flags );
 
     MBEDTLS_MPS_STATE_VALIDATE( mps->in.state != MBEDTLS_MPS_MSG_NONE,
            "mbedtls_mps_read_set_flags() must only be called while reading." );
@@ -1449,7 +1449,7 @@ int mbedtls_mps_read_consume( mbedtls_mps *mps )
             break;
     }
 
-    MBEDTLS_MPS_TRACE( trace_comment, "New incoming state: NONE" );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "New incoming state: NONE" );
     mps->in.state = MBEDTLS_MPS_MSG_NONE;
 
     MPS_API_BOUNDARY_FAILURE_HANDLER
@@ -1481,7 +1481,7 @@ int mbedtls_mps_write_set_flags( mbedtls_mps *mps, mbedtls_mps_msg_flags flags )
     int ret = 0;
 
     MBEDTLS_MPS_TRACE_INIT( "mbedtls_mps_write_set_flags" );
-    MBEDTLS_MPS_TRACE( trace_comment, "* Flags: %02x", (unsigned) flags );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* Flags: %02x", (unsigned) flags );
 
     MBEDTLS_MPS_STATE_VALIDATE( mps->out.state != MBEDTLS_MPS_MSG_NONE,
          "mbedtls_mps_write_set_flags() must only be called while writing." );
@@ -1591,7 +1591,7 @@ int mbedtls_mps_write_handshake( mbedtls_mps *mps,
          */
         if( mps_get_hs_state( mps ) == MBEDTLS_MPS_FLIGHT_FINALIZE )
         {
-            MBEDTLS_MPS_TRACE( trace_comment, "Last flight-exchange complete for us, "
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Last flight-exchange complete for us, "
                                   "but not necessarily for peer - ignore." );
             MPS_CHK( mps_handshake_state_transition( mps,
                          MBEDTLS_MPS_FLIGHT_FINALIZE,
@@ -1607,7 +1607,7 @@ int mbedtls_mps_write_handshake( mbedtls_mps *mps,
         /* No `else` because we want to fall through. */
         if( mps_get_hs_state( mps ) == MBEDTLS_MPS_FLIGHT_DONE )
         {
-            MBEDTLS_MPS_TRACE( trace_comment,
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT,
                    "No flight-exchange in progress. Start a new one" );
             mps->dtls.seq_nr = MPS_INITIAL_HS_SEQ_NR;
             MPS_CHK( mps_handshake_state_transition( mps,
@@ -1629,7 +1629,7 @@ int mbedtls_mps_write_handshake( mbedtls_mps *mps,
         if( hs->state == MBEDTLS_MPS_HS_ACTIVE )
         {
             mbedtls_mps_msg_metadata * const metadata = hs->metadata;
-            MBEDTLS_MPS_TRACE( trace_comment, "Handshake message has been paused - continue" );
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Handshake message has been paused - continue" );
 
             /* Check consistency of parameters and forward to the user. */
             /* OPTIMIZATION: Consider ignoring the metadata passed on
@@ -1637,7 +1637,7 @@ int mbedtls_mps_write_handshake( mbedtls_mps *mps,
             if( metadata->len  != hs_new->length ||
                 metadata->type != hs_new->type )
             {
-                MBEDTLS_MPS_TRACE( trace_error,
+                MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR,
                        "Inconsistent parameters on continuation "
                        "of handshake write." );
                 MPS_CHK( MBEDTLS_ERR_MPS_INVALID_ARGS );
@@ -1650,7 +1650,7 @@ int mbedtls_mps_write_handshake( mbedtls_mps *mps,
             size_t queue_len;
             uint8_t write_mode;
 
-            MBEDTLS_MPS_TRACE( trace_comment,
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT,
                    "No handshake message paused - start a new one." );
 
             /* No handshake message is paused -- start a new one.
@@ -1709,13 +1709,13 @@ int mbedtls_mps_write_handshake( mbedtls_mps *mps,
                 size_t backup_len;
                 unsigned char *backup_buf;
 
-                MBEDTLS_MPS_TRACE( trace_comment, "Retransmission via raw backup" );
+                MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Retransmission via raw backup" );
                 handle->handle_type = MBEDTLS_MPS_RETRANSMISSION_HANDLE_HS_RAW;
 
                 /* Infer length for backup buffer. */
                 if( handle->metadata.len != MBEDTLS_MPS_SIZE_UNKNOWN )
                 {
-                    MBEDTLS_MPS_TRACE( trace_comment, "Total handshake length known: %u",
+                    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Total handshake length known: %u",
                            (unsigned) hs_new->length );
 
                     MBEDTLS_MPS_ASSERT(
@@ -1726,7 +1726,7 @@ int mbedtls_mps_write_handshake( mbedtls_mps *mps,
                 }
                 else
                 {
-                    MBEDTLS_MPS_TRACE( trace_comment,
+                    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT,
                            "Total handshake length unknown, "
                            "puse backup buffer of maximum size %u",
                            (unsigned) MBEDTLS_MPS_MAX_HS_LENGTH );
@@ -1737,7 +1737,7 @@ int mbedtls_mps_write_handshake( mbedtls_mps *mps,
                 backup_buf = mbedtls_calloc( 1, backup_len );
                 if( backup_buf == NULL )
                 {
-                    MBEDTLS_MPS_TRACE( trace_error, "Error allocating backup buffer" );
+                    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR, "Error allocating backup buffer" );
                     MPS_CHK( MBEDTLS_ERR_MPS_OUT_OF_MEMORY );
                 }
                 handle->handle.raw.buf = backup_buf;
@@ -1750,7 +1750,7 @@ int mbedtls_mps_write_handshake( mbedtls_mps *mps,
             else
             {
                 /* Retransmission via callback. */
-                MBEDTLS_MPS_TRACE( trace_comment, "Retransmission via callback" );
+                MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Retransmission via callback" );
                 handle->handle_type =
                     MBEDTLS_MPS_RETRANSMISSION_HANDLE_HS_CALLBACK;
 
@@ -1761,7 +1761,7 @@ int mbedtls_mps_write_handshake( mbedtls_mps *mps,
                  * a handshake write (shouldn't be difficult). */
                 if( handle->metadata.len == MBEDTLS_MPS_SIZE_UNKNOWN )
                 {
-                    MBEDTLS_MPS_TRACE( trace_error,
+                    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR,
                            "Handshake messages with retransmission callback "
                            "and unknown size not supported." );
                     MPS_CHK( MBEDTLS_ERR_MPS_OPERATION_UNSUPPORTED );
@@ -1897,7 +1897,7 @@ int mbedtls_mps_write_pause( mbedtls_mps *mps )
         /* Check that the handshake message is not yet fully written. */
         if( mbedtls_writer_check_done( &mps->dtls.io.out.hs.wr_ext ) == 0 )
         {
-            MBEDTLS_MPS_TRACE( trace_error,
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR,
                    "Attempt to pause a fully written handshake message." );
             MPS_CHK( MBEDTLS_ERR_MPS_INTERNAL_ERROR );
         }
@@ -1941,7 +1941,7 @@ int mbedtls_mps_dispatch( mbedtls_mps *mps )
 
         if( mps->out.state == MBEDTLS_MPS_MSG_NONE )
         {
-            MBEDTLS_MPS_TRACE( trace_error, "No message open" );
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR, "No message open" );
             MPS_CHK( MBEDTLS_ERR_MPS_INTERNAL_ERROR );
         }
 
@@ -1980,7 +1980,7 @@ int mbedtls_mps_dispatch( mbedtls_mps *mps )
 
             if( flags == MBEDTLS_MPS_FLIGHT_END )
             {
-                MBEDTLS_MPS_TRACE( trace_comment,
+                MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT,
                        "Message finishes the flight, "
                        "move from SEND to AWAIT state." );
                 MPS_CHK( mps_handshake_state_transition(
@@ -1990,7 +1990,7 @@ int mbedtls_mps_dispatch( mbedtls_mps *mps )
             }
             else
             {
-                MBEDTLS_MPS_TRACE( trace_comment,
+                MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT,
                        "Message finishes the flight-exchange, "
                        "move from SEND to FINALIZE state." );
                 MPS_CHK( mps_handshake_state_transition(
@@ -2063,7 +2063,7 @@ int mbedtls_mps_set_incoming_keys( mbedtls_mps *mps,
 
     if( mps->in_epoch == id )
     {
-        MBEDTLS_MPS_TRACE( trace_comment, "Epoch %u is already the current incoming epoch",
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Epoch %u is already the current incoming epoch",
                (unsigned) id );
         MBEDTLS_MPS_TRACE_RETURN( 0 );
     }
@@ -2099,7 +2099,7 @@ int mbedtls_mps_set_outgoing_keys( mbedtls_mps *mps,
 
     if( mps->out_epoch == id )
     {
-        MBEDTLS_MPS_TRACE( trace_comment, "Epoch %u is already the current incoming epoch",
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Epoch %u is already the current incoming epoch",
                (unsigned) id );
         MBEDTLS_MPS_TRACE_RETURN( 0 );
     }
@@ -2170,7 +2170,7 @@ MBEDTLS_MPS_STATIC int mps_retransmission_timer_increase_timeout( mbedtls_mps *m
         new_timeout = max_timeout;
 
     mps->dtls.wait.retransmit_timeout = new_timeout;
-    MBEDTLS_MPS_TRACE( trace_comment, "Update timeout value to %u milliseonds",
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Update timeout value to %u milliseonds",
            (unsigned) new_timeout );
 
     MBEDTLS_MPS_TRACE_RETURN( 0 );
@@ -2184,7 +2184,7 @@ MBEDTLS_MPS_STATIC int mps_retransmission_timer_update( mbedtls_mps *mps )
 
     if( set_timer == NULL )
     {
-        MBEDTLS_MPS_TRACE( trace_comment, "No timer configured" );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "No timer configured" );
         MBEDTLS_MPS_TRACE_RETURN( 0 );
     }
 
@@ -2202,7 +2202,7 @@ MBEDTLS_MPS_STATIC int mps_retransmission_timer_stop( mbedtls_mps *mps )
 
     if( set_timer == NULL )
     {
-        MBEDTLS_MPS_TRACE( trace_comment, "No timer configured" );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "No timer configured" );
         MBEDTLS_MPS_TRACE_RETURN( 0 );
     }
 
@@ -2219,7 +2219,7 @@ MBEDTLS_MPS_STATIC int mps_retransmission_timer_check( mbedtls_mps *mps )
 
     if( get_timer != NULL && get_timer( timer_ctx ) == 2 )
     {
-        MBEDTLS_MPS_TRACE( trace_comment, "Retransmission timer fired" );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Retransmission timer fired" );
         mps_retransmission_timer_stop( mps );
 
         /* The retransmission timer is used in various states of the
@@ -2230,7 +2230,7 @@ MBEDTLS_MPS_STATIC int mps_retransmission_timer_check( mbedtls_mps *mps )
             /* When waiting for the first message of the next flight
              * from the peer, resend the last outgoing flight. */
             case MBEDTLS_MPS_FLIGHT_AWAIT:
-                MBEDTLS_MPS_TRACE( trace_comment,
+                MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT,
                        "Trigger retransmission of last outgoing flight." );
                 MPS_CHK( mps_trigger_retransmission( mps ) );
                 break;
@@ -2238,7 +2238,7 @@ MBEDTLS_MPS_STATIC int mps_retransmission_timer_check( mbedtls_mps *mps )
             /* If we have already received some parts of the next
              * flight from the peer, send a retransmission request. */
             case MBEDTLS_MPS_FLIGHT_RECEIVE:
-                MBEDTLS_MPS_TRACE( trace_comment,
+                MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT,
                        "Trigger sending retransmission request to peer." );
                 MPS_CHK( mps_trigger_retransmission_request( mps ) );
                 break;
@@ -2339,9 +2339,9 @@ MBEDTLS_MPS_STATIC int mps_retransmit_in_check( mbedtls_mps *mps,
      */
 
     MBEDTLS_MPS_TRACE_INIT( "mps_retransmit_in_check" );
-    MBEDTLS_MPS_TRACE( trace_comment, "Seq Nr: %u", (unsigned) hs->seq_nr );
-    MBEDTLS_MPS_TRACE( trace_comment, "Type:   %u", (unsigned) hs->type   );
-    MBEDTLS_MPS_TRACE( trace_comment, "Length: %u", (unsigned) hs->len    );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Seq Nr: %u", (unsigned) hs->seq_nr );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Type:   %u", (unsigned) hs->type   );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Length: %u", (unsigned) hs->len    );
 
     /* We only consider handshake fragments with offset 0. */
     if( hs->frag_offset != 0 )
@@ -2362,7 +2362,7 @@ MBEDTLS_MPS_STATIC int mps_retransmit_in_check( mbedtls_mps *mps,
     if( match_idx == 0xff )
         MBEDTLS_MPS_TRACE_RETURN( 0 );
 
-    MBEDTLS_MPS_TRACE( trace_comment, "Retransmission of %u-th message detected",
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Retransmission of %u-th message detected",
            (unsigned) match_idx );
 
     status = &mps->dtls.retransmission_detection.msg_state[match_idx];
@@ -2372,7 +2372,7 @@ MBEDTLS_MPS_STATIC int mps_retransmit_in_check( mbedtls_mps *mps,
         /* Observed a retransmission - move all messages to 'on hold'
          * state to omit triggering multiple retransmissions from a
          * single retransmission of the peer. */
-        MBEDTLS_MPS_TRACE( trace_comment, "Retransmission active for message"
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Retransmission active for message"
                " - retransmit and put all other messages on hold." );
 
         status = &mps->dtls.retransmission_detection.msg_state[0];
@@ -2384,7 +2384,7 @@ MBEDTLS_MPS_STATIC int mps_retransmit_in_check( mbedtls_mps *mps,
     else
     {
         /* Re-activate retransmission detection for message. */
-        MBEDTLS_MPS_TRACE( trace_comment, "Retransmission currently put on hold "
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Retransmission currently put on hold "
                "for this messsage - reactivate." );
         *status = MBEDTLS_MPS_RETRANSMISSION_DETECTION_ENABLED;
         MBEDTLS_MPS_TRACE_RETURN( 0 );
@@ -2447,10 +2447,10 @@ MBEDTLS_MPS_STATIC int mps_retransmit_in_free( mbedtls_mps *mps )
     flight_len = mps->dtls.retransmission_detection.flight_len;
     info       = &mps->dtls.retransmission_detection.msgs[0];
 
-    MBEDTLS_MPS_TRACE( trace_comment, "Flight length: %u", (unsigned) flight_len );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Flight length: %u", (unsigned) flight_len );
     for( msg_idx=0; msg_idx < flight_len; msg_idx++, info++ )
     {
-        MBEDTLS_MPS_TRACE( trace_comment,
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT,
                "Epoch %u no longer needed for retransmission detection",
                (unsigned) info->epoch );
 
@@ -2528,12 +2528,12 @@ MBEDTLS_MPS_STATIC int mps_reassembly_feed( mbedtls_mps *mps,
     mps_l3* const l3 = mbedtls_mps_l4_get_l3( mps );
 
     MBEDTLS_MPS_TRACE_INIT( "mps_reassembly_feed" );
-    MBEDTLS_MPS_TRACE( trace_comment, "* Sequence number: %u", (unsigned) hs->seq_nr      );
-    MBEDTLS_MPS_TRACE( trace_comment, "* Type:            %u", (unsigned) hs->type        );
-    MBEDTLS_MPS_TRACE( trace_comment, "* Total length:    %u", (unsigned) hs->len         );
-    MBEDTLS_MPS_TRACE( trace_comment, "* Fragment offset: %u", (unsigned) hs->frag_offset );
-    MBEDTLS_MPS_TRACE( trace_comment, "* Fragment length: %u", (unsigned) hs->frag_len    );
-    MBEDTLS_MPS_TRACE( trace_comment, "Sequence number of next HS message: %u",
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* Sequence number: %u", (unsigned) hs->seq_nr      );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* Type:            %u", (unsigned) hs->type        );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* Total length:    %u", (unsigned) hs->len         );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* Fragment offset: %u", (unsigned) hs->frag_offset );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* Fragment length: %u", (unsigned) hs->frag_len    );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Sequence number of next HS message: %u",
            (unsigned) mps->dtls.seq_nr );
 
     MBEDTLS_MPS_ASSERT(
@@ -2553,7 +2553,7 @@ MBEDTLS_MPS_STATIC int mps_reassembly_feed( mbedtls_mps *mps,
     {
         unsigned char *tmp;
 
-        MBEDTLS_MPS_TRACE( trace_error, "Sequence number %u outside current window [%u,%u]",
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR, "Sequence number %u outside current window [%u,%u]",
           (unsigned) seq_nr, (unsigned) mps->dtls.seq_nr,
           (unsigned) ( mps->dtls.seq_nr + MBEDTLS_MPS_FUTURE_MESSAGE_BUFFERS ) );
 
@@ -2572,7 +2572,7 @@ MBEDTLS_MPS_STATIC int mps_reassembly_feed( mbedtls_mps *mps,
 
     if( reassembly->status == MBEDTLS_MPS_REASSEMBLY_NO_FRAGMENTATION )
     {
-        MBEDTLS_MPS_TRACE( trace_error,
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR,
                "Attempt to feed a fragment for a message that "
                "has previously been fully received." );
         MPS_CHK( MBEDTLS_ERR_MPS_INTERNAL_ERROR );
@@ -2583,7 +2583,7 @@ MBEDTLS_MPS_STATIC int mps_reassembly_feed( mbedtls_mps *mps,
         uint8_t complete_msg;
 
         /* Sequence number not seen before. */
-        MBEDTLS_MPS_TRACE( trace_comment,
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT,
            "Sequence number %u not seen before - setup reassembly structure.",
            (unsigned) seq_nr );
 
@@ -2598,7 +2598,7 @@ MBEDTLS_MPS_STATIC int mps_reassembly_feed( mbedtls_mps *mps,
                        ( hs->frag_len    == hs->len );
         if( seq_nr_offset == 0 && complete_msg )
         {
-            MBEDTLS_MPS_TRACE( trace_comment,
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT,
                    "Received next handshake message in single fragment." );
             reassembly->status = MBEDTLS_MPS_REASSEMBLY_NO_FRAGMENTATION;
             reassembly->data.rd_ext_l3 = hs->rd_ext;
@@ -2609,7 +2609,7 @@ MBEDTLS_MPS_STATIC int mps_reassembly_feed( mbedtls_mps *mps,
             size_t bitmask_len, msg_len;
             unsigned char *bitmask;
             unsigned char *buf;
-            MBEDTLS_MPS_TRACE( trace_comment, "Feed handshake message into reassembler." );
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Feed handshake message into reassembler." );
 
             /* For proper fragments of the next expected message,
              * or for any fragments (even full ones) belonging
@@ -2643,7 +2643,7 @@ MBEDTLS_MPS_STATIC int mps_reassembly_feed( mbedtls_mps *mps,
             hs->type  != reassembly->type  ||
             hs->len   != reassembly->length )
         {
-            MBEDTLS_MPS_TRACE( trace_error,
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR,
                    "Inconsistent parameters (%u,%u,%u) != (%u,%u,%u) "
                    "for fragments of HS msg of sequence number %u",
                    (unsigned) hs->epoch,        (unsigned) hs->type,
@@ -2663,7 +2663,7 @@ MBEDTLS_MPS_STATIC int mps_reassembly_feed( mbedtls_mps *mps,
     {
         unsigned char* bitmask = reassembly->data.window.bitmask;
         unsigned char *frag_content;
-        MBEDTLS_MPS_TRACE( trace_comment, "Contribute to ongoing reassembly." );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Contribute to ongoing reassembly." );
 
         MPS_CHK( mbedtls_mps_reader_get_ext( hs->rd_ext, hs->frag_len,
                                          &frag_content, NULL ) );
@@ -2681,13 +2681,13 @@ MBEDTLS_MPS_STATIC int mps_reassembly_feed( mbedtls_mps *mps,
             if( mps_bitmask_check( bitmask, hs->len ) == 0 )
             {
                 /* Free bitmask to indicate that the message is complete. */
-                MBEDTLS_MPS_TRACE( trace_comment, "Message fully reassembled." );
+                MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Message fully reassembled." );
                 reassembly->data.window.bitmask = NULL;
                 MPS_CHK( mps_reassembly_next_msg_complete( mps ) );
             }
             else
             {
-                MBEDTLS_MPS_TRACE( trace_comment,
+                MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT,
                        "Reassembly incomplete -- need more fragments." );
                 MPS_CHK( MBEDTLS_ERR_MPS_REASSEMBLY_FEED_NEED_MORE );
             }
@@ -2785,7 +2785,7 @@ MBEDTLS_MPS_STATIC int mps_reassembly_check_and_load( mbedtls_mps *mps )
     /* Check that message's epoch matches the current incoming epoch. */
     if( reassembly->epoch != mps->in_epoch )
     {
-        MBEDTLS_MPS_TRACE( trace_error, "Reassembled message isn't protected through current incoming epoch." );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR, "Reassembled message isn't protected through current incoming epoch." );
         MPS_CHK( MBEDTLS_ERR_MPS_INVALID_CONTENT );
     }
 
@@ -2808,14 +2808,14 @@ MBEDTLS_MPS_STATIC int mps_reassembly_read( mbedtls_mps *mps,
 
     hs->length = reassembly->length;
     hs->type   = reassembly->type;
-    MBEDTLS_MPS_TRACE( trace_comment, "Length: %u", (unsigned) hs->length );
-    MBEDTLS_MPS_TRACE( trace_comment, "Type:   %u", (unsigned) hs->type   );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Length: %u", (unsigned) hs->length );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Type:   %u", (unsigned) hs->type   );
 
     /* TODO: Add additional data (sequence number). */
 
     if( reassembly->status == MBEDTLS_MPS_REASSEMBLY_NO_FRAGMENTATION )
     {
-        MBEDTLS_MPS_TRACE( trace_comment,
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT,
                "Handshake message received as single fragment "
                "on Layer 3 - pass on to user." );
         /* The message has been received in a single fragment
@@ -2825,14 +2825,14 @@ MBEDTLS_MPS_STATIC int mps_reassembly_read( mbedtls_mps *mps,
     else if( reassembly->status == MBEDTLS_MPS_REASSEMBLY_WINDOW &&
              reassembly->data.window.bitmask == NULL )
     {
-        MBEDTLS_MPS_TRACE( trace_comment, "Fully reassembled handshake messaged" );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Fully reassembled handshake messaged" );
         hs->handle = &in->rd_ext;
     }
     else
     {
         /* We should never call this function unless we know
          * that a message is ready. */
-        MBEDTLS_MPS_TRACE( trace_comment,
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT,
                "Should never call mps_reassembly_read unless it is "
                "known that a message is ready." );
         MPS_CHK( MBEDTLS_ERR_MPS_INTERNAL_ERROR );
@@ -2878,7 +2878,7 @@ MBEDTLS_MPS_STATIC int mps_reassembly_done( mbedtls_mps *mps )
 
     if( mps->dtls.seq_nr == MBEDTLS_MPS_LIMIT_SEQUENCE_NUMBER )
     {
-        MBEDTLS_MPS_TRACE( trace_error, "Reached maximum incoming sequence number %u",
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR, "Reached maximum incoming sequence number %u",
                (unsigned) MBEDTLS_MPS_LIMIT_SEQUENCE_NUMBER );
         MPS_CHK( MBEDTLS_ERR_MPS_COUNTER_WRAP );
     }
@@ -2904,7 +2904,7 @@ MBEDTLS_MPS_STATIC int mps_reassembly_next_msg_complete( mbedtls_mps *mps )
     if( reassembly->status == MBEDTLS_MPS_REASSEMBLY_WINDOW &&
         reassembly->data.window.bitmask == NULL )
     {
-        MBEDTLS_MPS_TRACE( trace_comment, "Next message already fully available." );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Next message already fully available." );
         mbedtls_mps_reader_init( &in->rd, NULL, 0 );
         mbedtls_mps_reader_init_ext( &in->rd_ext, reassembly->length );
         MPS_CHK( mbedtls_mps_reader_attach( &in->rd_ext, &in->rd ) );
@@ -2914,7 +2914,7 @@ MBEDTLS_MPS_STATIC int mps_reassembly_next_msg_complete( mbedtls_mps *mps )
     }
     else
     {
-        MBEDTLS_MPS_TRACE( trace_comment, "Next message not yet available." );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Next message not yet available." );
     }
 
     MPS_INTERNAL_FAILURE_HANDLER
@@ -2998,13 +2998,13 @@ MBEDTLS_MPS_STATIC int mps_retransmit_out_core( mbedtls_mps *mps,
 
     if( mps->dtls.wait.resend_offset == 0 )
     {
-        MBEDTLS_MPS_TRACE( trace_comment,
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT,
                "Start retransmission of last outgoing flight of length %u",
                (unsigned) mps->dtls.outgoing.flight_len );
     }
     else
     {
-        MBEDTLS_MPS_TRACE( trace_comment,
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT,
                "Continue retransmission of last outgoing flight "
                "of length %u at message %u.",
                (unsigned) mps->dtls.outgoing.flight_len,
@@ -3016,7 +3016,7 @@ MBEDTLS_MPS_STATIC int mps_retransmit_out_core( mbedtls_mps *mps,
 
     while( offset < mps->dtls.outgoing.flight_len )
     {
-        MBEDTLS_MPS_TRACE( trace_comment,
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT,
                "Retransmitting message %u of last outgoing flight.",
                (unsigned) offset );
 
@@ -3226,7 +3226,7 @@ int mps_handshake_state_transition( mbedtls_mps *mps,
 
     mps->dtls.state = new;
 
-    MBEDTLS_MPS_TRACE( trace_comment, "State transition from %u to %u done.",
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "State transition from %u to %u done.",
            (unsigned) old, (unsigned) new );
     MPS_INTERNAL_FAILURE_HANDLER
 }
@@ -3298,7 +3298,7 @@ int mbedtls_mps_retransmission_handle_incoming_fragment( mbedtls_mps *mps )
      *   getting out of sync with the actual flight state.
      */
 
-    MBEDTLS_MPS_TRACE( trace_comment, "Fetch new fragment from Layer 3" );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Fetch new fragment from Layer 3" );
     MPS_CHK( mps_l3_read_handshake( l3, &hs_l3 ) );
 
     /* 1. Check if the message is recognized as a retransmission
@@ -3307,7 +3307,7 @@ int mbedtls_mps_retransmission_handle_incoming_fragment( mbedtls_mps *mps )
     if( MBEDTLS_MPS_FLIGHT_STATE_EITHER_OR( mps_get_hs_state( mps ),
             MBEDTLS_MPS_FLIGHT_AWAIT, MBEDTLS_MPS_FLIGHT_FINALIZE ) )
     {
-        MBEDTLS_MPS_TRACE( trace_comment,
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT,
                "Check if the fragment is a retransmission from old flight." );
         ret = mps_retransmit_in_check( mps, &hs_l3 );
 
@@ -3317,7 +3317,7 @@ int mbedtls_mps_retransmission_handle_incoming_fragment( mbedtls_mps *mps )
             unsigned char *tmp;
 
             /* Message is a retransmission from the last incoming flight. */
-            MBEDTLS_MPS_TRACE( trace_comment,
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT,
                    "Retransmission detected - retransmit last flight." );
 
             /* Layer 3 will error out if we don't fully consume a fragment,
@@ -3339,7 +3339,7 @@ int mbedtls_mps_retransmission_handle_incoming_fragment( mbedtls_mps *mps )
         else
             MPS_CHK( ret );
 
-        MBEDTLS_MPS_TRACE( trace_comment, "Frag not recognized as a retransmission." );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Frag not recognized as a retransmission." );
 
         /* Logically, we should also be able to forget about our last
          * outgoing flight, because we know that our peer has already
@@ -3408,7 +3408,7 @@ int mbedtls_mps_retransmission_handle_incoming_fragment( mbedtls_mps *mps )
             mbedtls_mps_reader_ext *hs_rd_ext;
             unsigned char *tmp;
 
-            MBEDTLS_MPS_TRACE( trace_comment,
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT,
                    "Discard non-initial fragments outside of handshake." );
 
             /* Layer 3 will error out if we don't fully consume a fragment,
@@ -3478,7 +3478,7 @@ int mbedtls_mps_retransmission_handle_incoming_fragment( mbedtls_mps *mps )
      *
      */
 
-    MBEDTLS_MPS_TRACE( trace_comment, "Feed fragment into reassembly module." );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Feed fragment into reassembly module." );
     ret = mps_reassembly_feed( mps, &hs_l3 );
     if( ret == MBEDTLS_ERR_MPS_REASSEMBLY_FEED_NEED_MORE )
     {
@@ -3505,7 +3505,7 @@ int mbedtls_mps_retransmission_handle_incoming_fragment( mbedtls_mps *mps )
         MPS_CHK( mps_l3_get_last_sequence_number( l3, hs_l3.epoch,
                                                   &rec_ctr ) );
 
-        MBEDTLS_MPS_TRACE( trace_comment, "Mirror rec seq nr %u", (unsigned) rec_ctr );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Mirror rec seq nr %u", (unsigned) rec_ctr );
         MPS_CHK( mps_l3_force_next_sequence_number( l3, hs_l3.epoch,
                                                     rec_ctr ) );
     }
@@ -3540,19 +3540,19 @@ MBEDTLS_MPS_STATIC int mps_retransmission_finish_incoming_message( mbedtls_mps *
 
     if( flags == MBEDTLS_MPS_FLIGHT_END )
     {
-        MBEDTLS_MPS_TRACE( trace_comment, "Incoming msg ends flight. -> PREPARE" );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Incoming msg ends flight. -> PREPARE" );
         MPS_CHK( mps_handshake_state_transition( mps,
                      MBEDTLS_MPS_FLIGHT_RECEIVE, MBEDTLS_MPS_FLIGHT_PREPARE ) );
     }
     else if( flags == MBEDTLS_MPS_FLIGHT_FINISHED )
     {
-        MBEDTLS_MPS_TRACE( trace_comment, "Incoming msg ends exchange. -> DONE" );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Incoming msg ends exchange. -> DONE" );
         MPS_CHK( mps_handshake_state_transition( mps,
                      MBEDTLS_MPS_FLIGHT_RECEIVE, MBEDTLS_MPS_FLIGHT_DONE ) );
     }
     else
     {
-        MBEDTLS_MPS_TRACE( trace_comment, "Incoming msg not last in flight. Keep RECEIVE" );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Incoming msg not last in flight. Keep RECEIVE" );
     }
 
     mps->in.flags = 0;
@@ -3584,7 +3584,7 @@ MBEDTLS_MPS_STATIC int mps_out_flight_free( mbedtls_mps *mps )
 
     flight_len =  mps->dtls.outgoing.flight_len;
     handle     = &mps->dtls.outgoing.backup[0];
-    MBEDTLS_MPS_TRACE( trace_comment, "Flight length: %u", (unsigned) flight_len );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Flight length: %u", (unsigned) flight_len );
 
     for( idx=0; idx < flight_len; idx++, handle++ )
     {
@@ -3676,7 +3676,7 @@ MBEDTLS_MPS_STATIC int mbedtls_mps_retransmission_handle_resend( mbedtls_mps *mp
             unsigned char * backup_buf    = handle->handle.raw.buf;
             mbedtls_mps_size_t backup_len = handle->handle.raw.len;
 
-            MBEDTLS_MPS_TRACE( trace_comment, "Retransmission via raw backup" );
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Retransmission via raw backup" );
 
             MPS_CHK( mps_clear_pending( mps, MPS_PAUSED_HS_FORBIDDEN ) );
 
@@ -3700,13 +3700,13 @@ MBEDTLS_MPS_STATIC int mbedtls_mps_retransmission_handle_resend( mbedtls_mps *mp
             int cb_unfinished = 0;
             mbedtls_mps_write_cb_t      const cb  = handle->handle.callback.cb;
             mbedtls_mps_write_cb_ctx_t* const ctx = handle->handle.callback.ctx;
-            MBEDTLS_MPS_TRACE( trace_comment, "Retransmission via callback" );
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Retransmission via callback" );
 
             MPS_CHK( mps_clear_pending( mps, MPS_PAUSED_HS_ALLOWED ) );
 
             if( mps->dtls.io.out.hs.state == MBEDTLS_MPS_HS_NONE )
             {
-                MBEDTLS_MPS_TRACE( trace_comment, "Open new outgoing handshake message." );
+                MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Open new outgoing handshake message." );
                 MPS_CHK( mps_dtls_frag_out_start( hs,
                                            hs->queue,
                                            hs->queue_len,
@@ -3723,7 +3723,7 @@ MBEDTLS_MPS_STATIC int mbedtls_mps_retransmission_handle_resend( mbedtls_mps *mp
             }
             else
             {
-                MBEDTLS_MPS_TRACE( trace_comment, "Retransmission in progress -- continue." );
+                MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Retransmission in progress -- continue." );
             }
 
             /* Call retransmission callback. */
@@ -3746,7 +3746,7 @@ MBEDTLS_MPS_STATIC int mbedtls_mps_retransmission_handle_resend( mbedtls_mps *mp
         case MBEDTLS_MPS_RETRANSMISSION_HANDLE_CCS:
         {
             mps_l3_ccs_out ccs_l3;
-            MBEDTLS_MPS_TRACE( trace_comment, "CCS retransmission" );
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "CCS retransmission" );
             MPS_CHK( mps_clear_pending( mps, MPS_PAUSED_HS_FORBIDDEN ) );
 
             ccs_l3.epoch = handle->metadata.epoch;
@@ -3768,7 +3768,7 @@ MBEDTLS_MPS_STATIC int mps_dtls_frag_out_unpause( mbedtls_mps *mps,
 
     if( mps->dtls.io.out.hs.state != MBEDTLS_MPS_HS_PAUSED )
     {
-        MBEDTLS_MPS_TRACE( trace_comment, "No handshake data queueing - skip." );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "No handshake data queueing - skip." );
         MBEDTLS_MPS_TRACE_RETURN( 0 );
     }
 
@@ -3778,7 +3778,7 @@ MBEDTLS_MPS_STATIC int mps_dtls_frag_out_unpause( mbedtls_mps *mps,
      * be that small. */
     do
     {
-        MBEDTLS_MPS_TRACE( trace_comment, "Fetch frag from L3 to dispatch queued data." );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Fetch frag from L3 to dispatch queued data." );
 
         ret = mps_dtls_frag_out_bind( mps );
         if( ret == 0 )
@@ -3787,7 +3787,7 @@ MBEDTLS_MPS_STATIC int mps_dtls_frag_out_unpause( mbedtls_mps *mps,
             MPS_CHK( ret );
 
         MPS_CHK( mps_dtls_frag_out_dispatch( mps ) );
-        MBEDTLS_MPS_TRACE( trace_comment, "More data queueing" );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "More data queueing" );
 
     } while( mps->dtls.io.out.hs.state == MBEDTLS_MPS_HS_PAUSED );
 
@@ -3797,14 +3797,14 @@ MBEDTLS_MPS_STATIC int mps_dtls_frag_out_unpause( mbedtls_mps *mps,
     /* Check if the handshake message has been fully written. */
     if( mbedtls_writer_check_done( &mps->dtls.io.out.hs.wr_ext ) == 0 )
     {
-        MBEDTLS_MPS_TRACE( trace_comment, "Handshake message fully written." );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Handshake message fully written." );
         MPS_CHK( mps_dtls_frag_out_close( mps ) );
         MPS_CHK( mps_dtls_frag_out_dispatch( mps ) );
 
         mbedtls_writer_free( &mps->dtls.io.out.hs.wr );
         mbedtls_writer_free_ext( &mps->dtls.io.out.hs.wr_ext );
 
-        MBEDTLS_MPS_TRACE( trace_comment,
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT,
                "New outgoing handshake message state: MBEDTLS_MPS_HS_NONE." );
         mps->dtls.io.out.hs.state = MBEDTLS_MPS_HS_NONE;
     }
@@ -3816,7 +3816,7 @@ MBEDTLS_MPS_STATIC int mps_dtls_frag_out_unpause( mbedtls_mps *mps,
         ((void) allow_active_hs);
         MBEDTLS_MPS_ASSERT( allow_active_hs,
                             "Caller doesn't allow active handshake" );
-        MBEDTLS_MPS_TRACE( trace_comment, "HS msg not yet fully written -- keep open" );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "HS msg not yet fully written -- keep open" );
     }
 
     MPS_INTERNAL_FAILURE_HANDLER
@@ -3843,7 +3843,7 @@ MBEDTLS_MPS_STATIC int mps_dtls_frag_out_bind( mbedtls_mps *mps )
     l3_hs.frag_len    = MBEDTLS_MPS_SIZE_UNKNOWN;
     MPS_CHK( mps_l3_write_handshake( l3, &l3_hs ) );
 
-    MBEDTLS_MPS_TRACE( trace_comment, "Get max len buffer from L3 and feed to writer." );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Get max len buffer from L3 and feed to writer." );
 
     /* Extract buffer for remaining handshake content from
      * reader obtained from Layer 3. */
@@ -3855,14 +3855,14 @@ MBEDTLS_MPS_STATIC int mps_dtls_frag_out_bind( mbedtls_mps *mps )
     MPS_CHK( mbedtls_writer_get_ext( hs->wr_ext_l3, remaining,
                                      &frag, &frag_len ) );
     hs->frag_len = frag_len;
-    MBEDTLS_MPS_TRACE( trace_comment, "Received len %u buf from L3.", (unsigned) frag_len );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Received len %u buf from L3.", (unsigned) frag_len );
 
     /* Feed the buffer into the user-facing writer
      * used to write the handshake message. */
     ret = mbedtls_writer_feed( &hs->wr, frag, frag_len );
     if( ret == MBEDTLS_ERR_WRITER_NEED_MORE )
     {
-        MBEDTLS_MPS_TRACE( trace_comment, "L3 buffer too small to dispatch queued data." );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "L3 buffer too small to dispatch queued data." );
         MPS_CHK( mbedtls_writer_commit_ext( hs->wr_ext_l3 ) );
         MPS_CHK( MBEDTLS_ERR_WRITER_NEED_MORE );
     }
@@ -3884,10 +3884,10 @@ MBEDTLS_MPS_STATIC int mps_dtls_frag_out_close( mbedtls_mps *mps )
      * is potentially still pending. */
     MPS_CHK( mbedtls_writer_reclaim( &hs->wr, &frag_len, &bytes_queued,
                                      MBEDTLS_WRITER_RECLAIM_FORCE ) );
-    MBEDTLS_MPS_TRACE( trace_comment, "* Fragment length: %u", (unsigned) frag_len );
-    MBEDTLS_MPS_TRACE( trace_comment, "* Bytes queued:    %u", (unsigned) bytes_queued );
-    MBEDTLS_MPS_TRACE( trace_comment, "* Total length:    %u", (unsigned) metadata->len );
-    MBEDTLS_MPS_TRACE( trace_comment, "* Fragment offset: %u", (unsigned) hs->offset );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* Fragment length: %u", (unsigned) frag_len );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* Bytes queued:    %u", (unsigned) bytes_queued );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* Total length:    %u", (unsigned) metadata->len );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* Fragment offset: %u", (unsigned) hs->offset );
 
     if( hs->wr_ext_l3 != NULL )
     {
@@ -3916,7 +3916,7 @@ MBEDTLS_MPS_STATIC int mps_dtls_frag_out_close( mbedtls_mps *mps )
                             (unsigned) metadata->len == bytes_queued,
               "Mismatch between HS msg size and amount of data written" );
 
-        MBEDTLS_MPS_TRACE( trace_comment, "Total HS len: %u", (unsigned) bytes_queued );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Total HS len: %u", (unsigned) bytes_queued );
 
         metadata->len = bytes_queued;
         hs->state  = MBEDTLS_MPS_HS_PAUSED;
@@ -3937,10 +3937,10 @@ MBEDTLS_MPS_STATIC int mps_dtls_frag_out_dispatch( mbedtls_mps *mps )
 
     if( mps->dtls.io.out.hs.wr_ext_l3 != NULL )
     {
-        MBEDTLS_MPS_TRACE( trace_comment, " * Seq: %u", (unsigned) metadata->seq_nr );
-        MBEDTLS_MPS_TRACE( trace_comment, " * Frag off: %u", (unsigned) hs->offset );
-        MBEDTLS_MPS_TRACE( trace_comment, " * Frag len: %u", (unsigned) hs->frag_len );
-        MBEDTLS_MPS_TRACE( trace_comment, " * Total len: %u", (unsigned) metadata->len );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, " * Seq: %u", (unsigned) metadata->seq_nr );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, " * Frag off: %u", (unsigned) hs->offset );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, " * Frag len: %u", (unsigned) hs->frag_len );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, " * Total len: %u", (unsigned) metadata->len );
 
         MPS_CHK( mps_l3_dispatch( l3 ) );
 
@@ -4003,13 +4003,13 @@ MBEDTLS_MPS_STATIC int mps_out_flight_msg_start( mbedtls_mps *mps,
     mbedtls_mps_retransmission_handle *hdl;
     MBEDTLS_MPS_TRACE_INIT( "mps_out_flight_msg_start" );
 
-    MBEDTLS_MPS_TRACE( trace_comment, "Add msg to flight, seq nr %u",
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Add msg to flight, seq nr %u",
            (unsigned) mps->dtls.seq_nr );
 
     cur_flight_len = mps->dtls.outgoing.flight_len;
     if( cur_flight_len == MBEDTLS_MPS_MAX_FLIGHT_LENGTH )
     {
-        MBEDTLS_MPS_TRACE( trace_error, "Outgoing flight reached max len %u",
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR, "Outgoing flight reached max len %u",
                (unsigned) MBEDTLS_MPS_MAX_FLIGHT_LENGTH );
         MPS_CHK( MBEDTLS_ERR_MPS_FLIGHT_TOO_LONG );
     }
@@ -4057,7 +4057,7 @@ MBEDTLS_MPS_STATIC int mps_out_flight_msg_done( mbedtls_mps *mps )
         cur_seq_nr = mps->dtls.seq_nr;
         if( cur_seq_nr == MBEDTLS_MPS_LIMIT_SEQUENCE_NUMBER )
         {
-            MBEDTLS_MPS_TRACE( trace_error, "Reached max seq nr %u",
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR, "Reached max seq nr %u",
                    (unsigned) MBEDTLS_MPS_LIMIT_SEQUENCE_NUMBER );
             MPS_CHK( MBEDTLS_ERR_MPS_COUNTER_WRAP );
         }

--- a/library/mps/reader.c
+++ b/library/mps/reader.c
@@ -600,13 +600,13 @@ int mbedtls_mps_reader_get_ext( mbedtls_mps_reader_ext *rd_ext,
     MBEDTLS_MPS_STATE_VALIDATE_RAW( rd_ext->rd != NULL,
                 "mbedtls_mps_reader_get_ext() without underlying reader" );
 
-    MBEDTLS_MPS_TRACE( trace_comment, "* Fetch offset: %u", (unsigned) rd_ext->ofs_fetch );
-    MBEDTLS_MPS_TRACE( trace_comment, "* Group end:    %u",
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* Fetch offset: %u", (unsigned) rd_ext->ofs_fetch );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* Group end:    %u",
            (unsigned) rd_ext->grp_end[rd_ext->cur_grp] );
     logic_avail = rd_ext->grp_end[rd_ext->cur_grp] - rd_ext->ofs_fetch;
     if( desired > logic_avail )
     {
-        MBEDTLS_MPS_TRACE( trace_comment, "Requesting more data (%u) than logically available (%u)",
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Requesting more data (%u) than logically available (%u)",
                (unsigned) desired, (unsigned) logic_avail );
         MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_READER_BOUNDS_VIOLATION );
     }

--- a/library/mps/reader.c
+++ b/library/mps/reader.c
@@ -1,7 +1,7 @@
 /*
  *  Message Processing Stack, Reader implementation
  *
- *  Copyright (C) 2006-2018, ARM Limited, All Rights Reserved
+ *  Copyright The Mbed TLS Contributors
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -19,18 +19,24 @@
  *  This file is part of Mbed TLS (https://tls.mbed.org)
  */
 
+#include "common.h"
+
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+
 #include "mbedtls/mps/reader.h"
 #include "mbedtls/mps/common.h"
 #include "mbedtls/mps/trace.h"
 
-#if defined(MBEDTLS_MPS_SEPARATE_LAYERS) ||     \
-    defined(MBEDTLS_MPS_TOP_TRANSLATION_UNIT)
-
-#if defined(MBEDTLS_MPS_TRACE)
-static int trace_id = TRACE_BIT_READER;
-#endif /* MBEDTLS_MPS_TRACE */
-
 #include <string.h>
+
+#if ( defined(__ARMCC_VERSION) || defined(_MSC_VER) ) && \
+    !defined(inline) && !defined(__cplusplus)
+#define inline __inline
+#endif
+
+#if defined(MBEDTLS_MPS_ENABLE_TRACE)
+static int mbedtls_mps_trace_id = MBEDTLS_MPS_TRACE_BIT_READER;
+#endif /* MBEDTLS_MPS_ENABLE_TRACE */
 
 /*
  * GENERAL NOTE ON CODING STYLE
@@ -41,8 +47,9 @@ static int trace_id = TRACE_BIT_READER;
  * and significantly increases the C-code line count, but
  * should not increase the size of generated assembly.
  *
- * This reason for this is twofold:
+ * The reason for this is twofold:
  * (1) It will ease verification efforts using the VST
+ *     (Verified Software Toolchain)
  *     whose program logic cannot directly reason
  *     about instructions containing a load or store in
  *     addition to other operations (e.g. *p = *q or
@@ -64,81 +71,153 @@ static int trace_id = TRACE_BIT_READER;
  *
  */
 
-int mbedtls_reader_init( mbedtls_reader *rd,
-                         unsigned char *acc,
-                         mbedtls_mps_size_t acc_len )
+static inline int mps_reader_is_accumulating(
+    mbedtls_mps_reader const *rd )
 {
-    mbedtls_reader const zero = { NULL, 0, 0, 0, 0, NULL, 0, 0, { 0 } };
-    *rd = zero;
-    TRACE_INIT( "reader_init, acc len %u", (unsigned) acc_len );
+    mbedtls_mps_size_t acc_remaining;
+    if( rd->acc == NULL )
+        return( 0 );
 
+    acc_remaining = rd->acc_share.acc_remaining;
+    return( acc_remaining > 0 );
+}
+
+static inline int mps_reader_is_producing(
+    mbedtls_mps_reader const *rd )
+{
+    unsigned char *frag = rd->frag;
+    return( frag == NULL );
+}
+
+static inline int mps_reader_is_consuming(
+    mbedtls_mps_reader const *rd )
+{
+    return( !mps_reader_is_producing( rd ) );
+}
+
+static inline mbedtls_mps_size_t mps_reader_get_fragment_offset(
+    mbedtls_mps_reader const *rd )
+{
+    unsigned char *acc = rd->acc;
+    mbedtls_mps_size_t frag_offset;
+
+    if( acc == NULL )
+        return( 0 );
+
+    frag_offset = rd->acc_share.frag_offset;
+    return( frag_offset );
+}
+
+static inline mbedtls_mps_size_t mps_reader_serving_from_accumulator(
+    mbedtls_mps_reader const *rd )
+{
+    mbedtls_mps_size_t frag_offset, end;
+
+    frag_offset = mps_reader_get_fragment_offset( rd );
+    end = rd->end;
+
+    return( end < frag_offset );
+}
+
+static inline void mps_reader_zero( mbedtls_mps_reader *rd )
+{
+    /* A plain memset() would likely be more efficient,
+     * but the current way of zeroing makes it harder
+     * to overlook fields which should not be zero-initialized.
+     * It's also more suitable for FV efforts since it
+     * doesn't require reasoning about structs being
+     * interpreted as unstructured binary blobs. */
+    static mbedtls_mps_reader const zero =
+        { .frag          = NULL,
+          .frag_len      = 0,
+          .commit        = 0,
+          .end           = 0,
+          .pending       = 0,
+          .acc           = NULL,
+          .acc_len       = 0,
+          .acc_available = 0,
+          .acc_share     = { .acc_remaining = 0 }
+        };
+    *rd = zero;
+}
+
+int mbedtls_mps_reader_init( mbedtls_mps_reader *rd,
+                             unsigned char *acc,
+                             mbedtls_mps_size_t acc_len )
+{
+    MBEDTLS_MPS_TRACE_INIT( "mbedtls_mps_reader_init" );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT,
+                       "* Accumulator size: %u bytes", (unsigned) acc_len );
+    mps_reader_zero( rd );
     rd->acc = acc;
     rd->acc_len = acc_len;
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
-int mbedtls_reader_free( mbedtls_reader *rd )
+int mbedtls_mps_reader_free( mbedtls_mps_reader *rd )
 {
-    mbedtls_reader const zero = { NULL, 0, 0, 0, 0, NULL, 0, 0, { 0 } };
-    TRACE_INIT( "reader_free" );
-    *rd = zero;
-    /* TODO: Use reliable way of zeroization, provided
-     * zeroization is necessary in the first place. If so,
-     * consider also zeroizing the accumulator buffer. */
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_INIT( "mbedtls_mps_reader_free" );
+    mps_reader_zero( rd );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
-int mbedtls_reader_feed( mbedtls_reader *rd,
-                         unsigned char *new_frag,
-                         mbedtls_mps_size_t new_frag_len )
+int mbedtls_mps_reader_feed( mbedtls_mps_reader *rd,
+                             unsigned char *new_frag,
+                             mbedtls_mps_size_t new_frag_len )
 {
-    unsigned char *acc;
     mbedtls_mps_size_t copy_to_acc;
-    TRACE_INIT( "reader_feed, frag %p, len %u",
-                (void*) new_frag, (unsigned) new_frag_len );
+    MBEDTLS_MPS_TRACE_INIT( "mbedtls_mps_reader_feed" );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT,
+                       "* Fragment length: %u bytes", (unsigned) new_frag_len );
 
     if( new_frag == NULL )
-        RETURN( MBEDTLS_ERR_READER_INVALID_ARG );
+        MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_READER_INVALID_ARG );
 
-    MBEDTLS_MPS_STATE_VALIDATE_RAW( rd->frag == NULL,
-        "mbedtls_reader_feed() requires reader to be in producing mode" );
+    MBEDTLS_MPS_STATE_VALIDATE_RAW( mps_reader_is_producing( rd ),
+        "mbedtls_mps_reader_feed() requires reader to be in producing mode" );
 
-    acc = rd->acc;
-    if( acc != NULL )
+    if( mps_reader_is_accumulating( rd ) )
     {
-        mbedtls_mps_size_t aa, ar;
+        unsigned char *acc    = rd->acc;
+        mbedtls_mps_size_t acc_remaining = rd->acc_share.acc_remaining;
+        mbedtls_mps_size_t acc_available = rd->acc_available;
 
-        ar = rd->acc_share.acc_remaining;
-        aa = rd->acc_avail;
+        /* Skip over parts of the accumulator that have already been filled. */
+        acc += acc_available;
 
-        copy_to_acc = ar;
+        copy_to_acc = acc_remaining;
         if( copy_to_acc > new_frag_len )
             copy_to_acc = new_frag_len;
 
-        acc += aa;
+        /* Copy new contents to accumulator. */
         memcpy( acc, new_frag, copy_to_acc );
 
-        TRACE( trace_comment, "Copy new data of size %u of %u into accumulator at offset %u",
-                (unsigned) copy_to_acc, (unsigned) new_frag_len, (unsigned) aa );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT,
+                "Copy new data of size %u of %u into accumulator at offset %u",
+                (unsigned) copy_to_acc, (unsigned) new_frag_len, (unsigned) acc_available );
 
         /* Check if, with the new fragment, we have enough data. */
-        ar -= copy_to_acc;
-        if( ar > 0 )
+        acc_remaining -= copy_to_acc;
+        if( acc_remaining > 0 )
         {
-            /* Need more data */
-            aa += copy_to_acc;
-            rd->acc_share.acc_remaining = ar;
-            rd->acc_avail = aa;
-            RETURN( MBEDTLS_ERR_READER_NEED_MORE );
+            /* We need to accumulate more data. Stay in producing mode. */
+            acc_available += copy_to_acc;
+            rd->acc_share.acc_remaining = acc_remaining;
+            rd->acc_available = acc_available;
+            MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_READER_NEED_MORE );
         }
 
-        TRACE( trace_comment, "Enough data available to serve user request" );
+        /* We have filled the accumulator: Move to consuming mode. */
 
-        rd->acc_share.frag_offset = aa;
-        aa += copy_to_acc;
-        rd->acc_avail = aa;
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT,
+                           "Enough data available to serve user request" );
+
+        /* Remember overlap of accumulator and fragment. */
+        rd->acc_share.frag_offset = acc_available;
+        acc_available += copy_to_acc;
+        rd->acc_available = acc_available;
     }
-    else
+    else /* Not accumulating */
     {
         rd->acc_share.frag_offset = 0;
     }
@@ -147,109 +226,102 @@ int mbedtls_reader_feed( mbedtls_reader *rd,
     rd->frag_len = new_frag_len;
     rd->commit = 0;
     rd->end = 0;
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
 
-int mbedtls_reader_get( mbedtls_reader *rd,
-                        mbedtls_mps_size_t desired,
-                        unsigned char **buffer,
-                        mbedtls_mps_size_t *buflen )
+int mbedtls_mps_reader_get( mbedtls_mps_reader *rd,
+                            mbedtls_mps_size_t desired,
+                            unsigned char **buffer,
+                            mbedtls_mps_size_t *buflen )
 {
-    unsigned char *frag, *acc;
-    mbedtls_mps_size_t end, fo, fl, frag_fetched, frag_remaining;
-    TRACE_INIT( "reader_get %p, desired %u", (void*) rd, (unsigned) desired );
+    unsigned char *frag;
+    mbedtls_mps_size_t frag_len, frag_offset, end, frag_fetched, frag_remaining;
+    MBEDTLS_MPS_TRACE_INIT( "mbedtls_mps_reader_get" );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT,
+                       "* Bytes requested: %u", (unsigned) desired );
 
-    frag = rd->frag;
-    MBEDTLS_MPS_STATE_VALIDATE_RAW( frag != NULL,
-          "mbedtls_reader_get() requires reader to be in consuming mode" );
+    MBEDTLS_MPS_STATE_VALIDATE_RAW( mps_reader_is_consuming( rd ),
+          "mbedtls_mps_reader_get() requires reader to be in consuming mode" );
 
-    /* The fragment offset indicates the offset of the fragment
-     * from the accmulator, if the latter is present. Use a offset
-     * of \c 0 if no accumulator is used. */
-    acc = rd->acc;
-    if( acc == NULL )
-        fo = 0;
-    else
-        fo = rd->acc_share.frag_offset;
-
-    TRACE( trace_comment, "frag_off %u, end %u, acc_avail %d",
-            (unsigned) fo, (unsigned) rd->end,
-            acc == NULL ? -1 : (int) rd->acc_avail );
+    end = rd->end;
+    frag_offset = mps_reader_get_fragment_offset( rd );
 
     /* Check if we're still serving from the accumulator. */
-    end = rd->end;
-    if( end < fo )
+    if( mps_reader_serving_from_accumulator( rd ) )
     {
-        TRACE( trace_comment, "Serve the request from the accumulator" );
-        if( fo - end < desired )
-        {
-            /* Illustration of supported and unsupported cases:
-             *
-             * - Allowed #1
-             *
-             *                          +-----------------------------------+
-             *                          |               frag                |
-             *                          +-----------------------------------+
-             *
-             *             end end+desired
-             *              |       |
-             *        +-----v-------v-------------+
-             *        |          acc              |
-             *        +---------------------------+
-             *                          |         |
-             *                   fo/frag_offset aa/acc_avail
-             *
-             * - Allowed #2
-             *
-             *                          +-----------------------------------+
-             *                          |               frag                |
-             *                          +-----------------------------------+
-             *
-             *                  end          end+desired
-             *                   |                |
-             *        +----------v----------------v
-             *        |          acc              |
-             *        +---------------------------+
-             *                          |         |
-             *                   fo/frag_offset aa/acc_avail
-             *
-             * - Not allowed #1 (could be served, but we don't actually use it):
-             *
-             *                      +-----------------------------------+
-             *                      |               frag                |
-             *                      +-----------------------------------+
-             *
-             *              end        end+desired
-             *               |             |
-             *        +------v-------------v------+
-             *        |          acc              |
-             *        +---------------------------+
-             *                      |              |
-             *                fo/frag_offset   aa/acc_avail
-             *
-             *
-             * - Not allowed #2 (can't be served with a contiguous buffer):
-             *
-             *                      +-----------------------------------+
-             *                      |               frag                |
-             *                      +-----------------------------------+
-             *
-             *              end                 end + desired
-             *               |                        |
-             *        +------v--------------------+   v
-             *        |            acc            |
-             *        +---------------------------+
-             *                      |             |
-             *                fo/frag_offset   aa/acc_avail
-             *
-             * In case of Allowed #1 and #2 we're switching to serve from
-             * `frag` starting from the next call to mbedtls_reader_get().
-             */
+        /* Illustration of supported and unsupported cases:
+         *
+         * - Allowed #1
+         *
+         *                          +-----------------------------------+
+         *                          |               frag                |
+         *                          +-----------------------------------+
+         *
+         *             end end+desired
+         *              |       |
+         *        +-----v-------v-------------+
+         *        |          acc              |
+         *        +---------------------------+
+         *                          |         |
+         *                     frag_offset  acc_available
+         *
+         * - Allowed #2
+         *
+         *                          +-----------------------------------+
+         *                          |               frag                |
+         *                          +-----------------------------------+
+         *
+         *                  end          end+desired
+         *                   |                |
+         *        +----------v----------------v
+         *        |          acc              |
+         *        +---------------------------+
+         *                          |         |
+         *                   frag_offset acc_available
+         *
+         * - Not allowed #1 (could be served, but we don't actually use it):
+         *
+         *                      +-----------------------------------+
+         *                      |               frag                |
+         *                      +-----------------------------------+
+         *
+         *              end        end+desired
+         *               |             |
+         *        +------v-------------v------+
+         *        |          acc              |
+         *        +---------------------------+
+         *                      |             |
+         *                frag_offset   acc_available
+         *
+         *
+         * - Not allowed #2 (can't be served with a contiguous buffer):
+         *
+         *                      +-----------------------------------+
+         *                      |               frag                |
+         *                      +-----------------------------------+
+         *
+         *              end                 end + desired
+         *               |                        |
+         *        +------v--------------------+   v
+         *        |            acc            |
+         *        +---------------------------+
+         *                      |             |
+         *                frag_offset   acc_available
+         *
+         * In case of Allowed #2 we're switching to serve from
+         * `frag` starting from the next call to mbedtls_mps_reader_get().
+         */
 
-            mbedtls_mps_size_t aa;
-            aa = rd->acc_avail;
-            if( aa - end != desired )
+        unsigned char *acc;
+
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT,
+                           "Serve the request from the accumulator" );
+        if( frag_offset - end < desired )
+        {
+            mbedtls_mps_size_t acc_available;
+            acc_available = rd->acc_available;
+            if( acc_available - end != desired )
             {
                 /* It might be possible to serve some of these situations by
                  * making additional space in the accumulator, removing those
@@ -261,11 +333,14 @@ int mbedtls_reader_get( mbedtls_reader *rd,
                  * If we believe we adhere to this restricted usage throughout
                  * the library, this check is a good opportunity to
                  * validate this. */
-                RETURN( MBEDTLS_ERR_READER_INCONSISTENT_REQUESTS );
+                MBEDTLS_MPS_TRACE_RETURN(
+                    MBEDTLS_ERR_MPS_READER_INCONSISTENT_REQUESTS );
             }
         }
 
+        acc = rd->acc;
         acc += end;
+
         *buffer = acc;
         if( buflen != NULL )
             *buflen = desired;
@@ -274,33 +349,37 @@ int mbedtls_reader_get( mbedtls_reader *rd,
         rd->end = end;
         rd->pending = 0;
 
-        RETURN( 0 );
+        MBEDTLS_MPS_TRACE_RETURN( 0 );
     }
 
     /* Attempt to serve the request from the current fragment */
-    TRACE( trace_comment, "Serve the request from the current fragment." );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT,
+                       "Serve the request from the current fragment." );
 
-    fl = rd->frag_len;
-    frag_fetched = end - fo; /* The amount of data from the current fragment
-                              * that has already been passed to the user. */
-    frag += frag_fetched;
-    frag_remaining = fl - frag_fetched; /* Remaining data in fragment */
+    frag_len = rd->frag_len;
+    frag_fetched = end - frag_offset; /* The amount of data from the current
+                                       * fragment that has already been passed
+                                       * to the user. */
+    frag_remaining = frag_len - frag_fetched; /* Remaining data in fragment */
 
     /* Check if we can serve the read request from the fragment. */
     if( frag_remaining < desired )
     {
-        TRACE( trace_comment, "There's not enough data in the current fragment to serve the request." );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT,
+                           "There's not enough data in the current fragment "
+                           "to serve the request." );
         /* There's not enough data in the current fragment,
-         * so either just RETURN what we have or fail. */
+         * so either just MBEDTLS_MPS_TRACE_RETURN what we have or fail. */
         if( buflen == NULL )
         {
             if( frag_remaining > 0 )
             {
                 rd->pending = desired - frag_remaining;
-                TRACE( trace_comment, "Remember to collect %u bytes before re-opening",
+                MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT,
+                       "Remember to collect %u bytes before re-opening",
                        (unsigned) rd->pending );
             }
-            RETURN( MBEDTLS_ERR_READER_OUT_OF_DATA );
+            MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_READER_OUT_OF_DATA );
         }
 
         desired = frag_remaining;
@@ -308,6 +387,10 @@ int mbedtls_reader_get( mbedtls_reader *rd,
 
     /* There's enough data in the current fragment to serve the
      * (potentially modified) read request. */
+
+    frag = rd->frag;
+    frag += frag_fetched;
+
     *buffer = frag;
     if( buflen != NULL )
         *buflen = desired;
@@ -315,164 +398,149 @@ int mbedtls_reader_get( mbedtls_reader *rd,
     end += desired;
     rd->end = end;
     rd->pending = 0;
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
-int mbedtls_reader_commit( mbedtls_reader *rd )
+int mbedtls_mps_reader_commit( mbedtls_mps_reader *rd )
 {
-    unsigned char *acc;
-    mbedtls_mps_size_t aa, end, fo, shift;
-    TRACE_INIT( "reader_commit" );
+    mbedtls_mps_size_t end;
+    MBEDTLS_MPS_TRACE_INIT( "mbedtls_mps_reader_commit" );
+    MBEDTLS_MPS_STATE_VALIDATE_RAW( mps_reader_is_consuming( rd ),
+       "mbedtls_mps_reader_commit() requires reader to be in consuming mode" );
 
-    MBEDTLS_MPS_STATE_VALIDATE_RAW( rd->frag != NULL,
-       "mbedtls_reader_commit() requires reader to be in consuming mode" );
-
-    acc = rd->acc;
     end = rd->end;
-
-    if( acc == NULL )
-    {
-        TRACE( trace_comment, "No accumulator, just shift end" );
-        rd->commit = end;
-        RETURN( 0 );
-    }
-
-    fo = rd->acc_share.frag_offset;
-    if( end >= fo )
-    {
-        TRACE( trace_comment, "Started to serve fragment, get rid of accumulator" );
-        shift = fo;
-        aa = 0;
-    }
-    else
-    {
-        TRACE( trace_comment, "Still serving from accumulator" );
-        aa = rd->acc_avail;
-        shift = end;
-        memmove( acc, acc + shift, aa - shift );
-        aa -= shift;
-    }
-
-    end -= shift;
-    fo -= shift;
-
-    rd->acc_share.frag_offset = fo;
-    rd->acc_avail = aa;
     rd->commit = end;
-    rd->end = end;
 
-    TRACE( trace_comment, "Final state: (end=commit,fo,avail) = (%u,%u,%u)",
-           (unsigned) end, (unsigned) fo, (unsigned) aa );
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
-int mbedtls_reader_reclaim( mbedtls_reader *rd,
-                            mbedtls_mps_size_t *paused )
+int mbedtls_mps_reader_reclaim( mbedtls_mps_reader *rd,
+                                int *paused )
 {
     unsigned char *frag, *acc;
     mbedtls_mps_size_t pending, commit;
-    mbedtls_mps_size_t al, fo, fl;
-    TRACE_INIT( "reader_reclaim" );
+    mbedtls_mps_size_t acc_len, frag_offset, frag_len;
+    MBEDTLS_MPS_TRACE_INIT( "mbedtls_mps_reader_reclaim" );
 
     if( paused != NULL )
         *paused = 0;
 
-    frag = rd->frag;
-    MBEDTLS_MPS_STATE_VALIDATE_RAW( frag != NULL,
-           "mbedtls_reader_reclaim() requires reader to be in consuming mode" );
+    MBEDTLS_MPS_STATE_VALIDATE_RAW( mps_reader_is_consuming( rd ),
+       "mbedtls_mps_reader_reclaim() requires reader to be in consuming mode" );
 
-    acc    = rd->acc;
-    pending = rd->pending;
-    commit = rd->commit;
-    fl     = rd->frag_len;
+    frag     = rd->frag;
+    acc      = rd->acc;
+    pending  = rd->pending;
+    commit   = rd->commit;
+    frag_len = rd->frag_len;
 
-    if( acc == NULL )
-        fo = 0;
-    else
-        fo = rd->acc_share.frag_offset;
+    frag_offset = mps_reader_get_fragment_offset( rd );
 
     if( pending == 0 )
     {
-        TRACE( trace_comment, "No unsatisfied read-request has been logged." );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT,
+                           "No unsatisfied read-request has been logged." );
+
         /* Check if there's data left to be consumed. */
-        if( commit < fo || commit - fo < fl )
+        if( commit < frag_offset || commit - frag_offset < frag_len )
         {
-            TRACE( trace_comment, "There is data left to be consumed." );
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT,
+                               "There is data left to be consumed." );
             rd->end = commit;
-            RETURN( MBEDTLS_ERR_READER_DATA_LEFT );
+            MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_READER_DATA_LEFT );
         }
-        TRACE( trace_comment, "The fragment has been completely processed and committed." );
+
+        rd->acc_available = 0;
+        rd->acc_share.acc_remaining = 0;
+
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT,
+                           "Fragment has been fully processed and committed." );
     }
     else
     {
+        int overflow;
+
+        mbedtls_mps_size_t acc_backup_offset;
+        mbedtls_mps_size_t acc_backup_len;
         mbedtls_mps_size_t frag_backup_offset;
         mbedtls_mps_size_t frag_backup_len;
-        TRACE( trace_comment, "There has been an unsatisfied read-request with %u bytes overhead.",
+
+        mbedtls_mps_size_t backup_len;
+        mbedtls_mps_size_t acc_len_needed;
+
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT,
+               "There has been an unsatisfied read with %u bytes overhead.",
                (unsigned) pending );
 
         if( acc == NULL )
         {
-            TRACE( trace_comment, "No accumulator present" );
-            RETURN( MBEDTLS_ERR_READER_NEED_ACCUMULATOR );
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT,
+                               "No accumulator present" );
+            MBEDTLS_MPS_TRACE_RETURN(
+                MBEDTLS_ERR_MPS_READER_NEED_ACCUMULATOR );
         }
-        al = rd->acc_len;
+        acc_len = rd->acc_len;
 
         /* Check if the upper layer has already fetched
          * and committed the contents of the accumulator. */
-        if( commit < fo )
+        if( commit < frag_offset )
         {
             /* No, accumulator is still being processed. */
-            int overflow;
-            TRACE( trace_comment, "Still processing data from the accumulator" );
-
-            overflow =
-                ( fo + fl < fo ) || ( fo + fl + pending < fo + fl );
-            if( overflow || al < fo + fl + pending )
-            {
-                rd->end = commit;
-                rd->pending = 0;
-                TRACE( trace_error, "The accumulator is too small to handle the backup." );
-                TRACE( trace_error, "* Remaining size: %u", (unsigned) al );
-                TRACE( trace_error, "* Needed: %u (%u + %u + %u)",
-                       (unsigned) ( fo + fl + pending ),
-                       (unsigned) fo, (unsigned) fl, (unsigned) pending );
-                RETURN( MBEDTLS_ERR_READER_ACCUMULATOR_TOO_SMALL );
-            }
             frag_backup_offset = 0;
-            frag_backup_len = fl;
+            frag_backup_len = frag_len;
+            acc_backup_offset = commit;
+            acc_backup_len = frag_offset - commit;
         }
         else
         {
             /* Yes, the accumulator is already processed. */
-            int overflow;
-            TRACE( trace_comment, "The accumulator has already been processed" );
-
-            frag_backup_offset = commit;
-            frag_backup_len = fl - commit;
-            overflow = ( frag_backup_len + pending < pending );
-
-            if( overflow ||
-                al - fo < frag_backup_len + pending )
-            {
-                rd->end = commit;
-                rd->pending = 0;
-                TRACE( trace_error, "The accumulator is too small to handle the backup." );
-                TRACE( trace_error, "* Remaining size: %u", (unsigned) ( al - fo ) );
-                TRACE( trace_error, "* Needed: %u (%u + %u)",
-                       (unsigned) ( frag_backup_len + pending ),
-                       (unsigned) frag_backup_len, (unsigned) pending );
-                RETURN( MBEDTLS_ERR_READER_ACCUMULATOR_TOO_SMALL );
-            }
+            frag_backup_offset = commit - frag_offset;
+            frag_backup_len = frag_len - frag_backup_offset;
+            acc_backup_offset = 0;
+            acc_backup_len = 0;
         }
 
-        frag += frag_backup_offset;
-        acc += fo;
-        memcpy( acc, frag, frag_backup_len );
+        backup_len = acc_backup_len + frag_backup_len;
+        acc_len_needed = backup_len + pending;
 
-        TRACE( trace_comment, "Backup %u bytes into accumulator",
-               (unsigned) frag_backup_len );
+        overflow  = 0;
+        overflow |= ( backup_len     < acc_backup_len );
+        overflow |= ( acc_len_needed < backup_len );
 
-        rd->acc_avail = fo + frag_backup_len;
+        if( overflow || acc_len < acc_len_needed )
+        {
+            /* Except for the different return code, we behave as if
+             * there hadn't been a call to mbedtls_mps_reader_get()
+             * since the last commit. */
+            rd->end = commit;
+            rd->pending = 0;
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR,
+                               "The accumulator is too small to handle the backup." );
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR,
+                               "* Size: %u", (unsigned) acc_len );
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR,
+                               "* Needed: %u (%u + %u)",
+                               (unsigned) acc_len_needed,
+                               (unsigned) backup_len, (unsigned) pending );
+            MBEDTLS_MPS_TRACE_RETURN(
+                MBEDTLS_ERR_MPS_READER_ACCUMULATOR_TOO_SMALL );
+        }
+
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT,
+                         "Fragment backup: %u", (unsigned) frag_backup_len );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT,
+                         "Accumulator backup: %u", (unsigned) acc_backup_len );
+
+        /* Move uncommitted parts from the accumulator to the front
+         * of the accumulator. */
+        memmove( acc, acc + acc_backup_offset, acc_backup_len );
+
+        /* Copy uncmmitted parts of the current fragment to the
+         * accumulator. */
+        memcpy( acc + acc_backup_len,
+                frag + frag_backup_offset, frag_backup_len );
+
+        rd->acc_available = backup_len;
         rd->acc_share.acc_remaining = pending;
 
         if( paused != NULL )
@@ -482,15 +550,17 @@ int mbedtls_reader_reclaim( mbedtls_reader *rd,
     rd->frag     = NULL;
     rd->frag_len = 0;
 
-    rd->commit = 0;
-    rd->end    = 0;
-    rd->pending  = 0;
+    rd->commit  = 0;
+    rd->end     = 0;
+    rd->pending = 0;
 
-    TRACE( trace_comment, "Final state: aa %u, al %u, ar %u",
-           (unsigned) rd->acc_avail, (unsigned) rd->acc_len,
-           (unsigned) rd->acc_share.acc_remaining );
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT,
+                       "Final state: aa %u, al %u, ar %u",
+                       (unsigned) rd->acc_available, (unsigned) rd->acc_len,
+                       (unsigned) rd->acc_share.acc_remaining );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
+
 
 /*
  * Implementation of extended reader
@@ -498,150 +568,149 @@ int mbedtls_reader_reclaim( mbedtls_reader *rd,
 
 /* TODO: Consider making (some of) these functions inline. */
 
-int mbedtls_reader_init_ext( mbedtls_reader_ext *rd_ext,
+int mbedtls_mps_reader_init_ext( mbedtls_mps_reader_ext *rd_ext,
                              mbedtls_mps_size_t size )
 {
-    mbedtls_reader_ext zero = { 0, { 0 }, NULL, 0, 0, };
-    TRACE_INIT( "reader_init_ext, size %u", (unsigned) size );
+    mbedtls_mps_reader_ext zero = { 0, { 0 }, NULL, 0, 0, };
+    MBEDTLS_MPS_TRACE_INIT( "reader_init_ext, size %u", (unsigned) size );
 
     *rd_ext = zero;
     rd_ext->grp_end[0] = size;
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
-int mbedtls_reader_free_ext( mbedtls_reader_ext *rd )
+int mbedtls_mps_reader_free_ext( mbedtls_mps_reader_ext *rd )
 {
-    mbedtls_reader_ext zero = { 0, { 0 }, NULL, 0, 0, };
-    TRACE_INIT( "reader_free_ext" );
+    mbedtls_mps_reader_ext zero = { 0, { 0 }, NULL, 0, 0, };
+    MBEDTLS_MPS_TRACE_INIT( "reader_free_ext" );
     *rd = zero;
 
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
-int mbedtls_reader_get_ext( mbedtls_reader_ext *rd_ext,
+int mbedtls_mps_reader_get_ext( mbedtls_mps_reader_ext *rd_ext,
                             mbedtls_mps_size_t desired,
                             unsigned char **buffer,
                             mbedtls_mps_size_t *buflen )
 {
     int ret;
     mbedtls_mps_size_t logic_avail;
-    TRACE_INIT( "reader_get_ext %p: desired %u", (void*) rd_ext, (unsigned) desired );
+    MBEDTLS_MPS_TRACE_INIT( "reader_get_ext %p: desired %u", (void*) rd_ext, (unsigned) desired );
 
     MBEDTLS_MPS_STATE_VALIDATE_RAW( rd_ext->rd != NULL,
-                "mbedtls_reader_get_ext() without underlying reader" );
+                "mbedtls_mps_reader_get_ext() without underlying reader" );
 
-    TRACE( trace_comment, "* Fetch offset: %u", (unsigned) rd_ext->ofs_fetch );
-    TRACE( trace_comment, "* Group end:    %u",
+    MBEDTLS_MPS_TRACE( trace_comment, "* Fetch offset: %u", (unsigned) rd_ext->ofs_fetch );
+    MBEDTLS_MPS_TRACE( trace_comment, "* Group end:    %u",
            (unsigned) rd_ext->grp_end[rd_ext->cur_grp] );
     logic_avail = rd_ext->grp_end[rd_ext->cur_grp] - rd_ext->ofs_fetch;
     if( desired > logic_avail )
     {
-        TRACE( trace_comment, "Requesting more data (%u) than logically available (%u)",
+        MBEDTLS_MPS_TRACE( trace_comment, "Requesting more data (%u) than logically available (%u)",
                (unsigned) desired, (unsigned) logic_avail );
-        RETURN( MBEDTLS_ERR_READER_BOUNDS_VIOLATION );
+        MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_READER_BOUNDS_VIOLATION );
     }
 
-    ret = mbedtls_reader_get( rd_ext->rd, desired, buffer, buflen );
+    ret = mbedtls_mps_reader_get( rd_ext->rd, desired, buffer, buflen );
     if( ret != 0 )
-        RETURN( ret );
+        MBEDTLS_MPS_TRACE_RETURN( ret );
 
     if( buflen != NULL )
         desired = *buflen;
 
     rd_ext->ofs_fetch += desired;
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
-int mbedtls_reader_commit_ext( mbedtls_reader_ext *rd_ext )
+int mbedtls_mps_reader_commit_ext( mbedtls_mps_reader_ext *rd_ext )
 {
     int ret;
-    TRACE_INIT( "reader_commit_ext" );
+    MBEDTLS_MPS_TRACE_INIT( "reader_commit_ext" );
 
     MBEDTLS_MPS_STATE_VALIDATE_RAW( rd_ext->rd != NULL,
-          "mbedtls_reader_commit_ext() without underlying reader" );
+          "mbedtls_mps_reader_commit_ext() without underlying reader" );
 
-    ret = mbedtls_reader_commit( rd_ext->rd );
+    ret = mbedtls_mps_reader_commit( rd_ext->rd );
     if( ret != 0 )
-        RETURN( ret );
+        MBEDTLS_MPS_TRACE_RETURN( ret );
 
     rd_ext->ofs_commit = rd_ext->ofs_fetch;
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
-int mbedtls_reader_group_open( mbedtls_reader_ext *rd_ext,
+int mbedtls_mps_reader_group_open( mbedtls_mps_reader_ext *rd_ext,
                                mbedtls_mps_size_t group_size )
 {
     /* Check how much space is left in the current group */
     mbedtls_mps_size_t const logic_avail =
         rd_ext->grp_end[rd_ext->cur_grp] - rd_ext->ofs_fetch;
-    TRACE_INIT( "reader_group_open, size %u", (unsigned) group_size );
+    MBEDTLS_MPS_TRACE_INIT( "reader_group_open, size %u", (unsigned) group_size );
 
-    if( rd_ext->cur_grp >= MBEDTLS_READER_MAX_GROUPS - 1 )
-        RETURN( MBEDTLS_ERR_READER_TOO_MANY_GROUPS );
+    if( rd_ext->cur_grp >= MBEDTLS_MPS_READER_MAX_GROUPS - 1 )
+        MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_READER_TOO_MANY_GROUPS );
 
     /* Make sure the new group doesn't exceed the present one */
     if( logic_avail < group_size )
-        RETURN( MBEDTLS_ERR_READER_BOUNDS_VIOLATION );
+        MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_READER_BOUNDS_VIOLATION );
 
     /* Add new group */
     rd_ext->cur_grp++;
     rd_ext->grp_end[rd_ext->cur_grp] = rd_ext->ofs_fetch + group_size;
 
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
-int mbedtls_reader_group_close( mbedtls_reader_ext *rd_ext )
+int mbedtls_mps_reader_group_close( mbedtls_mps_reader_ext *rd_ext )
 {
     /* Check how much space is left in the current group */
     mbedtls_mps_size_t const logic_avail =
         rd_ext->grp_end[rd_ext->cur_grp] - rd_ext->ofs_fetch;
-    TRACE_INIT( "reader_group_close" );
+    MBEDTLS_MPS_TRACE_INIT( "reader_group_close" );
 
     /* Ensure that the group is fully exhausted */
     if( logic_avail != 0 )
-        RETURN( MBEDTLS_ERR_READER_BOUNDS_VIOLATION );
+        MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_READER_BOUNDS_VIOLATION );
 
     if( rd_ext->cur_grp > 0 )
         rd_ext->cur_grp--;
 
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
-int mbedtls_reader_attach( mbedtls_reader_ext *rd_ext,
-                           mbedtls_reader *rd )
+int mbedtls_mps_reader_attach( mbedtls_mps_reader_ext *rd_ext,
+                           mbedtls_mps_reader *rd )
 {
-    TRACE_INIT( "reader_attach" );
+    MBEDTLS_MPS_TRACE_INIT( "reader_attach" );
 
     MBEDTLS_MPS_STATE_VALIDATE_RAW( rd_ext->rd == NULL,
-       "mbedtls_reader_attach() called with already attached ext. reader" );
+       "mbedtls_mps_reader_attach() called with already attached ext. reader" );
 
     rd_ext->rd = rd;
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
-int mbedtls_reader_detach( mbedtls_reader_ext *rd_ext )
+int mbedtls_mps_reader_detach( mbedtls_mps_reader_ext *rd_ext )
 {
-    TRACE_INIT( "reader_detach" );
+    MBEDTLS_MPS_TRACE_INIT( "reader_detach" );
 
     MBEDTLS_MPS_STATE_VALIDATE_RAW( rd_ext->rd != NULL,
-       "mbedtls_reader_attach() called with already detached ext. reader" );
+       "mbedtls_mps_reader_attach() called with already detached ext. reader" );
 
     rd_ext->ofs_fetch = rd_ext->ofs_commit;
     rd_ext->rd = NULL;
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
-int mbedtls_reader_check_done( mbedtls_reader_ext const *rd_ext )
+int mbedtls_mps_reader_check_done( mbedtls_mps_reader_ext const *rd_ext )
 {
-    TRACE_INIT( "reader_check_done" );
+    MBEDTLS_MPS_TRACE_INIT( "reader_check_done" );
     if( rd_ext->cur_grp > 0 ||
         rd_ext->ofs_commit != rd_ext->grp_end[0] )
     {
-        RETURN( MBEDTLS_ERR_READER_BOUNDS_VIOLATION );
+        MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_READER_BOUNDS_VIOLATION );
     }
 
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
-#endif /* MBEDTLS_MPS_SEPARATE_LAYERS) ||
-          MBEDTLS_MPS_TOP_TRANSLATION_UNIT */
+#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */

--- a/library/mps/trace.c
+++ b/library/mps/trace.c
@@ -1,11 +1,36 @@
+/*
+ *  Message Processing Stack, Trace module
+ *
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of Mbed TLS (https://tls.mbed.org)
+ */
 
-#include "../../include/mbedtls/mps/trace.h"
+#include "common.h"
 
-#if defined(MBEDTLS_MPS_TRACE)
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
 
-#include <stdio.h>
+#include "mbedtls/mps/common.h"
 
-static int trace_depth_ = 0;
+#if defined(MBEDTLS_MPS_ENABLE_TRACE)
+
+#include "mbedtls/mps/trace.h"
+#include <stdarg.h>
+
+static int trace_depth = 0;
 
 #define color_default  "\x1B[0m"
 #define color_red      "\x1B[1;31m"
@@ -27,27 +52,45 @@ static char const * colors[] =
     color_white
 };
 
-int get_trace_depth()
+#define MPS_TRACE_BUF_SIZE 100
+
+void mbedtls_mps_trace_print_msg( int id, int line, const char *format, ... )
 {
-    return trace_depth_;
-}
-void dec_trace_depth()
-{
-    trace_depth_--;
-}
-void inc_trace_depth()
-{
-    trace_depth_++;
+    int ret;
+    char str[MPS_TRACE_BUF_SIZE];
+    va_list argp;
+    va_start( argp, format );
+    ret = mbedtls_vsnprintf( str, MPS_TRACE_BUF_SIZE, format, argp );
+    va_end( argp );
+
+    if( ret >= 0 && ret < MPS_TRACE_BUF_SIZE )
+    {
+        str[ret] = '\0';
+        mbedtls_printf( "[%d|L%d]: %s\n", id, line, str );
+    }
 }
 
-void trace_color( int id )
+int mbedtls_mps_trace_get_depth()
+{
+    return trace_depth;
+}
+void mbedtls_mps_trace_dec_depth()
+{
+    trace_depth--;
+}
+void mbedtls_mps_trace_inc_depth()
+{
+    trace_depth++;
+}
+
+void mbedtls_mps_trace_color( int id )
 {
     if( id > (int) ( sizeof( colors ) / sizeof( *colors ) ) )
         return;
     printf( "%s", colors[ id ] );
 }
 
-void trace_indent( int level, trace_type ty )
+void mbedtls_mps_trace_indent( int level, mbedtls_mps_trace_type ty )
 {
     if( level > 0 )
     {
@@ -59,20 +102,20 @@ void trace_indent( int level, trace_type ty )
 
     switch( ty )
     {
-        case trace_comment:
-            printf( "@ " );
+        case MBEDTLS_MPS_TRACE_TYPE_COMMENT:
+            mbedtls_printf( "@ " );
             break;
 
-        case trace_call:
-            printf( "+--> " );
+        case MBEDTLS_MPS_TRACE_TYPE_CALL:
+            mbedtls_printf( "+--> " );
             break;
 
-        case trace_error:
-            printf( "E " );
+        case MBEDTLS_MPS_TRACE_TYPE_ERROR:
+            mbedtls_printf( "E " );
             break;
 
-        case trace_return:
-            printf( "< " );
+        case MBEDTLS_MPS_TRACE_TYPE_RETURN:
+            mbedtls_printf( "< " );
             break;
 
         default:
@@ -80,4 +123,5 @@ void trace_indent( int level, trace_type ty )
     }
 }
 
-#endif /* MBEDTLS_MPS_TRACE */
+#endif /* MBEDTLS_MPS_ENABLE_TRACE */
+#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */

--- a/library/mps/writer.c
+++ b/library/mps/writer.c
@@ -75,7 +75,7 @@ int mbedtls_writer_feed( mbedtls_writer *wr,
         mbedtls_mps_size_t qa, qr;
         qr = wr->queue_remaining;
         qa = wr->queue_next;
-        MBEDTLS_MPS_TRACE( trace_comment, "Queue data pending to be dispatched: %u",
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Queue data pending to be dispatched: %u",
                (unsigned) wr->queue_remaining );
 
         /* Copy as much data from the queue to
@@ -94,7 +94,7 @@ int mbedtls_writer_feed( mbedtls_writer *wr,
         if( qr > 0 )
         {
             /* More data waiting in the queue */
-            MBEDTLS_MPS_TRACE( trace_comment, "There are %u bytes remaining in the queue.",
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "There are %u bytes remaining in the queue.",
                    (unsigned) qr );
 
             qa += copy_from_queue;
@@ -104,7 +104,7 @@ int mbedtls_writer_feed( mbedtls_writer *wr,
         }
 
         /* The queue is empty. */
-        MBEDTLS_MPS_TRACE( trace_comment, "Queue is empty" );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Queue is empty" );
         wr->queue_next = 0;
         wr->queue_remaining = 0;
 
@@ -130,7 +130,7 @@ int mbedtls_writer_reclaim( mbedtls_writer *wr,
 {
     mbedtls_mps_size_t commit, ol;
     MBEDTLS_MPS_TRACE_INIT( "writer_reclaim" );
-    MBEDTLS_MPS_TRACE( trace_comment," * Force reclaim: %u", (unsigned) force );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT," * Force reclaim: %u", (unsigned) force );
 
     /* Check that the writer is in consuming mode. */
     MBEDTLS_MPS_STATE_VALIDATE_RAW(
@@ -141,8 +141,8 @@ int mbedtls_writer_reclaim( mbedtls_writer *wr,
     commit = wr->committed;
     ol = wr->out_len;
 
-    MBEDTLS_MPS_TRACE( trace_comment, "* Committed: %u Bytes", (unsigned) commit );
-    MBEDTLS_MPS_TRACE( trace_comment, "* Buffer length: %u Bytes", (unsigned) ol );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* Committed: %u Bytes", (unsigned) commit );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* Buffer length: %u Bytes", (unsigned) ol );
 
     if( commit <= ol )
     {
@@ -176,7 +176,7 @@ int mbedtls_writer_reclaim( mbedtls_writer *wr,
     if( queued != NULL )
     {
         mbedtls_mps_size_t qr = wr->queue_remaining;
-        MBEDTLS_MPS_TRACE( trace_comment, "%u Bytes are queued for dispatching.",
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "%u Bytes are queued for dispatching.",
                 (unsigned) wr->queue_remaining );
         *queued = qr;
     }
@@ -224,7 +224,7 @@ int mbedtls_writer_get( mbedtls_writer *wr,
     /* Check if we're already serving from the queue */
     if( end > ol )
     {
-        MBEDTLS_MPS_TRACE( trace_comment, "already serving from the queue, attempt to continue" );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "already serving from the queue, attempt to continue" );
 
         ql = wr->queue_len;
         /* If we're serving from the queue, queue_next denotes
@@ -238,13 +238,13 @@ int mbedtls_writer_get( mbedtls_writer *wr,
         {
             if( buflen == NULL )
             {
-                MBEDTLS_MPS_TRACE( trace_comment, "not enough space remaining in queue" );
+                MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "not enough space remaining in queue" );
                 MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_WRITER_OUT_OF_DATA );
             }
             desired = ql - qo;
         }
 
-        MBEDTLS_MPS_TRACE( trace_comment, "serving %u bytes from queue", (unsigned) desired );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "serving %u bytes from queue", (unsigned) desired );
 
         queue = wr->queue;
         end += desired;
@@ -260,11 +260,11 @@ int mbedtls_writer_get( mbedtls_writer *wr,
     /* We're still serving from the output buffer.
      * Check if there's enough space left in it. */
     or = ol - end;
-    MBEDTLS_MPS_TRACE( trace_comment, "%u bytes remaining in output buffer",
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "%u bytes remaining in output buffer",
            (unsigned) or );
     if( or < desired )
     {
-        MBEDTLS_MPS_TRACE( trace_comment, "need %u, but only %u remains in write buffer",
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "need %u, but only %u remains in write buffer",
                (unsigned) desired, (unsigned) or );
 
         queue  = wr->queue;
@@ -282,7 +282,7 @@ int mbedtls_writer_get( mbedtls_writer *wr,
             overflow = ( end + desired < end );
             if( overflow || desired > ql )
             {
-                MBEDTLS_MPS_TRACE( trace_comment, "queue present but too small, need %u but only got %u",
+                MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "queue present but too small, need %u but only got %u",
                        (unsigned) desired, (unsigned) ql );
                 MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_WRITER_OUT_OF_DATA );
             }
@@ -297,7 +297,7 @@ int mbedtls_writer_get( mbedtls_writer *wr,
 
             /* Remember the overlap between queue and output buffer. */
             wr->queue_next = or;
-            MBEDTLS_MPS_TRACE( trace_comment, "served from queue, qo %u",
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "served from queue, qo %u",
                    (unsigned) wr->queue_next );
 
             MBEDTLS_MPS_TRACE_RETURN( 0 );
@@ -307,7 +307,7 @@ int mbedtls_writer_get( mbedtls_writer *wr,
          * in the output buffer, provided the user allows it. */
         if( buflen == NULL )
         {
-            MBEDTLS_MPS_TRACE( trace_comment, "no queue present" );
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "no queue present" );
             MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_WRITER_OUT_OF_DATA );
         }
 
@@ -338,7 +338,7 @@ int mbedtls_writer_commit_partial( mbedtls_writer *wr,
     mbedtls_mps_size_t out_len, copy_from_queue;
     unsigned char *out, *queue;
     MBEDTLS_MPS_TRACE_INIT( "writer_commit_partial" );
-    MBEDTLS_MPS_TRACE( trace_comment, "* Omit %u bytes", (unsigned) omit );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* Omit %u bytes", (unsigned) omit );
 
     MBEDTLS_MPS_STATE_VALIDATE_RAW(
         wr->state == MBEDTLS_WRITER_CONSUMING,
@@ -426,11 +426,11 @@ int mbedtls_writer_get_ext( mbedtls_writer_ext *wr_ext,
         "Extended writer is blocked." );
 
     logic_avail = wr_ext->grp_end[wr_ext->cur_grp] - wr_ext->ofs_fetch;
-    MBEDTLS_MPS_TRACE( trace_comment, "desired %u, logic_avail %u",
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "desired %u, logic_avail %u",
            (unsigned) desired, (unsigned) logic_avail );
     if( desired > logic_avail )
     {
-        MBEDTLS_MPS_TRACE( trace_comment, "bounds violation!" );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "bounds violation!" );
         MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_WRITER_BOUNDS_VIOLATION );
     }
 
@@ -441,7 +441,7 @@ int mbedtls_writer_get_ext( mbedtls_writer_ext *wr_ext,
     if( buflen != NULL )
         desired = *buflen;
 
-    MBEDTLS_MPS_TRACE( trace_comment, "increase fetch offset from %u to %u",
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "increase fetch offset from %u to %u",
            (unsigned) wr_ext->ofs_fetch,
            (unsigned) ( wr_ext->ofs_fetch + desired )  );
 
@@ -472,7 +472,7 @@ int mbedtls_writer_commit_partial_ext( mbedtls_writer_ext *wr,
 
     if( omit > ofs_fetch - ofs_commit )
     {
-        MBEDTLS_MPS_TRACE( trace_error, "Try to omit %u bytes from commit, but only %u are uncommitted.",
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR, "Try to omit %u bytes from commit, but only %u are uncommitted.",
                (unsigned) omit, (unsigned)( ofs_fetch - ofs_commit ) );
         MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_WRITER_BOUNDS_VIOLATION );
     }
@@ -481,7 +481,7 @@ int mbedtls_writer_commit_partial_ext( mbedtls_writer_ext *wr,
 
     if( wr->passthrough == MBEDTLS_WRITER_EXT_PASS )
     {
-        MBEDTLS_MPS_TRACE( trace_comment, "Forward commit to underlying writer" );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Forward commit to underlying writer" );
         ret = mbedtls_writer_commit_partial( wr->wr, omit );
         if( ret != 0 )
             MBEDTLS_MPS_TRACE_RETURN( ret );
@@ -563,13 +563,13 @@ int mbedtls_writer_detach( mbedtls_writer_ext *wr_ext,
     if( uncommitted != NULL )
     {
         *uncommitted = wr_ext->ofs_fetch - wr_ext->ofs_commit;
-        MBEDTLS_MPS_TRACE( trace_comment, "Uncommitted: %u",
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Uncommitted: %u",
                (unsigned) *uncommitted );
     }
     if( committed != NULL )
     {
         *committed = wr_ext->ofs_commit;
-        MBEDTLS_MPS_TRACE( trace_comment, "Committed: %u",
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "Committed: %u",
                (unsigned) *committed );
     }
 
@@ -582,12 +582,12 @@ int mbedtls_writer_detach( mbedtls_writer_ext *wr_ext,
 int mbedtls_writer_check_done( mbedtls_writer_ext *wr_ext )
 {
     MBEDTLS_MPS_TRACE_INIT( "writer_check_done" );
-    MBEDTLS_MPS_TRACE( trace_comment, "* Commit: %u", (unsigned) wr_ext->ofs_commit );
-    MBEDTLS_MPS_TRACE( trace_comment, "* Group end: %u", (unsigned) wr_ext->grp_end[0] );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* Commit: %u", (unsigned) wr_ext->ofs_commit );
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "* Group end: %u", (unsigned) wr_ext->grp_end[0] );
 
     if( wr_ext->cur_grp > 0 )
     {
-        MBEDTLS_MPS_TRACE( trace_comment, "cur_grp > 0" );
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "cur_grp > 0" );
         MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_WRITER_BOUNDS_VIOLATION );
     }
 

--- a/library/mps/writer.c
+++ b/library/mps/writer.c
@@ -25,9 +25,9 @@
 #if defined(MBEDTLS_MPS_SEPARATE_LAYERS) ||     \
     defined(MBEDTLS_MPS_TOP_TRANSLATION_UNIT)
 
-#if defined(MBEDTLS_MPS_TRACE)
-static int trace_id = TRACE_BIT_WRITER;
-#endif /* MBEDTLS_MPS_TRACE */
+#if defined(MBEDTLS_MPS_ENABLE_TRACE)
+static int mbedtls_mps_trace_id = MBEDTLS_MPS_TRACE_BIT_WRITER;
+#endif /* MBEDTLS_MPS_ENABLE_TRACE */
 
 #include <string.h>
 
@@ -59,7 +59,7 @@ int mbedtls_writer_feed( mbedtls_writer *wr,
 {
     unsigned char *queue;
     mbedtls_mps_size_t copy_from_queue;
-    TRACE_INIT( "writer_feed, buflen %u",
+    MBEDTLS_MPS_TRACE_INIT( "writer_feed, buflen %u",
                 (unsigned) buf_len );
 
     /* Feeding is only possible in providing state. */
@@ -75,7 +75,7 @@ int mbedtls_writer_feed( mbedtls_writer *wr,
         mbedtls_mps_size_t qa, qr;
         qr = wr->queue_remaining;
         qa = wr->queue_next;
-        TRACE( trace_comment, "Queue data pending to be dispatched: %u",
+        MBEDTLS_MPS_TRACE( trace_comment, "Queue data pending to be dispatched: %u",
                (unsigned) wr->queue_remaining );
 
         /* Copy as much data from the queue to
@@ -94,17 +94,17 @@ int mbedtls_writer_feed( mbedtls_writer *wr,
         if( qr > 0 )
         {
             /* More data waiting in the queue */
-            TRACE( trace_comment, "There are %u bytes remaining in the queue.",
+            MBEDTLS_MPS_TRACE( trace_comment, "There are %u bytes remaining in the queue.",
                    (unsigned) qr );
 
             qa += copy_from_queue;
             wr->queue_remaining = qr;
             wr->queue_next = qa;
-            RETURN( MBEDTLS_ERR_WRITER_NEED_MORE );
+            MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_WRITER_NEED_MORE );
         }
 
         /* The queue is empty. */
-        TRACE( trace_comment, "Queue is empty" );
+        MBEDTLS_MPS_TRACE( trace_comment, "Queue is empty" );
         wr->queue_next = 0;
         wr->queue_remaining = 0;
 
@@ -120,7 +120,7 @@ int mbedtls_writer_feed( mbedtls_writer *wr,
     wr->committed = copy_from_queue;
     wr->end = copy_from_queue;
     wr->state = MBEDTLS_WRITER_CONSUMING;
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
 int mbedtls_writer_reclaim( mbedtls_writer *wr,
@@ -129,8 +129,8 @@ int mbedtls_writer_reclaim( mbedtls_writer *wr,
                             int force )
 {
     mbedtls_mps_size_t commit, ol;
-    TRACE_INIT( "writer_reclaim" );
-    TRACE( trace_comment," * Force reclaim: %u", (unsigned) force );
+    MBEDTLS_MPS_TRACE_INIT( "writer_reclaim" );
+    MBEDTLS_MPS_TRACE( trace_comment," * Force reclaim: %u", (unsigned) force );
 
     /* Check that the writer is in consuming mode. */
     MBEDTLS_MPS_STATE_VALIDATE_RAW(
@@ -141,8 +141,8 @@ int mbedtls_writer_reclaim( mbedtls_writer *wr,
     commit = wr->committed;
     ol = wr->out_len;
 
-    TRACE( trace_comment, "* Committed: %u Bytes", (unsigned) commit );
-    TRACE( trace_comment, "* Buffer length: %u Bytes", (unsigned) ol );
+    MBEDTLS_MPS_TRACE( trace_comment, "* Committed: %u Bytes", (unsigned) commit );
+    MBEDTLS_MPS_TRACE( trace_comment, "* Buffer length: %u Bytes", (unsigned) ol );
 
     if( commit <= ol )
     {
@@ -157,7 +157,7 @@ int mbedtls_writer_reclaim( mbedtls_writer *wr,
         if( commit < ol && force == 0 )
         {
             wr->end = commit;
-            RETURN( MBEDTLS_ERR_WRITER_DATA_LEFT );
+            MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_WRITER_DATA_LEFT );
         }
     }
     else
@@ -176,7 +176,7 @@ int mbedtls_writer_reclaim( mbedtls_writer *wr,
     if( queued != NULL )
     {
         mbedtls_mps_size_t qr = wr->queue_remaining;
-        TRACE( trace_comment, "%u Bytes are queued for dispatching.",
+        MBEDTLS_MPS_TRACE( trace_comment, "%u Bytes are queued for dispatching.",
                 (unsigned) wr->queue_remaining );
         *queued = qr;
     }
@@ -186,14 +186,14 @@ int mbedtls_writer_reclaim( mbedtls_writer *wr,
     wr->out = NULL;
     wr->out_len = 0;
     wr->state = MBEDTLS_WRITER_PROVIDING;
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
 int mbedtls_writer_bytes_written( mbedtls_writer *wr,
                                   mbedtls_mps_size_t *written )
 {
     mbedtls_mps_size_t commit;
-    TRACE_INIT( "writer_bytes_written" );
+    MBEDTLS_MPS_TRACE_INIT( "writer_bytes_written" );
 
     MBEDTLS_MPS_STATE_VALIDATE_RAW(
         wr->state == MBEDTLS_WRITER_PROVIDING,
@@ -202,7 +202,7 @@ int mbedtls_writer_bytes_written( mbedtls_writer *wr,
     commit = wr->committed;
     *written = commit;
 
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
 int mbedtls_writer_get( mbedtls_writer *wr,
@@ -212,7 +212,7 @@ int mbedtls_writer_get( mbedtls_writer *wr,
 {
     unsigned char *out, *queue;
     mbedtls_mps_size_t end, ol, or, ql, qn, qo;
-    TRACE_INIT( "writer_get, desired %u", (unsigned) desired );
+    MBEDTLS_MPS_TRACE_INIT( "writer_get, desired %u", (unsigned) desired );
 
     MBEDTLS_MPS_STATE_VALIDATE_RAW( wr->state == MBEDTLS_WRITER_CONSUMING,
                   "Attempt to request write-buffer outside consuming mode." );
@@ -224,27 +224,27 @@ int mbedtls_writer_get( mbedtls_writer *wr,
     /* Check if we're already serving from the queue */
     if( end > ol )
     {
-        TRACE( trace_comment, "already serving from the queue, attempt to continue" );
+        MBEDTLS_MPS_TRACE( trace_comment, "already serving from the queue, attempt to continue" );
 
         ql = wr->queue_len;
         /* If we're serving from the queue, queue_next denotes
          * the size of the overlap between queue and output buffer. */
         qn = wr->queue_next;
         qo = qn + ( end - ol );
-        TRACE( trace_comment, "queue overlap %u, queue used %u, queue remaining %u",
+        MBEDTLS_MPS_TRACE( trace_comment, "queue overlap %u, queue used %u, queue remaining %u",
                (unsigned) qn, (unsigned) qo, (unsigned) ( ql - qo ) );
 
         if( ql - qo < desired )
         {
             if( buflen == NULL )
             {
-                TRACE( trace_comment, "not enough space remaining in queue" );
-                RETURN( MBEDTLS_ERR_WRITER_OUT_OF_DATA );
+                MBEDTLS_MPS_TRACE( trace_comment, "not enough space remaining in queue" );
+                MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_WRITER_OUT_OF_DATA );
             }
             desired = ql - qo;
         }
 
-        TRACE( trace_comment, "serving %u bytes from queue", (unsigned) desired );
+        MBEDTLS_MPS_TRACE( trace_comment, "serving %u bytes from queue", (unsigned) desired );
 
         queue = wr->queue;
         end += desired;
@@ -254,17 +254,17 @@ int mbedtls_writer_get( mbedtls_writer *wr,
         if( buflen != NULL )
             *buflen = desired;
 
-        RETURN( 0 );
+        MBEDTLS_MPS_TRACE_RETURN( 0 );
     }
 
     /* We're still serving from the output buffer.
      * Check if there's enough space left in it. */
     or = ol - end;
-    TRACE( trace_comment, "%u bytes remaining in output buffer",
+    MBEDTLS_MPS_TRACE( trace_comment, "%u bytes remaining in output buffer",
            (unsigned) or );
     if( or < desired )
     {
-        TRACE( trace_comment, "need %u, but only %u remains in write buffer",
+        MBEDTLS_MPS_TRACE( trace_comment, "need %u, but only %u remains in write buffer",
                (unsigned) desired, (unsigned) or );
 
         queue  = wr->queue;
@@ -282,9 +282,9 @@ int mbedtls_writer_get( mbedtls_writer *wr,
             overflow = ( end + desired < end );
             if( overflow || desired > ql )
             {
-                TRACE( trace_comment, "queue present but too small, need %u but only got %u",
+                MBEDTLS_MPS_TRACE( trace_comment, "queue present but too small, need %u but only got %u",
                        (unsigned) desired, (unsigned) ql );
-                RETURN( MBEDTLS_ERR_WRITER_OUT_OF_DATA );
+                MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_WRITER_OUT_OF_DATA );
             }
 
             /* Queue large enough, transition to serving from queue. */
@@ -297,18 +297,18 @@ int mbedtls_writer_get( mbedtls_writer *wr,
 
             /* Remember the overlap between queue and output buffer. */
             wr->queue_next = or;
-            TRACE( trace_comment, "served from queue, qo %u",
+            MBEDTLS_MPS_TRACE( trace_comment, "served from queue, qo %u",
                    (unsigned) wr->queue_next );
 
-            RETURN( 0 );
+            MBEDTLS_MPS_TRACE_RETURN( 0 );
         }
 
         /* No queue present, so serve only what's available
          * in the output buffer, provided the user allows it. */
         if( buflen == NULL )
         {
-            TRACE( trace_comment, "no queue present" );
-            RETURN( MBEDTLS_ERR_WRITER_OUT_OF_DATA );
+            MBEDTLS_MPS_TRACE( trace_comment, "no queue present" );
+            MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_WRITER_OUT_OF_DATA );
         }
 
         desired = or;
@@ -323,7 +323,7 @@ int mbedtls_writer_get( mbedtls_writer *wr,
     if( buflen != NULL)
         *buflen = desired;
 
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
 int mbedtls_writer_commit( mbedtls_writer *wr )
@@ -337,8 +337,8 @@ int mbedtls_writer_commit_partial( mbedtls_writer *wr,
     mbedtls_mps_size_t to_be_committed, commit, end, queue_overlap;
     mbedtls_mps_size_t out_len, copy_from_queue;
     unsigned char *out, *queue;
-    TRACE_INIT( "writer_commit_partial" );
-    TRACE( trace_comment, "* Omit %u bytes", (unsigned) omit );
+    MBEDTLS_MPS_TRACE_INIT( "writer_commit_partial" );
+    MBEDTLS_MPS_TRACE( trace_comment, "* Omit %u bytes", (unsigned) omit );
 
     MBEDTLS_MPS_STATE_VALIDATE_RAW(
         wr->state == MBEDTLS_WRITER_CONSUMING,
@@ -351,13 +351,13 @@ int mbedtls_writer_commit_partial( mbedtls_writer *wr,
     out_len       = wr->out_len;
 
     if( omit > end - commit )
-        RETURN( MBEDTLS_ERR_WRITER_INVALID_ARG );
+        MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_WRITER_INVALID_ARG );
 
     to_be_committed = end - omit;
 
-    TRACE( trace_comment, "* Last commit:       %u", (unsigned) commit );
-    TRACE( trace_comment, "* End of last fetch: %u", (unsigned) end );
-    TRACE( trace_comment, "* New commit:        %u", (unsigned) to_be_committed );
+    MBEDTLS_MPS_TRACE( trace_comment, "* Last commit:       %u", (unsigned) commit );
+    MBEDTLS_MPS_TRACE( trace_comment, "* End of last fetch: %u", (unsigned) end );
+    MBEDTLS_MPS_TRACE( trace_comment, "* New commit:        %u", (unsigned) to_be_committed );
 
     if( end     > out_len &&
         commit  < out_len &&
@@ -369,7 +369,7 @@ int mbedtls_writer_commit_partial( mbedtls_writer *wr,
         if( copy_from_queue > queue_overlap )
             copy_from_queue = queue_overlap;
 
-        TRACE( trace_comment, "copy %u bytes from queue to output buffer",
+        MBEDTLS_MPS_TRACE( trace_comment, "copy %u bytes from queue to output buffer",
                (unsigned) copy_from_queue );
 
         queue = wr->queue;
@@ -383,7 +383,7 @@ int mbedtls_writer_commit_partial( mbedtls_writer *wr,
     wr->end       = to_be_committed;
     wr->committed = to_be_committed;
 
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
 /*
@@ -418,7 +418,7 @@ int mbedtls_writer_get_ext( mbedtls_writer_ext *wr_ext,
 {
     int ret;
     mbedtls_mps_size_t logic_avail;
-    TRACE_INIT( "writer_get_ext: desired %u", (unsigned) desired );
+    MBEDTLS_MPS_TRACE_INIT( "writer_get_ext: desired %u", (unsigned) desired );
 
     MBEDTLS_MPS_STATE_VALIDATE_RAW( wr_ext->wr != NULL, "No writer attached" );
     MBEDTLS_MPS_STATE_VALIDATE_RAW(
@@ -426,27 +426,27 @@ int mbedtls_writer_get_ext( mbedtls_writer_ext *wr_ext,
         "Extended writer is blocked." );
 
     logic_avail = wr_ext->grp_end[wr_ext->cur_grp] - wr_ext->ofs_fetch;
-    TRACE( trace_comment, "desired %u, logic_avail %u",
+    MBEDTLS_MPS_TRACE( trace_comment, "desired %u, logic_avail %u",
            (unsigned) desired, (unsigned) logic_avail );
     if( desired > logic_avail )
     {
-        TRACE( trace_comment, "bounds violation!" );
-        RETURN( MBEDTLS_ERR_WRITER_BOUNDS_VIOLATION );
+        MBEDTLS_MPS_TRACE( trace_comment, "bounds violation!" );
+        MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_WRITER_BOUNDS_VIOLATION );
     }
 
     ret = mbedtls_writer_get( wr_ext->wr, desired, buffer, buflen );
     if( ret != 0 )
-        RETURN( ret );
+        MBEDTLS_MPS_TRACE_RETURN( ret );
 
     if( buflen != NULL )
         desired = *buflen;
 
-    TRACE( trace_comment, "increase fetch offset from %u to %u",
+    MBEDTLS_MPS_TRACE( trace_comment, "increase fetch offset from %u to %u",
            (unsigned) wr_ext->ofs_fetch,
            (unsigned) ( wr_ext->ofs_fetch + desired )  );
 
     wr_ext->ofs_fetch += desired;
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
 int mbedtls_writer_commit_ext( mbedtls_writer_ext *wr )
@@ -459,7 +459,7 @@ int mbedtls_writer_commit_partial_ext( mbedtls_writer_ext *wr,
 {
     int ret;
     mbedtls_mps_size_t ofs_fetch, ofs_commit;
-    TRACE_INIT( "writer_commit_partial_ext, omit %u",
+    MBEDTLS_MPS_TRACE_INIT( "writer_commit_partial_ext, omit %u",
                 (unsigned) omit );
 
     MBEDTLS_MPS_STATE_VALIDATE_RAW( wr->wr != NULL, "No writer attached" );
@@ -472,19 +472,19 @@ int mbedtls_writer_commit_partial_ext( mbedtls_writer_ext *wr,
 
     if( omit > ofs_fetch - ofs_commit )
     {
-        TRACE( trace_error, "Try to omit %u bytes from commit, but only %u are uncommitted.",
+        MBEDTLS_MPS_TRACE( trace_error, "Try to omit %u bytes from commit, but only %u are uncommitted.",
                (unsigned) omit, (unsigned)( ofs_fetch - ofs_commit ) );
-        RETURN( MBEDTLS_ERR_WRITER_BOUNDS_VIOLATION );
+        MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_WRITER_BOUNDS_VIOLATION );
     }
 
     ofs_commit = ofs_fetch - omit;
 
     if( wr->passthrough == MBEDTLS_WRITER_EXT_PASS )
     {
-        TRACE( trace_comment, "Forward commit to underlying writer" );
+        MBEDTLS_MPS_TRACE( trace_comment, "Forward commit to underlying writer" );
         ret = mbedtls_writer_commit_partial( wr->wr, omit );
         if( ret != 0 )
-            RETURN( ret );
+            MBEDTLS_MPS_TRACE_RETURN( ret );
 
         ofs_fetch = ofs_commit;
     }
@@ -492,13 +492,13 @@ int mbedtls_writer_commit_partial_ext( mbedtls_writer_ext *wr,
     if( wr->passthrough == MBEDTLS_WRITER_EXT_HOLD &&
         omit > 0 )
     {
-        TRACE( trace_comment, "Partial commit, blocking writer" );
+        MBEDTLS_MPS_TRACE( trace_comment, "Partial commit, blocking writer" );
         wr->passthrough = MBEDTLS_WRITER_EXT_BLOCK;
     }
 
     wr->ofs_fetch  = ofs_fetch;
     wr->ofs_commit = ofs_commit;
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
 int mbedtls_writer_group_open( mbedtls_writer_ext *wr_ext,
@@ -507,20 +507,20 @@ int mbedtls_writer_group_open( mbedtls_writer_ext *wr_ext,
     /* Check how much space is left in the current group */
     mbedtls_mps_size_t const logic_avail =
         wr_ext->grp_end[wr_ext->cur_grp] - wr_ext->ofs_fetch;
-    TRACE_INIT( "writer_group_open, size %u", (unsigned) group_size );
+    MBEDTLS_MPS_TRACE_INIT( "writer_group_open, size %u", (unsigned) group_size );
 
     if( wr_ext->cur_grp >= MBEDTLS_WRITER_MAX_GROUPS - 1 )
-        RETURN( MBEDTLS_ERR_WRITER_TOO_MANY_GROUPS );
+        MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_WRITER_TOO_MANY_GROUPS );
 
     /* Make sure the new group doesn't exceed the present one */
     if( logic_avail < group_size )
-        RETURN( MBEDTLS_ERR_WRITER_BOUNDS_VIOLATION );
+        MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_WRITER_BOUNDS_VIOLATION );
 
     /* Add new group */
     wr_ext->cur_grp++;
     wr_ext->grp_end[wr_ext->cur_grp] = wr_ext->ofs_fetch + group_size;
 
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
 int mbedtls_writer_group_close( mbedtls_writer_ext *wr_ext )
@@ -528,76 +528,76 @@ int mbedtls_writer_group_close( mbedtls_writer_ext *wr_ext )
     /* Check how much space is left in the current group */
     mbedtls_mps_size_t const logic_avail =
         wr_ext->grp_end[wr_ext->cur_grp] - wr_ext->ofs_fetch;
-    TRACE_INIT( "writer_group_close" );
+    MBEDTLS_MPS_TRACE_INIT( "writer_group_close" );
 
     /* Ensure that the group is fully exhausted */
     if( logic_avail != 0 )
-        RETURN( MBEDTLS_ERR_WRITER_BOUNDS_VIOLATION );
+        MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_WRITER_BOUNDS_VIOLATION );
 
     if( wr_ext->cur_grp > 0 )
         wr_ext->cur_grp--;
 
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
 int mbedtls_writer_attach( mbedtls_writer_ext *wr_ext,
                            mbedtls_writer *wr,
                            int pass )
 {
-    TRACE_INIT( "mbedtls_writer_attach" );
+    MBEDTLS_MPS_TRACE_INIT( "mbedtls_writer_attach" );
     MBEDTLS_MPS_STATE_VALIDATE_RAW( wr_ext->wr == NULL, "Writer attached" );
 
     wr_ext->passthrough = pass;
     wr_ext->wr = wr;
 
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
 int mbedtls_writer_detach( mbedtls_writer_ext *wr_ext,
                            mbedtls_mps_size_t *committed,
                            mbedtls_mps_size_t *uncommitted )
 {
-    TRACE_INIT( "writer_check_detach" );
+    MBEDTLS_MPS_TRACE_INIT( "writer_check_detach" );
     MBEDTLS_MPS_STATE_VALIDATE_RAW( wr_ext->wr != NULL, "No writer attached" );
 
     if( uncommitted != NULL )
     {
         *uncommitted = wr_ext->ofs_fetch - wr_ext->ofs_commit;
-        TRACE( trace_comment, "Uncommitted: %u",
+        MBEDTLS_MPS_TRACE( trace_comment, "Uncommitted: %u",
                (unsigned) *uncommitted );
     }
     if( committed != NULL )
     {
         *committed = wr_ext->ofs_commit;
-        TRACE( trace_comment, "Committed: %u",
+        MBEDTLS_MPS_TRACE( trace_comment, "Committed: %u",
                (unsigned) *committed );
     }
 
     wr_ext->ofs_fetch = wr_ext->ofs_commit;
     wr_ext->wr = NULL;
 
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
 int mbedtls_writer_check_done( mbedtls_writer_ext *wr_ext )
 {
-    TRACE_INIT( "writer_check_done" );
-    TRACE( trace_comment, "* Commit: %u", (unsigned) wr_ext->ofs_commit );
-    TRACE( trace_comment, "* Group end: %u", (unsigned) wr_ext->grp_end[0] );
+    MBEDTLS_MPS_TRACE_INIT( "writer_check_done" );
+    MBEDTLS_MPS_TRACE( trace_comment, "* Commit: %u", (unsigned) wr_ext->ofs_commit );
+    MBEDTLS_MPS_TRACE( trace_comment, "* Group end: %u", (unsigned) wr_ext->grp_end[0] );
 
     if( wr_ext->cur_grp > 0 )
     {
-        TRACE( trace_comment, "cur_grp > 0" );
-        RETURN( MBEDTLS_ERR_WRITER_BOUNDS_VIOLATION );
+        MBEDTLS_MPS_TRACE( trace_comment, "cur_grp > 0" );
+        MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_WRITER_BOUNDS_VIOLATION );
     }
 
     if( wr_ext->grp_end[0] != MBEDTLS_MPS_SIZE_MAX &&
         wr_ext->ofs_commit != wr_ext->grp_end[0] )
     {
-        RETURN( MBEDTLS_ERR_WRITER_BOUNDS_VIOLATION );
+        MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_WRITER_BOUNDS_VIOLATION );
     }
 
-    RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
 #endif /* MBEDTLS_MPS_SEPARATE_LAYERS) ||

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -5837,7 +5837,7 @@ int mbedtls_ssl_read( mbedtls_ssl_context *ssl, unsigned char *buf, size_t len )
     int ret, msg_type;
     size_t data_read;
     unsigned char *src;
-    mbedtls_reader *rd;
+    mbedtls_mps_reader *rd;
 
     ret = mbedtls_ssl_handle_pending_alert( ssl );
     if( ret != 0 )
@@ -5877,9 +5877,9 @@ int mbedtls_ssl_read( mbedtls_ssl_context *ssl, unsigned char *buf, size_t len )
         return( MBEDTLS_ERR_SSL_UNEXPECTED_MESSAGE );
 
     MBEDTLS_SSL_PROC_CHK( mbedtls_mps_read_application( &ssl->mps.l4, &rd ) );
-    MBEDTLS_SSL_PROC_CHK( mbedtls_reader_get( rd, len, &src, &data_read ) );
+    MBEDTLS_SSL_PROC_CHK( mbedtls_mps_reader_get( rd, len, &src, &data_read ) );
     memcpy( buf, src, data_read );
-    MBEDTLS_SSL_PROC_CHK( mbedtls_reader_commit( rd ) );
+    MBEDTLS_SSL_PROC_CHK( mbedtls_mps_reader_commit( rd ) );
     MBEDTLS_SSL_PROC_CHK( mbedtls_mps_read_consume( &ssl->mps.l4 ) );
     return( data_read );
 

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -2977,7 +2977,7 @@ static int ssl_server_hello_process( mbedtls_ssl_context* ssl )
         mbedtls_ssl_add_hs_msg_to_checksum( ssl, MBEDTLS_SSL_HS_SERVER_HELLO,
                                             buf, buflen );
 
-        MBEDTLS_SSL_PROC_CHK( mbedtls_reader_commit_ext( msg.handle ) );
+        MBEDTLS_SSL_PROC_CHK( mbedtls_mps_reader_commit_ext( msg.handle ) );
         MBEDTLS_SSL_PROC_CHK( mbedtls_mps_read_consume( &ssl->mps.l4  ) );
 #endif /* MBEDTLS_SSL_USE_MPS */
 
@@ -2988,7 +2988,7 @@ static int ssl_server_hello_process( mbedtls_ssl_context* ssl )
         MBEDTLS_SSL_PROC_CHK( ssl_hrr_parse( ssl, buf, buflen ) );
 
 #if defined(MBEDTLS_SSL_USE_MPS)
-        MBEDTLS_SSL_PROC_CHK( mbedtls_reader_commit_ext( msg.handle ) );
+        MBEDTLS_SSL_PROC_CHK( mbedtls_mps_reader_commit_ext( msg.handle ) );
         MBEDTLS_SSL_PROC_CHK( mbedtls_mps_read_consume( &ssl->mps.l4  ) );
 #endif /* MBEDTLS_SSL_USE_MPS */
 
@@ -3064,12 +3064,12 @@ static int ssl_server_hello_coordinate( mbedtls_ssl_context* ssl,
     if( msg->type != MBEDTLS_SSL_HS_SERVER_HELLO )
         return( MBEDTLS_ERR_SSL_UNEXPECTED_MESSAGE );
 
-    ret = mbedtls_reader_get_ext( msg->handle,
+    ret = mbedtls_mps_reader_get_ext( msg->handle,
                                   msg->length,
                                   &peak,
                                   NULL );
 
-    if( ret == MBEDTLS_ERR_READER_OUT_OF_DATA )
+    if( ret == MBEDTLS_ERR_MPS_READER_OUT_OF_DATA )
     {
         MBEDTLS_SSL_PROC_CHK( mbedtls_mps_read_pause( &ssl->mps.l4 ) );
         ret = MBEDTLS_ERR_SSL_WANT_READ;

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -172,12 +172,12 @@ int mbedtls_ssl_mps_fetch_full_hs_msg( mbedtls_ssl_context *ssl,
     if( msg.type != hs_type )
         return( MBEDTLS_ERR_SSL_UNEXPECTED_MESSAGE );
 
-    ret = mbedtls_reader_get_ext( msg.handle,
+    ret = mbedtls_mps_reader_get_ext( msg.handle,
                                   msg.length,
                                   buf,
                                   NULL );
 
-    if( ret == MBEDTLS_ERR_READER_OUT_OF_DATA )
+    if( ret == MBEDTLS_ERR_MPS_READER_OUT_OF_DATA )
     {
         MBEDTLS_SSL_PROC_CHK( mbedtls_mps_read_pause( &ssl->mps.l4 ) );
         ret = MBEDTLS_ERR_SSL_WANT_READ;
@@ -186,7 +186,7 @@ int mbedtls_ssl_mps_fetch_full_hs_msg( mbedtls_ssl_context *ssl,
     {
         MBEDTLS_SSL_PROC_CHK( ret );
 
-        /* *buf already set in mbedtls_reader_get_ext() */
+        /* *buf already set in mbedtls_mps_reader_get_ext() */
         *buflen = msg.length;
     }
 
@@ -203,7 +203,7 @@ int mbedtls_ssl_mps_hs_consume_full_hs_msg( mbedtls_ssl_context *ssl )
     MBEDTLS_SSL_PROC_CHK( mbedtls_mps_read_handshake( &ssl->mps.l4,
                                                       &msg ) );
 
-    MBEDTLS_SSL_PROC_CHK( mbedtls_reader_commit_ext( msg.handle ) );
+    MBEDTLS_SSL_PROC_CHK( mbedtls_mps_reader_commit_ext( msg.handle ) );
     MBEDTLS_SSL_PROC_CHK( mbedtls_mps_read_consume( &ssl->mps.l4 ) );
 
 cleanup:

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -1843,7 +1843,7 @@ int ssl_read_early_data_process( mbedtls_ssl_context* ssl );
 
 #if defined(MBEDTLS_SSL_USE_MPS)
 static int ssl_early_data_fetch( mbedtls_ssl_context* ssl,
-                                 mbedtls_reader **reader );
+                                 mbedtls_mps_reader **reader );
 #else
 static int ssl_early_data_fetch( mbedtls_ssl_context* ssl,
                                  unsigned char** buf,
@@ -1879,17 +1879,17 @@ int ssl_read_early_data_process( mbedtls_ssl_context* ssl )
         unsigned char *buf;
         size_t buflen;
 #if defined(MBEDTLS_SSL_USE_MPS)
-        mbedtls_reader *rd;
+        mbedtls_mps_reader *rd;
 #endif /* MBEDTLS_SSL_USE_MPS */
 
 #if defined(MBEDTLS_SSL_USE_MPS)
         MBEDTLS_SSL_PROC_CHK( ssl_early_data_fetch( ssl, &rd ) );
-        MBEDTLS_SSL_PROC_CHK( mbedtls_reader_get( rd,
+        MBEDTLS_SSL_PROC_CHK( mbedtls_mps_reader_get( rd,
                                                   MBEDTLS_MPS_SIZE_MAX,
                                                   &buf,
                                                   &buflen ) );
         MBEDTLS_SSL_PROC_CHK( ssl_read_early_data_parse( ssl, buf, buflen ) );
-        MBEDTLS_SSL_PROC_CHK( mbedtls_reader_commit( rd ) );
+        MBEDTLS_SSL_PROC_CHK( mbedtls_mps_reader_commit( rd ) );
         MBEDTLS_SSL_PROC_CHK( mbedtls_mps_read_consume( &ssl->mps.l4 ) );
 
 #else /* MBEDTLS_SSL_USE_MPS */
@@ -1922,7 +1922,7 @@ cleanup:
 
 #if defined(MBEDTLS_SSL_USE_MPS)
 static int ssl_early_data_fetch( mbedtls_ssl_context *ssl,
-                                 mbedtls_reader **rd )
+                                 mbedtls_mps_reader **rd )
 {
     int ret;
     MBEDTLS_SSL_PROC_CHK_NEG( mbedtls_mps_read( &ssl->mps.l4 ) );

--- a/tests/suites/test_suite_mps.data
+++ b/tests/suites/test_suite_mps.data
@@ -59,31 +59,31 @@ MPS Reader: Pausing, feed 50 bytes in 49x1b + 51b
 mbedtls_mps_reader_pausing_multiple_feeds:2
 
 MPS Reader: Pausing, inconsistent continuation, #0
-mbedtls_reader_inconsistent_usage:0
+mbedtls_mps_reader_inconsistent_usage:0
 
 MPS Reader: Pausing, inconsistent continuation, #1
-mbedtls_reader_inconsistent_usage:1
+mbedtls_mps_reader_inconsistent_usage:1
 
 MPS Reader: Pausing, inconsistent continuation, #2
-mbedtls_reader_inconsistent_usage:2
+mbedtls_mps_reader_inconsistent_usage:2
 
 MPS Reader: Pausing, inconsistent continuation, #3
-mbedtls_reader_inconsistent_usage:3
+mbedtls_mps_reader_inconsistent_usage:3
 
 MPS Reader: Pausing, inconsistent continuation, #4
-mbedtls_reader_inconsistent_usage:4
+mbedtls_mps_reader_inconsistent_usage:4
 
 MPS Reader: Pausing, inconsistent continuation, #5
-mbedtls_reader_inconsistent_usage:5
+mbedtls_mps_reader_inconsistent_usage:5
 
 MPS Reader: Pausing, inconsistent continuation, #6
-mbedtls_reader_inconsistent_usage:6
+mbedtls_mps_reader_inconsistent_usage:6
 
 MPS Reader: Pausing, inconsistent continuation, #7
-mbedtls_reader_inconsistent_usage:7
+mbedtls_mps_reader_inconsistent_usage:7
 
 MPS Reader: Pausing, inconsistent continuation, #8
-mbedtls_reader_inconsistent_usage:8
+mbedtls_mps_reader_inconsistent_usage:8
 
 MPS Reader: Reclaim with data remaining #0
 mbedtls_mps_reader_reclaim_data_left:0

--- a/tests/suites/test_suite_mps.function
+++ b/tests/suites/test_suite_mps.function
@@ -1,6 +1,6 @@
 
 /*
- * TODO: Test second argument in mbedtls_reader_reclaim!
+ * TODO: Test second argument in mbedtls_mps_reader_reclaim!
  */
 
 /* BEGIN_HEADER */
@@ -1371,17 +1371,17 @@ void mbedtls_mps_reader_feed_empty( int option )
 {
     unsigned char buf[100];
     unsigned char *tmp;
-    mbedtls_reader rd;
+    mbedtls_mps_reader rd;
     for( int i=0; (unsigned) i < sizeof( buf ); i++ )
         buf[i] = (unsigned char) i;
 
     /* Preparation (lower layer) */
-    mbedtls_reader_init( &rd, NULL, 0 );
+    mbedtls_mps_reader_init( &rd, NULL, 0 );
     switch( option )
     {
         case 0: /* NULL buffer */
-            TEST_ASSERT( mbedtls_reader_feed( &rd, NULL, sizeof( buf ) ) ==
-                         MBEDTLS_ERR_READER_INVALID_ARG );
+            TEST_ASSERT( mbedtls_mps_reader_feed( &rd, NULL, sizeof( buf ) ) ==
+                         MBEDTLS_ERR_MPS_READER_INVALID_ARG );
             break;
 
         default:
@@ -1389,16 +1389,16 @@ void mbedtls_mps_reader_feed_empty( int option )
             break;
     }
     /* Subsequent feed-calls should still succeed. */
-    TEST_ASSERT( mbedtls_reader_feed( &rd, buf, sizeof( buf ) ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_feed( &rd, buf, sizeof( buf ) ) == 0 );
 
     /* Consumption (upper layer) */
-    TEST_ASSERT( mbedtls_reader_get( &rd, 100, &tmp, NULL ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_get( &rd, 100, &tmp, NULL ) == 0 );
     TEST_ASSERT( memcmp( tmp, buf, 100 ) == 0 );
-    TEST_ASSERT( mbedtls_reader_commit( &rd ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_commit( &rd ) == 0 );
 
     /* Wrapup */
-    TEST_ASSERT( mbedtls_reader_reclaim( &rd, NULL ) == 0 );
-    mbedtls_reader_free( &rd );
+    TEST_ASSERT( mbedtls_mps_reader_reclaim( &rd, NULL ) == 0 );
+    mbedtls_mps_reader_free( &rd );
 }
 /* END_CASE */
 
@@ -1410,24 +1410,24 @@ void mbedtls_mps_reader_no_pausing_single_step_single_round( int with_acc )
     unsigned char bufA[100];
     unsigned char acc[10];
     unsigned char *tmp;
-    mbedtls_reader rd;
+    mbedtls_mps_reader rd;
     for( int i=0; (unsigned) i < sizeof( bufA ); i++ )
         bufA[i] = (unsigned char) i;
 
     /* Preparation (lower layer) */
     if( with_acc == 0 )
-        mbedtls_reader_init( &rd, NULL, 0 );
+        mbedtls_mps_reader_init( &rd, NULL, 0 );
     else
-        mbedtls_reader_init( &rd, acc, sizeof( acc ) );
-    TEST_ASSERT( mbedtls_reader_feed( &rd, bufA, sizeof( bufA ) ) == 0 );
+        mbedtls_mps_reader_init( &rd, acc, sizeof( acc ) );
+    TEST_ASSERT( mbedtls_mps_reader_feed( &rd, bufA, sizeof( bufA ) ) == 0 );
     /* Consumption (upper layer) */
     /* Consume exactly what's available */
-    TEST_ASSERT( mbedtls_reader_get( &rd, 100, &tmp, NULL ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_get( &rd, 100, &tmp, NULL ) == 0 );
     TEST_ASSERT( memcmp( tmp, bufA, 100 ) == 0 );
-    TEST_ASSERT( mbedtls_reader_commit( &rd ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_commit( &rd ) == 0 );
     /* Wrapup (lower layer) */
-    TEST_ASSERT( mbedtls_reader_reclaim( &rd, NULL ) == 0 );
-    mbedtls_reader_free( &rd );
+    TEST_ASSERT( mbedtls_mps_reader_reclaim( &rd, NULL ) == 0 );
+    mbedtls_mps_reader_free( &rd );
 }
 /* END_CASE */
 
@@ -1439,7 +1439,7 @@ void mbedtls_mps_reader_no_pausing_single_step_multiple_rounds( int with_acc )
     unsigned char bufA[100], bufB[100];
     unsigned char acc[10];
     unsigned char *tmp;
-    mbedtls_reader rd;
+    mbedtls_mps_reader rd;
     for( int i=0; (unsigned) i < sizeof( bufA ); i++ )
         bufA[i] = (unsigned char) i;
     for( int i=0; (unsigned) i < sizeof( bufB ); i++ )
@@ -1447,25 +1447,25 @@ void mbedtls_mps_reader_no_pausing_single_step_multiple_rounds( int with_acc )
 
     /* Preparation (lower layer) */
     if( with_acc == 0 )
-        mbedtls_reader_init( &rd, NULL, 0 );
+        mbedtls_mps_reader_init( &rd, NULL, 0 );
     else
-        mbedtls_reader_init( &rd, acc, sizeof( acc ) );
-    TEST_ASSERT( mbedtls_reader_feed( &rd, bufA, sizeof( bufA ) ) == 0 );
+        mbedtls_mps_reader_init( &rd, acc, sizeof( acc ) );
+    TEST_ASSERT( mbedtls_mps_reader_feed( &rd, bufA, sizeof( bufA ) ) == 0 );
     /* Consumption (upper layer) */
     /* Consume exactly what's available */
-    TEST_ASSERT( mbedtls_reader_get( &rd, 100, &tmp, NULL ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_get( &rd, 100, &tmp, NULL ) == 0 );
     TEST_ASSERT( memcmp( tmp, bufA, 100 ) == 0 );
-    TEST_ASSERT( mbedtls_reader_commit( &rd ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_commit( &rd ) == 0 );
     /* Preparation */
-    TEST_ASSERT( mbedtls_reader_reclaim( &rd, NULL ) == 0 );
-    TEST_ASSERT( mbedtls_reader_feed( &rd, bufB, sizeof( bufB ) ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_reclaim( &rd, NULL ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_feed( &rd, bufB, sizeof( bufB ) ) == 0 );
     /* Consumption */
-    TEST_ASSERT( mbedtls_reader_get( &rd, 100, &tmp, NULL ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_get( &rd, 100, &tmp, NULL ) == 0 );
     TEST_ASSERT( memcmp( tmp, bufB, 100 ) == 0 );
-    TEST_ASSERT( mbedtls_reader_commit( &rd ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_commit( &rd ) == 0 );
     /* Wrapup (lower layer) */
-    TEST_ASSERT( mbedtls_reader_reclaim( &rd, NULL ) == 0 );
-    mbedtls_reader_free( &rd );
+    TEST_ASSERT( mbedtls_mps_reader_reclaim( &rd, NULL ) == 0 );
+    mbedtls_mps_reader_free( &rd );
 }
 /* END_CASE */
 
@@ -1478,28 +1478,28 @@ void mbedtls_mps_reader_no_pausing_multiple_steps_single_round( int with_acc )
     unsigned char acc[10];
     unsigned char *tmp;
     mbedtls_mps_size_t tmp_len;
-    mbedtls_reader rd;
+    mbedtls_mps_reader rd;
     for( int i=0; (unsigned) i < sizeof( buf ); i++ )
         buf[i] = (unsigned char) i;
 
     /* Preparation (lower layer) */
     if( with_acc == 0 )
-        mbedtls_reader_init( &rd, NULL, 0 );
+        mbedtls_mps_reader_init( &rd, NULL, 0 );
     else
-        mbedtls_reader_init( &rd, acc, sizeof( acc ) );
-    TEST_ASSERT( mbedtls_reader_feed( &rd, buf, sizeof( buf ) ) == 0 );
+        mbedtls_mps_reader_init( &rd, acc, sizeof( acc ) );
+    TEST_ASSERT( mbedtls_mps_reader_feed( &rd, buf, sizeof( buf ) ) == 0 );
     /* Consumption (upper layer) */
-    TEST_ASSERT( mbedtls_reader_get( &rd, 10, &tmp, NULL ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_get( &rd, 10, &tmp, NULL ) == 0 );
     TEST_ASSERT( memcmp( tmp, buf, 10 ) == 0 );
-    TEST_ASSERT( mbedtls_reader_get( &rd, 70, &tmp, NULL ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_get( &rd, 70, &tmp, NULL ) == 0 );
     TEST_ASSERT( memcmp( tmp, buf + 10, 70 ) == 0 );
-    TEST_ASSERT( mbedtls_reader_get( &rd, 30, &tmp, &tmp_len ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_get( &rd, 30, &tmp, &tmp_len ) == 0 );
     TEST_ASSERT( tmp_len == 20 );
     TEST_ASSERT( memcmp( tmp, buf + 80, 20 ) == 0 );
-    TEST_ASSERT( mbedtls_reader_commit( &rd ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_commit( &rd ) == 0 );
     /* Wrapup (lower layer) */
-    TEST_ASSERT( mbedtls_reader_reclaim( &rd, NULL ) == 0 );
-    mbedtls_reader_free( &rd );
+    TEST_ASSERT( mbedtls_mps_reader_reclaim( &rd, NULL ) == 0 );
+    mbedtls_mps_reader_free( &rd );
 }
 /* END_CASE */
 
@@ -1512,7 +1512,7 @@ void mbedtls_mps_reader_no_pausing_multiple_steps_multiple_rounds( int with_acc 
     unsigned char acc[10];
     unsigned char *tmp;
     mbedtls_mps_size_t tmp_len;
-    mbedtls_reader rd;
+    mbedtls_mps_reader rd;
     for( int i=0; (unsigned) i < sizeof( bufA ); i++ )
         bufA[i] = (unsigned char) i;
     for( int i=0; (unsigned) i < sizeof( bufB ); i++ )
@@ -1520,29 +1520,29 @@ void mbedtls_mps_reader_no_pausing_multiple_steps_multiple_rounds( int with_acc 
 
     /* Preparation (lower layer) */
     if( with_acc == 0 )
-        mbedtls_reader_init( &rd, NULL, 0 );
+        mbedtls_mps_reader_init( &rd, NULL, 0 );
     else
-        mbedtls_reader_init( &rd, acc, sizeof( acc ) );
-    TEST_ASSERT( mbedtls_reader_feed( &rd, bufA, sizeof( bufA ) ) == 0 );
+        mbedtls_mps_reader_init( &rd, acc, sizeof( acc ) );
+    TEST_ASSERT( mbedtls_mps_reader_feed( &rd, bufA, sizeof( bufA ) ) == 0 );
     /* Consumption (upper layer) */
-    TEST_ASSERT( mbedtls_reader_get( &rd, 10, &tmp, NULL ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_get( &rd, 10, &tmp, NULL ) == 0 );
     TEST_ASSERT( memcmp( tmp, bufA, 10 ) == 0 );
-    TEST_ASSERT( mbedtls_reader_get( &rd, 70, &tmp, NULL ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_get( &rd, 70, &tmp, NULL ) == 0 );
     TEST_ASSERT( memcmp( tmp, bufA + 10, 70 ) == 0 );
-    TEST_ASSERT( mbedtls_reader_get( &rd, 30, &tmp, &tmp_len ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_get( &rd, 30, &tmp, &tmp_len ) == 0 );
     TEST_ASSERT( tmp_len == 20 );
     TEST_ASSERT( memcmp( tmp, bufA + 80, 20 ) == 0 );
-    TEST_ASSERT( mbedtls_reader_commit( &rd ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_commit( &rd ) == 0 );
     /* Preparation */
-    TEST_ASSERT( mbedtls_reader_reclaim( &rd, NULL ) == 0 );
-    TEST_ASSERT( mbedtls_reader_feed( &rd, bufB, sizeof( bufB ) ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_reclaim( &rd, NULL ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_feed( &rd, bufB, sizeof( bufB ) ) == 0 );
     /* Consumption */
-    TEST_ASSERT( mbedtls_reader_get( &rd, 100, &tmp, NULL ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_get( &rd, 100, &tmp, NULL ) == 0 );
     TEST_ASSERT( memcmp( tmp, bufB, 100 ) == 0 );
-    TEST_ASSERT( mbedtls_reader_commit( &rd ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_commit( &rd ) == 0 );
     /* Wrapup */
-    TEST_ASSERT( mbedtls_reader_reclaim( &rd, NULL ) == 0 );
-    mbedtls_reader_free( &rd );
+    TEST_ASSERT( mbedtls_mps_reader_reclaim( &rd, NULL ) == 0 );
+    mbedtls_mps_reader_free( &rd );
 }
 /* END_CASE */
 
@@ -1553,23 +1553,23 @@ void mbedtls_mps_reader_pausing_needed_disabled()
      * and pausing is not used, expected OUT_OF_DATA. */
     unsigned char buf[100];
     unsigned char *tmp;
-    mbedtls_reader rd;
+    mbedtls_mps_reader rd;
     for( int i=0; (unsigned) i < sizeof( buf ); i++ )
         buf[i] = (unsigned char) i;
 
     /* Preparation (lower layer) */
-    mbedtls_reader_init( &rd, NULL, 0 );
-    TEST_ASSERT( mbedtls_reader_feed( &rd, buf, sizeof( buf ) ) == 0 );
+    mbedtls_mps_reader_init( &rd, NULL, 0 );
+    TEST_ASSERT( mbedtls_mps_reader_feed( &rd, buf, sizeof( buf ) ) == 0 );
     /* Consumption (upper layer) */
-    TEST_ASSERT( mbedtls_reader_get( &rd, 50, &tmp, NULL ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_get( &rd, 50, &tmp, NULL ) == 0 );
     TEST_ASSERT( memcmp( tmp, buf, 50 ) == 0 );
-    TEST_ASSERT( mbedtls_reader_commit( &rd ) == 0 );
-    TEST_ASSERT( mbedtls_reader_get( &rd, 100, &tmp, NULL ) ==
-                 MBEDTLS_ERR_READER_OUT_OF_DATA );
+    TEST_ASSERT( mbedtls_mps_reader_commit( &rd ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_get( &rd, 100, &tmp, NULL ) ==
+                 MBEDTLS_ERR_MPS_READER_OUT_OF_DATA );
     /* Wrapup (lower layer) */
-    TEST_ASSERT( mbedtls_reader_reclaim( &rd, NULL ) ==
-                 MBEDTLS_ERR_READER_NEED_ACCUMULATOR );
-    mbedtls_reader_free( &rd );
+    TEST_ASSERT( mbedtls_mps_reader_reclaim( &rd, NULL ) ==
+                 MBEDTLS_ERR_MPS_READER_NEED_ACCUMULATOR );
+    mbedtls_mps_reader_free( &rd );
 }
 /* END_CASE */
 
@@ -1582,23 +1582,23 @@ void mbedtls_mps_reader_pausing_needed_buffer_too_small()
     unsigned char buf[100];
     unsigned char acc[10];
     unsigned char *tmp;
-    mbedtls_reader rd;
+    mbedtls_mps_reader rd;
     for( int i=0; (unsigned) i < sizeof( buf ); i++ )
         buf[i] = (unsigned char) i;
 
     /* Preparation (lower layer) */
-    mbedtls_reader_init( &rd, acc, sizeof( acc ) );
-    TEST_ASSERT( mbedtls_reader_feed( &rd, buf, sizeof( buf ) ) == 0 );
+    mbedtls_mps_reader_init( &rd, acc, sizeof( acc ) );
+    TEST_ASSERT( mbedtls_mps_reader_feed( &rd, buf, sizeof( buf ) ) == 0 );
     /* Consumption (upper layer) */
-    TEST_ASSERT( mbedtls_reader_get( &rd, 50, &tmp, NULL ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_get( &rd, 50, &tmp, NULL ) == 0 );
     TEST_ASSERT( memcmp( tmp, buf, 50 ) == 0 );
-    TEST_ASSERT( mbedtls_reader_commit( &rd ) == 0 );
-    TEST_ASSERT( mbedtls_reader_get( &rd, 100, &tmp, NULL ) ==
-                 MBEDTLS_ERR_READER_OUT_OF_DATA );
+    TEST_ASSERT( mbedtls_mps_reader_commit( &rd ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_get( &rd, 100, &tmp, NULL ) ==
+                 MBEDTLS_ERR_MPS_READER_OUT_OF_DATA );
     /* Wrapup (lower layer) */
-    TEST_ASSERT( mbedtls_reader_reclaim( &rd, NULL ) ==
-                 MBEDTLS_ERR_READER_ACCUMULATOR_TOO_SMALL );
-    mbedtls_reader_free( &rd );
+    TEST_ASSERT( mbedtls_mps_reader_reclaim( &rd, NULL ) ==
+                 MBEDTLS_ERR_MPS_READER_ACCUMULATOR_TOO_SMALL );
+    mbedtls_mps_reader_free( &rd );
 }
 /* END_CASE */
 
@@ -1609,7 +1609,7 @@ void mbedtls_mps_reader_multiple_pausing( int option )
     unsigned char *tmp;
     unsigned char acc[50];
     mbedtls_mps_size_t tmp_len;
-    mbedtls_reader rd;
+    mbedtls_mps_reader rd;
     for( int i=0; (unsigned) i < sizeof( bufA ); i++ )
         bufA[i] = (unsigned char) i;
     for( int i=0; (unsigned) i < sizeof( bufB ); i++ )
@@ -1618,22 +1618,22 @@ void mbedtls_mps_reader_multiple_pausing( int option )
         bufC[i] = ~ ((unsigned char) i);
 
     /* Preparation (lower layer) */
-    mbedtls_reader_init( &rd, acc, sizeof( acc ) );
-    TEST_ASSERT( mbedtls_reader_feed( &rd, bufA, sizeof( bufA ) ) == 0 );
+    mbedtls_mps_reader_init( &rd, acc, sizeof( acc ) );
+    TEST_ASSERT( mbedtls_mps_reader_feed( &rd, bufA, sizeof( bufA ) ) == 0 );
 
     /* Consumption (upper layer) */
     /* Ask for more than what's available. */
-    TEST_ASSERT( mbedtls_reader_get( &rd, 80, &tmp, NULL ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_get( &rd, 80, &tmp, NULL ) == 0 );
     TEST_ASSERT( memcmp( tmp, bufA, 80 ) == 0 );
-    TEST_ASSERT( mbedtls_reader_commit( &rd ) == 0 );
-    TEST_ASSERT( mbedtls_reader_get( &rd, 10, &tmp, NULL ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_commit( &rd ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_get( &rd, 10, &tmp, NULL ) == 0 );
     TEST_ASSERT( memcmp( tmp, bufA + 80, 10 ) == 0 );
-    TEST_ASSERT( mbedtls_reader_get( &rd, 20, &tmp, NULL ) ==
-                 MBEDTLS_ERR_READER_OUT_OF_DATA );
+    TEST_ASSERT( mbedtls_mps_reader_get( &rd, 20, &tmp, NULL ) ==
+                 MBEDTLS_ERR_MPS_READER_OUT_OF_DATA );
 
     /* Preparation */
-    TEST_ASSERT( mbedtls_reader_reclaim( &rd, NULL ) == 0 );
-    TEST_ASSERT( mbedtls_reader_feed( &rd, bufB, sizeof( bufB ) ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_reclaim( &rd, NULL ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_feed( &rd, bufB, sizeof( bufB ) ) == 0 );
 
     switch( option )
     {
@@ -1642,22 +1642,22 @@ void mbedtls_mps_reader_multiple_pausing( int option )
                  * large enough. */
 
             /* Consume */
-            TEST_ASSERT( mbedtls_reader_get( &rd, 10, &tmp, &tmp_len ) == 0 );
+            TEST_ASSERT( mbedtls_mps_reader_get( &rd, 10, &tmp, &tmp_len ) == 0 );
             TEST_ASSERT( tmp_len == 10 );
             TEST_ASSERT( memcmp( tmp, bufA + 80, 10 ) == 0 );
-            TEST_ASSERT( mbedtls_reader_get( &rd, 20, &tmp, NULL ) == 0 );
+            TEST_ASSERT( mbedtls_mps_reader_get( &rd, 20, &tmp, NULL ) == 0 );
             TEST_ASSERT( memcmp( tmp, bufA + 90, 10 ) == 0 );
             TEST_ASSERT( memcmp( tmp + 10, bufB, 10 ) == 0 );
-            TEST_ASSERT( mbedtls_reader_commit( &rd ) == 0 );
-            TEST_ASSERT( mbedtls_reader_get( &rd, 20, &tmp, NULL ) ==
-                         MBEDTLS_ERR_READER_OUT_OF_DATA );
+            TEST_ASSERT( mbedtls_mps_reader_commit( &rd ) == 0 );
+            TEST_ASSERT( mbedtls_mps_reader_get( &rd, 20, &tmp, NULL ) ==
+                         MBEDTLS_ERR_MPS_READER_OUT_OF_DATA );
 
             /* Prepare */
-            TEST_ASSERT( mbedtls_reader_reclaim( &rd, NULL ) == 0 );
-            TEST_ASSERT( mbedtls_reader_feed( &rd, bufC, sizeof( bufC ) ) == 0 );;
+            TEST_ASSERT( mbedtls_mps_reader_reclaim( &rd, NULL ) == 0 );
+            TEST_ASSERT( mbedtls_mps_reader_feed( &rd, bufC, sizeof( bufC ) ) == 0 );;
 
             /* Consume */
-            TEST_ASSERT( mbedtls_reader_get( &rd, 20, &tmp, NULL ) == 0 );
+            TEST_ASSERT( mbedtls_mps_reader_get( &rd, 20, &tmp, NULL ) == 0 );
             TEST_ASSERT( memcmp( tmp, bufB + 10, 10 ) == 0 );
             TEST_ASSERT( memcmp( tmp + 10, bufC, 10 ) == 0 );
             break;
@@ -1665,37 +1665,37 @@ void mbedtls_mps_reader_multiple_pausing( int option )
         case 1: /* Fetch same chunks, commit afterwards, and
                  * then exceed bounds of new buffer; accumulator
                  * not large enough. */
-            TEST_ASSERT( mbedtls_reader_get( &rd, 10, &tmp, NULL ) == 0 );
+            TEST_ASSERT( mbedtls_mps_reader_get( &rd, 10, &tmp, NULL ) == 0 );
             TEST_ASSERT( memcmp( tmp, bufA + 80, 10 ) == 0 );
-            TEST_ASSERT( mbedtls_reader_get( &rd, 20, &tmp, NULL ) == 0 );
+            TEST_ASSERT( mbedtls_mps_reader_get( &rd, 20, &tmp, NULL ) == 0 );
             TEST_ASSERT( memcmp( tmp, bufA + 90, 10 ) == 0 );
             TEST_ASSERT( memcmp( tmp + 10, bufB, 10 ) == 0 );
-            TEST_ASSERT( mbedtls_reader_commit( &rd ) == 0 );
-            TEST_ASSERT( mbedtls_reader_get( &rd, 51, &tmp, NULL ) ==
-                         MBEDTLS_ERR_READER_OUT_OF_DATA );
+            TEST_ASSERT( mbedtls_mps_reader_commit( &rd ) == 0 );
+            TEST_ASSERT( mbedtls_mps_reader_get( &rd, 51, &tmp, NULL ) ==
+                         MBEDTLS_ERR_MPS_READER_OUT_OF_DATA );
 
             /* Prepare */
-            TEST_ASSERT( mbedtls_reader_reclaim( &rd, NULL ) ==
-                         MBEDTLS_ERR_READER_ACCUMULATOR_TOO_SMALL );
+            TEST_ASSERT( mbedtls_mps_reader_reclaim( &rd, NULL ) ==
+                         MBEDTLS_ERR_MPS_READER_ACCUMULATOR_TOO_SMALL );
             break;
 
         case 2: /* Fetch same chunks, don't commit afterwards, and
                  * then exceed bounds of new buffer; accumulator
                  * large enough. */
-            TEST_ASSERT( mbedtls_reader_get( &rd, 10, &tmp, NULL ) == 0 );
+            TEST_ASSERT( mbedtls_mps_reader_get( &rd, 10, &tmp, NULL ) == 0 );
             TEST_ASSERT( memcmp( tmp, bufA + 80, 10 ) == 0 );
-            TEST_ASSERT( mbedtls_reader_get( &rd, 20, &tmp, NULL ) == 0 );
+            TEST_ASSERT( mbedtls_mps_reader_get( &rd, 20, &tmp, NULL ) == 0 );
             TEST_ASSERT( memcmp( tmp, bufA + 90, 10 ) == 0 );
             TEST_ASSERT( memcmp( tmp + 10, bufB, 10 ) == 0 );
-            TEST_ASSERT( mbedtls_reader_get( &rd, 20, &tmp, NULL ) ==
-                         MBEDTLS_ERR_READER_OUT_OF_DATA );
+            TEST_ASSERT( mbedtls_mps_reader_get( &rd, 20, &tmp, NULL ) ==
+                         MBEDTLS_ERR_MPS_READER_OUT_OF_DATA );
 
             /* Prepare */
-            TEST_ASSERT( mbedtls_reader_reclaim( &rd, NULL ) == 0 );
-            TEST_ASSERT( mbedtls_reader_feed( &rd, bufC, sizeof( bufC ) ) == 0 );;
+            TEST_ASSERT( mbedtls_mps_reader_reclaim( &rd, NULL ) == 0 );
+            TEST_ASSERT( mbedtls_mps_reader_feed( &rd, bufC, sizeof( bufC ) ) == 0 );;
 
             /* Consume */
-            TEST_ASSERT( mbedtls_reader_get( &rd, 50, &tmp, NULL ) == 0 );
+            TEST_ASSERT( mbedtls_mps_reader_get( &rd, 50, &tmp, NULL ) == 0 );
             TEST_ASSERT( memcmp( tmp, bufA + 80, 20 ) == 0 );
             TEST_ASSERT( memcmp( tmp + 20, bufB, 20 ) == 0 );
             TEST_ASSERT( memcmp( tmp + 40, bufC, 10 ) == 0 );
@@ -1704,17 +1704,17 @@ void mbedtls_mps_reader_multiple_pausing( int option )
         case 3: /* Fetch same chunks, don't commit afterwards, and
                  * then exceed bounds of new buffer; accumulator
                  * not large enough. */
-            TEST_ASSERT( mbedtls_reader_get( &rd, 10, &tmp, NULL ) == 0 );
+            TEST_ASSERT( mbedtls_mps_reader_get( &rd, 10, &tmp, NULL ) == 0 );
             TEST_ASSERT( memcmp( tmp, bufA + 80, 10 ) == 0 );
-            TEST_ASSERT( mbedtls_reader_get( &rd, 20, &tmp, NULL ) == 0 );
+            TEST_ASSERT( mbedtls_mps_reader_get( &rd, 20, &tmp, NULL ) == 0 );
             TEST_ASSERT( memcmp( tmp, bufA + 90, 10 ) == 0 );
             TEST_ASSERT( memcmp( tmp + 10, bufB, 10 ) == 0 );
-            TEST_ASSERT( mbedtls_reader_get( &rd, 21, &tmp, NULL ) ==
-                         MBEDTLS_ERR_READER_OUT_OF_DATA );
+            TEST_ASSERT( mbedtls_mps_reader_get( &rd, 21, &tmp, NULL ) ==
+                         MBEDTLS_ERR_MPS_READER_OUT_OF_DATA );
 
             /* Prepare */
-            TEST_ASSERT( mbedtls_reader_reclaim( &rd, NULL ) ==
-                         MBEDTLS_ERR_READER_ACCUMULATOR_TOO_SMALL );
+            TEST_ASSERT( mbedtls_mps_reader_reclaim( &rd, NULL ) ==
+                         MBEDTLS_ERR_MPS_READER_ACCUMULATOR_TOO_SMALL );
             break;
 
         default:
@@ -1722,7 +1722,7 @@ void mbedtls_mps_reader_multiple_pausing( int option )
             break;
     }
 
-    mbedtls_reader_free( &rd );
+    mbedtls_mps_reader_free( &rd );
 }
 /* END_CASE */
 
@@ -1733,27 +1733,27 @@ void mbedtls_mps_reader_reclaim_data_left( int option )
      * hasn't fully consumed the buffer. */
     unsigned char buf[100];
     unsigned char *tmp;
-    mbedtls_reader rd;
+    mbedtls_mps_reader rd;
     for( int i=0; (unsigned) i < sizeof( buf ); i++ )
         buf[i] = (unsigned char) i;
 
     /* Preparation (lower layer) */
-    mbedtls_reader_init( &rd, NULL, 0 );
-    TEST_ASSERT( mbedtls_reader_feed( &rd, buf, sizeof( buf ) ) == 0 );
+    mbedtls_mps_reader_init( &rd, NULL, 0 );
+    TEST_ASSERT( mbedtls_mps_reader_feed( &rd, buf, sizeof( buf ) ) == 0 );
 
     /* Consumption (upper layer) */
     switch( option )
     {
         case 0:
             /* Fetch (but not commit) the entire buffer. */
-            TEST_ASSERT( mbedtls_reader_get( &rd, sizeof( buf ), &tmp, NULL )
+            TEST_ASSERT( mbedtls_mps_reader_get( &rd, sizeof( buf ), &tmp, NULL )
                          == 0 );
             TEST_ASSERT( memcmp( tmp, buf, 100 ) == 0 );
             break;
 
         case 1:
             /* Fetch (but not commit) parts of the buffer. */
-            TEST_ASSERT( mbedtls_reader_get( &rd, sizeof( buf ) / 2,
+            TEST_ASSERT( mbedtls_mps_reader_get( &rd, sizeof( buf ) / 2,
                                              &tmp, NULL ) == 0 );
             TEST_ASSERT( memcmp( tmp, buf, sizeof( buf ) / 2 ) == 0 );
             break;
@@ -1761,11 +1761,11 @@ void mbedtls_mps_reader_reclaim_data_left( int option )
         case 2:
             /* Fetch and commit parts of the buffer, then
              * fetch but not commit the rest of the buffer. */
-            TEST_ASSERT( mbedtls_reader_get( &rd, sizeof( buf ) / 2,
+            TEST_ASSERT( mbedtls_mps_reader_get( &rd, sizeof( buf ) / 2,
                                              &tmp, NULL ) == 0 );
             TEST_ASSERT( memcmp( tmp, buf, sizeof( buf ) / 2 ) == 0 );
-            TEST_ASSERT( mbedtls_reader_commit( &rd ) == 0 );
-            TEST_ASSERT( mbedtls_reader_get( &rd, sizeof( buf ) / 2,
+            TEST_ASSERT( mbedtls_mps_reader_commit( &rd ) == 0 );
+            TEST_ASSERT( mbedtls_mps_reader_get( &rd, sizeof( buf ) / 2,
                                              &tmp, NULL ) == 0 );
             TEST_ASSERT( memcmp( tmp, buf + sizeof( buf ) / 2,
                                  sizeof( buf ) / 2 ) == 0 );
@@ -1777,9 +1777,9 @@ void mbedtls_mps_reader_reclaim_data_left( int option )
     }
 
     /* Wrapup */
-    TEST_ASSERT( mbedtls_reader_reclaim( &rd, NULL ) ==
-                 MBEDTLS_ERR_READER_DATA_LEFT );
-    mbedtls_reader_free( &rd );
+    TEST_ASSERT( mbedtls_mps_reader_reclaim( &rd, NULL ) ==
+                 MBEDTLS_ERR_MPS_READER_DATA_LEFT );
+    mbedtls_mps_reader_free( &rd );
 }
 /* END_CASE */
 
@@ -1791,30 +1791,30 @@ void mbedtls_mps_reader_reclaim_data_left_retry()
      * back to upper layer who continues processing. */
     unsigned char buf[100];
     unsigned char *tmp;
-    mbedtls_reader rd;
+    mbedtls_mps_reader rd;
 
     for( int i=0; (unsigned) i < sizeof( buf ); i++ )
         buf[i] = (unsigned char) i;
 
     /* Preparation (lower layer) */
-    mbedtls_reader_init( &rd, NULL, 0 );
-    TEST_ASSERT( mbedtls_reader_feed( &rd, buf, sizeof( buf ) ) == 0 );
+    mbedtls_mps_reader_init( &rd, NULL, 0 );
+    TEST_ASSERT( mbedtls_mps_reader_feed( &rd, buf, sizeof( buf ) ) == 0 );
     /* Consumption (upper layer) */
-    TEST_ASSERT( mbedtls_reader_get( &rd, 50, &tmp, NULL ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_get( &rd, 50, &tmp, NULL ) == 0 );
     TEST_ASSERT( memcmp( tmp, buf, 50 ) == 0 );
-    TEST_ASSERT( mbedtls_reader_commit( &rd ) == 0 );
-    TEST_ASSERT( mbedtls_reader_get( &rd, 50, &tmp, NULL ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_commit( &rd ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_get( &rd, 50, &tmp, NULL ) == 0 );
     TEST_ASSERT( memcmp( tmp, buf + 50, 50 ) == 0 );
     /* Preparation */
-    TEST_ASSERT( mbedtls_reader_reclaim( &rd, NULL ) ==
-                 MBEDTLS_ERR_READER_DATA_LEFT );
+    TEST_ASSERT( mbedtls_mps_reader_reclaim( &rd, NULL ) ==
+                 MBEDTLS_ERR_MPS_READER_DATA_LEFT );
     /* Consumption */
-    TEST_ASSERT( mbedtls_reader_get( &rd, 50, &tmp, NULL ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_get( &rd, 50, &tmp, NULL ) == 0 );
     TEST_ASSERT( memcmp( tmp, buf + 50, 50 ) == 0 );
-    TEST_ASSERT( mbedtls_reader_commit( &rd ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_commit( &rd ) == 0 );
     /* Wrapup */
-    TEST_ASSERT( mbedtls_reader_reclaim( &rd, NULL ) == 0 );
-    mbedtls_reader_free( &rd );
+    TEST_ASSERT( mbedtls_mps_reader_reclaim( &rd, NULL ) == 0 );
+    mbedtls_mps_reader_free( &rd );
 }
 /* END_CASE */
 
@@ -1824,89 +1824,89 @@ void mbedtls_mps_reader_pausing( int option )
     unsigned char bufA[100], bufB[100];
     unsigned char *tmp;
     unsigned char acc[40];
-    mbedtls_reader rd;
+    mbedtls_mps_reader rd;
     for( int i=0; (unsigned) i < sizeof( bufA ); i++ )
         bufA[i] = (unsigned char) i;
     for( int i=0; (unsigned) i < sizeof( bufB ); i++ )
         bufB[i] = ~ ((unsigned char) i);
 
     /* Preparation (lower layer) */
-    mbedtls_reader_init( &rd, acc, sizeof( acc ) );
-    TEST_ASSERT( mbedtls_reader_feed( &rd, bufA, sizeof( bufA ) ) == 0 );
+    mbedtls_mps_reader_init( &rd, acc, sizeof( acc ) );
+    TEST_ASSERT( mbedtls_mps_reader_feed( &rd, bufA, sizeof( bufA ) ) == 0 );
 
     /* Consumption (upper layer) */
     /* Ask for more than what's available. */
-    TEST_ASSERT( mbedtls_reader_get( &rd, 80, &tmp, NULL ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_get( &rd, 80, &tmp, NULL ) == 0 );
     TEST_ASSERT( memcmp( tmp, bufA, 80 ) == 0 );
-    TEST_ASSERT( mbedtls_reader_commit( &rd ) == 0 );
-    TEST_ASSERT( mbedtls_reader_get( &rd, 10, &tmp, NULL ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_commit( &rd ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_get( &rd, 10, &tmp, NULL ) == 0 );
     TEST_ASSERT( memcmp( tmp, bufA + 80, 10 ) == 0 );
     switch( option )
     {
         case 0:  /* Single uncommited fetch at pausing */
         case 1:
-            TEST_ASSERT( mbedtls_reader_commit( &rd ) == 0 );
+            TEST_ASSERT( mbedtls_mps_reader_commit( &rd ) == 0 );
             break;
         default: /* Multiple uncommitted fetches at pausing */
             break;
     }
-    TEST_ASSERT( mbedtls_reader_get( &rd, 20, &tmp, NULL ) ==
-                 MBEDTLS_ERR_READER_OUT_OF_DATA );
+    TEST_ASSERT( mbedtls_mps_reader_get( &rd, 20, &tmp, NULL ) ==
+                 MBEDTLS_ERR_MPS_READER_OUT_OF_DATA );
 
     /* Preparation */
-    TEST_ASSERT( mbedtls_reader_reclaim( &rd, NULL ) == 0 );
-    TEST_ASSERT( mbedtls_reader_feed( &rd, bufB, sizeof( bufB ) ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_reclaim( &rd, NULL ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_feed( &rd, bufB, sizeof( bufB ) ) == 0 );
 
     /* Consumption */
     switch( option )
     {
         case 0: /* Single fetch at pausing, re-fetch with commit. */
-            TEST_ASSERT( mbedtls_reader_get( &rd, 20, &tmp, NULL ) == 0 );
+            TEST_ASSERT( mbedtls_mps_reader_get( &rd, 20, &tmp, NULL ) == 0 );
             TEST_ASSERT( memcmp( tmp, bufA + 90, 10 ) == 0 );
             TEST_ASSERT( memcmp( tmp + 10, bufB, 10 ) == 0 );
-            TEST_ASSERT( mbedtls_reader_commit( &rd ) == 0 );
+            TEST_ASSERT( mbedtls_mps_reader_commit( &rd ) == 0 );
             break;
 
         case 1: /* Single fetch at pausing, re-fetch without commit. */
-            TEST_ASSERT( mbedtls_reader_get( &rd, 20, &tmp, NULL ) == 0 );
+            TEST_ASSERT( mbedtls_mps_reader_get( &rd, 20, &tmp, NULL ) == 0 );
             TEST_ASSERT( memcmp( tmp, bufA + 90, 10 ) == 0 );
             TEST_ASSERT( memcmp( tmp + 10, bufB, 10 ) == 0 );
             break;
 
         case 2: /* Multiple fetches at pausing, repeat without commit. */
-            TEST_ASSERT( mbedtls_reader_get( &rd, 10, &tmp, NULL ) == 0 );
+            TEST_ASSERT( mbedtls_mps_reader_get( &rd, 10, &tmp, NULL ) == 0 );
             TEST_ASSERT( memcmp( tmp, bufA + 80, 10 ) == 0 );
-            TEST_ASSERT( mbedtls_reader_get( &rd, 20, &tmp, NULL ) == 0 );
+            TEST_ASSERT( mbedtls_mps_reader_get( &rd, 20, &tmp, NULL ) == 0 );
             TEST_ASSERT( memcmp( tmp, bufA + 90, 10 ) == 0 );
             TEST_ASSERT( memcmp( tmp + 10, bufB, 10 ) == 0 );
             break;
 
         case 3: /* Multiple fetches at pausing, repeat with commit 1. */
-            TEST_ASSERT( mbedtls_reader_get( &rd, 10, &tmp, NULL ) == 0 );
+            TEST_ASSERT( mbedtls_mps_reader_get( &rd, 10, &tmp, NULL ) == 0 );
             TEST_ASSERT( memcmp( tmp, bufA + 80, 10 ) == 0 );
-            TEST_ASSERT( mbedtls_reader_commit( &rd ) == 0 );
-            TEST_ASSERT( mbedtls_reader_get( &rd, 20, &tmp, NULL ) == 0 );
+            TEST_ASSERT( mbedtls_mps_reader_commit( &rd ) == 0 );
+            TEST_ASSERT( mbedtls_mps_reader_get( &rd, 20, &tmp, NULL ) == 0 );
             TEST_ASSERT( memcmp( tmp, bufA + 90, 10 ) == 0 );
             TEST_ASSERT( memcmp( tmp + 10, bufB, 10 ) == 0 );
             break;
 
         case 4: /* Multiple fetches at pausing, repeat with commit 2. */
-            TEST_ASSERT( mbedtls_reader_get( &rd, 10, &tmp, NULL ) == 0 );
+            TEST_ASSERT( mbedtls_mps_reader_get( &rd, 10, &tmp, NULL ) == 0 );
             TEST_ASSERT( memcmp( tmp, bufA + 80, 10 ) == 0 );
-            TEST_ASSERT( mbedtls_reader_get( &rd, 20, &tmp, NULL ) == 0 );
+            TEST_ASSERT( mbedtls_mps_reader_get( &rd, 20, &tmp, NULL ) == 0 );
             TEST_ASSERT( memcmp( tmp, bufA + 90, 10 ) == 0 );
             TEST_ASSERT( memcmp( tmp + 10, bufB, 10 ) == 0 );
-            TEST_ASSERT( mbedtls_reader_commit( &rd ) == 0 );
+            TEST_ASSERT( mbedtls_mps_reader_commit( &rd ) == 0 );
             break;
 
         case 5: /* Multiple fetches at pausing, repeat with commit 3. */
-            TEST_ASSERT( mbedtls_reader_get( &rd, 10, &tmp, NULL ) == 0 );
+            TEST_ASSERT( mbedtls_mps_reader_get( &rd, 10, &tmp, NULL ) == 0 );
             TEST_ASSERT( memcmp( tmp, bufA + 80, 10 ) == 0 );
-            TEST_ASSERT( mbedtls_reader_commit( &rd ) == 0 );
-            TEST_ASSERT( mbedtls_reader_get( &rd, 20, &tmp, NULL ) == 0 );
+            TEST_ASSERT( mbedtls_mps_reader_commit( &rd ) == 0 );
+            TEST_ASSERT( mbedtls_mps_reader_get( &rd, 20, &tmp, NULL ) == 0 );
             TEST_ASSERT( memcmp( tmp, bufA + 90, 10 ) == 0 );
             TEST_ASSERT( memcmp( tmp + 10, bufB, 10 ) == 0 );
-            TEST_ASSERT( mbedtls_reader_commit( &rd ) == 0 );
+            TEST_ASSERT( mbedtls_mps_reader_commit( &rd ) == 0 );
             break;
 
         default:
@@ -1914,13 +1914,13 @@ void mbedtls_mps_reader_pausing( int option )
     }
 
     /* In all cases, fetch the rest of the second buffer. */
-    TEST_ASSERT( mbedtls_reader_get( &rd, 90, &tmp, NULL ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_get( &rd, 90, &tmp, NULL ) == 0 );
     TEST_ASSERT( memcmp( tmp, bufB + 10, 90 ) == 0 );
-    TEST_ASSERT( mbedtls_reader_commit( &rd ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_commit( &rd ) == 0 );
 
     /* Wrapup */
-    TEST_ASSERT( mbedtls_reader_reclaim( &rd, NULL ) == 0 );
-    mbedtls_reader_free( &rd );
+    TEST_ASSERT( mbedtls_mps_reader_reclaim( &rd, NULL ) == 0 );
+    mbedtls_mps_reader_free( &rd );
 }
 /* END_CASE */
 
@@ -1930,7 +1930,7 @@ void mbedtls_mps_reader_pausing_multiple_feeds( int option )
     unsigned char bufA[100], bufB[100];
     unsigned char *tmp;
     unsigned char acc[70];
-    mbedtls_reader rd;
+    mbedtls_mps_reader rd;
     mbedtls_mps_size_t fetch_len;
     for( int i=0; (unsigned) i < sizeof( bufA ); i++ )
         bufA[i] = (unsigned char) i;
@@ -1938,46 +1938,46 @@ void mbedtls_mps_reader_pausing_multiple_feeds( int option )
         bufB[i] = ~ ((unsigned char) i);
 
     /* Preparation (lower layer) */
-    mbedtls_reader_init( &rd, acc, sizeof( acc ) );
-    TEST_ASSERT( mbedtls_reader_feed( &rd, bufA, sizeof( bufA ) ) == 0 );
+    mbedtls_mps_reader_init( &rd, acc, sizeof( acc ) );
+    TEST_ASSERT( mbedtls_mps_reader_feed( &rd, bufA, sizeof( bufA ) ) == 0 );
 
     /* Consumption (upper layer) */
     /* Ask for more than what's available. */
-    TEST_ASSERT( mbedtls_reader_get( &rd, 80, &tmp, NULL ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_get( &rd, 80, &tmp, NULL ) == 0 );
     TEST_ASSERT( memcmp( tmp, bufA, 80 ) == 0 );
-    TEST_ASSERT( mbedtls_reader_commit( &rd ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_commit( &rd ) == 0 );
     /* 20 left, ask for 70 -> 50 overhead */
-    TEST_ASSERT( mbedtls_reader_get( &rd, 70, &tmp, NULL ) ==
-                 MBEDTLS_ERR_READER_OUT_OF_DATA );
+    TEST_ASSERT( mbedtls_mps_reader_get( &rd, 70, &tmp, NULL ) ==
+                 MBEDTLS_ERR_MPS_READER_OUT_OF_DATA );
 
     /* Preparation */
-    TEST_ASSERT( mbedtls_reader_reclaim( &rd, NULL ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_reclaim( &rd, NULL ) == 0 );
     switch( option )
     {
         case 0: /* 10 + 10 + 80 byte feed */
-            TEST_ASSERT( mbedtls_reader_feed( &rd, bufB, 10 ) ==
-                         MBEDTLS_ERR_READER_NEED_MORE );
-            TEST_ASSERT( mbedtls_reader_feed( &rd, bufB + 10, 10 ) ==
-                         MBEDTLS_ERR_READER_NEED_MORE );
-            TEST_ASSERT( mbedtls_reader_feed( &rd, bufB + 20, 80 ) == 0 );
+            TEST_ASSERT( mbedtls_mps_reader_feed( &rd, bufB, 10 ) ==
+                         MBEDTLS_ERR_MPS_READER_NEED_MORE );
+            TEST_ASSERT( mbedtls_mps_reader_feed( &rd, bufB + 10, 10 ) ==
+                         MBEDTLS_ERR_MPS_READER_NEED_MORE );
+            TEST_ASSERT( mbedtls_mps_reader_feed( &rd, bufB + 20, 80 ) == 0 );
             break;
 
         case 1: /* 50 x 1byte */
             for( int num_feed=0; num_feed<49; num_feed++ )
             {
-                TEST_ASSERT( mbedtls_reader_feed( &rd, bufB + num_feed, 1 ) ==
-                             MBEDTLS_ERR_READER_NEED_MORE );
+                TEST_ASSERT( mbedtls_mps_reader_feed( &rd, bufB + num_feed, 1 ) ==
+                             MBEDTLS_ERR_MPS_READER_NEED_MORE );
             }
-            TEST_ASSERT( mbedtls_reader_feed( &rd, bufB + 49, 1 ) == 0 );
+            TEST_ASSERT( mbedtls_mps_reader_feed( &rd, bufB + 49, 1 ) == 0 );
             break;
 
         case 2: /* 49 x 1byte + 51bytes */
             for( int num_feed=0; num_feed<49; num_feed++ )
             {
-                TEST_ASSERT( mbedtls_reader_feed( &rd, bufB + num_feed, 1 ) ==
-                             MBEDTLS_ERR_READER_NEED_MORE );
+                TEST_ASSERT( mbedtls_mps_reader_feed( &rd, bufB + num_feed, 1 ) ==
+                             MBEDTLS_ERR_MPS_READER_NEED_MORE );
             }
-            TEST_ASSERT( mbedtls_reader_feed( &rd, bufB + 49, 51 ) == 0 );
+            TEST_ASSERT( mbedtls_mps_reader_feed( &rd, bufB + 49, 51 ) == 0 );
             break;
 
         default:
@@ -1986,10 +1986,10 @@ void mbedtls_mps_reader_pausing_multiple_feeds( int option )
     }
 
     /* Consumption */
-    TEST_ASSERT( mbedtls_reader_get( &rd, 70, &tmp, NULL ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_get( &rd, 70, &tmp, NULL ) == 0 );
     TEST_ASSERT( memcmp( tmp, bufA + 80, 20 ) == 0 );
     TEST_ASSERT( memcmp( tmp + 20, bufB, 50 ) == 0 );
-    TEST_ASSERT( mbedtls_reader_get( &rd, 1000, &tmp, &fetch_len ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_get( &rd, 1000, &tmp, &fetch_len ) == 0 );
     switch( option )
     {
         case 0:
@@ -2008,11 +2008,11 @@ void mbedtls_mps_reader_pausing_multiple_feeds( int option )
             TEST_ASSERT( 0 );
             break;
     }
-    TEST_ASSERT( mbedtls_reader_commit( &rd ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_commit( &rd ) == 0 );
 
     /* Wrapup */
-    TEST_ASSERT( mbedtls_reader_reclaim( &rd, NULL ) == 0 );
-    mbedtls_reader_free( &rd );
+    TEST_ASSERT( mbedtls_mps_reader_reclaim( &rd, NULL ) == 0 );
+    mbedtls_mps_reader_free( &rd );
 }
 /* END_CASE */
 
@@ -2022,64 +2022,64 @@ void mbedtls_mps_reader_commit_in_old()
     unsigned char bufA[100], bufB[100];
     unsigned char *tmp;
     unsigned char acc[40];
-    mbedtls_reader rd;
+    mbedtls_mps_reader rd;
     for( int i=0; (unsigned) i < sizeof( bufA ); i++ )
         bufA[i] = (unsigned char) i;
     for( int i=0; (unsigned) i < sizeof( bufB ); i++ )
         bufB[i] = ~ ((unsigned char) i);
 
     /* Preparation (lower layer) */
-    mbedtls_reader_init( &rd, acc, sizeof( acc ) );
-    TEST_ASSERT( mbedtls_reader_feed( &rd, bufA, sizeof( bufA ) ) == 0 );
+    mbedtls_mps_reader_init( &rd, acc, sizeof( acc ) );
+    TEST_ASSERT( mbedtls_mps_reader_feed( &rd, bufA, sizeof( bufA ) ) == 0 );
 
 #if defined(MBEDTLS_MPS_STATE_VALIDATION)
-    TEST_ASSERT( mbedtls_reader_feed( &rd, bufA, sizeof( bufA ) ) ==
+    TEST_ASSERT( mbedtls_mps_reader_feed( &rd, bufA, sizeof( bufA ) ) ==
                  MBEDTLS_ERR_MPS_OPERATION_UNEXPECTED );
 #endif /* MBEDTLS_MPS_STATE_VALIDATION */
 
     /* Consumption (upper layer) */
     /* Ask for more than what's available. */
-    TEST_ASSERT( mbedtls_reader_get( &rd, 80, &tmp, NULL ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_get( &rd, 80, &tmp, NULL ) == 0 );
     TEST_ASSERT( memcmp( tmp, bufA, 80 ) == 0 );
-    TEST_ASSERT( mbedtls_reader_commit( &rd ) == 0 );
-    TEST_ASSERT( mbedtls_reader_get( &rd, 10, &tmp, NULL ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_commit( &rd ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_get( &rd, 10, &tmp, NULL ) == 0 );
     TEST_ASSERT( memcmp( tmp, bufA + 80, 10 ) == 0 );
-    TEST_ASSERT( mbedtls_reader_get( &rd, 20, &tmp, NULL ) ==
-                 MBEDTLS_ERR_READER_OUT_OF_DATA );
-    TEST_ASSERT( mbedtls_reader_get( &rd, 10, &tmp, NULL ) ==
+    TEST_ASSERT( mbedtls_mps_reader_get( &rd, 20, &tmp, NULL ) ==
+                 MBEDTLS_ERR_MPS_READER_OUT_OF_DATA );
+    TEST_ASSERT( mbedtls_mps_reader_get( &rd, 10, &tmp, NULL ) ==
                  MBEDTLS_ERR_MPS_OPERATION_UNEXPECTED );
     /* Preparation */
-    TEST_ASSERT( mbedtls_reader_reclaim( &rd, NULL ) == 0 );
-    TEST_ASSERT( mbedtls_reader_feed( &rd, bufB, 5 ) ==
-                 MBEDTLS_ERR_READER_NEED_MORE );
-    TEST_ASSERT( mbedtls_reader_feed( &rd, bufB + 5, 3 ) ==
-                 MBEDTLS_ERR_READER_NEED_MORE );
-    TEST_ASSERT( mbedtls_reader_feed( &rd, bufB + 8, sizeof( bufB ) - 8 ) ==
+    TEST_ASSERT( mbedtls_mps_reader_reclaim( &rd, NULL ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_feed( &rd, bufB, 5 ) ==
+                 MBEDTLS_ERR_MPS_READER_NEED_MORE );
+    TEST_ASSERT( mbedtls_mps_reader_feed( &rd, bufB + 5, 3 ) ==
+                 MBEDTLS_ERR_MPS_READER_NEED_MORE );
+    TEST_ASSERT( mbedtls_mps_reader_feed( &rd, bufB + 8, sizeof( bufB ) - 8 ) ==
                  0 );
 
 #if defined(MBEDTLS_MPS_STATE_VALIDATION)
-    TEST_ASSERT( mbedtls_reader_feed( &rd, bufB, sizeof( bufB ) ) ==
+    TEST_ASSERT( mbedtls_mps_reader_feed( &rd, bufB, sizeof( bufB ) ) ==
                  MBEDTLS_ERR_MPS_OPERATION_UNEXPECTED );
 #endif /* MBEDTLS_MPS_STATE_VALIDATION */
 
     /* Consumption */
-    TEST_ASSERT( mbedtls_reader_get( &rd, 10, &tmp, NULL ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_get( &rd, 10, &tmp, NULL ) == 0 );
     TEST_ASSERT( memcmp( tmp, bufA + 80, 10 ) == 0 );
-    TEST_ASSERT( mbedtls_reader_get( &rd, 20, &tmp, NULL ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_get( &rd, 20, &tmp, NULL ) == 0 );
     TEST_ASSERT( memcmp( tmp, bufA + 90, 10 ) == 0 );
     TEST_ASSERT( memcmp( tmp + 10, bufB, 10 ) == 0 );
     /* Wrapup */
-    mbedtls_reader_free( &rd );
+    mbedtls_mps_reader_free( &rd );
 }
 /* END_CASE */
 
 /* BEGIN_CASE depends_on:TEST_SUITE_MPS_READER */
-void mbedtls_reader_inconsistent_usage( int option )
+void mbedtls_mps_reader_inconsistent_usage( int option )
 {
     unsigned char bufA[100], bufB[100];
     unsigned char *tmp;
     unsigned char acc[40];
-    mbedtls_reader rd;
+    mbedtls_mps_reader rd;
     int success = 0;
     for( int i=0; (unsigned) i < sizeof( bufA ); i++ )
         bufA[i] = (unsigned char) i;
@@ -2087,23 +2087,23 @@ void mbedtls_reader_inconsistent_usage( int option )
         bufB[i] = ~ ((unsigned char) i);
 
     /* Preparation (lower layer) */
-    mbedtls_reader_init( &rd, acc, sizeof( acc ) );
-    TEST_ASSERT( mbedtls_reader_feed( &rd, bufA, sizeof( bufA ) ) == 0 );
+    mbedtls_mps_reader_init( &rd, acc, sizeof( acc ) );
+    TEST_ASSERT( mbedtls_mps_reader_feed( &rd, bufA, sizeof( bufA ) ) == 0 );
     /* Consumption (upper layer) */
-    TEST_ASSERT( mbedtls_reader_get( &rd, 80, &tmp, NULL ) == 0 );
-    TEST_ASSERT( mbedtls_reader_commit( &rd ) == 0 );
-    TEST_ASSERT( mbedtls_reader_get( &rd, 10, &tmp, NULL ) == 0 );
-    TEST_ASSERT( mbedtls_reader_get( &rd, 20, &tmp, NULL ) ==
-                 MBEDTLS_ERR_READER_OUT_OF_DATA );
+    TEST_ASSERT( mbedtls_mps_reader_get( &rd, 80, &tmp, NULL ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_commit( &rd ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_get( &rd, 10, &tmp, NULL ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_get( &rd, 20, &tmp, NULL ) ==
+                 MBEDTLS_ERR_MPS_READER_OUT_OF_DATA );
     /* Preparation */
-    TEST_ASSERT( mbedtls_reader_reclaim( &rd, NULL ) == 0 );
-    TEST_ASSERT( mbedtls_reader_feed( &rd, bufB, sizeof( bufB ) ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_reclaim( &rd, NULL ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_feed( &rd, bufB, sizeof( bufB ) ) == 0 );
     /* Consumption */
     switch( option )
     {
         case 0:
             /* Ask for buffered data in a single chunk, no commit */
-            TEST_ASSERT( mbedtls_reader_get( &rd, 30, &tmp, NULL ) == 0 );
+            TEST_ASSERT( mbedtls_mps_reader_get( &rd, 30, &tmp, NULL ) == 0 );
             TEST_ASSERT( memcmp( tmp, bufA + 80, 20 ) == 0 );
             TEST_ASSERT( memcmp( tmp + 20, bufB, 10 ) == 0 );
             success = 1;
@@ -2111,40 +2111,40 @@ void mbedtls_reader_inconsistent_usage( int option )
 
         case 1:
             /* Ask for buffered data in a single chunk, with commit */
-            TEST_ASSERT( mbedtls_reader_get( &rd, 30, &tmp, NULL ) == 0 );
+            TEST_ASSERT( mbedtls_mps_reader_get( &rd, 30, &tmp, NULL ) == 0 );
             TEST_ASSERT( memcmp( tmp, bufA + 80, 20 ) == 0 );
             TEST_ASSERT( memcmp( tmp + 20, bufB, 10 ) == 0 );
-            TEST_ASSERT( mbedtls_reader_commit( &rd ) == 0 );
+            TEST_ASSERT( mbedtls_mps_reader_commit( &rd ) == 0 );
             success = 1;
             break;
 
         case 2:
             /* Ask for more than was requested when pausing, #1 */
-            TEST_ASSERT( mbedtls_reader_get( &rd, 31, &tmp, NULL ) ==
-                         MBEDTLS_ERR_READER_INCONSISTENT_REQUESTS );
+            TEST_ASSERT( mbedtls_mps_reader_get( &rd, 31, &tmp, NULL ) ==
+                         MBEDTLS_ERR_MPS_READER_INCONSISTENT_REQUESTS );
             break;
 
         case 3:
             /* Ask for more than was requested when pausing #2 */
-            TEST_ASSERT( mbedtls_reader_get( &rd, (mbedtls_mps_size_t) -1, &tmp, NULL ) ==
-                         MBEDTLS_ERR_READER_INCONSISTENT_REQUESTS );
+            TEST_ASSERT( mbedtls_mps_reader_get( &rd, (mbedtls_mps_size_t) -1, &tmp, NULL ) ==
+                         MBEDTLS_ERR_MPS_READER_INCONSISTENT_REQUESTS );
             break;
 
         case 4:
             /* Asking for buffered data in different
              * chunks than before CAN fail. */
-            TEST_ASSERT( mbedtls_reader_get( &rd, 15, &tmp, NULL ) == 0 );
+            TEST_ASSERT( mbedtls_mps_reader_get( &rd, 15, &tmp, NULL ) == 0 );
             TEST_ASSERT( memcmp( tmp, bufA + 80, 15 ) == 0 );
-            TEST_ASSERT( mbedtls_reader_get( &rd, 10, &tmp, NULL ) ==
-                         MBEDTLS_ERR_READER_INCONSISTENT_REQUESTS );
+            TEST_ASSERT( mbedtls_mps_reader_get( &rd, 10, &tmp, NULL ) ==
+                         MBEDTLS_ERR_MPS_READER_INCONSISTENT_REQUESTS );
             break;
 
         case 5:
             /* Asking for buffered data different chunks
              * than before NEED NOT fail - no commits */
-            TEST_ASSERT( mbedtls_reader_get( &rd, 15, &tmp, NULL ) == 0 );
+            TEST_ASSERT( mbedtls_mps_reader_get( &rd, 15, &tmp, NULL ) == 0 );
             TEST_ASSERT( memcmp( tmp, bufA + 80, 15 ) == 0 );
-            TEST_ASSERT( mbedtls_reader_get( &rd, 15, &tmp, NULL ) == 0 );
+            TEST_ASSERT( mbedtls_mps_reader_get( &rd, 15, &tmp, NULL ) == 0 );
             TEST_ASSERT( memcmp( tmp, bufA + 95, 5 ) == 0 );
             TEST_ASSERT( memcmp( tmp + 5, bufB, 10 ) == 0 );
             success = 1;
@@ -2153,10 +2153,10 @@ void mbedtls_reader_inconsistent_usage( int option )
         case 6:
             /* Asking for buffered data different chunks
              * than before NEED NOT fail - intermediate commit */
-            TEST_ASSERT( mbedtls_reader_get( &rd, 15, &tmp, NULL ) == 0 );
+            TEST_ASSERT( mbedtls_mps_reader_get( &rd, 15, &tmp, NULL ) == 0 );
             TEST_ASSERT( memcmp( tmp, bufA + 80, 15 ) == 0 );
-            TEST_ASSERT( mbedtls_reader_commit( &rd ) == 0 );
-            TEST_ASSERT( mbedtls_reader_get( &rd, 15, &tmp, NULL ) == 0 );
+            TEST_ASSERT( mbedtls_mps_reader_commit( &rd ) == 0 );
+            TEST_ASSERT( mbedtls_mps_reader_get( &rd, 15, &tmp, NULL ) == 0 );
             TEST_ASSERT( memcmp( tmp, bufA + 95, 5 ) == 0 );
             TEST_ASSERT( memcmp( tmp + 5, bufB, 10 ) == 0 );
             success = 1;
@@ -2165,25 +2165,25 @@ void mbedtls_reader_inconsistent_usage( int option )
         case 7:
             /* Asking for buffered data different chunks
              * than before NEED NOT fail - end commit */
-            TEST_ASSERT( mbedtls_reader_get( &rd, 15, &tmp, NULL ) == 0 );
+            TEST_ASSERT( mbedtls_mps_reader_get( &rd, 15, &tmp, NULL ) == 0 );
             TEST_ASSERT( memcmp( tmp, bufA + 80, 15 ) == 0 );
-            TEST_ASSERT( mbedtls_reader_get( &rd, 15, &tmp, NULL ) == 0 );
+            TEST_ASSERT( mbedtls_mps_reader_get( &rd, 15, &tmp, NULL ) == 0 );
             TEST_ASSERT( memcmp( tmp, bufA + 95, 5 ) == 0 );
             TEST_ASSERT( memcmp( tmp + 5, bufB, 10 ) == 0 );
-            TEST_ASSERT( mbedtls_reader_commit( &rd ) == 0 );
+            TEST_ASSERT( mbedtls_mps_reader_commit( &rd ) == 0 );
             success = 1;
             break;
 
         case 8:
             /* Asking for buffered data different chunks
              * than before NEED NOT fail - intermediate & end commit */
-            TEST_ASSERT( mbedtls_reader_get( &rd, 15, &tmp, NULL ) == 0 );
+            TEST_ASSERT( mbedtls_mps_reader_get( &rd, 15, &tmp, NULL ) == 0 );
             TEST_ASSERT( memcmp( tmp, bufA + 80, 15 ) == 0 );
-            TEST_ASSERT( mbedtls_reader_get( &rd, 15, &tmp, NULL ) == 0 );
-            TEST_ASSERT( mbedtls_reader_commit( &rd ) == 0 );
+            TEST_ASSERT( mbedtls_mps_reader_get( &rd, 15, &tmp, NULL ) == 0 );
+            TEST_ASSERT( mbedtls_mps_reader_commit( &rd ) == 0 );
             TEST_ASSERT( memcmp( tmp, bufA + 95, 5 ) == 0 );
             TEST_ASSERT( memcmp( tmp + 5, bufB, 10 ) == 0 );
-            TEST_ASSERT( mbedtls_reader_commit( &rd ) == 0 );
+            TEST_ASSERT( mbedtls_mps_reader_commit( &rd ) == 0 );
             success = 1;
             break;
 
@@ -2195,16 +2195,16 @@ void mbedtls_reader_inconsistent_usage( int option )
     if( success == 1 )
     {
         /* In all succeeding cases, fetch the rest of the second buffer. */
-        TEST_ASSERT( mbedtls_reader_get( &rd, 90, &tmp, NULL ) == 0 );
+        TEST_ASSERT( mbedtls_mps_reader_get( &rd, 90, &tmp, NULL ) == 0 );
         TEST_ASSERT( memcmp( tmp, bufB + 10, 90 ) == 0 );
-        TEST_ASSERT( mbedtls_reader_commit( &rd ) == 0 );
+        TEST_ASSERT( mbedtls_mps_reader_commit( &rd ) == 0 );
 
         /* Wrapup */
-        TEST_ASSERT( mbedtls_reader_reclaim( &rd, NULL ) == 0 );
+        TEST_ASSERT( mbedtls_mps_reader_reclaim( &rd, NULL ) == 0 );
     }
 
     /* Wrapup */
-    mbedtls_reader_free( &rd );
+    mbedtls_mps_reader_free( &rd );
 }
 /* END_CASE */
 
@@ -2250,7 +2250,7 @@ void mbedtls_mps_reader_random_usage( int num_out_chunks,
     int mode = 0; /* Lower layer (0) or Upper layer (1) */
     int reclaimed = 1; /* Have to call reclaim at least once before
                         * returning the reader to the upper layer. */
-    mbedtls_reader rd;
+    mbedtls_mps_reader rd;
 
     if( acc_size > 0 )
     {
@@ -2267,7 +2267,7 @@ void mbedtls_mps_reader_random_usage( int num_out_chunks,
     TEST_ASSERT( outgoing != NULL );
     TEST_ASSERT( incoming != NULL );
 
-    mbedtls_reader_init( &rd, acc, acc_size );
+    mbedtls_mps_reader_init( &rd, acc, acc_size );
 
     cur_out_chunk = 0;
     in_commit = 0;
@@ -2283,7 +2283,7 @@ void mbedtls_mps_reader_random_usage( int num_out_chunks,
             if( rand_op == 0 )
             {
                 /* Reclaim */
-                ret = mbedtls_reader_reclaim( &rd, NULL );
+                ret = mbedtls_mps_reader_reclaim( &rd, NULL );
 
                 if( ret == 0 )
                 {
@@ -2306,9 +2306,9 @@ void mbedtls_mps_reader_random_usage( int num_out_chunks,
                 TEST_ASSERT( tmp != NULL );
 
                 TEST_ASSERT( mbedtls_test_rnd_std_rand( NULL, tmp, tmp_size ) == 0 );
-                ret = mbedtls_reader_feed( &rd, tmp, tmp_size );
+                ret = mbedtls_mps_reader_feed( &rd, tmp, tmp_size );
 
-                if( ret == 0 || ret == MBEDTLS_ERR_READER_NEED_MORE )
+                if( ret == 0 || ret == MBEDTLS_ERR_MPS_READER_NEED_MORE )
                 {
                     cur_out_chunk++;
                     memcpy( outgoing + out_pos, tmp, tmp_size );
@@ -2347,13 +2347,13 @@ void mbedtls_mps_reader_random_usage( int num_out_chunks,
                 get_size = ( rand() % max_request ) + 1;
                 if( rand_op == 0 )
                 {
-                    ret = mbedtls_reader_get( &rd, get_size, &chunk_get,
+                    ret = mbedtls_mps_reader_get( &rd, get_size, &chunk_get,
                                               &real_size );
                 }
                 else
                 {
                     real_size = get_size;
-                    ret = mbedtls_reader_get( &rd, get_size, &chunk_get, NULL );
+                    ret = mbedtls_mps_reader_get( &rd, get_size, &chunk_get, NULL );
                 }
 
                 /* Check if output is in accordance with what was written */
@@ -2369,7 +2369,7 @@ void mbedtls_mps_reader_random_usage( int num_out_chunks,
             }
             else if( rand_op == 2 ) /* Commit */
             {
-                ret = mbedtls_reader_commit( &rd );
+                ret = mbedtls_mps_reader_commit( &rd );
                 if( ret == 0 )
                 {
                     in_commit += in_fetch;
@@ -2387,7 +2387,7 @@ void mbedtls_mps_reader_random_usage( int num_out_chunks,
     }
 
     /* Cleanup */
-    mbedtls_reader_free( &rd );
+    mbedtls_mps_reader_free( &rd );
     free( incoming );
     free( outgoing );
     free( acc );
@@ -2401,53 +2401,53 @@ void mbedtls_mps_reader_ext_basic( )
     /* This test checks whether the extended reader correctly
      * checks for the global bounds of the logical buffer. */
 
-    mbedtls_reader_ext rd_ext;
-    mbedtls_reader rd;
+    mbedtls_mps_reader_ext rd_ext;
+    mbedtls_mps_reader rd;
     unsigned char buf[75];
     unsigned char *tmp;
     mbedtls_mps_size_t tmp_sz;
 
     /* Initialize reader and extended reader separately. */
-    TEST_ASSERT( mbedtls_reader_init_ext( &rd_ext, 100 ) == 0 );
-    mbedtls_reader_init( &rd, NULL, 0 );
+    TEST_ASSERT( mbedtls_mps_reader_init_ext( &rd_ext, 100 ) == 0 );
+    mbedtls_mps_reader_init( &rd, NULL, 0 );
     for( size_t idx=0; idx < sizeof( buf ); idx++ )
         buf[idx] = (unsigned char) idx;
 
     /* Prepare reader and bind it to extended reader */
-    TEST_ASSERT( mbedtls_reader_feed( &rd, buf, sizeof( buf ) ) == 0 );
-    TEST_ASSERT( mbedtls_reader_attach( &rd_ext, &rd ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_feed( &rd, buf, sizeof( buf ) ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_attach( &rd_ext, &rd ) == 0 );
 
     /* Do actual fetching */
-    TEST_ASSERT( mbedtls_reader_get_ext( &rd_ext, 101, &tmp, NULL ) ==
-                 MBEDTLS_ERR_READER_BOUNDS_VIOLATION );
+    TEST_ASSERT( mbedtls_mps_reader_get_ext( &rd_ext, 101, &tmp, NULL ) ==
+                 MBEDTLS_ERR_MPS_READER_BOUNDS_VIOLATION );
 
     /* ([C]ommit, [F]etch) = (0,0) */
-    TEST_ASSERT( mbedtls_reader_get_ext( &rd_ext, 50, &tmp, NULL ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_get_ext( &rd_ext, 50, &tmp, NULL ) == 0 );
     /* Now (C,F) = (0,50) */
-    TEST_ASSERT( mbedtls_reader_get_ext( &rd_ext, 10, &tmp, NULL ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_get_ext( &rd_ext, 10, &tmp, NULL ) == 0 );
     /* Now (C,F) = (0,60) */
-    TEST_ASSERT( mbedtls_reader_commit_ext( &rd_ext ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_commit_ext( &rd_ext ) == 0 );
     /* Now (C,F) = (60,60) */
-    TEST_ASSERT( mbedtls_reader_get_ext( &rd_ext, 41, &tmp, NULL ) ==
-                 MBEDTLS_ERR_READER_BOUNDS_VIOLATION );
+    TEST_ASSERT( mbedtls_mps_reader_get_ext( &rd_ext, 41, &tmp, NULL ) ==
+                 MBEDTLS_ERR_MPS_READER_BOUNDS_VIOLATION );
     /* Now (C,F) = (60,60) */
-    TEST_ASSERT( mbedtls_reader_get_ext( &rd_ext, 40,
+    TEST_ASSERT( mbedtls_mps_reader_get_ext( &rd_ext, 40,
                                          &tmp, &tmp_sz ) == 0 );
     TEST_ASSERT( tmp_sz == 15 );
     /* Now (C,F) = (60,75) */
-    TEST_ASSERT( mbedtls_reader_get_ext( &rd_ext, 26, &tmp, &tmp_sz ) ==
-                 MBEDTLS_ERR_READER_BOUNDS_VIOLATION );
-    TEST_ASSERT( mbedtls_reader_get_ext( &rd_ext, 25, &tmp, NULL ) ==
-                 MBEDTLS_ERR_READER_OUT_OF_DATA );
-    TEST_ASSERT( mbedtls_reader_get_ext( &rd_ext, 25, &tmp, &tmp_sz ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_get_ext( &rd_ext, 26, &tmp, &tmp_sz ) ==
+                 MBEDTLS_ERR_MPS_READER_BOUNDS_VIOLATION );
+    TEST_ASSERT( mbedtls_mps_reader_get_ext( &rd_ext, 25, &tmp, NULL ) ==
+                 MBEDTLS_ERR_MPS_READER_OUT_OF_DATA );
+    TEST_ASSERT( mbedtls_mps_reader_get_ext( &rd_ext, 25, &tmp, &tmp_sz ) == 0 );
     TEST_ASSERT( tmp_sz == 0 );
     /* Now still (C,F) = (60,75) */
 
-    TEST_ASSERT( mbedtls_reader_detach( &rd_ext ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_detach( &rd_ext ) == 0 );
 
 exit:
 
-    mbedtls_reader_free_ext( &rd_ext );
+    mbedtls_mps_reader_free_ext( &rd_ext );
 }
 /* END_CASE */
 
@@ -2457,61 +2457,61 @@ void mbedtls_mps_reader_ext_group_open_close( )
     /* This test checks whether the extended reader correctly
      * checks for the global bounds of the logical buffer. */
 
-    mbedtls_reader_ext rd_ext;
-    mbedtls_reader rd;
+    mbedtls_mps_reader_ext rd_ext;
+    mbedtls_mps_reader rd;
     unsigned char buf[75];
     unsigned char *tmp;
     mbedtls_mps_size_t tmp_sz;
 
     /* Initialize reader and extended reader separately. */
-    TEST_ASSERT( mbedtls_reader_init_ext( &rd_ext, 100 ) == 0 );
-    mbedtls_reader_init( &rd, NULL, 0 );
+    TEST_ASSERT( mbedtls_mps_reader_init_ext( &rd_ext, 100 ) == 0 );
+    mbedtls_mps_reader_init( &rd, NULL, 0 );
     for( size_t idx=0; idx < sizeof( buf ); idx++ )
         buf[idx] = (unsigned char) idx;
 
     /* Prepare reader and bind it to extended reader */
-    TEST_ASSERT( mbedtls_reader_feed( &rd, buf, sizeof( buf ) ) == 0 );
-    TEST_ASSERT( mbedtls_reader_attach( &rd_ext, &rd ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_feed( &rd, buf, sizeof( buf ) ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_attach( &rd_ext, &rd ) == 0 );
 
     /* Do actual fetching */
-    TEST_ASSERT( mbedtls_reader_get_ext( &rd_ext, 101, &tmp, NULL ) ==
-                 MBEDTLS_ERR_READER_BOUNDS_VIOLATION );
+    TEST_ASSERT( mbedtls_mps_reader_get_ext( &rd_ext, 101, &tmp, NULL ) ==
+                 MBEDTLS_ERR_MPS_READER_BOUNDS_VIOLATION );
 
     /* ([C]ommit, [F]etch) = (0,0) */
-    TEST_ASSERT( mbedtls_reader_get_ext( &rd_ext, 50, &tmp, NULL ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_get_ext( &rd_ext, 50, &tmp, NULL ) == 0 );
     /* Now (C,F) = (0,50) */
-    TEST_ASSERT( mbedtls_reader_group_open( &rd_ext, 51 ) ==
-                 MBEDTLS_ERR_READER_BOUNDS_VIOLATION );
-    TEST_ASSERT( mbedtls_reader_group_open( &rd_ext, 20 ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_group_open( &rd_ext, 51 ) ==
+                 MBEDTLS_ERR_MPS_READER_BOUNDS_VIOLATION );
+    TEST_ASSERT( mbedtls_mps_reader_group_open( &rd_ext, 20 ) == 0 );
     /* Now (C,F) have a sub-group in the range from 50-70 */
-    TEST_ASSERT( mbedtls_reader_get_ext( &rd_ext, 21, &tmp, NULL ) ==
-                 MBEDTLS_ERR_READER_BOUNDS_VIOLATION );
-    TEST_ASSERT( mbedtls_reader_get_ext( &rd_ext, 10, &tmp, NULL ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_get_ext( &rd_ext, 21, &tmp, NULL ) ==
+                 MBEDTLS_ERR_MPS_READER_BOUNDS_VIOLATION );
+    TEST_ASSERT( mbedtls_mps_reader_get_ext( &rd_ext, 10, &tmp, NULL ) == 0 );
     /* Now (C,F) = (0,60) */
     /* Cannot close group yet */
-    TEST_ASSERT( mbedtls_reader_group_close( &rd_ext ) ==
-                 MBEDTLS_ERR_READER_BOUNDS_VIOLATION );
-    TEST_ASSERT( mbedtls_reader_get_ext( &rd_ext, 10, &tmp, NULL ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_group_close( &rd_ext ) ==
+                 MBEDTLS_ERR_MPS_READER_BOUNDS_VIOLATION );
+    TEST_ASSERT( mbedtls_mps_reader_get_ext( &rd_ext, 10, &tmp, NULL ) == 0 );
     /* Now (C,F) = (0,70) */
-    TEST_ASSERT( mbedtls_reader_get_ext( &rd_ext, 1, &tmp, NULL ) ==
-                 MBEDTLS_ERR_READER_BOUNDS_VIOLATION );
-    TEST_ASSERT( mbedtls_reader_group_close( &rd_ext ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_get_ext( &rd_ext, 1, &tmp, NULL ) ==
+                 MBEDTLS_ERR_MPS_READER_BOUNDS_VIOLATION );
+    TEST_ASSERT( mbedtls_mps_reader_group_close( &rd_ext ) == 0 );
     /* Now only open group is 0-100 again */
-    TEST_ASSERT( mbedtls_reader_commit_ext( &rd_ext ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_commit_ext( &rd_ext ) == 0 );
     /* Now (C,F) = (70,70) */
-    TEST_ASSERT( mbedtls_reader_get_ext( &rd_ext, 1, &tmp, NULL ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_get_ext( &rd_ext, 1, &tmp, NULL ) == 0 );
     /* Now (C,F) = (70,71) */
-    TEST_ASSERT( mbedtls_reader_get_ext( &rd_ext, 30, &tmp, NULL ) ==
-                 MBEDTLS_ERR_READER_BOUNDS_VIOLATION );
-    TEST_ASSERT( mbedtls_reader_get_ext( &rd_ext, 29, &tmp, &tmp_sz ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_get_ext( &rd_ext, 30, &tmp, NULL ) ==
+                 MBEDTLS_ERR_MPS_READER_BOUNDS_VIOLATION );
+    TEST_ASSERT( mbedtls_mps_reader_get_ext( &rd_ext, 29, &tmp, &tmp_sz ) == 0 );
     TEST_ASSERT( tmp_sz == 4 );
     /* Now (C,F) = (70, 75) */
 
-    TEST_ASSERT( mbedtls_reader_detach( &rd_ext ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_detach( &rd_ext ) == 0 );
 
 exit:
 
-    mbedtls_reader_free_ext( &rd_ext );
+    mbedtls_mps_reader_free_ext( &rd_ext );
 }
 /* END_CASE */
 
@@ -2521,42 +2521,42 @@ void mbedtls_mps_reader_ext_many_groups( )
     /* This test checks whether the extended reader correctly
      * checks for the global bounds of the logical buffer. */
 
-    mbedtls_reader_ext rd_ext;
-    mbedtls_reader rd;
+    mbedtls_mps_reader_ext rd_ext;
+    mbedtls_mps_reader rd;
     unsigned char buf[75];
     unsigned char *tmp;
 
     /* Initialize reader and extended reader separately. */
-    TEST_ASSERT( mbedtls_reader_init_ext( &rd_ext, 100 ) == 0 );
-    mbedtls_reader_init( &rd, NULL, 0 );
+    TEST_ASSERT( mbedtls_mps_reader_init_ext( &rd_ext, 100 ) == 0 );
+    mbedtls_mps_reader_init( &rd, NULL, 0 );
     for( size_t idx=0; idx < sizeof( buf ); idx++ )
         buf[idx] = (unsigned char) idx;
 
     /* Prepare reader and bind it to extended reader */
-    TEST_ASSERT( mbedtls_reader_feed( &rd, buf, sizeof( buf ) ) == 0 );
-    TEST_ASSERT( mbedtls_reader_attach( &rd_ext, &rd ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_feed( &rd, buf, sizeof( buf ) ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_attach( &rd_ext, &rd ) == 0 );
 
-    for( size_t cur_grp=1; cur_grp < MBEDTLS_READER_MAX_GROUPS; cur_grp++ )
+    for( size_t cur_grp=1; cur_grp < MBEDTLS_MPS_READER_MAX_GROUPS; cur_grp++ )
     {
-        TEST_ASSERT( mbedtls_reader_get_ext( &rd_ext, 100 - 2 * cur_grp + 3,
+        TEST_ASSERT( mbedtls_mps_reader_get_ext( &rd_ext, 100 - 2 * cur_grp + 3,
                                              &tmp, NULL ) ==
-                     MBEDTLS_ERR_READER_BOUNDS_VIOLATION );
-        TEST_ASSERT( mbedtls_reader_get_ext( &rd_ext, 1, &tmp, NULL ) == 0 );
-        TEST_ASSERT( mbedtls_reader_group_open( &rd_ext,
+                     MBEDTLS_ERR_MPS_READER_BOUNDS_VIOLATION );
+        TEST_ASSERT( mbedtls_mps_reader_get_ext( &rd_ext, 1, &tmp, NULL ) == 0 );
+        TEST_ASSERT( mbedtls_mps_reader_group_open( &rd_ext,
                                                 100 - 2 * ( cur_grp - 1 ) ) ==
-                     MBEDTLS_ERR_READER_BOUNDS_VIOLATION );
-        TEST_ASSERT( mbedtls_reader_group_open( &rd_ext,
+                     MBEDTLS_ERR_MPS_READER_BOUNDS_VIOLATION );
+        TEST_ASSERT( mbedtls_mps_reader_group_open( &rd_ext,
                                                 100 - 2 * cur_grp ) == 0 );
     }
 
-    TEST_ASSERT( mbedtls_reader_group_open( &rd_ext, 1 ) ==
-                 MBEDTLS_ERR_READER_TOO_MANY_GROUPS );
+    TEST_ASSERT( mbedtls_mps_reader_group_open( &rd_ext, 1 ) ==
+                 MBEDTLS_ERR_MPS_READER_TOO_MANY_GROUPS );
 
-    TEST_ASSERT( mbedtls_reader_detach( &rd_ext ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_detach( &rd_ext ) == 0 );
 
 exit:
 
-    mbedtls_reader_free_ext( &rd_ext );
+    mbedtls_mps_reader_free_ext( &rd_ext );
 }
 /* END_CASE */
 
@@ -4214,13 +4214,13 @@ void mbedtls_mps_l2_basic( int mode,
     TEST_ASSERT( in_srv.type == ty_A );
 
     /* Step 3: Request record contents from writer. */
-    TEST_ASSERT( mbedtls_reader_get( in_srv.rd, rec_sz, &buf, &sz ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_get( in_srv.rd, rec_sz, &buf, &sz ) == 0 );
 
     /* Step 4: Process and commti record contents. */
     TEST_ASSERT( sz == (unsigned) rec_sz );
     for( uint8_t idx = 0; idx < sz; idx++ )
         TEST_ASSERT( buf[idx] == idx );
-    TEST_ASSERT( mbedtls_reader_commit( in_srv.rd ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_commit( in_srv.rd ) == 0 );
 
     /* Step 5: Close record. */
     TEST_ASSERT( mps_l2_read_done( &srv_l2 ) == 0 );
@@ -4231,11 +4231,11 @@ void mbedtls_mps_l2_basic( int mode,
     TEST_ASSERT( mps_l2_read_start( &srv_l2, &in_srv ) == 0 );
     TEST_ASSERT( in_srv.epoch == epoch_init );
     TEST_ASSERT( in_srv.type == ty_B );
-    TEST_ASSERT( mbedtls_reader_get( in_srv.rd, 2 * rec_sz, &buf, &sz ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_get( in_srv.rd, 2 * rec_sz, &buf, &sz ) == 0 );
     TEST_ASSERT( sz == (unsigned) ( 2 * rec_sz ) );
     for( uint8_t idx = 0; idx < sz; idx++ )
         TEST_ASSERT( buf[idx] == ( sz - idx ) );
-    TEST_ASSERT( mbedtls_reader_commit( in_srv.rd ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_commit( in_srv.rd ) == 0 );
     TEST_ASSERT( mps_l2_read_done( &srv_l2 ) == 0 );
 
 exit:
@@ -4331,8 +4331,8 @@ void mbedtls_mps_l2_non_packable_type( int mode,
     TEST_ASSERT( in_srv.epoch == epoch_init );
     TEST_ASSERT( in_srv.type  == ty_A );
 
-    TEST_ASSERT( mbedtls_reader_get( in_srv.rd, 5, &buf, NULL ) == 0 );
-    TEST_ASSERT( mbedtls_reader_commit( in_srv.rd ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_get( in_srv.rd, 5, &buf, NULL ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_commit( in_srv.rd ) == 0 );
 
     /* Attempting to close should fail immediately, because more
      * data of type ty_A is available that wasn't requested. */
@@ -4371,10 +4371,10 @@ void mbedtls_mps_l2_non_packable_type( int mode,
     TEST_ASSERT( in_cli.epoch == epoch_init );
     TEST_ASSERT( in_cli.type  == ty_A );
 
-    TEST_ASSERT( mbedtls_reader_get( in_cli.rd, 10, &buf, &sz ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_get( in_cli.rd, 10, &buf, &sz ) == 0 );
     /* We should see only 5 bytes */
     TEST_ASSERT( sz == 5 );
-    TEST_ASSERT( mbedtls_reader_commit( in_cli.rd ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_commit( in_cli.rd ) == 0 );
     TEST_ASSERT( mps_l2_read_done( &cli_l2 ) == 0 );
 
     /*
@@ -4385,10 +4385,10 @@ void mbedtls_mps_l2_non_packable_type( int mode,
     TEST_ASSERT( in_cli.epoch == epoch_init );
     TEST_ASSERT( in_cli.type  == ty_A );
 
-    TEST_ASSERT( mbedtls_reader_get( in_cli.rd, 10, &buf, &sz ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_get( in_cli.rd, 10, &buf, &sz ) == 0 );
     /* We should see only 5 bytes */
     TEST_ASSERT( sz == 5 );
-    TEST_ASSERT( mbedtls_reader_commit( in_cli.rd ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_commit( in_cli.rd ) == 0 );
     TEST_ASSERT( mps_l2_read_done( &cli_l2 ) == 0 );
 
 exit:
@@ -4639,11 +4639,11 @@ void mbedtls_mps_l2_bad_record( int mode,
         TEST_ASSERT( mps_l2_read_start( &srv_l2, &in_srv ) == 0 );
         TEST_ASSERT( in_srv.type == ty_A );
 
-        TEST_ASSERT( mbedtls_reader_get( in_srv.rd, rec_sz, &buf, &sz ) == 0 );
+        TEST_ASSERT( mbedtls_mps_reader_get( in_srv.rd, rec_sz, &buf, &sz ) == 0 );
         TEST_ASSERT( sz == (unsigned) rec_sz );
         for( uint8_t idx = 0; idx < sz; idx++ )
             TEST_ASSERT( buf[idx] == ((uint8_t) ( sz - idx ) ) );
-        TEST_ASSERT( mbedtls_reader_commit( in_srv.rd ) == 0 );
+        TEST_ASSERT( mbedtls_mps_reader_commit( in_srv.rd ) == 0 );
         TEST_ASSERT( mps_l2_read_done( &srv_l2 ) == 0 );
 
         TEST_ASSERT( mps_l2_read_start( &srv_l2, &in_srv ) ==
@@ -4839,11 +4839,11 @@ void mbedtls_mps_l2_anti_replay( int variant )
             TEST_ASSERT( mps_l2_read_start( &srv_l2, &in_srv ) == 0 );
             TEST_ASSERT( in_srv.epoch == epoch_init );
             TEST_ASSERT( in_srv.type == ty_A );
-            TEST_ASSERT( mbedtls_reader_get( in_srv.rd, rec_sz, &buf, &sz ) == 0 );
+            TEST_ASSERT( mbedtls_mps_reader_get( in_srv.rd, rec_sz, &buf, &sz ) == 0 );
             TEST_ASSERT( sz == (unsigned) rec_sz );
             for( uint8_t idx = 0; idx < sz; idx++ )
                 TEST_ASSERT( buf[idx] == idx );
-            TEST_ASSERT( mbedtls_reader_commit( in_srv.rd ) == 0 );
+            TEST_ASSERT( mbedtls_mps_reader_commit( in_srv.rd ) == 0 );
             TEST_ASSERT( mps_l2_read_done( &srv_l2 ) == 0 );
 
             TEST_ASSERT( mps_l2_get_last_sequence_number( &srv_l2, epoch_init, &in_ctr ) == 0 );
@@ -4863,11 +4863,11 @@ void mbedtls_mps_l2_anti_replay( int variant )
             TEST_ASSERT( mps_l2_read_start( &srv_l2, &in_srv ) == 0 );
             TEST_ASSERT( in_srv.epoch == epoch_init );
             TEST_ASSERT( in_srv.type == ty_A );
-            TEST_ASSERT( mbedtls_reader_get( in_srv.rd, rec_sz, &buf, &sz ) == 0 );
+            TEST_ASSERT( mbedtls_mps_reader_get( in_srv.rd, rec_sz, &buf, &sz ) == 0 );
             TEST_ASSERT( sz == (unsigned) rec_sz );
             for( uint8_t idx = 0; idx < sz; idx++ )
                 TEST_ASSERT( buf[idx] == idx );
-            TEST_ASSERT( mbedtls_reader_commit( in_srv.rd ) == 0 );
+            TEST_ASSERT( mbedtls_mps_reader_commit( in_srv.rd ) == 0 );
             TEST_ASSERT( mps_l2_read_done( &srv_l2 ) == 0 );
 
             TEST_ASSERT( mps_l2_get_last_sequence_number( &srv_l2, epoch_init, &in_ctr ) == 0 );
@@ -4876,11 +4876,11 @@ void mbedtls_mps_l2_anti_replay( int variant )
             TEST_ASSERT( mps_l2_read_start( &srv_l2, &in_srv ) == 0 );
             TEST_ASSERT( in_srv.epoch == epoch_init );
             TEST_ASSERT( in_srv.type == ty_A );
-            TEST_ASSERT( mbedtls_reader_get( in_srv.rd, rec_sz, &buf, &sz ) == 0 );
+            TEST_ASSERT( mbedtls_mps_reader_get( in_srv.rd, rec_sz, &buf, &sz ) == 0 );
             TEST_ASSERT( sz == (unsigned) rec_sz );
             for( uint8_t idx = 0; idx < sz; idx++ )
                 TEST_ASSERT( buf[idx] == idx + 1 );
-            TEST_ASSERT( mbedtls_reader_commit( in_srv.rd ) == 0 );
+            TEST_ASSERT( mbedtls_mps_reader_commit( in_srv.rd ) == 0 );
             TEST_ASSERT( mps_l2_read_done( &srv_l2 ) == 0 );
 
             TEST_ASSERT( mps_l2_get_last_sequence_number( &srv_l2, epoch_init, &in_ctr ) == 0 );
@@ -4901,11 +4901,11 @@ void mbedtls_mps_l2_anti_replay( int variant )
             TEST_ASSERT( mps_l2_read_start( &srv_l2, &in_srv ) == 0 );
             TEST_ASSERT( in_srv.epoch == epoch_init );
             TEST_ASSERT( in_srv.type == ty_A );
-            TEST_ASSERT( mbedtls_reader_get( in_srv.rd, rec_sz, &buf, &sz ) == 0 );
+            TEST_ASSERT( mbedtls_mps_reader_get( in_srv.rd, rec_sz, &buf, &sz ) == 0 );
             TEST_ASSERT( sz == (unsigned) rec_sz );
             for( uint8_t idx = 0; idx < sz; idx++ )
                 TEST_ASSERT( buf[idx] == idx );
-            TEST_ASSERT( mbedtls_reader_commit( in_srv.rd ) == 0 );
+            TEST_ASSERT( mbedtls_mps_reader_commit( in_srv.rd ) == 0 );
             TEST_ASSERT( mps_l2_read_done( &srv_l2 ) == 0 );
 
             TEST_ASSERT( mps_l2_get_last_sequence_number( &srv_l2, epoch_init, &in_ctr ) == 0 );
@@ -4916,11 +4916,11 @@ void mbedtls_mps_l2_anti_replay( int variant )
                 TEST_ASSERT( mps_l2_read_start( &srv_l2, &in_srv ) == 0 );
                 TEST_ASSERT( in_srv.epoch == epoch_init );
                 TEST_ASSERT( in_srv.type == ty_A );
-                TEST_ASSERT( mbedtls_reader_get( in_srv.rd, rec_sz, &buf, &sz ) == 0 );
+                TEST_ASSERT( mbedtls_mps_reader_get( in_srv.rd, rec_sz, &buf, &sz ) == 0 );
                 TEST_ASSERT( sz == (unsigned) rec_sz );
                 for( uint8_t idx = 0; idx < sz; idx++ )
                     TEST_ASSERT( buf[idx] == idx + 1 );
-                TEST_ASSERT( mbedtls_reader_commit( in_srv.rd ) == 0 );
+                TEST_ASSERT( mbedtls_mps_reader_commit( in_srv.rd ) == 0 );
                 TEST_ASSERT( mps_l2_read_done( &srv_l2 ) == 0 );
 
                 TEST_ASSERT( mps_l2_get_last_sequence_number( &srv_l2, epoch_init, &in_ctr ) == 0 );
@@ -5082,16 +5082,16 @@ void mbedtls_mps_l2_pausing( int accumulator_too_small,
     TEST_ASSERT( in_srv.epoch == epoch_init );
     TEST_ASSERT( in_srv.type == ty_A );
     /* Read first half of first type-A record. */
-    TEST_ASSERT( mbedtls_reader_get( in_srv.rd, msg_chunk_size_A / 2,
+    TEST_ASSERT( mbedtls_mps_reader_get( in_srv.rd, msg_chunk_size_A / 2,
                                      &buf, &sz ) == 0 );
     TEST_ASSERT( sz == msg_chunk_size_A / 2 );
     for( uint8_t idx = 0; idx < sz; idx++ )
         TEST_ASSERT( buf[idx] == idx );
-    TEST_ASSERT( mbedtls_reader_commit( in_srv.rd ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_commit( in_srv.rd ) == 0 );
     /* Attempt to read more, exceeding the record bounds. */
-    TEST_ASSERT( mbedtls_reader_get( in_srv.rd, msg_chunk_size_A,
+    TEST_ASSERT( mbedtls_mps_reader_get( in_srv.rd, msg_chunk_size_A,
                                      &buf, NULL ) ==
-                 MBEDTLS_ERR_READER_OUT_OF_DATA );
+                 MBEDTLS_ERR_MPS_READER_OUT_OF_DATA );
     /* Pause reading. */
 
     TEST_ASSERT( mps_l2_read_done( &srv_l2 ) ==
@@ -5118,12 +5118,12 @@ void mbedtls_mps_l2_pausing( int accumulator_too_small,
     TEST_ASSERT( in_srv.epoch == epoch_init );
     TEST_ASSERT( in_srv.type == ty_B );
     /* Read and process its entire contents. */
-    TEST_ASSERT( mbedtls_reader_get( in_srv.rd, msg_chunk_size_B,
+    TEST_ASSERT( mbedtls_mps_reader_get( in_srv.rd, msg_chunk_size_B,
                                      &buf, &sz ) == 0 );
     TEST_ASSERT( sz == msg_chunk_size_B );
     for( uint8_t idx = 0; idx < sz; idx++ )
         TEST_ASSERT( buf[idx] == idx );
-    TEST_ASSERT( mbedtls_reader_commit( in_srv.rd ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_commit( in_srv.rd ) == 0 );
     TEST_ASSERT( mps_l2_read_done( &srv_l2 ) == 0 );
 
     /* Open the type-A stream again and retry the request
@@ -5133,7 +5133,7 @@ void mbedtls_mps_l2_pausing( int accumulator_too_small,
     TEST_ASSERT( in_srv.type == ty_A );
 
     /* ... now it should work thanks to the reader's pausing ability. */
-    TEST_ASSERT( mbedtls_reader_get( in_srv.rd, msg_chunk_size_A,
+    TEST_ASSERT( mbedtls_mps_reader_get( in_srv.rd, msg_chunk_size_A,
                                      &buf, &sz ) == 0 );
 
     TEST_ASSERT( sz == msg_chunk_size_A );
@@ -5146,7 +5146,7 @@ void mbedtls_mps_l2_pausing( int accumulator_too_small,
         TEST_ASSERT( buf[msg_chunk_size_A / 2 + idx] ==
                      ( msg_chunk_size_A - idx ) );
     }
-    TEST_ASSERT( mbedtls_reader_commit( in_srv.rd ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_commit( in_srv.rd ) == 0 );
     TEST_ASSERT( mps_l2_read_done( &srv_l2 ) == 0 );
 
 #endif /* MBEDTLS_MPS_SUPPORT_TWO_INTERLEAVED_MESSAGES < 2 */
@@ -5307,12 +5307,12 @@ void mbedtls_mps_l2_switch_epoch( int mode,
     TEST_ASSERT( in_srv.epoch == epoch_init );
     TEST_ASSERT( in_srv.type == ty_A );
 
-    TEST_ASSERT( mbedtls_reader_get( in_srv.rd, 20, &buf, &sz ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_get( in_srv.rd, 20, &buf, &sz ) == 0 );
 
     TEST_ASSERT( sz == 20 );
     for( uint8_t idx = 0; idx < sz; idx++ )
         TEST_ASSERT( buf[idx] == idx );
-    TEST_ASSERT( mbedtls_reader_commit( in_srv.rd ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_commit( in_srv.rd ) == 0 );
 
     TEST_ASSERT( mps_l2_read_done( &srv_l2 ) == 0 );
 
@@ -5331,12 +5331,12 @@ void mbedtls_mps_l2_switch_epoch( int mode,
     TEST_ASSERT( in_srv.epoch == epoch_crypt );
     TEST_ASSERT( in_srv.type == ty_B );
 
-    TEST_ASSERT( mbedtls_reader_get( in_srv.rd, 20, &buf, &sz ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_get( in_srv.rd, 20, &buf, &sz ) == 0 );
 
     TEST_ASSERT( sz == 20 );
     for( uint8_t idx = 0; idx < sz; idx++ )
         TEST_ASSERT( buf[idx] == idx );
-    TEST_ASSERT( mbedtls_reader_commit( in_srv.rd ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_commit( in_srv.rd ) == 0 );
 
     TEST_ASSERT( mps_l2_read_done( &srv_l2 ) == 0 );
 
@@ -5427,14 +5427,14 @@ void mbedtls_mps_l2_queueing( int allocator_buffer_sz,
         TEST_ASSERT( mps_l2_read_start( &srv_l2, &in_srv ) == 0 );
         TEST_ASSERT( in_srv.epoch == epoch_init );
         TEST_ASSERT( in_srv.type == ty_A );
-        TEST_ASSERT( mbedtls_reader_get( in_srv.rd,
+        TEST_ASSERT( mbedtls_mps_reader_get( in_srv.rd,
                                          (size_t) msg_size - server_read_pos,
                                          &buf, &sz ) == 0 );
         for( uint8_t idx = 0; idx < sz; idx++ )
             TEST_ASSERT( buf[idx] == (uint8_t) ( server_read_pos + idx ) );
 
         server_read_pos += sz;
-        TEST_ASSERT( mbedtls_reader_commit( in_srv.rd ) == 0 );
+        TEST_ASSERT( mbedtls_mps_reader_commit( in_srv.rd ) == 0 );
         TEST_ASSERT( mps_l2_read_done( &srv_l2 ) == 0 );
     }
 
@@ -5634,13 +5634,13 @@ void mbedtls_mps_l2_many_epochs( int mode,
             TEST_ASSERT( in_srv.epoch == (mbedtls_mps_epoch_id) rd );
             TEST_ASSERT( in_srv.type == ty_A );
 
-            ret = mbedtls_reader_get( in_srv.rd, 20, &buf, NULL );
-            TEST_ASSERT( ret == MBEDTLS_ERR_READER_OUT_OF_DATA || ret == 0 );
+            ret = mbedtls_mps_reader_get( in_srv.rd, 20, &buf, NULL );
+            TEST_ASSERT( ret == MBEDTLS_ERR_MPS_READER_OUT_OF_DATA || ret == 0 );
             if( ret == 0 )
                 for( uint8_t idx = 0; idx < 20; idx++ )
                     TEST_ASSERT( buf[idx] == idx );
 
-            TEST_ASSERT( mbedtls_reader_commit( in_srv.rd ) == 0 );
+            TEST_ASSERT( mbedtls_mps_reader_commit( in_srv.rd ) == 0 );
             TEST_ASSERT( mps_l2_read_done( &srv_l2 ) == 0 );
             if( ret == 0 )
                 break;
@@ -5675,13 +5675,13 @@ void mbedtls_mps_l2_many_epochs( int mode,
             TEST_ASSERT( in_srv.epoch == (mbedtls_mps_epoch_id) ( rd + 1 ) );
             TEST_ASSERT( in_srv.type == ty_B );
 
-            ret = mbedtls_reader_get( in_srv.rd, 20, &buf, NULL );
-            TEST_ASSERT( ret == MBEDTLS_ERR_READER_OUT_OF_DATA || ret == 0 );
+            ret = mbedtls_mps_reader_get( in_srv.rd, 20, &buf, NULL );
+            TEST_ASSERT( ret == MBEDTLS_ERR_MPS_READER_OUT_OF_DATA || ret == 0 );
             if( ret == 0 )
                 for( uint8_t idx = 0; idx < 20; idx++ )
                     TEST_ASSERT( buf[idx] == idx );
 
-            TEST_ASSERT( mbedtls_reader_commit( in_srv.rd ) == 0 );
+            TEST_ASSERT( mbedtls_mps_reader_commit( in_srv.rd ) == 0 );
             TEST_ASSERT( mps_l2_read_done( &srv_l2 ) == 0 );
             if( ret == 0 )
                 break;
@@ -5804,12 +5804,12 @@ void mbedtls_mps_l2_piggyback_data( int mode,
     TEST_ASSERT( in_srv.epoch == epoch_init );
     TEST_ASSERT( in_srv.type == ty_A );
 
-    TEST_ASSERT( mbedtls_reader_get( in_srv.rd, 10, &buf, &sz ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_get( in_srv.rd, 10, &buf, &sz ) == 0 );
 
     TEST_ASSERT( sz == 10 );
     for( uint8_t idx = 0; idx < sz; idx++ )
         TEST_ASSERT( buf[idx] == idx );
-    TEST_ASSERT( mbedtls_reader_commit( in_srv.rd ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_commit( in_srv.rd ) == 0 );
 
     TEST_ASSERT( mps_l2_read_done( &srv_l2 ) == 0 );
 
@@ -6082,14 +6082,14 @@ void mbedtls_mps_l2_random( int allocator_buffer_sz,
             printf( " READ START DONE\n" );
 
             TEST_ASSERT( in.type == chunk->type );
-            ret = mbedtls_reader_get( in.rd, data_requested, &buf,
+            ret = mbedtls_mps_reader_get( in.rd, data_requested, &buf,
                                       &data_obtained );
             TEST_ASSERT( ret == 0 );
             TEST_ASSERT( memcmp( buf, chunk->buf + chunk->read_progress,
                                  data_obtained ) == 0 );
             chunk->read_progress += data_obtained;
 
-            TEST_ASSERT( mbedtls_reader_commit( in.rd ) == 0 );
+            TEST_ASSERT( mbedtls_mps_reader_commit( in.rd ) == 0 );
             TEST_ASSERT( mps_l2_read_done( endpoint[self] ) == 0 );
 
             printf( "     PROGRESS %u / %u\n",
@@ -6580,14 +6580,14 @@ void mbedtls_mps_l3_basic_handshake(
     }
 
     /* Fetch next chunk of incoming data */
-    TEST_ASSERT( mbedtls_reader_get_ext( hs_in.rd_ext, 20, &tmp, NULL ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_get_ext( hs_in.rd_ext, 20, &tmp, NULL ) == 0 );
 
     /* Process incoming data */
     for( size_t idx=0; idx<10; idx++ )
         TEST_ASSERT( tmp[idx] == (unsigned char) idx );
 
     /* Commit last incoming chunk and update state */
-    TEST_ASSERT( mbedtls_reader_commit_ext( hs_in.rd_ext ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_commit_ext( hs_in.rd_ext ) == 0 );
 
     /* Signal that message has been processed. */
     TEST_ASSERT( mps_l3_read_consume( &srv_l3 ) == 0 );
@@ -7047,10 +7047,10 @@ repeat:
                 case 0:
 
                     /* Fetch next chunk of incoming data */
-                    res = mbedtls_reader_get_ext( hs_in.rd_ext, 4, &tmp, NULL );
+                    res = mbedtls_mps_reader_get_ext( hs_in.rd_ext, 4, &tmp, NULL );
                     TEST_ASSERT( res == 0 ||
-                                 res == MBEDTLS_ERR_READER_OUT_OF_DATA );
-                    if( res == MBEDTLS_ERR_READER_OUT_OF_DATA )
+                                 res == MBEDTLS_ERR_MPS_READER_OUT_OF_DATA );
+                    if( res == MBEDTLS_ERR_MPS_READER_OUT_OF_DATA )
                     {
                         pause = 1;
                         break;
@@ -7062,7 +7062,7 @@ repeat:
                                      (uint8_t)( msgs_remaining + idx ) );
 
                     /* Commit last incoming chunk and update state */
-                    TEST_ASSERT( mbedtls_reader_commit_ext(
+                    TEST_ASSERT( mbedtls_mps_reader_commit_ext(
                                      hs_in.rd_ext ) == 0 );
                     recv_state = 1;
 
@@ -7077,11 +7077,11 @@ repeat:
                 case 1:
 
                     /* Fetch next chunk of incoming data */
-                    res = mbedtls_reader_get_ext( hs_in.rd_ext, 4,
+                    res = mbedtls_mps_reader_get_ext( hs_in.rd_ext, 4,
                                                   &tmp, NULL );
                     TEST_ASSERT( res == 0 ||
-                                 res == MBEDTLS_ERR_READER_OUT_OF_DATA );
-                    if( res == MBEDTLS_ERR_READER_OUT_OF_DATA )
+                                 res == MBEDTLS_ERR_MPS_READER_OUT_OF_DATA );
+                    if( res == MBEDTLS_ERR_MPS_READER_OUT_OF_DATA )
                     {
                         pause = 1;
                         break;
@@ -7093,7 +7093,7 @@ repeat:
                                      (uint8_t) ( 4 + msgs_remaining + idx ) );
 
                     /* Commit last incoming chunk and update state */
-                    TEST_ASSERT( mbedtls_reader_commit_ext(
+                    TEST_ASSERT( mbedtls_mps_reader_commit_ext(
                                      hs_in.rd_ext ) == 0 );
                     recv_state = 2;
 
@@ -7205,14 +7205,14 @@ void mbedtls_mps_l3_basic_application( int mode,
     TEST_ASSERT( mps_l3_read_app( &srv_l3, &app_in ) == 0 );
 
     /* Fetch next chunk of incoming data */
-    TEST_ASSERT( mbedtls_reader_get( app_in.rd , 10, &tmp, NULL ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_get( app_in.rd , 10, &tmp, NULL ) == 0 );
 
     /* Process incoming data */
     for( size_t idx=0; idx<10; idx++ )
         TEST_ASSERT( tmp[idx] == (unsigned char) idx );
 
     /* Commit last incoming chunk and update state */
-    TEST_ASSERT( mbedtls_reader_commit( app_in.rd ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_commit( app_in.rd ) == 0 );
 
     /* Signal that message has been processed. */
     TEST_ASSERT( mps_l3_read_consume( &srv_l3 ) == 0 );
@@ -7789,11 +7789,11 @@ recv_start:
                 case 0:
 
                     /* Fetch next chunk of incoming data */
-                    res = mbedtls_reader_get_ext( hs_in.rd_ext, 3,
+                    res = mbedtls_mps_reader_get_ext( hs_in.rd_ext, 3,
                                                   &tmp, NULL );
                     TEST_ASSERT( res == 0 ||
-                                 res == MBEDTLS_ERR_READER_OUT_OF_DATA );
-                    if( res == MBEDTLS_ERR_READER_OUT_OF_DATA )
+                                 res == MBEDTLS_ERR_MPS_READER_OUT_OF_DATA );
+                    if( res == MBEDTLS_ERR_MPS_READER_OUT_OF_DATA )
                     {
                         pause = 1;
                         break;
@@ -7805,7 +7805,7 @@ recv_start:
                                      (uint8_t)( msgs_remaining + idx ) );
 
                     /* Commit last incoming chunk and update state */
-                    TEST_ASSERT( mbedtls_reader_commit_ext(
+                    TEST_ASSERT( mbedtls_mps_reader_commit_ext(
                                      hs_in.rd_ext ) == 0 );
                     recv_state = 1;
 
@@ -7820,11 +7820,11 @@ recv_start:
                 case 1:
 
                     /* Fetch next chunk of incoming data */
-                    res = mbedtls_reader_get_ext( hs_in.rd_ext, 5,
+                    res = mbedtls_mps_reader_get_ext( hs_in.rd_ext, 5,
                                                   &tmp, NULL );
                     TEST_ASSERT( res == 0 ||
-                                 res == MBEDTLS_ERR_READER_OUT_OF_DATA );
-                    if( res == MBEDTLS_ERR_READER_OUT_OF_DATA )
+                                 res == MBEDTLS_ERR_MPS_READER_OUT_OF_DATA );
+                    if( res == MBEDTLS_ERR_MPS_READER_OUT_OF_DATA )
                     {
                         pause = 1;
                         break;
@@ -7836,7 +7836,7 @@ recv_start:
                                      (uint8_t) ( 3 + msgs_remaining + idx ) );
 
                     /* Commit last incoming chunk and update state */
-                    TEST_ASSERT( mbedtls_reader_commit_ext(
+                    TEST_ASSERT( mbedtls_mps_reader_commit_ext(
                                      hs_in.rd_ext ) == 0 );
                     recv_state = 2;
 
@@ -8177,14 +8177,14 @@ void mbedtls_mps_l3_random( int allocator_buffer_sz,
                     ret = mps_l3_read_handshake( endpoint[self], &hs_in );
                     TEST_ASSERT( ret == 0 );
 
-                    ret = mbedtls_reader_get_ext( hs_in.rd_ext ,
+                    ret = mbedtls_mps_reader_get_ext( hs_in.rd_ext ,
                                                   data_requested, &buf,
                                                   &data_obtained );
                     TEST_ASSERT( ret == 0 );
                     TEST_ASSERT( memcmp( buf, chunk->data.hs.buf +
                                          chunk->data.hs.read_progress,
                                          data_obtained ) == 0 );
-                    TEST_ASSERT( mbedtls_reader_commit_ext( hs_in.rd_ext ) == 0 );
+                    TEST_ASSERT( mbedtls_mps_reader_commit_ext( hs_in.rd_ext ) == 0 );
 
                     chunk->data.hs.read_progress += data_obtained;
 
@@ -8228,14 +8228,14 @@ void mbedtls_mps_l3_random( int allocator_buffer_sz,
 
                     printf( "Requested amount of data: %u\n",
                             (unsigned) data_requested );
-                    ret = mbedtls_reader_get( app_in.rd ,
+                    ret = mbedtls_mps_reader_get( app_in.rd ,
                                               data_requested, &buf,
                                               &data_obtained );
                     TEST_ASSERT( ret == 0 );
                     TEST_ASSERT( memcmp( buf, chunk->data.app.buf +
                                          chunk->data.app.read_progress,
                                          data_obtained ) == 0 );
-                    TEST_ASSERT( mbedtls_reader_commit( app_in.rd ) == 0 );
+                    TEST_ASSERT( mbedtls_mps_reader_commit( app_in.rd ) == 0 );
 
                     chunk->data.app.read_progress += data_obtained;
                     TEST_ASSERT( mps_l3_read_consume( endpoint[self] ) == 0 );
@@ -8686,14 +8686,14 @@ void mbedtls_mps_l4_basic_handshake(
     TEST_ASSERT( hs_in.length == 20 );
 
     /* Fetch next chunk of incoming data */
-    TEST_ASSERT( mbedtls_reader_get_ext( hs_in.handle, 20, &tmp, NULL ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_get_ext( hs_in.handle, 20, &tmp, NULL ) == 0 );
 
     /* Process incoming data */
     for( size_t idx=0; idx<10; idx++ )
         TEST_ASSERT( tmp[idx] == (unsigned char) idx );
 
     /* Commit last incoming chunk and update state */
-    TEST_ASSERT( mbedtls_reader_commit_ext( hs_in.handle ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_commit_ext( hs_in.handle ) == 0 );
 
     /* Signal that message has been processed. */
     TEST_ASSERT( mbedtls_mps_read_consume( &srv_l4 ) == 0 );
@@ -9053,9 +9053,9 @@ void mbedtls_mps_l4_hs_inconsistent_continuation( int variant )
     TEST_ASSERT( mbedtls_mps_read_handshake( &srv_l4, &hs_in_srv ) == 0 );
     TEST_ASSERT( mbedtls_mps_read_set_flags( &srv_l4,
                                  MBEDTLS_MPS_FLIGHT_END ) == 0 );
-    TEST_ASSERT( mbedtls_reader_get_ext( hs_in_srv.handle, 10,
+    TEST_ASSERT( mbedtls_mps_reader_get_ext( hs_in_srv.handle, 10,
                                          &tmp, NULL ) == 0 );
-    TEST_ASSERT( mbedtls_reader_commit_ext( hs_in_srv.handle ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_commit_ext( hs_in_srv.handle ) == 0 );
     TEST_ASSERT( mbedtls_mps_read_consume( &srv_l4 ) == 0 );
 
     hs_out_srv.type = 0;
@@ -9185,9 +9185,9 @@ void mbedtls_mps_l4_hs_inconsistent_continuation( int variant )
     {
         TEST_ASSERT( mbedtls_mps_read( &srv_l4 ) == MBEDTLS_MPS_MSG_HS );
         TEST_ASSERT( mbedtls_mps_read_handshake( &srv_l4, &hs_in_srv ) == 0 );
-        TEST_ASSERT( mbedtls_reader_get_ext( hs_in_srv.handle, 20,
+        TEST_ASSERT( mbedtls_mps_reader_get_ext( hs_in_srv.handle, 20,
                                              &tmp, NULL ) == 0 );
-        TEST_ASSERT( mbedtls_reader_commit_ext( hs_in_srv.handle ) == 0 );
+        TEST_ASSERT( mbedtls_mps_reader_commit_ext( hs_in_srv.handle ) == 0 );
         TEST_ASSERT( mbedtls_mps_read_consume( &srv_l4 ) == 0 );
 
         TEST_ASSERT( mbedtls_mps_set_incoming_keys( &srv_l4, srv_epoch[1] ) == 0 );
@@ -9327,14 +9327,14 @@ void mbedtls_mps_l4_disruption( int mode,
     TEST_ASSERT( hs_in.length == 20 );
 
     /* Fetch next chunk of incoming data */
-    TEST_ASSERT( mbedtls_reader_get_ext( hs_in.handle, 20, &tmp, NULL ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_get_ext( hs_in.handle, 20, &tmp, NULL ) == 0 );
 
     /* Process incoming data */
     for( size_t idx=0; idx<10; idx++ )
         TEST_ASSERT( tmp[idx] == (unsigned char) idx );
 
     /* Commit last incoming chunk and update state */
-    TEST_ASSERT( mbedtls_reader_commit_ext( hs_in.handle ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_commit_ext( hs_in.handle ) == 0 );
 
     /* An orderly shutdown cannot happen in the middle of a handshake. */
     TEST_ASSERT( mbedtls_mps_read_set_flags( &srv_l4,
@@ -9397,14 +9397,14 @@ void mbedtls_mps_l4_disruption( int mode,
         TEST_ASSERT( hs_in.length == 20 );
 
         /* Fetch next chunk of incoming data */
-        TEST_ASSERT( mbedtls_reader_get_ext( hs_in.handle, 20, &tmp, NULL ) == 0 );
+        TEST_ASSERT( mbedtls_mps_reader_get_ext( hs_in.handle, 20, &tmp, NULL ) == 0 );
 
         /* Process incoming data */
         for( size_t idx=0; idx<10; idx++ )
             TEST_ASSERT( tmp[idx] == (unsigned char) idx );
 
         /* Commit last incoming chunk and update state */
-        TEST_ASSERT( mbedtls_reader_commit_ext( hs_in.handle ) == 0 );
+        TEST_ASSERT( mbedtls_mps_reader_commit_ext( hs_in.handle ) == 0 );
 
         /* An orderly shutdown cannot happen in the middle of a handshake. */
         TEST_ASSERT( mbedtls_mps_read_set_flags( &cli_l4,
@@ -9544,14 +9544,14 @@ void mbedtls_mps_l4_dtls_fragmentation( int allocator_buffer_sz,
             TEST_ASSERT( hs_in.len         == ( hs_len + iteration) );
             TEST_ASSERT( hs_in.seq_nr      == iteration             );
 
-            TEST_ASSERT( mbedtls_reader_get_ext( hs_in.rd_ext ,
+            TEST_ASSERT( mbedtls_mps_reader_get_ext( hs_in.rd_ext ,
                                                  hs_in.frag_len,
                                                  &tmp, NULL ) == 0 );
             for( size_t idx=0; idx<(unsigned) hs_in.frag_len; idx++ )
                 TEST_ASSERT( tmp[idx] == (unsigned char)( hs_offset + idx ) );
 
             /* Commit last incoming chunk and update state */
-            TEST_ASSERT( mbedtls_reader_commit_ext( hs_in.rd_ext ) == 0 );
+            TEST_ASSERT( mbedtls_mps_reader_commit_ext( hs_in.rd_ext ) == 0 );
 
             /* Signal that message fragment has been processed. */
             TEST_ASSERT( mps_l3_read_consume( &srv_l3 ) == 0 );
@@ -9760,11 +9760,11 @@ void mbedtls_mps_l4_dtls_reassembly( int allocator_buffer_sz,
         TEST_ASSERT( hs_in.length == hs_len    );
         TEST_ASSERT( hs_in.type   == iteration );
 
-        TEST_ASSERT( mbedtls_reader_get_ext( hs_in.handle, hs_in.length,
+        TEST_ASSERT( mbedtls_mps_reader_get_ext( hs_in.handle, hs_in.length,
                                              &tmp, NULL ) == 0 );
         for( size_t idx=0; idx<(unsigned) ( hs_len ); idx++ )
             TEST_ASSERT( tmp[idx] == (unsigned char) idx );
-        TEST_ASSERT( mbedtls_reader_commit_ext( hs_in.handle ) == 0 );
+        TEST_ASSERT( mbedtls_mps_reader_commit_ext( hs_in.handle ) == 0 );
         TEST_ASSERT( mbedtls_mps_read_consume( &srv_l4 ) == 0 );
 
     }
@@ -10327,9 +10327,9 @@ void mbedtls_mps_l4_flight_exchange( int mode,
             TEST_ASSERT( hs_in.length == hs_len + iteration );
             TEST_ASSERT( hs_in.type   == iteration );
 
-            ret = mbedtls_reader_get_ext( hs_in.handle, hs_in.length,
+            ret = mbedtls_mps_reader_get_ext( hs_in.handle, hs_in.length,
                                           &tmp, NULL );
-            if( ret == MBEDTLS_ERR_READER_OUT_OF_DATA )
+            if( ret == MBEDTLS_ERR_MPS_READER_OUT_OF_DATA )
             {
                 TEST_ASSERT( mbedtls_mps_read_pause( receiver ) == 0 );
                 continue;
@@ -10338,7 +10338,7 @@ void mbedtls_mps_l4_flight_exchange( int mode,
 
             for( size_t idx=0; idx<(unsigned) ( hs_len + iteration ); idx++ )
                 TEST_ASSERT( tmp[idx] == (unsigned char) idx );
-            TEST_ASSERT( mbedtls_reader_commit_ext( hs_in.handle ) == 0 );
+            TEST_ASSERT( mbedtls_mps_reader_commit_ext( hs_in.handle ) == 0 );
 
             if( iteration == (unsigned) ( num_hs - 1 ) )
             {


### PR DESCRIPTION
The MPS reader component has recently been [merged](https://github.com/ARMmbed/mbedtls/pull/4014) into upstream Mbed TLS after a number of smaller changes, mostly about naming.

This PR synchronizes the MPS reader in the TLS 1.3 prototype branch with the version that has been upstreamed.