### PR TITLE
Key schedule rework, pt 2: Simplify `Finished` calculations

### DIFF
--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -812,7 +812,6 @@ struct mbedtls_ssl_handshake_params
     unsigned char* ptr_to_psk_ext;
 #endif /* MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED */
 
-    unsigned char exporter_secret[MBEDTLS_MD_MAX_SIZE];
     unsigned char early_secret[MBEDTLS_MD_MAX_SIZE];
     unsigned char handshake_secret[MBEDTLS_MD_MAX_SIZE];
     mbedtls_ssl_tls1_3_handshake_secrets hs_secrets;

--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -818,9 +818,6 @@ struct mbedtls_ssl_handshake_params
 
     mbedtls_ssl_tls1_3_handshake_secrets hs_secrets;
 
-    unsigned char client_finished_key[MBEDTLS_MD_MAX_SIZE];
-    unsigned char server_finished_key[MBEDTLS_MD_MAX_SIZE];
-
 #if defined(MBEDTLS_ZERO_RTT)
     mbedtls_ssl_tls1_3_early_secrets early_secrets;
 

--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -814,8 +814,10 @@ struct mbedtls_ssl_handshake_params
 
     unsigned char early_secret[MBEDTLS_MD_MAX_SIZE];
     unsigned char handshake_secret[MBEDTLS_MD_MAX_SIZE];
-    mbedtls_ssl_tls1_3_handshake_secrets hs_secrets;
     unsigned char master_secret[MBEDTLS_MD_MAX_SIZE];
+
+    mbedtls_ssl_tls1_3_handshake_secrets hs_secrets;
+
     unsigned char client_finished_key[MBEDTLS_MD_MAX_SIZE];
     unsigned char server_finished_key[MBEDTLS_MD_MAX_SIZE];
 

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -2383,17 +2383,6 @@ static int ssl_finished_out_prepare( mbedtls_ssl_context* ssl )
         return( ret );
     }
 
-#if defined(MBEDTLS_SSL_HW_RECORD_ACCEL)
-    if( mbedtls_ssl_hw_record_activate != NULL )
-    {
-        if( ( ret = mbedtls_ssl_hw_record_activate( ssl, MBEDTLS_SSL_CHANNEL_OUTBOUND ) ) != 0 )
-        {
-            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_hw_record_activate", ret );
-            return( MBEDTLS_ERR_SSL_HW_ACCEL_FAILED );
-        }
-    }
-#endif /* MBEDTLS_SSL_HW_RECORD_ACCEL */
-
     return( 0 );
 }
 

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -2373,9 +2373,11 @@ static int ssl_finished_out_prepare( mbedtls_ssl_context* ssl )
     int ret;
 
     /* Compute transcript of handshake up to now. */
-    ret = ssl->handshake->calc_finished( ssl,
-                                   ssl->handshake->state_local.finished_out.digest,
-                                   ssl->conf->endpoint );
+    ret = mbedtls_ssl_tls1_3_calc_finished( ssl,
+                    ssl->handshake->state_local.finished_out.digest,
+                    sizeof( ssl->handshake->state_local.finished_out.digest ),
+                    &ssl->handshake->state_local.finished_out.digest_len,
+                    ssl->conf->endpoint );
 
     if( ret != 0 )
     {
@@ -2611,26 +2613,18 @@ cleanup:
 
 static int ssl_finished_in_preprocess( mbedtls_ssl_context* ssl )
 {
-    unsigned int hash_len;
-    const mbedtls_ssl_ciphersuite_t* suite_info;
+    int ret;
 
-    suite_info = mbedtls_ssl_ciphersuite_from_id( ssl->session_negotiate->ciphersuite );
-
-    if( suite_info == NULL )
+    ret = mbedtls_ssl_tls1_3_calc_finished( ssl,
+                    ssl->handshake->state_local.finished_in.digest,
+                    sizeof( ssl->handshake->state_local.finished_in.digest ),
+                    &ssl->handshake->state_local.finished_in.digest_len,
+                    ssl->conf->endpoint ^ 1 );
+    if( ret != 0 )
     {
-        MBEDTLS_SSL_DEBUG_MSG( 1, ( "mbedtls_ssl_ciphersuite_from_id in ssl_finished_in_preprocess failed" ) );
-        return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
+        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_tls1_3_calc_finished", ret );
+        return( ret );
     }
-
-    hash_len = mbedtls_hash_size_for_ciphersuite( suite_info );
-    if( hash_len == 0 )
-        return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
-
-    ssl->handshake->state_local.finished_in.digest_len = hash_len;
-
-    ssl->handshake->calc_finished( ssl,
-                                   ssl->handshake->state_local.finished_in.digest,
-                                   ssl->conf->endpoint ^ 1 );
 
     return( 0 );
 }

--- a/library/ssl_tls13_keys.c
+++ b/library/ssl_tls13_keys.c
@@ -923,9 +923,6 @@ int mbedtls_ssl_handshake_key_derivation( mbedtls_ssl_context *ssl, mbedtls_ssl_
         return( ret );
     }
 
-    if( ( ret = mbedtls_ssl_tls1_3_set_verify( ssl ) ) != 0 )
-        return( ret );
-
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "<= mbedtls_ssl_handshake_key_derivation" ) );
 
 #if defined(MBEDTLS_KEY_EXCHANGE_SOME_ECDHE_ENABLED)
@@ -1238,37 +1235,38 @@ int mbedtls_ssl_tls1_3_derive_master_secret( mbedtls_ssl_context *ssl,
     return( 0 );
 }
 
-#if defined(MBEDTLS_SHA256_C)
-static int ssl_calc_finished_tls_sha256(
-    mbedtls_ssl_context* ssl, unsigned char* buf, int from )
+int mbedtls_ssl_tls1_3_calc_finished( mbedtls_ssl_context* ssl,
+                                      unsigned char* dst,
+                                      size_t dst_len,
+                                      size_t *actual_len,
+                                      int from )
 {
     int ret;
-    mbedtls_sha256_context sha256;
-    unsigned char transcript[32];
-    unsigned char* finished_key;
-    const mbedtls_md_info_t* md;
 
-    md = mbedtls_md_info_from_type( MBEDTLS_MD_SHA256 );
+    unsigned char transcript[MBEDTLS_MD_MAX_SIZE];
+    size_t transcript_len;
 
-    if( md == NULL )
+    unsigned char finished_key[MBEDTLS_MD_MAX_SIZE];
+    unsigned char const *base_key = NULL;
+
+    mbedtls_md_type_t const md_type = ssl->handshake->ciphersuite_info->mac;
+    const mbedtls_md_info_t* const md = mbedtls_md_info_from_type( md_type );
+    size_t const md_size = mbedtls_md_get_size( md );
+
+    MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> mbedtls_ssl_tls1_3_calc_finished" ) );
+
+    if( dst_len < md_size )
+        return( MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL );
+
+    ret = mbedtls_ssl_get_handshake_transcript( ssl, md_type,
+                                                transcript, sizeof( transcript ),
+                                                &transcript_len );
+    if( ret != 0 )
     {
-        MBEDTLS_SSL_DEBUG_MSG( 2, ( "mbedtls_md_info_from_type failed" ) );
-        return ( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
+        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_get_handshake_transcript", ret );
+        return( ret );
     }
-
-    mbedtls_sha256_init( &sha256 );
-
-    MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> calc finished tls sha256" ) );
-
-    mbedtls_sha256_clone( &sha256, &ssl->handshake->fin_sha256 );
-
-    if( ( ret = mbedtls_sha256_finish_ret( &sha256, transcript ) ) != 0 )
-    {
-        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha256_finish_ret", ret );
-        goto exit;
-    }
-
-    MBEDTLS_SSL_DEBUG_BUF( 5, "handshake hash", transcript, 32 );
+    MBEDTLS_SSL_DEBUG_BUF( 4, "handshake hash", transcript, transcript_len );
 
     /* TLS 1.3 Finished message
      *
@@ -1277,17 +1275,12 @@ static int ssl_calc_finished_tls_sha256(
      * } Finished;
      *
      * verify_data =
-     *     HMAC( finished_key, Hash(
-     *         Handshake Context +
-     *         Certificate* +
-     *         CertificateVerify* )
+     *     HMAC( finished_key,
+     *            Hash( Handshake Context +
+     *                  Certificate*      +
+     *                  CertificateVerify* )
      *    )
      *
-     *   * Only included if present.
-     */
-
-
-    /*
      * finished_key =
      *    HKDF-Expand-Label( BaseKey, "finished", "", Hash.length )
      *
@@ -1295,240 +1288,43 @@ static int ssl_calc_finished_tls_sha256(
      * but with the BaseKey being the binder_key.
      */
 
-    /* create client finished_key */
-    ret = mbedtls_ssl_tls1_3_hkdf_expand_label( MBEDTLS_MD_SHA256,
-                          ssl->handshake->hs_secrets.client_handshake_traffic_secret, 32,
-                          MBEDTLS_SSL_TLS1_3_LBL_WITH_LEN( finished ),
-                          NULL, 0,
-                          ssl->handshake->client_finished_key, 32 );
+    if( from == MBEDTLS_SSL_IS_CLIENT )
+        base_key = ssl->handshake->hs_secrets.client_handshake_traffic_secret;
+    else
+        base_key = ssl->handshake->hs_secrets.server_handshake_traffic_secret;
 
+    ret = mbedtls_ssl_tls1_3_hkdf_expand_label(
+                                 md_type, base_key, md_size,
+                                 MBEDTLS_SSL_TLS1_3_LBL_WITH_LEN( finished ),
+                                 NULL, 0,
+                                 finished_key, md_size );
     if( ret != 0 )
     {
         MBEDTLS_SSL_DEBUG_RET( 2, "Creating the client_finished_key failed", ret );
         goto exit;
     }
+    MBEDTLS_SSL_DEBUG_BUF( 3, "finished_key", finished_key, md_size );
 
-    MBEDTLS_SSL_DEBUG_BUF( 3, "client_finished_key", ssl->handshake->client_finished_key, 32 );
-
-    /* create server finished_key */
-    ret = mbedtls_ssl_tls1_3_hkdf_expand_label( MBEDTLS_MD_SHA256,
-                           ssl->handshake->hs_secrets.server_handshake_traffic_secret, 32,
-                           MBEDTLS_SSL_TLS1_3_LBL_WITH_LEN( finished ),
-                           NULL, 0,
-                           ssl->handshake->server_finished_key, 32 );
-
-    if( ret != 0 )
-    {
-        MBEDTLS_SSL_DEBUG_RET( 2, "Creating the server_finished_key failed", ret );
-        goto exit;
-    }
-
-    MBEDTLS_SSL_DEBUG_BUF( 3, "server_finished_key", ssl->handshake->server_finished_key, 32 );
-
-    if( from == MBEDTLS_SSL_IS_CLIENT )
-    {
-        /* In this case the server is receiving a finished message
-         * sent by the client. It therefore needs to use the client_finished_key.
-         */
-        MBEDTLS_SSL_DEBUG_MSG( 3, ( "Using client_finished_key to compute mac ( for creating finished message )" ) );
-        finished_key = ssl->handshake->client_finished_key;
-    }
-    else
-    {
-        /* If the server is sending a finished message then it needs to use
-         * the server_finished_key.
-         */
-        MBEDTLS_SSL_DEBUG_MSG( 3, ( "Using server_finished_key to compute mac ( for verification procedure )" ) );
-        finished_key = ssl->handshake->server_finished_key;
-    }
-
-    /* compute mac and write it into the buffer */
-    ret = mbedtls_md_hmac( md, finished_key, 32, transcript, 32, buf );
-
-    ssl->handshake->state_local.finished_out.digest_len = 32;
-
+    /* Compute verify_data */
+    ret = mbedtls_md_hmac( md, finished_key, md_size, transcript, md_size, dst );
     if( ret != 0 )
     {
         MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_md_hmac", ret );
         goto exit;
     }
+    *actual_len = md_size;
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "verify_data of Finished message" ) );
-    MBEDTLS_SSL_DEBUG_BUF( 3, "Input", transcript, 32 );
-    MBEDTLS_SSL_DEBUG_BUF( 3, "Key", finished_key, 32 );
-    MBEDTLS_SSL_DEBUG_BUF( 3, "Output", buf, 32 );
+    MBEDTLS_SSL_DEBUG_BUF( 3, "Input",  transcript, md_size );
+    MBEDTLS_SSL_DEBUG_BUF( 3, "Key",    finished_key, md_size );
+    MBEDTLS_SSL_DEBUG_BUF( 3, "Output", dst, md_size );
 
 exit:
-    mbedtls_sha256_free( &sha256 );
     mbedtls_platform_zeroize( transcript, sizeof( transcript ) );
+    mbedtls_platform_zeroize( finished_key, sizeof( finished_key ) );
 
-    MBEDTLS_SSL_DEBUG_MSG( 2, ( "<= calc  finished" ) );
-    return ( ret );
-}
-#endif /* MBEDTLS_SHA256_C */
-
-#if defined(MBEDTLS_SHA512_C)
-static int ssl_calc_finished_tls_sha384(
-    mbedtls_ssl_context* ssl, unsigned char* buf, int from )
-{
-    mbedtls_sha512_context sha512;
-    int ret;
-    unsigned char padbuf[48];
-    unsigned char* finished_key;
-    const mbedtls_md_info_t* md;
-
-    md = mbedtls_md_info_from_type( MBEDTLS_MD_SHA384 );
-
-    if( md == NULL )
-    {
-        MBEDTLS_SSL_DEBUG_MSG( 2, ( "mbedtls_md_info_from_type failed" ) );
-        return ( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
-    }
-
-
-    mbedtls_sha512_init( &sha512 );
-
-    if( ( ret = mbedtls_sha512_starts_ret( &sha512, 1 ) ) != 0 )
-    {
-        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha512_starts_ret", ret );
-        goto exit;
-    }
-
-    MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> calc finished tls sha384" ) );
-
-    mbedtls_sha512_clone( &sha512, &ssl->handshake->fin_sha512 );
-
-    /* TLS 1.3 Finished message
-     *
-     * struct {
-     *     opaque verify_data[Hash.length];
-     * } Finished;
-     *
-     * verify_data =
-     *     HMAC( finished_key, Hash(
-     *         Handshake Context +
-     *         Certificate* +
-     *         CertificateVerify*
-     *         )
-     *    )
-     *
-     *   * Only included if present.
-     */
-
-    /*#if !defined(MBEDTLS_SHA512_ALT)
-      MBEDTLS_SSL_DEBUG_BUF( 4, "finished sha512 state", ( unsigned char * )
-      sha512.state, sizeof( sha512.state ) );
-      #endif
-    */
-
-    if( ( ret = mbedtls_sha512_finish_ret( &sha512, padbuf ) ) != 0 )
-    {
-        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha512_finish_ret", ret );
-        goto exit;
-    }
-
-    MBEDTLS_SSL_DEBUG_BUF( 5, "handshake hash", padbuf, 48 );
-
-    /* create client finished_key */
-    ret = mbedtls_ssl_tls1_3_hkdf_expand_label( MBEDTLS_MD_SHA384,
-                      ssl->handshake->hs_secrets.client_handshake_traffic_secret, 48,
-                      MBEDTLS_SSL_TLS1_3_LBL_WITH_LEN( finished ),
-                      NULL, 0,
-                      ssl->handshake->client_finished_key, 48 );
-
-    if( ret != 0 )
-    {
-        MBEDTLS_SSL_DEBUG_RET( 2, "Creating the client_finished_key failed", ret );
-        goto exit;
-    }
-
-    MBEDTLS_SSL_DEBUG_BUF( 3, "client_finished_key", ssl->handshake->client_finished_key, 48 );
-
-    /* create server finished_key */
-    ret = mbedtls_ssl_tls1_3_hkdf_expand_label( MBEDTLS_MD_SHA384,
-                          ssl->handshake->hs_secrets.server_handshake_traffic_secret, 48,
-                          MBEDTLS_SSL_TLS1_3_LBL_WITH_LEN( finished ),
-                          NULL, 0,
-                          ssl->handshake->server_finished_key, 48 );
-
-    if( ret != 0 )
-    {
-        MBEDTLS_SSL_DEBUG_RET( 2, "Creating the server_finished_key failed", ret );
-        goto exit;
-    }
-
-    MBEDTLS_SSL_DEBUG_BUF( 3, "server_finished_key", ssl->handshake->server_finished_key, 48 );
-
-
-    if( from == MBEDTLS_SSL_IS_CLIENT )
-    {
-        /* In this case the server is receiving a finished message
-         * sent by the client. It therefore needs to use the client_finished_key.
-         */
-        MBEDTLS_SSL_DEBUG_MSG( 2, ( "Using client_finished_key to compute mac ( for creating finished message )" ) );
-        finished_key = ssl->handshake->client_finished_key;
-    }
-    else
-    {
-        /* If the server is sending a finished message then it needs to use
-         * the server_finished_key.
-         */
-        MBEDTLS_SSL_DEBUG_MSG( 2, ( "Using server_finished_key to compute mac ( for verification procedure )" ) );
-        finished_key = ssl->handshake->server_finished_key;
-    }
-
-    /* compute mac and write it into the buffer */
-    ret = mbedtls_md_hmac( md, finished_key, 48, padbuf, 48, buf );
-
-    ssl->handshake->state_local.finished_out.digest_len = 48;
-
-    if( ret != 0 )
-    {
-        MBEDTLS_SSL_DEBUG_RET( 2, "mbedtls_md_hmac", ret );
-        goto exit;
-    }
-
-    MBEDTLS_SSL_DEBUG_MSG( 2, ( "verify_data of Finished message" ) );
-    MBEDTLS_SSL_DEBUG_BUF( 3, "Input", padbuf, 48 );
-    MBEDTLS_SSL_DEBUG_BUF( 3, "Key", finished_key, 48 );
-    MBEDTLS_SSL_DEBUG_BUF( 3, "Output", buf, 48 );
-
-exit:
-    mbedtls_sha512_free( &sha512 );
-
-    mbedtls_platform_zeroize( padbuf, sizeof( padbuf ) );
-
-    MBEDTLS_SSL_DEBUG_MSG( 2, ( "<= calc  finished" ) );
-    return( 0 );
-}
-#endif /* MBEDTLS_SHA512_C */
-
-/* TODO: Temporary extraction from mbedtls_ssl_generate_handshake_traffic_keys()
- *       Need to find a proper place for this. */
-int mbedtls_ssl_tls1_3_set_verify( mbedtls_ssl_context *ssl )
-{
-    mbedtls_md_type_t const md_type = ssl->handshake->ciphersuite_info->mac;
-
-#if defined(MBEDTLS_SHA256_C)
-    if( md_type == MBEDTLS_MD_SHA256 )
-    {
-        ssl->handshake->calc_finished = ssl_calc_finished_tls_sha256;
-    }
-    else
-#endif /* MBEDTLS_SHA256_C */
-#if defined(MBEDTLS_SHA512_C)
-    if( md_type == MBEDTLS_MD_SHA384 )
-    {
-        ssl->handshake->calc_finished = ssl_calc_finished_tls_sha384;
-    }
-    else
-#endif /* MBEDTLS_SHA512_C */
-    {
-        MBEDTLS_SSL_DEBUG_MSG( 1, ( "should never happen" ) );
-        return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
-    }
-
-    return( 0 );
+    MBEDTLS_SSL_DEBUG_MSG( 2, ( "<= mbedtls_ssl_tls1_3_calc_finished" ) );
+    return( ret );
 }
 
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */

--- a/library/ssl_tls13_keys.h
+++ b/library/ssl_tls13_keys.h
@@ -336,10 +336,16 @@ int mbedtls_ssl_generate_early_data_keys( mbedtls_ssl_context *ssl,
                                           mbedtls_ssl_key_set *traffic_keys );
 int mbedtls_ssl_handshake_key_derivation( mbedtls_ssl_context* ssl,
                                           mbedtls_ssl_key_set* traffic_keys );
-int mbedtls_ssl_tls1_3_set_verify( mbedtls_ssl_context *ssl );
+
 int mbedtls_ssl_generate_handshake_traffic_keys( mbedtls_ssl_context* ssl,
                                                  mbedtls_ssl_key_set* traffic_keys );
 int mbedtls_ssl_generate_resumption_master_secret( mbedtls_ssl_context* ssl );
+
+int mbedtls_ssl_tls1_3_calc_finished( mbedtls_ssl_context* ssl,
+                                      unsigned char* dst,
+                                      size_t dst_len,
+                                      size_t *actual_len,
+                                      int from );
 
 #if defined(MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED)
 int mbedtls_ssl_tls1_3_create_psk_binder( mbedtls_ssl_context *ssl,

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -3325,17 +3325,6 @@ static int ssl_encrypted_extensions_prepare( mbedtls_ssl_context* ssl )
     memset( ssl->out_ctr, 0, 8 );
 #endif /* MBEDTLS_SSL_USE_MPS */
 
-#if defined(MBEDTLS_SSL_HW_RECORD_ACCEL)
-    if( mbedtls_ssl_hw_record_activate != NULL )
-    {
-        if( ( ret = mbedtls_ssl_hw_record_activate( ssl, MBEDTLS_SSL_CHANNEL_OUTBOUND ) ) != 0 )
-        {
-            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_hw_record_activate", ret );
-            return( MBEDTLS_ERR_SSL_HW_ACCEL_FAILED );
-        }
-    }
-#endif
-
     return( 0 );
 }
 


### PR DESCRIPTION
This PR continues preparing the remaining TLS 1.3 key schedule functions for upstreaming, building on #204.

The main change is a simplification of the way the Finished digests are calculated. Previously, we had two different though mostly equivalent routines, one for SHA-256 and one for SHA-384. One of them would be  referenced through the `calc_finished` function pointer and invoked when incoming or outgoing Finished message needs to be calculated.

After this change, we have a single routine `mbedtls_ssl_tls1_3_calc_finished()` which performs the Finished calculations, simplifying the structure of the code and saving a bit of code size.