### PR TITLE
Fix style of mbedtls_ssl_finished_in_process

### DIFF
--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -1284,8 +1284,8 @@ int mbedtls_ssl_write_change_cipher_spec( mbedtls_ssl_context *ssl );
 #endif  /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL && MBEDTLS_SSL_TLS13_COMPATIBILITY_MODE */
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
-int mbedtls_ssl_finished_in_process(mbedtls_ssl_context* ssl);
-int mbedtls_ssl_finished_out_process(mbedtls_ssl_context* ssl);
+int mbedtls_ssl_finished_in_process( mbedtls_ssl_context* ssl );
+int mbedtls_ssl_finished_out_process( mbedtls_ssl_context* ssl );
 #else
 int mbedtls_ssl_parse_finished( mbedtls_ssl_context *ssl );
 int mbedtls_ssl_write_finished( mbedtls_ssl_context *ssl );


### PR DESCRIPTION
Summary:

Fix style of `mbedtls_ssl_finished_out_process` and
`mbedtls_ssl_finished_out_process`.

Test Plan:
tests/ssl-opt.sh

Reviewers:

Subscribers:

Tasks:
#187 

Tags: