### PR TITLE
Replace resumption_master_secret by exporter_master_secret

### DIFF
--- a/library/ssl_tls13_keys.c
+++ b/library/ssl_tls13_keys.c
@@ -526,10 +526,10 @@ int mbedtls_ssl_tls1_3_derive_application_secrets(
 
     ret = mbedtls_ssl_tls1_3_derive_secret( md_type,
               application_secret, md_size,
-              MBEDTLS_SSL_TLS1_3_LBL_WITH_LEN( res_master ),
+              MBEDTLS_SSL_TLS1_3_LBL_WITH_LEN( exp_master ),
               transcript, transcript_len,
               MBEDTLS_SSL_TLS1_3_CONTEXT_HASHED,
-              derived_application_secrets->resumption_master_secret,
+              derived_application_secrets->exporter_master_secret,
               md_size );
 
     if( ret != 0 )


### PR DESCRIPTION
Summary:
According to the [RFC](https://tools.ietf.org/html/rfc8446#section-7.1),
we should put exporter_master_secret here instead of
resumption_master_secret.

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags: