### PR TITLE
Remove unused MBEDTLS_SSL_PROTO_DTLS in ssl_internal.h

### DIFF
--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -1465,15 +1465,6 @@ int mbedtls_ssl_parse_new_session_ticket_server(mbedtls_ssl_context* ssl, unsign
 int mbedtls_ssl_parse_client_psk_identity_ext(mbedtls_ssl_context* ssl, const unsigned char* buf, size_t len);
 #endif /* MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED */
 
-#if defined(MBEDTLS_SSL_PROTO_DTLS)
-#define MBEDTLS_SSL_ACK_RECORDS_SENT 0
-#define MBEDTLS_SSL_ACK_RECORDS_RECEIVED 1
-int mbedtls_ssl_parse_ack(mbedtls_ssl_context* ssl);
-int mbedtls_ssl_write_ack(mbedtls_ssl_context* ssl);
-void mbedtls_ack_clear_all(mbedtls_ssl_context* ssl, int mode);
-int mbedtls_ack_add_record(mbedtls_ssl_context* ssl, uint8_t record, int mode);
-#endif /* MBEDTLS_SSL_PROTO_DTLS */
-
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 
 


### PR DESCRIPTION
Summary:
This block of definition/declaration under MBEDTLS_SSL_PROTO_DTLS is not used
anywhere. It is also guarded by MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL where
MBEDTLS_SSL_PROTO_DTLS won't be turned on.

Test Plan:
```
make test
tests/ssl-opt.sh
```

Reviewers:

Subscribers:

Tasks:

Tags: