### PR TITLE
Simplify MBEDTLS_SSL_TLS13_COMPATIBILITY_MODE  in `ssl_server_hello_parse` and `ssl_hrr_parse`

### DIFF
--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -3069,7 +3069,6 @@ static int ssl_server_hello_parse( mbedtls_ssl_context* ssl,
     /* skip random bytes */
     buf += 32;
 
-#if defined(MBEDTLS_SSL_TLS13_COMPATIBILITY_MODE)
     /* legacy_session_id_echo */
     if( ssl->session_negotiate->id_len != buf[0] )
     {
@@ -3094,19 +3093,6 @@ static int ssl_server_hello_parse( mbedtls_ssl_context* ssl,
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "session id length ( %d )", ssl->session_negotiate->id_len ) );
     MBEDTLS_SSL_DEBUG_BUF( 3, "session id", ssl->session_negotiate->id, ssl->session_negotiate->id_len );
-#else
-    /* Length of the session id must be zero */
-    if( *buf == 0 )
-    {
-        buf++; /* skip session id length */
-    }
-    else
-    {
-        SSL_PEND_FATAL_ALERT( MBEDTLS_SSL_ALERT_MSG_ILLEGAL_PARAMETER,
-                              MBEDTLS_ERR_SSL_BAD_HS_SERVER_HELLO );
-        return( MBEDTLS_ERR_SSL_BAD_HS_SERVER_HELLO );
-    }
-#endif /* MBEDTLS_SSL_TLS13_COMPATIBILITY_MODE */
 
     /* read server-selected ciphersuite, which follows random bytes */
     i = ( buf[0] << 8 ) | buf[1];
@@ -3454,7 +3440,6 @@ static int ssl_hrr_parse( mbedtls_ssl_context* ssl,
     /* skip random bytes */
     buf += 32;
 
-#if defined(MBEDTLS_SSL_TLS13_COMPATIBILITY_MODE)
     /* legacy_session_id_echo */
     if( ssl->session_negotiate->id_len != buf[0] )
     {
@@ -3479,19 +3464,6 @@ static int ssl_hrr_parse( mbedtls_ssl_context* ssl,
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "session id length ( %d )", ssl->session_negotiate->id_len ) );
     MBEDTLS_SSL_DEBUG_BUF( 3, "session id", ssl->session_negotiate->id, ssl->session_negotiate->id_len );
-#else
-    /* Length of the session id must be zero */
-    if( *buf == 0 )
-    {
-        buf++; /* skip session id length */
-    }
-    else
-    {
-        SSL_PEND_FATAL_ALERT( MBEDTLS_SSL_ALERT_MSG_ILLEGAL_PARAMETER,
-                              MBEDTLS_ERR_SSL_BAD_HS_HELLO_RETRY_REQUEST );
-        return( MBEDTLS_ERR_SSL_BAD_HS_HELLO_RETRY_REQUEST );
-    }
-#endif /* MBEDTLS_SSL_TLS13_COMPATIBILITY_MODE */
 
     /* read server-selected ciphersuite, which follows random bytes */
     i = ( buf[0] << 8 ) | buf[1];

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -2991,34 +2991,48 @@ cleanup:
 }
 #endif /* MBEDTLS_SSL_USE_MPS */
 
-static int ssl_server_hello_session_id_check ( mbedtls_ssl_context* ssl,
-                                   const unsigned char** buf, int is_hrr )
+static int ssl_server_hello_session_id_check( mbedtls_ssl_context* ssl,
+                                              const unsigned char** buf,
+                                              const unsigned char* end )
 {
-    int bad_ret_code = is_hrr ? MBEDTLS_ERR_SSL_BAD_HS_HELLO_RETRY_REQUEST : MBEDTLS_ERR_SSL_BAD_HS_SERVER_HELLO;
+    size_t buflen = (size_t)( end - *buf );
+    size_t recv_id_len;
+
+    if( buflen == 0 )
+        return( 1 );
+
+    recv_id_len = **buf;
+    *buf   += 1; /* skip session id length */
+    buflen -= 1;
+
     /* legacy_session_id_echo */
-    if( ssl->session_negotiate->id_len != **buf )
+    if( ssl->session_negotiate->id_len != recv_id_len )
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "Mismatch of session id length" ) );
-        SSL_PEND_FATAL_ALERT( MBEDTLS_SSL_ALERT_MSG_ILLEGAL_PARAMETER,
-                              bad_ret_code );
-        return( bad_ret_code );
+        return( 1 );
     }
-    (*buf)++; /* skip session id length */
 
-    if( memcmp( ssl->session_negotiate->id, *buf, ssl->session_negotiate->id_len ) != 0 )
+    if( buflen < recv_id_len )
+        return( 1 );
+
+    if( memcmp( ssl->session_negotiate->id, *buf,
+                ssl->session_negotiate->id_len ) != 0 )
     {
-        MBEDTLS_SSL_DEBUG_MSG( 1, ( "Mismatch of session id" ) );
-        MBEDTLS_SSL_DEBUG_BUF( 3, "- expected session id", ssl->session_negotiate->id, ssl->session_negotiate->id_len );
-        MBEDTLS_SSL_DEBUG_BUF( 3, "- received session id", *buf, ssl->session_negotiate->id_len );
-
-        SSL_PEND_FATAL_ALERT( MBEDTLS_SSL_ALERT_MSG_ILLEGAL_PARAMETER,
-                              bad_ret_code );
-        return( bad_ret_code );
+        MBEDTLS_SSL_DEBUG_MSG( 1, ( "Unexpected legacy_session_id_echo" ) );
+        MBEDTLS_SSL_DEBUG_BUF( 3, "Expected Session ID",
+                               ssl->session_negotiate->id,
+                               ssl->session_negotiate->id_len );
+        MBEDTLS_SSL_DEBUG_BUF( 3, "Received Session ID", *buf,
+                               ssl->session_negotiate->id_len );
+        return( 1 );
     }
-    *buf += ssl->session_negotiate->id_len; /* skip session id */
 
-    MBEDTLS_SSL_DEBUG_MSG( 3, ( "session id length ( %d )", ssl->session_negotiate->id_len ) );
-    MBEDTLS_SSL_DEBUG_BUF( 3, "session id", ssl->session_negotiate->id, ssl->session_negotiate->id_len );
+    *buf   += recv_id_len;
+    buflen -= recv_id_len;
+
+    MBEDTLS_SSL_DEBUG_BUF( 3, "Session ID",
+                           ssl->session_negotiate->id,
+                           ssl->session_negotiate->id_len );
     return( 0 );
 }
 
@@ -3100,10 +3114,11 @@ static int ssl_server_hello_parse( mbedtls_ssl_context* ssl,
     /* skip random bytes */
     buf += 32;
 
-    ret = ssl_server_hello_session_id_check( ssl, &buf, 0 );
-    if ( ret != 0 )
+    if( ssl_server_hello_session_id_check( ssl, &buf, msg_end ) != 0 )
     {
-        return ( ret );
+        SSL_PEND_FATAL_ALERT( MBEDTLS_SSL_ALERT_MSG_ILLEGAL_PARAMETER,
+                              MBEDTLS_ERR_SSL_BAD_HS_SERVER_HELLO );
+        return( MBEDTLS_ERR_SSL_BAD_HS_SERVER_HELLO );
     }
 
     /* read server-selected ciphersuite, which follows random bytes */
@@ -3452,10 +3467,11 @@ static int ssl_hrr_parse( mbedtls_ssl_context* ssl,
     /* skip random bytes */
     buf += 32;
 
-    ret = ssl_server_hello_session_id_check( ssl, &buf, 1 );
-    if ( ret != 0 )
+    if( ssl_server_hello_session_id_check( ssl, &buf, msg_end ) != 0 )
     {
-        return ( ret );
+        SSL_PEND_FATAL_ALERT( MBEDTLS_SSL_ALERT_MSG_ILLEGAL_PARAMETER,
+                              MBEDTLS_ERR_SSL_BAD_HS_HELLO_RETRY_REQUEST );
+        return( MBEDTLS_ERR_SSL_BAD_HS_HELLO_RETRY_REQUEST );
     }
 
     /* read server-selected ciphersuite, which follows random bytes */


### PR DESCRIPTION
Summary:
Simplify MBEDTLS_SSL_TLS13_COMPATIBILITY_MODE  in
`ssl_server_hello_parse` and `ssl_hrr_parse`.
When MBEDTLS_SSL_TLS13_COMPATIBILITY_MODE is on, the
[ssl->session_negotiate->id_len will be non zero](https://github.com/hannestschofenig/mbedtls/blob/tls13-prototype/library/ssl_tls13_client.c#L1512).
The
[else](https://github.com/hannestschofenig/mbedtls/blob/tls13-prototype/library/ssl_tls13_client.c#L3097-L3109) block is the same as [if](https://github.com/hannestschofenig/mbedtls/blob/tls13-prototype/library/ssl_tls13_client.c#L3074-L3093) block when
`ssl->session_negotiate->id_len` is 0.
So we could remove the else block in `ssl_server_hello_parse`. Same
thing applies to `ssl_hrr_parse`.

Test Plan:
`tests/ssl-opt.sh` when MBEDTLS_SSL_TLS13_COMPATIBILITY_MODE is on and
off.

Reviewers:

Subscribers:

Tasks:

Tags: