### PR TITLE
Fix unused variable compiler error for md_size

### DIFF
--- a/library/ssl_tls13_keys.c
+++ b/library/ssl_tls13_keys.c
@@ -1160,8 +1160,10 @@ int mbedtls_ssl_tls1_3_derive_master_secret( mbedtls_ssl_context *ssl,
 
     int ret = 0;
     mbedtls_md_type_t const md_type = ssl->handshake->ciphersuite_info->mac;
+#if defined(MBEDTLS_DEBUG_C)
     mbedtls_md_info_t const * const md_info = mbedtls_md_info_from_type( md_type );
     size_t const md_size = mbedtls_md_get_size( md_info );
+#endif /* MBEDTLS_DEBUG_C */
 
     unsigned char *psk = NULL;
     size_t psk_len = 0;


### PR DESCRIPTION
Summary:
Found the following compiler error when I disable the MBEDTLS_DEBUG_C

```
/home/lhuang04/upstream/library/ssl_tls13_keys.c: In function ‘mbedtls_ssl_tls1_3_derive_master_secret’:
/home/lhuang04/upstream/library/ssl_tls13_keys.c:1164:18: error: unused variable ‘md_size’ [-Werror=unused-variable]
     size_t const md_size = mbedtls_md_get_size( md_info );
                  ^
/home/lhuang04/upstream/library/ssl_tls13_server.c: In function ‘ssl_debug_print_client_hello_exts’:
/home/lhuang04/upstream/library/ssl_tls13_server.c:2288:69: warning: unused parameter ‘ssl’ [-Wunused-parameter]
 static void ssl_debug_print_client_hello_exts( mbedtls_ssl_context *ssl )
```

Test Plan:
# Disable `MBEDTLS_DEBUG_C`
```
diff --git a/include/mbedtls/config.h b/include/mbedtls/config.h
index 9a8cd63ad..983c28fc9 100644
--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -2636,7 +2636,7 @@
  *
  * This module provides debugging functions.
  */
-#define MBEDTLS_DEBUG_C
+//#define MBEDTLS_DEBUG_C

 /**
  * \def MBEDTLS_DES_C
```
# make
```
rm -rf build/; mkdir build; cd build; CFLAGS="-std=c99 -g -Wno-unused-but-set-variable -Wno-error=unused-parameter" cmake ..; make -j;
```
# unit test with and without MBEDTLS_DEBUG_C
```
tests/ssl-opt.sh
```

Reviewers:

Subscribers:

Tasks:

Tags: