### PR TITLE
Simplify mbedtls_ssl_hdr_len

### DIFF
--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -1620,44 +1620,9 @@ void mbedtls_ssl_read_version( int *major, int *minor, int transport,
 
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
-static inline size_t mbedtls_ssl_hdr_len(const mbedtls_ssl_context* ssl,
-                                         mbedtls_ssl_transform* transform)
-{
-#if defined(MBEDTLS_SSL_PROTO_DTLS)
-    if (ssl->conf->transport == MBEDTLS_SSL_TRANSPORT_DATAGRAM) {
-
-        int len;
-
-        /* We are dealing with a plaintext DTLS 1.3 packet if transform is NULL */
-        if (transform == NULL)  return(13);
-
-        /* If the DTLS 1.3 packet is encrypted then we need to deterine the header size.
-         * For the moment we assumed a 16-bit sequence number and that the length field
-         * is included in the payload.
-         */
-        len = 1 /* unified header */ + 2 /* sequence number */ + 2 /* length */;
-
-        return (len);
-    }
-    else
-#else
-    {
-        ((void)transform);
-        ((void)ssl);
-    }
-#endif /* MBEDTLS_SSL_PROTO_DTLS */
-    return(5); /* TLS 1.3 header */
-}
-#else
 static inline size_t mbedtls_ssl_hdr_len(const mbedtls_ssl_context* ssl)
 {
-#if defined(MBEDTLS_SSL_PROTO_DTLS)
-    if (ssl->conf->transport == MBEDTLS_SSL_TRANSPORT_DATAGRAM) {
-        return(13);
-    }
-#else
-    ((void)ssl);
-#endif
+    ((void) ssl);
     return(5);
 }
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -2152,7 +2152,7 @@ static int ssl_client_hello_fetch( mbedtls_ssl_context* ssl,
     buf = ssl->in_hdr;
 
     MBEDTLS_SSL_DEBUG_BUF( 4, "record header", buf,
-             mbedtls_ssl_hdr_len( ssl, NULL ) );
+             mbedtls_ssl_hdr_len( ssl ) );
 
     /*
      * TLS Client Hello
@@ -2181,7 +2181,7 @@ static int ssl_client_hello_fetch( mbedtls_ssl_context* ssl,
             MBEDTLS_SSL_DEBUG_MSG( 3, ( "CCS, message len.: %d", msg_len ) );
 
             if( ( ret = mbedtls_ssl_fetch_input( ssl,
-                            mbedtls_ssl_hdr_len( ssl, NULL ) + msg_len ) ) != 0 )
+                            mbedtls_ssl_hdr_len( ssl ) + msg_len ) ) != 0 )
             {
                 MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_fetch_input", ret );
                 return( MBEDTLS_ERR_SSL_BAD_HS_CHANGE_CIPHER_SPEC );
@@ -2225,7 +2225,7 @@ static int ssl_client_hello_fetch( mbedtls_ssl_context* ssl,
     }
 
     if( ( ret = mbedtls_ssl_fetch_input( ssl,
-                      mbedtls_ssl_hdr_len( ssl, ssl->transform_in ) + msg_len ) ) != 0 )
+                      mbedtls_ssl_hdr_len( ssl ) + msg_len ) ) != 0 )
     {
         MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_fetch_input", ret );
         return( MBEDTLS_ERR_SSL_BAD_HS_CLIENT_HELLO );


### PR DESCRIPTION
Summary:
`mbedtls_ssl_hdr_len` is only called on `ssl_tls13_server.c` where `MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL` is always on. And when it is on, the MBEDTLS_SSL_PROTO_DTLS will be off. Simplify it by removing `MBEDTLS_SSL_PROTO_DTLS` from `mbedtls_ssl_hdr_len`.

Test Plan:
```
tests/ssl-opt.sh
```

Reviewers:

Subscribers:

Tasks:

Tags: