### PR TITLE
Add functions to parse NST extensions.

### DIFF
--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -1183,7 +1183,7 @@ struct mbedtls_ssl_session
 #if defined(MBEDTLS_HAVE_TIME) && defined(MBEDTLS_SSL_CLI_C)
     time_t ticket_received;         /*!< time ticket was received */
 #endif /* MBEDTLS_HAVE_TIME && MBEDTLS_SSL_CLI_C */
-
+    uint32_t max_early_data_size;   /*!< max data allowed */
 #endif /*  MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL && MBEDTLS_SSL_NEW_SESSION_TICKET */
 
 

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -3925,6 +3925,55 @@ static int ssl_new_session_ticket_fetch( mbedtls_ssl_context* ssl,
 }
 #endif /* MBEDTLS_SSL_USE_MPS */
 
+static int ssl_new_session_ticket_early_data_ext_parse( mbedtls_ssl_context* ssl,
+                                                        const unsigned char* buf,
+                                                        size_t ext_size )
+{
+    if( ext_size == 4 && ssl->session != NULL )
+    {
+	    ssl->session->max_early_data_size =
+            ( (uint32_t) buf[0] << 24 ) | ( (uint32_t) buf[1] << 16 ) |
+            ( (uint32_t) buf[2] << 8  ) | ( (uint32_t) buf[3] );
+        MBEDTLS_SSL_DEBUG_MSG( 3, ( "ticket->max_early_data_size: %u", ssl->session->max_early_data_size ) );
+        ssl->session->ticket_flags |= allow_early_data;
+        return( 0 );
+    }
+    return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
+}
+
+static int ssl_new_session_ticket_extensions_parse( mbedtls_ssl_context* ssl,
+                                                    const unsigned char* buf,
+                                                    size_t buf_remain )
+{
+    int ret;
+    while( buf_remain != 0 )
+    {
+        if( buf_remain < 4 )
+        {
+            return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
+        }
+
+        unsigned int ext_id = ( ( buf[0] << 8 ) | ( buf[1] ) );
+        size_t ext_size = ( ( buf[2] << 8 ) | ( buf[3] ) );
+        if( ext_size > buf_remain - 4 )
+        {
+            return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
+        }
+
+        if( ext_id == MBEDTLS_TLS_EXT_EARLY_DATA )
+        {
+            if( ( ret = ssl_new_session_ticket_early_data_ext_parse( ssl, &buf[4], ext_size ) ) != 0 )
+            {
+                MBEDTLS_SSL_DEBUG_RET( 1, "ssl_new_session_ticket_early_data_ext_parse", ret );
+                return( ret );
+            }
+        }
+        buf += 4 + ext_size;
+        buf_remain -= 4 + ext_size;
+    }
+    return( 0 );
+}
+
 static int ssl_new_session_ticket_parse( mbedtls_ssl_context* ssl,
                                          unsigned char* buf,
                                          size_t buflen )
@@ -4021,18 +4070,6 @@ static int ssl_new_session_ticket_parse( mbedtls_ssl_context* ssl,
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "ticket->length: %u", ticket_len ) );
 
-    /* Ticket Extension */
-    ext_len = ( (size_t) buf[ i + ticket_len ] << 8 ) |
-              ( (size_t) buf[ i + ticket_len + 1 ] );
-
-    used += ext_len;
-
-    if( used != buflen )
-    {
-         MBEDTLS_SSL_DEBUG_MSG( 1, ( "bad new session ticket message" ) );
-         return( MBEDTLS_ERR_SSL_BAD_HS_NEW_SESSION_TICKET );
-    }
-
     /* Check if we previously received a ticket already. */
     if( ssl->session->ticket != NULL || ssl->session->ticket_len > 0 )
     {
@@ -4052,11 +4089,27 @@ static int ssl_new_session_ticket_parse( mbedtls_ssl_context* ssl,
     ssl->session->ticket = ticket;
     ssl->session->ticket_len = ticket_len;
 
-    MBEDTLS_SSL_DEBUG_MSG( 4, ( "ticket->extension length: %u", ext_len ) );
-
+    /* Ticket Extension */
+    ext_len = ( (size_t) buf[ i + 0 ] << 8 ) |
+              ( (size_t) buf[ i + 1 ] );
     i += 2;
-    /* We are not storing any extensions at the moment */
+
+    used += ext_len;
+    if( used != buflen )
+    {
+         MBEDTLS_SSL_DEBUG_MSG( 1, ( "bad new session ticket message" ) );
+         return( MBEDTLS_ERR_SSL_BAD_HS_NEW_SESSION_TICKET );
+    }
+
     MBEDTLS_SSL_DEBUG_BUF( 3, "ticket->extension", &buf[i], ext_len );
+
+    ret = ssl_new_session_ticket_extensions_parse( ssl, &buf[i], ext_len );
+    if( ret != 0 )
+    {
+        MBEDTLS_SSL_DEBUG_RET( 1, "ssl_new_session_ticket_extensions_parse", ret );
+        return( ret );
+    }
+    i += ext_len;
 
     /* Compute PSK based on received nonce and resumption_master_secret
      * in the following style:


### PR DESCRIPTION
Add functions to parse extensions in NewSessionTicket.

Test with 
```
./ssl_client2 debug_level=3 server_name=enabled.tls13.com server_port=443 auth_mode=none
```
And the parsed `max_early_data_size` is reported in the debug log.
