### PR TITLE
derive_resumption_master_secret should be based on master_secret

### DIFF
--- a/library/ssl_tls13_keys.c
+++ b/library/ssl_tls13_keys.c
@@ -988,7 +988,7 @@ int mbedtls_ssl_generate_resumption_master_secret( mbedtls_ssl_context *ssl )
         return( ret );
 
     ret = mbedtls_ssl_tls1_3_derive_resumption_master_secret( md_type,
-                                         ssl->handshake->handshake_secret,
+                                         ssl->handshake->master_secret,
                                          transcript, transcript_len,
                                          &ssl->session_negotiate->app_secrets );
     if( ret != 0 )


### PR DESCRIPTION
Summary:
`mbedtls_ssl_tls1_3_derive_resumption_master_secret` uses
[handshake_secret]() to get `resumption_master_secret`.  It should use
`master_secret` based on the
[RFC](https://tools.ietf.org/html/rfc8446#section-7.1).
It was
[correct](https://github.com/hannestschofenig/mbedtls/pull/204/files#diff-b67c0adff0a54f6cc5e2401f775e88ab9a2946c4e2e1c5c9cf07f3222a5f2eacL1380) before PR [204](https://github.com/hannestschofenig/mbedtls/pull/204/files#diff-b67c0adff0a54f6cc5e2401f775e88ab9a2946c4e2e1c5c9cf07f3222a5f2eacR991).

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags: