### PR TITLE
Key schedule rework, pt 1

### DIFF
--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -3324,7 +3324,7 @@
  *
  * This module adds support for SHA-384 and SHA-512.
  */
-// #define MBEDTLS_SHA512_C
+ #define MBEDTLS_SHA512_C
 
 /**
  * \def MBEDTLS_SSL_CACHE_C

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -1084,6 +1084,16 @@ typedef void mbedtls_ssl_async_cancel_t( mbedtls_ssl_context *ssl );
 #endif /* MBEDTLS_KEY_EXCHANGE_WITH_CERT_ENABLED &&
           !MBEDTLS_SSL_KEEP_PEER_CERTIFICATE */
 
+typedef struct
+{
+    unsigned char client_application_traffic_secret_N[ MBEDTLS_MD_MAX_SIZE ];
+    unsigned char server_application_traffic_secret_N[ MBEDTLS_MD_MAX_SIZE ];
+    unsigned char exporter_master_secret             [ MBEDTLS_MD_MAX_SIZE ];
+#if defined(MBEDTLS_SSL_NEW_SESSION_TICKET)
+    unsigned char resumption_master_secret           [ MBEDTLS_MD_MAX_SIZE ];
+#endif /* MBEDTLS_SSL_NEW_SESSION_TICKET */
+} mbedtls_ssl_tls1_3_application_secrets;
+
 /*
  * This structure is used for storing current session data.
  *
@@ -1108,13 +1118,8 @@ struct mbedtls_ssl_session
     size_t id_len;              /*!< session id length  */
     unsigned char id[32];       /*!< session identifier */
     unsigned char master[48];   /*!< the master secret  */
-#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
-#if defined(MBEDTLS_SHA256_C) && !defined(MBEDTLS_SHA512_C)
-    unsigned char resumption_master_secret[32];
-#else /* MBEDTLS_SHA512_C */
-    unsigned char resumption_master_secret[48];
-#endif /* MBEDTLS_SHA256_C && !MBEDTLS_SHA512_C */
-#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
+
+    mbedtls_ssl_tls1_3_application_secrets app_secrets;
 
 #if defined(MBEDTLS_X509_CRT_PARSE_C)
 #if defined(MBEDTLS_SSL_KEEP_PEER_CERTIFICATE)

--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -481,6 +481,30 @@ struct mbedtls_ssl_key_set
 };
 typedef struct mbedtls_ssl_key_set mbedtls_ssl_key_set;
 
+typedef struct
+{
+    unsigned char binder_key                  [ MBEDTLS_MD_MAX_SIZE ];
+    unsigned char client_early_traffic_secret [ MBEDTLS_MD_MAX_SIZE ];
+    unsigned char early_exporter_master_secret[ MBEDTLS_MD_MAX_SIZE ];
+    size_t secret_len;
+} mbedtls_ssl_tls1_3_early_secrets;
+
+typedef struct
+{
+    unsigned char client_handshake_traffic_secret[ MBEDTLS_MD_MAX_SIZE ];
+    unsigned char server_handshake_traffic_secret[ MBEDTLS_MD_MAX_SIZE ];
+    size_t secret_len;
+} mbedtls_ssl_tls1_3_handshake_secrets;
+
+typedef struct
+{
+    unsigned char client_application_traffic_secret_N[ MBEDTLS_MD_MAX_SIZE ];
+    unsigned char server_application_traffic_secret_N[ MBEDTLS_MD_MAX_SIZE ];
+    unsigned char exporter_master_secret             [ MBEDTLS_MD_MAX_SIZE ];
+    unsigned char resumption_master_secret           [ MBEDTLS_MD_MAX_SIZE ];
+    size_t secret_len;
+} mbedtls_ssl_tls1_3_application_secrets;
+
 /*
  * This structure contains the parameters only needed during handshake.
  */
@@ -817,8 +841,7 @@ struct mbedtls_ssl_handshake_params
     unsigned char exporter_secret[MBEDTLS_MD_MAX_SIZE];
     unsigned char early_secret[MBEDTLS_MD_MAX_SIZE];
     unsigned char handshake_secret[MBEDTLS_MD_MAX_SIZE];
-    unsigned char client_handshake_traffic_secret[MBEDTLS_MD_MAX_SIZE];
-    unsigned char server_handshake_traffic_secret[MBEDTLS_MD_MAX_SIZE];
+    mbedtls_ssl_tls1_3_handshake_secrets hs_secrets;
     unsigned char master_secret[MBEDTLS_MD_MAX_SIZE];
     unsigned char client_traffic_secret[MBEDTLS_MD_MAX_SIZE];
     unsigned char server_traffic_secret[MBEDTLS_MD_MAX_SIZE];

--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -486,24 +486,13 @@ typedef struct
     unsigned char binder_key                  [ MBEDTLS_MD_MAX_SIZE ];
     unsigned char client_early_traffic_secret [ MBEDTLS_MD_MAX_SIZE ];
     unsigned char early_exporter_master_secret[ MBEDTLS_MD_MAX_SIZE ];
-    size_t secret_len;
 } mbedtls_ssl_tls1_3_early_secrets;
 
 typedef struct
 {
     unsigned char client_handshake_traffic_secret[ MBEDTLS_MD_MAX_SIZE ];
     unsigned char server_handshake_traffic_secret[ MBEDTLS_MD_MAX_SIZE ];
-    size_t secret_len;
 } mbedtls_ssl_tls1_3_handshake_secrets;
-
-typedef struct
-{
-    unsigned char client_application_traffic_secret_N[ MBEDTLS_MD_MAX_SIZE ];
-    unsigned char server_application_traffic_secret_N[ MBEDTLS_MD_MAX_SIZE ];
-    unsigned char exporter_master_secret             [ MBEDTLS_MD_MAX_SIZE ];
-    unsigned char resumption_master_secret           [ MBEDTLS_MD_MAX_SIZE ];
-    size_t secret_len;
-} mbedtls_ssl_tls1_3_application_secrets;
 
 /*
  * This structure contains the parameters only needed during handshake.
@@ -709,11 +698,6 @@ struct mbedtls_ssl_handshake_params
 
     mbedtls_ssl_tls_prf_cb *tls_prf;
 
-   /* Buffer holding the digest up to, and including,
-     * the Finished message sent by the server.
-     */
-    unsigned char server_finished_digest[MBEDTLS_MD_MAX_SIZE];
-
     /*
      * State-local variables used during the processing
      * of a specific handshake state.
@@ -843,8 +827,6 @@ struct mbedtls_ssl_handshake_params
     unsigned char handshake_secret[MBEDTLS_MD_MAX_SIZE];
     mbedtls_ssl_tls1_3_handshake_secrets hs_secrets;
     unsigned char master_secret[MBEDTLS_MD_MAX_SIZE];
-    unsigned char client_traffic_secret[MBEDTLS_MD_MAX_SIZE];
-    unsigned char server_traffic_secret[MBEDTLS_MD_MAX_SIZE];
     unsigned char client_finished_key[MBEDTLS_MD_MAX_SIZE];
     unsigned char server_finished_key[MBEDTLS_MD_MAX_SIZE];
 

--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -831,8 +831,8 @@ struct mbedtls_ssl_handshake_params
     unsigned char server_finished_key[MBEDTLS_MD_MAX_SIZE];
 
 #if defined(MBEDTLS_ZERO_RTT)
+    mbedtls_ssl_tls1_3_early_secrets early_secrets;
     unsigned char binder_key[MBEDTLS_MD_MAX_SIZE];
-    unsigned char client_early_traffic_secret[MBEDTLS_MD_MAX_SIZE];
 
     /*!< Early data indication:
     0  -- MBEDTLS_SSL_EARLY_DATA_DISABLED (for no early data), and

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -970,8 +970,7 @@ int mbedtls_ssl_write_pre_shared_key_ext( mbedtls_ssl_context *ssl,
         ret = mbedtls_ssl_create_binder( ssl,
                   external_psk,
                   psk, psk_len,
-                  mbedtls_md_info_from_type( suite_info->mac ),
-                  suite_info, p );
+                  suite_info->mac, p );
 
         if( ret != 0 )
         {

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -978,7 +978,7 @@ int mbedtls_ssl_write_pre_shared_key_ext( mbedtls_ssl_context *ssl,
         if( ret != 0 )
             return( ret );
 
-        ret = mbedtls_ssl_create_binder( ssl,
+        ret = mbedtls_ssl_tls1_3_create_psk_binder( ssl,
                   external_psk,
                   psk, psk_len,
                   suite_info->mac,

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -2503,25 +2503,6 @@ static int ssl_finished_out_postprocess( mbedtls_ssl_context* ssl )
 #if defined(MBEDTLS_SSL_SRV_C)
     if( ssl->conf->endpoint == MBEDTLS_SSL_IS_SERVER )
     {
-        size_t transcript_len;
-
-        ret = mbedtls_ssl_get_handshake_transcript( ssl,
-                              ssl->handshake->ciphersuite_info->mac,
-                              ssl->handshake->server_finished_digest,
-                              sizeof(ssl->handshake->server_finished_digest),
-                              &transcript_len );
-        if( ret != 0 )
-        {
-            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_get_handshake_transcript",
-                                   ret );
-            return( ret );
-        }
-
-        MBEDTLS_SSL_DEBUG_BUF( 3, "Transcript hash (incl. Server.Finished):",
-                               ssl->handshake->server_finished_digest,
-                               transcript_len );
-
-
         mbedtls_ssl_key_set traffic_keys;
         ret = mbedtls_ssl_generate_application_traffic_keys( ssl,
                                                              &traffic_keys );
@@ -2789,94 +2770,6 @@ static int ssl_finished_in_parse( mbedtls_ssl_context* ssl,
 static int ssl_finished_in_postprocess_cli( mbedtls_ssl_context *ssl )
 {
     int ret = 0;
-
-    const mbedtls_ssl_ciphersuite_t *suite_info =
-        mbedtls_ssl_ciphersuite_from_id( ssl->session_negotiate->ciphersuite );
-    const mbedtls_cipher_info_t *cipher_info;
-
-    mbedtls_md_type_t hash_type;
-
-    /* Compute hash over transcript of all messages sent up to the Finished
-     * message sent by the server and store it in the digest variable of the
-     * handshake state. This digest will be needed later when computing the
-     * application traffic secrets. */
-    cipher_info = mbedtls_cipher_info_from_type(
-                                ssl->handshake->ciphersuite_info->cipher );
-    if( cipher_info == NULL )
-    {
-        MBEDTLS_SSL_DEBUG_MSG( 1, ( "cipher info for %d not found",
-                                  ssl->handshake->ciphersuite_info->cipher ) );
-        return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
-    }
-
-    if( suite_info == NULL )
-    {
-        MBEDTLS_SSL_DEBUG_MSG( 1, ( "mbedtls_ssl_ciphersuite_from_id in "
-                                  "mbedtls_ssl_generate_handshake_traffic_keys failed" ) );
-        return( MBEDTLS_ERR_SSL_BAD_HS_SERVER_HELLO );
-    }
-
-    hash_type = suite_info->mac;
-
-#if defined(MBEDTLS_SHA256_C)
-    if( hash_type == MBEDTLS_MD_SHA256 )
-    {
-        mbedtls_sha256_context sha256;
-        mbedtls_sha256_init( &sha256 );
-
-        if( ( ret = mbedtls_sha256_starts_ret( &sha256, 0 ) ) != 0 )
-        {
-            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha256_starts_ret", ret );
-            goto exit;
-        }
-
-        mbedtls_sha256_clone( &sha256, &ssl->handshake->fin_sha256 );
-
-        ret = mbedtls_sha256_finish_ret( &sha256,
-                               ssl->handshake->server_finished_digest );
-
-        mbedtls_sha256_free( &sha256 );
-
-        if( ret != 0 )
-        {
-            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha256_finish_ret", ret );
-            goto exit;
-        }
-    }
-    else
-#endif /* MBEDTLS_SHA256_C */
-#if defined(MBEDTLS_SHA512_C)
-    if( hash_type == MBEDTLS_MD_SHA384 )
-    {
-        mbedtls_sha512_context sha512;
-        mbedtls_sha512_init( &sha512 );
-
-        if( ( ret = mbedtls_sha512_starts_ret( &sha512, 1 ) ) != 0 )
-        {
-            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha512_starts_ret", ret );
-            goto exit;
-        }
-
-        mbedtls_sha512_clone( &sha512, &ssl->handshake->fin_sha512 );
-
-        ret = mbedtls_sha512_finish_ret( &sha512,
-                                  ssl->handshake->server_finished_digest );
-
-        mbedtls_sha512_free( &sha512 );
-
-        if( ret != 0 )
-        {
-            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha512_finish_ret", ret );
-            goto exit;
-        }
-    }
-    else
-#endif /* MBEDTLS_SHA512_C */
-    {
-        MBEDTLS_SSL_DEBUG_MSG( 1, ( "should never happen" ) );
-        return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
-    }
-
     mbedtls_ssl_key_set traffic_keys;
     ret = mbedtls_ssl_generate_application_traffic_keys( ssl, &traffic_keys );
 
@@ -2921,16 +2814,7 @@ static int ssl_finished_in_postprocess_cli( mbedtls_ssl_context *ssl )
     }
 #endif /* MBEDTLS_SSL_USE_MPS */
 
-exit:
-
-    if( ret == 0 )
-    {
-        MBEDTLS_SSL_DEBUG_BUF( 3, "Transcript hash (incl. Srv.Finished):",
-                             ssl->handshake->server_finished_digest,
-                             mbedtls_hash_size_for_ciphersuite( suite_info ) );
-    }
-
-    return( ret );
+    return( 0 );
 }
 #endif /* MBEDTLS_SSL_CLI_C */
 
@@ -3217,7 +3101,7 @@ static int ssl_new_session_ticket_parse( mbedtls_ssl_context* ssl,
         return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
 
     MBEDTLS_SSL_DEBUG_BUF( 3, "resumption_master_secret",
-                           ssl->session->resumption_master_secret,
+                           ssl->session->app_secrets.resumption_master_secret,
                            hash_length );
 
     /* Computer resumption key
@@ -3226,7 +3110,7 @@ static int ssl_new_session_ticket_parse( mbedtls_ssl_context* ssl,
      *                    "resumption", ticket_nonce, Hash.length )
      */
     ret = mbedtls_ssl_tls1_3_hkdf_expand_label( suite_info->mac,
-                    ssl->session->resumption_master_secret,
+                    ssl->session->app_secrets.resumption_master_secret,
                     hash_length,
                     MBEDTLS_SSL_TLS1_3_LBL_WITH_LEN( resumption ),
                     ssl->session->ticket_nonce,

--- a/library/ssl_tls13_keys.c
+++ b/library/ssl_tls13_keys.c
@@ -867,14 +867,6 @@ int mbedtls_ssl_handshake_key_derivation( mbedtls_ssl_context *ssl, mbedtls_ssl_
     if( ( ret = mbedtls_ssl_tls1_3_set_verify( ssl ) ) != 0 )
         return( ret );
 
-#if !defined(MBEDTLS_SSL_USE_MPS)
-    /*
-     * Set the in_msg pointer to the correct location based on IV length
-     * For TLS 1.3 the record layer header has changed and hence we need to accomodate for it.
-     */
-    ssl->in_msg = ssl->in_iv;
-#endif /* MBEDTLS_SSL_USE_MPS */
-
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "<= mbedtls_ssl_handshake_key_derivation" ) );
     return( 0 );
 }

--- a/library/ssl_tls13_keys.c
+++ b/library/ssl_tls13_keys.c
@@ -1055,6 +1055,48 @@ int mbedtls_ssl_tls1_3_set_verify( mbedtls_ssl_context *ssl )
     return( 0 );
 }
 
+int mbedtls_ssl_tls1_3_derive_early_secrets(
+          mbedtls_md_type_t md_type,
+          unsigned char const *early_secret,
+          unsigned char const *transcript, size_t transcript_len,
+          mbedtls_ssl_tls1_3_early_secrets *derived_early_secrets )
+{
+    ((void) md_type);
+    ((void) early_secret);
+    ((void) transcript);
+    ((void) transcript_len);
+    ((void) derived_early_secrets);
+    return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
+}
+
+int mbedtls_ssl_tls1_3_derive_handshake_secrets(
+          mbedtls_md_type_t md_type,
+          unsigned char const *handshake_secret,
+          unsigned char const *transcript, size_t transcript_len,
+          mbedtls_ssl_tls1_3_handshake_secrets *derived_handshake_secrets )
+{
+    ((void) md_type);
+    ((void) handshake_secret);
+    ((void) transcript);
+    ((void) transcript_len);
+    ((void) derived_handshake_secrets);
+    return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
+}
+
+int mbedtls_ssl_tls1_3_derive_application_secrets(
+          mbedtls_md_type_t md_type,
+          unsigned char const *application_secret,
+          unsigned char const *transcript, size_t transcript_len,
+          mbedtls_ssl_tls1_3_application_secrets *derived_application_secrets )
+{
+    ((void) md_type);
+    ((void) application_secret);
+    ((void) transcript);
+    ((void) transcript_len);
+    ((void) derived_application_secrets);
+    return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
+}
+
 /* mbedtls_ssl_generate_handshake_traffic_keys() generates keys necessary for
  * protecting the handshake messages, as described in Section 7 of TLS 1.3. */
 int mbedtls_ssl_generate_handshake_traffic_keys( mbedtls_ssl_context *ssl,

--- a/library/ssl_tls13_keys.c
+++ b/library/ssl_tls13_keys.c
@@ -1448,11 +1448,11 @@ int mbedtls_ssl_create_binder( mbedtls_ssl_context *ssl,
                                int is_external,
                                unsigned char *psk, size_t psk_len,
                                const mbedtls_md_type_t md_type,
+                               unsigned char const *transcript,
+                               size_t transcript_len,
                                unsigned char *result )
 {
     int ret = 0;
-    unsigned char transcript[MBEDTLS_MD_MAX_SIZE];
-    size_t transcript_len;
     unsigned char binder_key[MBEDTLS_MD_MAX_SIZE];
     unsigned char finished_key[MBEDTLS_MD_MAX_SIZE];
     mbedtls_md_info_t const *md_info = mbedtls_md_info_from_type( md_type );
@@ -1498,13 +1498,6 @@ int mbedtls_ssl_create_binder( mbedtls_ssl_context *ssl,
         MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_tls1_3_derive_secret", ret );
         return( ret );
     }
-
-    /* Get current state of handshake transcript. */
-    ret = mbedtls_ssl_get_handshake_transcript( ssl, md_type,
-                                                transcript, sizeof( transcript ),
-                                                &transcript_len );
-    if( ret != 0 )
-        return( ret );
 
     /*
      * finished_key =

--- a/library/ssl_tls13_keys.c
+++ b/library/ssl_tls13_keys.c
@@ -1425,7 +1425,7 @@ int mbedtls_ssl_generate_resumption_master_secret( mbedtls_ssl_context *ssl )
 
 
 #if defined(MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED)
-/* mbedtls_ssl_create_binder():
+/* mbedtls_ssl_tls1_3_create_psk_binder():
  *
  *                0
  *                |
@@ -1444,7 +1444,7 @@ int mbedtls_ssl_generate_resumption_master_secret( mbedtls_ssl_context *ssl )
  *               ...
  */
 
-int mbedtls_ssl_create_binder( mbedtls_ssl_context *ssl,
+int mbedtls_ssl_tls1_3_create_psk_binder( mbedtls_ssl_context *ssl,
                                int is_external,
                                unsigned char *psk, size_t psk_len,
                                const mbedtls_md_type_t md_type,

--- a/library/ssl_tls13_keys.h
+++ b/library/ssl_tls13_keys.h
@@ -351,6 +351,8 @@ int mbedtls_ssl_tls1_3_create_psk_binder( mbedtls_ssl_context *ssl,
                                unsigned char *result );
 #endif /* MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED */
 
-int mbedtls_ssl_tls1_3_derive_master_secret( mbedtls_ssl_context* ssl );
+int mbedtls_ssl_tls1_3_derive_master_secret( mbedtls_ssl_context *ssl,
+                                             unsigned char *ephemeral,
+                                             size_t ephemeral_len );
 
 #endif /* MBEDTLS_SSL_TLS1_3_KEYS_H */

--- a/library/ssl_tls13_keys.h
+++ b/library/ssl_tls13_keys.h
@@ -316,8 +316,7 @@ int mbedtls_ssl_generate_resumption_master_secret( mbedtls_ssl_context* ssl );
 int mbedtls_ssl_create_binder( mbedtls_ssl_context *ssl,
                                int is_external,
                                unsigned char *psk, size_t psk_len,
-                               const mbedtls_md_info_t *md,
-                               const mbedtls_ssl_ciphersuite_t *suite_info,
+                               const mbedtls_md_type_t md_type,
                                unsigned char *result );
 #endif /* MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED */
 

--- a/library/ssl_tls13_keys.h
+++ b/library/ssl_tls13_keys.h
@@ -321,6 +321,14 @@ int mbedtls_ssl_tls1_3_derive_application_secrets(
           unsigned char const *transcript, size_t transcript_len,
           mbedtls_ssl_tls1_3_application_secrets *derived_application_secrets );
 
+#if defined(MBEDTLS_SSL_NEW_SESSION_TICKET)
+int mbedtls_ssl_tls1_3_derive_resumption_master_secret(
+          mbedtls_md_type_t md_type,
+          unsigned char const *application_secret,
+          unsigned char const *transcript, size_t transcript_len,
+          mbedtls_ssl_tls1_3_application_secrets *derived_application_secrets );
+#endif /* MBEDTLS_SSL_NEW_SESSION_TICKET */
+
 /* TODO: Document */
 int mbedtls_ssl_generate_application_traffic_keys( mbedtls_ssl_context* ssl,
                                                    mbedtls_ssl_key_set* traffic_keys );

--- a/library/ssl_tls13_keys.h
+++ b/library/ssl_tls13_keys.h
@@ -19,6 +19,8 @@
 #if !defined(MBEDTLS_SSL_TLS1_3_KEYS_H)
 #define MBEDTLS_SSL_TLS1_3_KEYS_H
 
+#include "mbedtls/ssl_internal.h"
+
 /* The maximum size of the intermediate key material.
  * The IKM can be a
  * - 0-string of length corresponding to the size of the
@@ -300,30 +302,6 @@ int mbedtls_ssl_tls1_3_evolve_secret(
                    const unsigned char *secret_old,
                    const unsigned char *input, size_t input_len,
                    unsigned char *secret_new );
-
-typedef struct
-{
-    unsigned char binder_key                  [ MBEDTLS_MD_MAX_SIZE ];
-    unsigned char client_early_traffic_secret [ MBEDTLS_MD_MAX_SIZE ];
-    unsigned char early_exporter_master_secret[ MBEDTLS_MD_MAX_SIZE ];
-    size_t secret_len;
-} mbedtls_ssl_tls1_3_early_secrets;
-
-typedef struct
-{
-    unsigned char client_handshake_traffic_secret[ MBEDTLS_MD_MAX_SIZE ];
-    unsigned char server_handshake_traffic_secret[ MBEDTLS_MD_MAX_SIZE ];
-    size_t secret_len;
-} mbedtls_ssl_tls1_3_handshake_secrets;
-
-typedef struct
-{
-    unsigned char client_application_traffic_secret_N[ MBEDTLS_MD_MAX_SIZE ];
-    unsigned char server_application_traffic_secret_N[ MBEDTLS_MD_MAX_SIZE ];
-    unsigned char exporter_master_secret             [ MBEDTLS_MD_MAX_SIZE ];
-    unsigned char resumption_master_secret           [ MBEDTLS_MD_MAX_SIZE ];
-    size_t secret_len;
-} mbedtls_ssl_tls1_3_application_secrets;
 
 int mbedtls_ssl_tls1_3_derive_early_secrets(
           mbedtls_md_type_t md_type,

--- a/library/ssl_tls13_keys.h
+++ b/library/ssl_tls13_keys.h
@@ -313,7 +313,7 @@ int mbedtls_ssl_generate_handshake_traffic_keys( mbedtls_ssl_context* ssl,
 int mbedtls_ssl_generate_resumption_master_secret( mbedtls_ssl_context* ssl );
 
 #if defined(MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED)
-int mbedtls_ssl_create_binder( mbedtls_ssl_context *ssl,
+int mbedtls_ssl_tls1_3_create_psk_binder( mbedtls_ssl_context *ssl,
                                int is_external,
                                unsigned char *psk, size_t psk_len,
                                const mbedtls_md_type_t md_type,

--- a/library/ssl_tls13_keys.h
+++ b/library/ssl_tls13_keys.h
@@ -301,6 +301,48 @@ int mbedtls_ssl_tls1_3_evolve_secret(
                    const unsigned char *input, size_t input_len,
                    unsigned char *secret_new );
 
+typedef struct
+{
+    unsigned char binder_key                  [ MBEDTLS_MD_MAX_SIZE ];
+    unsigned char client_early_traffic_secret [ MBEDTLS_MD_MAX_SIZE ];
+    unsigned char early_exporter_master_secret[ MBEDTLS_MD_MAX_SIZE ];
+    size_t secret_len;
+} mbedtls_ssl_tls1_3_early_secrets;
+
+typedef struct
+{
+    unsigned char client_handshake_traffic_secret[ MBEDTLS_MD_MAX_SIZE ];
+    unsigned char server_handshake_traffic_secret[ MBEDTLS_MD_MAX_SIZE ];
+    size_t secret_len;
+} mbedtls_ssl_tls1_3_handshake_secrets;
+
+typedef struct
+{
+    unsigned char client_application_traffic_secret_N[ MBEDTLS_MD_MAX_SIZE ];
+    unsigned char server_application_traffic_secret_N[ MBEDTLS_MD_MAX_SIZE ];
+    unsigned char exporter_master_secret             [ MBEDTLS_MD_MAX_SIZE ];
+    unsigned char resumption_master_secret           [ MBEDTLS_MD_MAX_SIZE ];
+    size_t secret_len;
+} mbedtls_ssl_tls1_3_application_secrets;
+
+int mbedtls_ssl_tls1_3_derive_early_secrets(
+          mbedtls_md_type_t md_type,
+          unsigned char const *early_secret,
+          unsigned char const *transcript, size_t transcript_len,
+          mbedtls_ssl_tls1_3_early_secrets *derived_early_secrets );
+
+int mbedtls_ssl_tls1_3_derive_handshake_secrets(
+          mbedtls_md_type_t md_type,
+          unsigned char const *handshake_secret,
+          unsigned char const *transcript, size_t transcript_len,
+          mbedtls_ssl_tls1_3_handshake_secrets *derived_handshake_secrets );
+
+int mbedtls_ssl_tls1_3_derive_application_secrets(
+          mbedtls_md_type_t md_type,
+          unsigned char const *application_secret,
+          unsigned char const *transcript, size_t transcript_len,
+          mbedtls_ssl_tls1_3_application_secrets *derived_application_secrets );
+
 /* TODO: Document */
 int mbedtls_ssl_generate_application_traffic_keys( mbedtls_ssl_context* ssl,
                                                    mbedtls_ssl_key_set* traffic_keys );

--- a/library/ssl_tls13_keys.h
+++ b/library/ssl_tls13_keys.h
@@ -317,6 +317,8 @@ int mbedtls_ssl_create_binder( mbedtls_ssl_context *ssl,
                                int is_external,
                                unsigned char *psk, size_t psk_len,
                                const mbedtls_md_type_t md_type,
+                               unsigned char const *transcript,
+                               size_t transcript_len,
                                unsigned char *result );
 #endif /* MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED */
 

--- a/library/ssl_tls13_keys.h
+++ b/library/ssl_tls13_keys.h
@@ -308,6 +308,7 @@ int mbedtls_ssl_generate_early_data_keys( mbedtls_ssl_context *ssl,
                                           mbedtls_ssl_key_set *traffic_keys );
 int mbedtls_ssl_handshake_key_derivation( mbedtls_ssl_context* ssl,
                                           mbedtls_ssl_key_set* traffic_keys );
+int mbedtls_ssl_tls1_3_set_verify( mbedtls_ssl_context *ssl );
 int mbedtls_ssl_generate_handshake_traffic_keys( mbedtls_ssl_context* ssl,
                                                  mbedtls_ssl_key_set* traffic_keys );
 int mbedtls_ssl_generate_resumption_master_secret( mbedtls_ssl_context* ssl );

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -1606,7 +1606,7 @@ static int ssl_write_new_session_ticket_write( mbedtls_ssl_context* ssl,
                            p, MBEDTLS_SSL_TICKET_NONCE_LENGTH );
 
     MBEDTLS_SSL_DEBUG_BUF( 3, "resumption_master_secret",
-                           ssl->session->resumption_master_secret,
+                           ssl->session->app_secrets.resumption_master_secret,
                            hash_length );
 
     /* Computer resumption key
@@ -1615,7 +1615,7 @@ static int ssl_write_new_session_ticket_write( mbedtls_ssl_context* ssl,
      *                    "resumption", ticket_nonce, Hash.length )
      */
     ret = mbedtls_ssl_tls1_3_hkdf_expand_label( suite_info->mac,
-               ssl->session->resumption_master_secret,
+               ssl->session->app_secrets.resumption_master_secret,
                hash_length,
                MBEDTLS_SSL_TLS1_3_LBL_WITH_LEN( resumption ),
                (const unsigned char *) p,

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -833,9 +833,7 @@ psk_parsing_successful:
                         0 /* resumption PSK */,
                         ssl->handshake->psk,
                         ssl->handshake->psk_len,
-                        mbedtls_md_info_from_type(
-                            ssl->handshake->ciphersuite_info->mac ),
-                        ssl->handshake->ciphersuite_info,
+                        ssl->handshake->ciphersuite_info->mac,
                         server_computed_binder );
         }
         else
@@ -847,9 +845,7 @@ psk_parsing_successful:
             ret = mbedtls_ssl_create_binder( ssl,
                      1 /* external PSK */,
                      (unsigned char *) psk, psk_len,
-                     mbedtls_md_info_from_type(
-                         ssl->handshake->ciphersuite_info->mac ),
-                     ssl->handshake->ciphersuite_info,
+                     ssl->handshake->ciphersuite_info->mac,
                      server_computed_binder );
         }
 

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -840,7 +840,7 @@ psk_parsing_successful:
         if( ssl->handshake->resume == 1 )
         {
             /* Case 1: We are using the PSK from a ticket */
-            ret = mbedtls_ssl_create_binder( ssl,
+            ret = mbedtls_ssl_tls1_3_create_psk_binder( ssl,
                         0 /* resumption PSK */,
                         ssl->handshake->psk,
                         ssl->handshake->psk_len,
@@ -854,7 +854,7 @@ psk_parsing_successful:
             if( ( ret = mbedtls_ssl_get_psk( ssl, &psk, &psk_len ) ) != 0 )
                 return( ret );
 
-            ret = mbedtls_ssl_create_binder( ssl,
+            ret = mbedtls_ssl_tls1_3_create_psk_binder( ssl,
                      1 /* external PSK */,
                      (unsigned char *) psk, psk_len,
                      ssl->handshake->ciphersuite_info->mac,


### PR DESCRIPTION
This PR restructures and cleans up the TLS 1.3 key schedule functionality, fixing part of #201. More changes will be necessary,but will be implemented in separate PRs.