### PR TITLE
Remove binder_key from global structure.

### DIFF
--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -473,6 +473,7 @@ typedef struct mbedtls_ssl_key_set mbedtls_ssl_key_set;
 
 typedef struct
 {
+    unsigned char binder_key                  [ MBEDTLS_MD_MAX_SIZE ];
     unsigned char client_early_traffic_secret [ MBEDTLS_MD_MAX_SIZE ];
     unsigned char early_exporter_master_secret[ MBEDTLS_MD_MAX_SIZE ];
 } mbedtls_ssl_tls1_3_early_secrets;

--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -473,7 +473,6 @@ typedef struct mbedtls_ssl_key_set mbedtls_ssl_key_set;
 
 typedef struct
 {
-    unsigned char binder_key                  [ MBEDTLS_MD_MAX_SIZE ];
     unsigned char client_early_traffic_secret [ MBEDTLS_MD_MAX_SIZE ];
     unsigned char early_exporter_master_secret[ MBEDTLS_MD_MAX_SIZE ];
 } mbedtls_ssl_tls1_3_early_secrets;
@@ -822,7 +821,6 @@ struct mbedtls_ssl_handshake_params
 
 #if defined(MBEDTLS_ZERO_RTT)
     mbedtls_ssl_tls1_3_early_secrets early_secrets;
-    unsigned char binder_key[MBEDTLS_MD_MAX_SIZE];
 
     /*!< Early data indication:
     0  -- MBEDTLS_SSL_EARLY_DATA_DISABLED (for no early data), and


### PR DESCRIPTION
Summary:
`binder_key` is only used as a local variable, there is no need to be in
global structure.
Test Plan:
make

Reviewers:

Subscribers:

Tasks:

Tags: