### PR TITLE
Typo in ssl.h comment

### DIFF
--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -1163,7 +1163,7 @@ struct mbedtls_ssl_session
     time_t ticket_received;         /*!< time ticket was received */
 #endif /* MBEDTLS_HAVE_TIME && MBEDTLS_SSL_CLI_C */
 
-#endif /*  MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL || MBEDTLS_SSL_NEW_SESSION_TICKET */
+#endif /*  MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL && MBEDTLS_SSL_NEW_SESSION_TICKET */
 
 
 


### PR DESCRIPTION
It looks to me like a typo in the comment.

See https://github.com/zhihan/mbedtls/blob/bd653caea125d8a77d805872864914977fd46c90/include/mbedtls/ssl.h#L1147

