### PR TITLE
Remove DTLS 1.3 specific code

### DIFF
--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -981,10 +981,6 @@
 #error "The new session ticket concept is only available with TLS 1.3 and is not compatible with RFC 5077-style session tickets."
 #endif
 
-#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && defined(MBEDTLS_SSL_PROTO_DTLS) && !defined(MBEDTLS_SSL_COOKIE_C)
-#error "Cookie functionality needs to be enabled for DTLS 1.3"
-#endif
-
 #if defined(MBEDTLS_SSL_TLS13_CTLS) && !defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
 #error "cTLS can only be used in context with TLS and/or DTLS 1.3"
 #endif

--- a/library/ssl_tls13_keys.c
+++ b/library/ssl_tls13_keys.c
@@ -561,13 +561,6 @@ int mbedtls_ssl_generate_early_data_keys( mbedtls_ssl_context *ssl,
         return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
     }
 
-#if defined(MBEDTLS_SSL_PROTO_DTLS) && defined(MBEDTLS_SSL_DTLS_ANTI_REPLAY)
-    if( ssl->conf->transport == MBEDTLS_SSL_TRANSPORT_DATAGRAM )
-    {
-        ssl_dtls_replay_reset( ssl );
-    }
-#endif /* MBEDTLS_SSL_PROTO_DTLS && MBEDTLS_SSL_DTLS_ANTI_REPLAY */
-
     if( ciphersuite_info->mac == MBEDTLS_MD_SHA256 )
     {
 #if defined(MBEDTLS_SHA256_C)


### PR DESCRIPTION
As discussed internally, this code is no longer maintained or tested, and moreover the plan is to implement DTLS 1.3 on top of MPS once TLS 1.3 + MPS are done.