### PR TITLE
Key schedule rework, pt3: API structure

### DIFF
--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -218,11 +218,12 @@ static int ssl_write_early_data_prepare( mbedtls_ssl_context* ssl )
     }
 
     /* Derive 0-RTT key material */
-    ret = mbedtls_ssl_tls1_3_generate_early_data_keys( ssl, &traffic_keys );
+    ret = mbedtls_ssl_tls1_3_generate_early_data_keys(
+        ssl, &traffic_keys );
     if( ret != 0 )
     {
         MBEDTLS_SSL_DEBUG_RET( 1,
-                "mbedtls_ssl_tls1_3_generate_early_data_keys", ret );
+            "mbedtls_ssl_tls1_3_generate_early_data_keys", ret );
         return( ret );
     }
 
@@ -3349,12 +3350,12 @@ static int ssl_server_hello_postprocess( mbedtls_ssl_context* ssl )
 
     /* Next evolution in key schedule: Establish handshake secret and
      * key material. */
-    ret = mbedtls_ssl_tls1_3_generate_handshake_traffic_keys(
+    ret = mbedtls_ssl_tls1_3_generate_handshake_keys(
                ssl, &traffic_keys );
     if( ret != 0 )
     {
         MBEDTLS_SSL_DEBUG_RET( 1,
-                "mbedtls_ssl_tls1_3_generate_handshake_traffic_keys", ret );
+                "mbedtls_ssl_tls1_3_generate_handshake_keys", ret );
         return( ret );
     }
 

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -2421,12 +2421,12 @@ static int ssl_finished_out_postprocess( mbedtls_ssl_context* ssl )
             return( ret );
         }
 
-        ret = mbedtls_ssl_tls1_3_generate_application_traffic_keys(
+        ret = mbedtls_ssl_tls1_3_generate_application_keys(
                      ssl, &traffic_keys );
         if( ret != 0 )
         {
             MBEDTLS_SSL_DEBUG_RET( 1,
-                  "mbedtls_ssl_tls1_3_generate_application_traffic_keys", ret );
+                  "mbedtls_ssl_tls1_3_generate_application_keys", ret );
             return( ret );
         }
 
@@ -2688,12 +2688,12 @@ static int ssl_finished_in_postprocess_cli( mbedtls_ssl_context *ssl )
         return( ret );
     }
 
-    ret = mbedtls_ssl_tls1_3_generate_application_traffic_keys(
+    ret = mbedtls_ssl_tls1_3_generate_application_keys(
         ssl, &traffic_keys );
     if( ret != 0 )
     {
         MBEDTLS_SSL_DEBUG_RET( 1,
-            "mbedtls_ssl_tls1_3_generate_application_traffic_keys", ret );
+            "mbedtls_ssl_tls1_3_generate_application_keys", ret );
         return( ret );
     }
 

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -2396,10 +2396,11 @@ static int ssl_finished_out_postprocess( mbedtls_ssl_context* ssl )
     if( ssl->conf->endpoint == MBEDTLS_SSL_IS_CLIENT )
     {
         /* Compute resumption_master_secret */
-        ret = mbedtls_ssl_generate_resumption_master_secret( ssl );
+        ret = mbedtls_ssl_tls1_3_generate_resumption_master_secret( ssl );
         if( ret != 0 )
         {
-            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_generate_resumption_master_secret ", ret );
+            MBEDTLS_SSL_DEBUG_RET( 1,
+                    "mbedtls_ssl_tls1_3_generate_resumption_master_secret ", ret );
             return ( ret );
         }
 
@@ -2411,13 +2412,21 @@ static int ssl_finished_out_postprocess( mbedtls_ssl_context* ssl )
     if( ssl->conf->endpoint == MBEDTLS_SSL_IS_SERVER )
     {
         mbedtls_ssl_key_set traffic_keys;
-        ret = mbedtls_ssl_generate_application_traffic_keys( ssl,
-                                                             &traffic_keys );
 
+        ret = mbedtls_ssl_tls1_3_key_schedule_stage_application( ssl );
         if( ret != 0 )
         {
             MBEDTLS_SSL_DEBUG_RET( 1,
-                    "mbedtls_ssl_generate_application_traffic_keys", ret );
+               "mbedtls_ssl_tls1_3_key_schedule_stage_application", ret );
+            return( ret );
+        }
+
+        ret = mbedtls_ssl_tls1_3_generate_application_traffic_keys(
+                     ssl, &traffic_keys );
+        if( ret != 0 )
+        {
+            MBEDTLS_SSL_DEBUG_RET( 1,
+                  "mbedtls_ssl_tls1_3_generate_application_traffic_keys", ret );
             return( ret );
         }
 
@@ -2670,11 +2679,21 @@ static int ssl_finished_in_postprocess_cli( mbedtls_ssl_context *ssl )
 {
     int ret = 0;
     mbedtls_ssl_key_set traffic_keys;
-    ret = mbedtls_ssl_generate_application_traffic_keys( ssl, &traffic_keys );
 
+    ret = mbedtls_ssl_tls1_3_key_schedule_stage_application( ssl );
     if( ret != 0 )
     {
-        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_generate_application_traffic_keys", ret );
+        MBEDTLS_SSL_DEBUG_RET( 1,
+           "mbedtls_ssl_tls1_3_key_schedule_stage_application", ret );
+        return( ret );
+    }
+
+    ret = mbedtls_ssl_tls1_3_generate_application_traffic_keys(
+        ssl, &traffic_keys );
+    if( ret != 0 )
+    {
+        MBEDTLS_SSL_DEBUG_RET( 1,
+            "mbedtls_ssl_tls1_3_generate_application_traffic_keys", ret );
         return( ret );
     }
 

--- a/library/ssl_tls13_keys.c
+++ b/library/ssl_tls13_keys.c
@@ -556,7 +556,8 @@ int mbedtls_ssl_tls1_3_generate_early_data_keys(
     mbedtls_cipher_info_t const *cipher_info;
     size_t keylen, ivlen;
 
-    MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> mbedtls_ssl_tls1_3_generate_early_data_keys" ) );
+    MBEDTLS_SSL_DEBUG_MSG( 2,
+         ( "=> mbedtls_ssl_tls1_3_generate_early_data_keys" ) );
 
     cipher_info = mbedtls_cipher_info_from_type(
                                   ssl->handshake->ciphersuite_info->cipher );
@@ -616,9 +617,9 @@ int mbedtls_ssl_tls1_3_generate_early_data_keys(
 }
 #endif /* MBEDTLS_ZERO_RTT */
 
-/* mbedtls_ssl_tls1_3_generate_handshake_traffic_keys() generates keys necessary for
+/* mbedtls_ssl_tls1_3_generate_handshake_keys() generates keys necessary for
  * protecting the handshake messages, as described in Section 7 of TLS 1.3. */
-int mbedtls_ssl_tls1_3_generate_handshake_traffic_keys(
+int mbedtls_ssl_tls1_3_generate_handshake_keys(
     mbedtls_ssl_context *ssl,
     mbedtls_ssl_key_set *traffic_keys )
 {
@@ -634,7 +635,7 @@ int mbedtls_ssl_tls1_3_generate_handshake_traffic_keys(
     mbedtls_cipher_info_t const *cipher_info;
     size_t keylen, ivlen;
 
-    MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> mbedtls_ssl_tls1_3_generate_handshake_traffic_keys" ) );
+    MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> mbedtls_ssl_tls1_3_generate_handshake_keys" ) );
 
     cipher_info = mbedtls_cipher_info_from_type(
                                   ssl->handshake->ciphersuite_info->cipher );
@@ -719,7 +720,7 @@ int mbedtls_ssl_tls1_3_generate_handshake_traffic_keys(
                            traffic_keys->server_write_iv,
                            traffic_keys->iv_len);
 
-    MBEDTLS_SSL_DEBUG_MSG( 2, ( "<= mbedtls_ssl_tls1_3_generate_handshake_traffic_keys" ) );
+    MBEDTLS_SSL_DEBUG_MSG( 2, ( "<= mbedtls_ssl_tls1_3_generate_handshake_keys" ) );
 
 exit:
 
@@ -729,7 +730,7 @@ exit:
 /* Generate application traffic keys since any records following a 1-RTT Finished message
  * MUST be encrypted under the application traffic key.
  */
-int mbedtls_ssl_tls1_3_generate_application_traffic_keys(
+int mbedtls_ssl_tls1_3_generate_application_keys(
                                         mbedtls_ssl_context *ssl,
                                         mbedtls_ssl_key_set *traffic_keys )
 {

--- a/library/ssl_tls13_keys.c
+++ b/library/ssl_tls13_keys.c
@@ -540,8 +540,9 @@ int mbedtls_ssl_tls1_3_derive_application_secrets(
 
 #if defined(MBEDTLS_ZERO_RTT)
 /* Early Data Key Derivation for TLS 1.3 */
-int mbedtls_ssl_generate_early_data_keys( mbedtls_ssl_context *ssl,
-                                          mbedtls_ssl_key_set *traffic_keys )
+int mbedtls_ssl_tls1_3_generate_early_data_keys(
+    mbedtls_ssl_context *ssl,
+    mbedtls_ssl_key_set *traffic_keys )
 {
     int ret = 0;
 
@@ -555,7 +556,7 @@ int mbedtls_ssl_generate_early_data_keys( mbedtls_ssl_context *ssl,
     mbedtls_cipher_info_t const *cipher_info;
     size_t keylen, ivlen;
 
-    MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> mbedtls_ssl_generate_early_data_keys" ) );
+    MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> mbedtls_ssl_tls1_3_generate_early_data_keys" ) );
 
     cipher_info = mbedtls_cipher_info_from_type(
                                   ssl->handshake->ciphersuite_info->cipher );
@@ -610,15 +611,16 @@ int mbedtls_ssl_generate_early_data_keys( mbedtls_ssl_context *ssl,
         return( ret );
     }
 
-    MBEDTLS_SSL_DEBUG_MSG( 2, ( "<= mbedtls_ssl_generate_early_data_keys" ) );
+    MBEDTLS_SSL_DEBUG_MSG( 2, ( "<= mbedtls_ssl_tls1_3_generate_early_data_keys" ) );
     return( ret );
 }
 #endif /* MBEDTLS_ZERO_RTT */
 
-/* mbedtls_ssl_generate_handshake_traffic_keys() generates keys necessary for
+/* mbedtls_ssl_tls1_3_generate_handshake_traffic_keys() generates keys necessary for
  * protecting the handshake messages, as described in Section 7 of TLS 1.3. */
-int mbedtls_ssl_generate_handshake_traffic_keys( mbedtls_ssl_context *ssl,
-                                                 mbedtls_ssl_key_set *traffic_keys )
+int mbedtls_ssl_tls1_3_generate_handshake_traffic_keys(
+    mbedtls_ssl_context *ssl,
+    mbedtls_ssl_key_set *traffic_keys )
 {
     int ret = 0;
 
@@ -632,7 +634,7 @@ int mbedtls_ssl_generate_handshake_traffic_keys( mbedtls_ssl_context *ssl,
     mbedtls_cipher_info_t const *cipher_info;
     size_t keylen, ivlen;
 
-    MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> mbedtls_ssl_generate_handshake_traffic_keys" ) );
+    MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> mbedtls_ssl_tls1_3_generate_handshake_traffic_keys" ) );
 
     cipher_info = mbedtls_cipher_info_from_type(
                                   ssl->handshake->ciphersuite_info->cipher );
@@ -717,7 +719,7 @@ int mbedtls_ssl_generate_handshake_traffic_keys( mbedtls_ssl_context *ssl,
                            traffic_keys->server_write_iv,
                            traffic_keys->iv_len);
 
-    MBEDTLS_SSL_DEBUG_MSG( 2, ( "<= mbedtls_ssl_generate_handshake_traffic_keys" ) );
+    MBEDTLS_SSL_DEBUG_MSG( 2, ( "<= mbedtls_ssl_tls1_3_generate_handshake_traffic_keys" ) );
 
 exit:
 
@@ -727,7 +729,7 @@ exit:
 /* Generate application traffic keys since any records following a 1-RTT Finished message
  * MUST be encrypted under the application traffic key.
  */
-int mbedtls_ssl_generate_application_traffic_keys(
+int mbedtls_ssl_tls1_3_generate_application_traffic_keys(
                                         mbedtls_ssl_context *ssl,
                                         mbedtls_ssl_key_set *traffic_keys )
 {
@@ -836,14 +838,84 @@ int mbedtls_ssl_generate_application_traffic_keys(
     return( 0 );
 }
 
-
-/* Key Derivation for TLS 1.3
+#if defined(MBEDTLS_SSL_NEW_SESSION_TICKET)
+/* Generate resumption_master_secret for use with the ticket exchange.
  *
- * Three tasks:
- *   - Switch transform for inbound data
- *   - Generate master key
- *   - Generate handshake traffic keys
- */
+ * This is not integrated with mbedtls_ssl_tls1_3_derive_application_secrets()
+ * because it uses the transcript hash up to and including ClientFinished. */
+int mbedtls_ssl_tls1_3_derive_resumption_master_secret(
+          mbedtls_md_type_t md_type,
+          unsigned char const *application_secret,
+          unsigned char const *transcript, size_t transcript_len,
+          mbedtls_ssl_tls1_3_application_secrets *derived_application_secrets )
+{
+    int ret;
+    mbedtls_md_info_t const * const md_info = mbedtls_md_info_from_type( md_type );
+    size_t const md_size = mbedtls_md_get_size( md_info );
+
+    ret = mbedtls_ssl_tls1_3_derive_secret( md_type,
+              application_secret, md_size,
+              MBEDTLS_SSL_TLS1_3_LBL_WITH_LEN( res_master ),
+              transcript, transcript_len,
+              MBEDTLS_SSL_TLS1_3_CONTEXT_HASHED,
+              derived_application_secrets->resumption_master_secret,
+              md_size );
+
+    if( ret != 0 )
+        return( ret );
+
+    return( 0 );
+}
+
+int mbedtls_ssl_tls1_3_generate_resumption_master_secret(
+    mbedtls_ssl_context *ssl )
+{
+    int ret = 0;
+
+    mbedtls_md_type_t md_type;
+    mbedtls_md_info_t const *md_info;
+    size_t md_size;
+
+    unsigned char transcript[MBEDTLS_MD_MAX_SIZE];
+    size_t transcript_len;
+
+    MBEDTLS_SSL_DEBUG_MSG( 2,
+          ( "=> mbedtls_ssl_tls1_3_generate_resumption_master_secret" ) );
+
+    md_type = ssl->handshake->ciphersuite_info->mac;
+    md_info = mbedtls_md_info_from_type( md_type );
+    md_size = mbedtls_md_get_size( md_info );
+
+    ret = mbedtls_ssl_get_handshake_transcript( ssl, md_type,
+                                                transcript, sizeof( transcript ),
+                                                &transcript_len );
+    if( ret != 0 )
+        return( ret );
+
+    ret = mbedtls_ssl_tls1_3_derive_resumption_master_secret( md_type,
+                                         ssl->handshake->master_secret,
+                                         transcript, transcript_len,
+                                         &ssl->session_negotiate->app_secrets );
+    if( ret != 0 )
+        return( ret );
+
+    MBEDTLS_SSL_DEBUG_BUF( 4, "Resumption master secret",
+             ssl->session_negotiate->app_secrets.resumption_master_secret,
+             md_size );
+
+    MBEDTLS_SSL_DEBUG_MSG( 2,
+          ( "<= mbedtls_ssl_tls1_3_generate_resumption_master_secret" ) );
+    return( 0 );
+}
+#else /* MBEDTLS_SSL_NEW_SESSION_TICKET */
+int mbedtls_ssl_tls1_3_generate_resumption_master_secret(
+    mbedtls_ssl_context *ssl )
+{
+    ((void) ssl);
+    return( 0 );
+}
+#endif /* MBEDTLS_SSL_NEW_SESSION_TICKET */
+
 static int ssl_tls1_3_complete_ephemeral_secret( mbedtls_ssl_context *ssl,
                                                  unsigned char *secret,
                                                  size_t secret_len,
@@ -885,276 +957,9 @@ static int ssl_tls1_3_complete_ephemeral_secret( mbedtls_ssl_context *ssl,
     return( 0 );
 }
 
-int mbedtls_ssl_handshake_key_derivation( mbedtls_ssl_context *ssl, mbedtls_ssl_key_set *traffic_keys )
+int mbedtls_ssl_tls1_3_key_schedule_stage_handshake(
+    mbedtls_ssl_context *ssl )
 {
-    int ret;
-    unsigned char *ephemeral = NULL;
-    size_t ephemeral_len = 0;
-
-#if defined(MBEDTLS_KEY_EXCHANGE_SOME_ECDHE_ENABLED)
-    unsigned char ecdhe[66]; /* TODO: Magic constant! */
-#endif
-
-    MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> mbedtls_ssl_handshake_key_derivation" ) );
-
-    /* Finalize calculation of ephemeral input to key schedule, if present. */
-#if defined(MBEDTLS_KEY_EXCHANGE_SOME_ECDHE_ENABLED)
-    ret = ssl_tls1_3_complete_ephemeral_secret( ssl,
-                                                ecdhe, sizeof( ecdhe ),
-                                                &ephemeral,
-                                                &ephemeral_len );
-    if( ret != 0 )
-        return( ret );
-#endif /* MBEDTLS_KEY_EXCHANGE_SOME_ECDHE_ENABLED */
-
-    /* Creating the Master Secret */
-    ret = mbedtls_ssl_tls1_3_derive_master_secret( ssl, ephemeral, ephemeral_len );
-    if( ret != 0 )
-    {
-        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_tls1_3_derive_master_secret", ret );
-        return( ret );
-    }
-
-    /* Creating the handshake traffic keys */
-    ret = mbedtls_ssl_generate_handshake_traffic_keys( ssl, traffic_keys );
-    if( ret != 0 )
-    {
-        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_generate_handshake_traffic_keys", ret );
-        return( ret );
-    }
-
-    MBEDTLS_SSL_DEBUG_MSG( 2, ( "<= mbedtls_ssl_handshake_key_derivation" ) );
-
-#if defined(MBEDTLS_KEY_EXCHANGE_SOME_ECDHE_ENABLED)
-    mbedtls_platform_zeroize( ecdhe, sizeof( ecdhe ) );
-#endif /* MBEDTLS_KEY_EXCHANGE_SOME_ECDHE_ENABLED */
-
-    return( 0 );
-}
-
-#if defined(MBEDTLS_SSL_NEW_SESSION_TICKET)
-/* Generate resumption_master_secret for use with the ticket exchange.
- *
- * This is not integrated with mbedtls_ssl_tls1_3_derive_application_secrets()
- * because it uses the transcript hash up to and including ClientFinished. */
-int mbedtls_ssl_tls1_3_derive_resumption_master_secret(
-          mbedtls_md_type_t md_type,
-          unsigned char const *application_secret,
-          unsigned char const *transcript, size_t transcript_len,
-          mbedtls_ssl_tls1_3_application_secrets *derived_application_secrets )
-{
-    int ret;
-    mbedtls_md_info_t const * const md_info = mbedtls_md_info_from_type( md_type );
-    size_t const md_size = mbedtls_md_get_size( md_info );
-
-    ret = mbedtls_ssl_tls1_3_derive_secret( md_type,
-              application_secret, md_size,
-              MBEDTLS_SSL_TLS1_3_LBL_WITH_LEN( res_master ),
-              transcript, transcript_len,
-              MBEDTLS_SSL_TLS1_3_CONTEXT_HASHED,
-              derived_application_secrets->resumption_master_secret,
-              md_size );
-
-    if( ret != 0 )
-        return( ret );
-
-    return( 0 );
-}
-
-int mbedtls_ssl_generate_resumption_master_secret( mbedtls_ssl_context *ssl )
-{
-    int ret = 0;
-
-    mbedtls_md_type_t md_type;
-    mbedtls_md_info_t const *md_info;
-    size_t md_size;
-
-    unsigned char transcript[MBEDTLS_MD_MAX_SIZE];
-    size_t transcript_len;
-
-    MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> mbedtls_ssl_generate_resumption_master_secret" ) );
-
-    md_type = ssl->handshake->ciphersuite_info->mac;
-    md_info = mbedtls_md_info_from_type( md_type );
-    md_size = mbedtls_md_get_size( md_info );
-
-    ret = mbedtls_ssl_get_handshake_transcript( ssl, md_type,
-                                                transcript, sizeof( transcript ),
-                                                &transcript_len );
-    if( ret != 0 )
-        return( ret );
-
-    ret = mbedtls_ssl_tls1_3_derive_resumption_master_secret( md_type,
-                                         ssl->handshake->master_secret,
-                                         transcript, transcript_len,
-                                         &ssl->session_negotiate->app_secrets );
-    if( ret != 0 )
-        return( ret );
-
-    MBEDTLS_SSL_DEBUG_BUF( 4, "Resumption master secret",
-                           ssl->session_negotiate->app_secrets.resumption_master_secret,
-                           md_size );
-
-    MBEDTLS_SSL_DEBUG_MSG( 2, ( "<= mbedtls_ssl_generate_resumption_master_secret" ) );
-
-    return( 0 );
-}
-#else /* MBEDTLS_SSL_NEW_SESSION_TICKET */
-int mbedtls_ssl_generate_resumption_master_secret( mbedtls_ssl_context *ssl )
-{
-    ((void) ssl);
-    return( 0 );
-}
-#endif /* MBEDTLS_SSL_NEW_SESSION_TICKET */
-
-
-#if defined(MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED)
-/* mbedtls_ssl_tls1_3_create_psk_binder():
- *
- *                0
- *                |
- *                v
- *   PSK ->  HKDF-Extract = Early Secret
- *                |
- *                +------> Derive-Secret( .,
- *                |                      "ext binder" |
- *                |                      "res binder",
- *                |                      "" )
- *                |                     = binder_key
-  *               ...
- */
-
-int mbedtls_ssl_tls1_3_create_psk_binder( mbedtls_ssl_context *ssl,
-                               int is_external,
-                               unsigned char *psk, size_t psk_len,
-                               const mbedtls_md_type_t md_type,
-                               unsigned char const *transcript,
-                               size_t transcript_len,
-                               unsigned char *result )
-{
-    int ret = 0;
-    unsigned char binder_key[MBEDTLS_MD_MAX_SIZE];
-    unsigned char finished_key[MBEDTLS_MD_MAX_SIZE];
-    mbedtls_md_info_t const *md_info = mbedtls_md_info_from_type( md_type );
-    size_t const md_size = mbedtls_md_get_size( md_info );
-
-    ret = mbedtls_ssl_tls1_3_evolve_secret( md_type,
-                                            NULL,          /* Old secret */
-                                            psk, psk_len,  /* Input      */
-                                            ssl->handshake->early_secret );
-    if( ret != 0 )
-    {
-        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_tls1_3_evolve_secret", ret );
-        return( ret );
-    }
-
-    /*
-     * Compute binder_key with
-     *
-     *    Derive-Secret( early_secret, "ext binder" | "res binder", "" )
-     */
-
-    if( !is_external )
-    {
-        ret = mbedtls_ssl_tls1_3_derive_secret( md_type,
-                            ssl->handshake->early_secret, md_size,
-                            MBEDTLS_SSL_TLS1_3_LBL_WITH_LEN( res_binder ),
-                            NULL, 0, MBEDTLS_SSL_TLS1_3_CONTEXT_UNHASHED,
-                            binder_key, md_size );
-        MBEDTLS_SSL_DEBUG_MSG( 5, ( "Derive Early Secret with 'res binder'" ) );
-    }
-    else
-    {
-        ret = mbedtls_ssl_tls1_3_derive_secret( md_type,
-                            ssl->handshake->early_secret, md_size,
-                            MBEDTLS_SSL_TLS1_3_LBL_WITH_LEN( ext_binder ),
-                            NULL, 0, MBEDTLS_SSL_TLS1_3_CONTEXT_UNHASHED,
-                            binder_key, md_size );
-        MBEDTLS_SSL_DEBUG_MSG( 5, ( "Derive Early Secret with 'ext binder'" ) );
-    }
-
-    if( ret != 0 )
-    {
-        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_tls1_3_derive_secret", ret );
-        return( ret );
-    }
-
-    /*
-     * finished_key =
-     *    HKDF-Expand-Label( BaseKey, "finished", "", Hash.length )
-     *
-     * The binding_value is computed in the same way as the Finished message
-     * but with the BaseKey being the binder_key.
-     */
-
-    ret = mbedtls_ssl_tls1_3_hkdf_expand_label( md_type, binder_key,
-                            md_size,
-                            MBEDTLS_SSL_TLS1_3_LBL_WITH_LEN( finished ),
-                            NULL, 0,
-                            finished_key, md_size );
-
-    if( ret != 0 )
-    {
-        MBEDTLS_SSL_DEBUG_RET( 2, "Creating the finished_key", ret );
-        goto exit;
-    }
-
-    MBEDTLS_SSL_DEBUG_BUF( 3, "finished_key", finished_key, md_size );
-
-    /* compute mac and write it into the buffer */
-    ret = mbedtls_md_hmac( md_info, finished_key, md_size,
-                           transcript, transcript_len,
-                           result );
-
-    if( ret != 0 )
-    {
-        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_md_hmac", ret );
-        goto exit;
-    }
-
-    MBEDTLS_SSL_DEBUG_MSG( 3, ( "verify_data of psk binder" ) );
-    MBEDTLS_SSL_DEBUG_BUF( 3, "Input", transcript, md_size );
-    MBEDTLS_SSL_DEBUG_BUF( 3, "Key", finished_key, md_size );
-    MBEDTLS_SSL_DEBUG_BUF( 3, "Output", result, md_size );
-
-exit:
-
-    mbedtls_platform_zeroize( finished_key, sizeof( finished_key ) );
-    mbedtls_platform_zeroize( binder_key,   sizeof( binder_key ) );
-    return( ret );
-}
-#endif /* MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED */
-
-int mbedtls_ssl_tls1_3_derive_master_secret( mbedtls_ssl_context *ssl,
-                                             unsigned char *ephemeral,
-                                             size_t ephemeral_len )
-{
-
-    /*
-     *   PSK ->  HKDF-Extract = Early Secret
-     *             |
-     *             .
-     *             .
-     *             .
-     *             |
-     *             v
-     *       Derive-Secret(., "derived", "")
-     *             |
-     *             v
-     *   (EC)DHE -> HKDF-Extract = Handshake Secret
-     *             |
-     *             .
-     *             .
-     *             .
-     *             |
-     *             v
-     *       Derive-Secret(., "derived", "")
-     *             |
-     *             v
-     *   0 -> HKDF-Extract = Master Secret
-     *
-     */
-
     int ret = 0;
     mbedtls_md_type_t const md_type = ssl->handshake->ciphersuite_info->mac;
 #if defined(MBEDTLS_DEBUG_C)
@@ -1162,42 +967,18 @@ int mbedtls_ssl_tls1_3_derive_master_secret( mbedtls_ssl_context *ssl,
     size_t const md_size = mbedtls_md_get_size( md_info );
 #endif /* MBEDTLS_DEBUG_C */
 
-    unsigned char *psk = NULL;
-    size_t psk_len = 0;
+    unsigned char *ephemeral;
+    size_t ephemeral_len;
 
-    /*
-     * Recompute EarlySecret
-     *
-     * TODO: This shouldn't be necessary...
-     */
+    unsigned char ecdhe[66]; /* TODO: Magic constant! */
 
-#if defined(MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED)
-    if( ssl->session_negotiate->key_exchange == MBEDTLS_KEY_EXCHANGE_PSK ||
-        ssl->session_negotiate->key_exchange == MBEDTLS_KEY_EXCHANGE_ECDHE_PSK )
-    {
-        if( ssl->handshake->psk != NULL )
-        {
-            psk = ssl->handshake->psk;
-            psk_len = ssl->handshake->psk_len;
-        }
-        else
-        {
-            psk = ssl->conf->psk;
-            psk_len = ssl->conf->psk_len;
-        }
-    }
-#endif /* MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED */
-
-    ret = mbedtls_ssl_tls1_3_evolve_secret( md_type,
-                                            NULL, /* use 0 as old secret */
-                                            psk, psk_len,
-                                            ssl->handshake->early_secret );
+    /* Finalize calculation of ephemeral input to key schedule, if present. */
+    ret = ssl_tls1_3_complete_ephemeral_secret( ssl,
+                                                ecdhe, sizeof( ecdhe ),
+                                                &ephemeral,
+                                                &ephemeral_len );
     if( ret != 0 )
-    {
-        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_tls1_3_evolve_secret", ret );
         return( ret );
-    }
-
 
     /*
      * Compute HandshakeSecret
@@ -1216,6 +997,22 @@ int mbedtls_ssl_tls1_3_derive_master_secret( mbedtls_ssl_context *ssl,
     MBEDTLS_SSL_DEBUG_BUF( 4, "Handshake secret",
                            ssl->handshake->handshake_secret, md_size );
 
+#if defined(MBEDTLS_KEY_EXCHANGE_SOME_ECDHE_ENABLED)
+    mbedtls_platform_zeroize( ecdhe, sizeof( ecdhe ) );
+#endif /* MBEDTLS_KEY_EXCHANGE_SOME_ECDHE_ENABLED */
+    return( 0 );
+}
+
+int mbedtls_ssl_tls1_3_key_schedule_stage_application(
+    mbedtls_ssl_context *ssl )
+{
+    int ret = 0;
+    mbedtls_md_type_t const md_type = ssl->handshake->ciphersuite_info->mac;
+#if defined(MBEDTLS_DEBUG_C)
+    mbedtls_md_info_t const * const md_info = mbedtls_md_info_from_type( md_type );
+    size_t const md_size = mbedtls_md_get_size( md_info );
+#endif /* MBEDTLS_DEBUG_C */
+
     /*
      * Compute MasterSecret
      */
@@ -1232,6 +1029,7 @@ int mbedtls_ssl_tls1_3_derive_master_secret( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_DEBUG_BUF( 4, "Master secret",
                            ssl->handshake->master_secret, md_size );
+
     return( 0 );
 }
 
@@ -1325,6 +1123,149 @@ exit:
 
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "<= mbedtls_ssl_tls1_3_calc_finished" ) );
     return( ret );
+}
+
+#if defined(MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED)
+/* mbedtls_ssl_tls1_3_create_psk_binder():
+ *
+ *                0
+ *                |
+ *                v
+ *   PSK ->  HKDF-Extract = Early Secret
+ *                |
+ *                +------> Derive-Secret( .,
+ *                |                      "ext binder" |
+ *                |                      "res binder",
+ *                |                      "" )
+ *                |                     = binder_key
+  *               ...
+ */
+
+int mbedtls_ssl_tls1_3_create_psk_binder( mbedtls_ssl_context *ssl,
+                               int is_external,
+                               unsigned char *psk, size_t psk_len,
+                               const mbedtls_md_type_t md_type,
+                               unsigned char const *transcript,
+                               size_t transcript_len,
+                               unsigned char *result )
+{
+    int ret = 0;
+    unsigned char binder_key[MBEDTLS_MD_MAX_SIZE];
+    unsigned char finished_key[MBEDTLS_MD_MAX_SIZE];
+    unsigned char early_secret[MBEDTLS_MD_MAX_SIZE];
+    mbedtls_md_info_t const *md_info = mbedtls_md_info_from_type( md_type );
+    size_t const md_size = mbedtls_md_get_size( md_info );
+
+    ret = mbedtls_ssl_tls1_3_evolve_secret( md_type,
+                                            NULL,          /* Old secret */
+                                            psk, psk_len,  /* Input      */
+                                            early_secret );
+    if( ret != 0 )
+    {
+        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_tls1_3_evolve_secret", ret );
+        return( ret );
+    }
+
+    /*
+     * Compute binder_key with
+     *
+     *    Derive-Secret( early_secret, "ext binder" | "res binder", "" )
+     */
+
+    if( !is_external )
+    {
+        ret = mbedtls_ssl_tls1_3_derive_secret( md_type,
+                            ssl->handshake->early_secret, md_size,
+                            MBEDTLS_SSL_TLS1_3_LBL_WITH_LEN( res_binder ),
+                            NULL, 0, MBEDTLS_SSL_TLS1_3_CONTEXT_UNHASHED,
+                            binder_key, md_size );
+        MBEDTLS_SSL_DEBUG_MSG( 5, ( "Derive Early Secret with 'res binder'" ) );
+    }
+    else
+    {
+        ret = mbedtls_ssl_tls1_3_derive_secret( md_type,
+                            ssl->handshake->early_secret, md_size,
+                            MBEDTLS_SSL_TLS1_3_LBL_WITH_LEN( ext_binder ),
+                            NULL, 0, MBEDTLS_SSL_TLS1_3_CONTEXT_UNHASHED,
+                            binder_key, md_size );
+        MBEDTLS_SSL_DEBUG_MSG( 5, ( "Derive Early Secret with 'ext binder'" ) );
+    }
+
+    if( ret != 0 )
+    {
+        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_tls1_3_derive_secret", ret );
+        return( ret );
+    }
+
+    /*
+     * finished_key =
+     *    HKDF-Expand-Label( BaseKey, "finished", "", Hash.length )
+     *
+     * The binding_value is computed in the same way as the Finished message
+     * but with the BaseKey being the binder_key.
+     */
+
+    ret = mbedtls_ssl_tls1_3_hkdf_expand_label( md_type, binder_key,
+                            md_size,
+                            MBEDTLS_SSL_TLS1_3_LBL_WITH_LEN( finished ),
+                            NULL, 0,
+                            finished_key, md_size );
+
+    if( ret != 0 )
+    {
+        MBEDTLS_SSL_DEBUG_RET( 2, "Creating the finished_key", ret );
+        goto exit;
+    }
+
+    MBEDTLS_SSL_DEBUG_BUF( 3, "finished_key", finished_key, md_size );
+
+    /* compute mac and write it into the buffer */
+    ret = mbedtls_md_hmac( md_info, finished_key, md_size,
+                           transcript, transcript_len,
+                           result );
+
+    if( ret != 0 )
+    {
+        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_md_hmac", ret );
+        goto exit;
+    }
+
+    MBEDTLS_SSL_DEBUG_MSG( 3, ( "verify_data of psk binder" ) );
+    MBEDTLS_SSL_DEBUG_BUF( 3, "Input", transcript, md_size );
+    MBEDTLS_SSL_DEBUG_BUF( 3, "Key", finished_key, md_size );
+    MBEDTLS_SSL_DEBUG_BUF( 3, "Output", result, md_size );
+
+exit:
+
+    mbedtls_platform_zeroize( finished_key, sizeof( finished_key ) );
+    mbedtls_platform_zeroize( early_secret, sizeof( early_secret ) );
+    mbedtls_platform_zeroize( binder_key,   sizeof( binder_key ) );
+    return( ret );
+}
+#endif /* MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED */
+
+int mbedtls_ssl_tls1_3_key_schedule_stage_early_data(
+    mbedtls_ssl_context *ssl )
+{
+    int ret = 0;
+    mbedtls_md_type_t const md_type = ssl->handshake->ciphersuite_info->mac;
+
+    unsigned char const *psk;
+    size_t psk_len;
+
+    mbedtls_ssl_get_psk( ssl, &psk, &psk_len );
+
+    ret = mbedtls_ssl_tls1_3_evolve_secret( md_type,
+                                            NULL,          /* Old secret */
+                                            psk, psk_len,  /* Input      */
+                                            ssl->handshake->early_secret );
+    if( ret != 0 )
+    {
+        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_tls1_3_evolve_secret", ret );
+        return( ret );
+    }
+
+    return( 0 );
 }
 
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */

--- a/library/ssl_tls13_keys.h
+++ b/library/ssl_tls13_keys.h
@@ -229,6 +229,40 @@ int mbedtls_ssl_tls1_3_derive_secret(
                    int ctx_hashed,
                    unsigned char *dstbuf, size_t buflen );
 
+/*
+ * TLS 1.3 key schedule secret derivations
+ *
+ * Standalone unit-testable wrappers around mbedtls_ssl_tls1_3_derive_secret().
+ *
+ */
+
+int mbedtls_ssl_tls1_3_derive_early_secrets(
+          mbedtls_md_type_t md_type,
+          unsigned char const *early_secret,
+          unsigned char const *transcript, size_t transcript_len,
+          mbedtls_ssl_tls1_3_early_secrets *derived_early_secrets );
+
+int mbedtls_ssl_tls1_3_derive_handshake_secrets(
+          mbedtls_md_type_t md_type,
+          unsigned char const *handshake_secret,
+          unsigned char const *transcript, size_t transcript_len,
+          mbedtls_ssl_tls1_3_handshake_secrets *derived_handshake_secrets );
+
+int mbedtls_ssl_tls1_3_derive_application_secrets(
+          mbedtls_md_type_t md_type,
+          unsigned char const *application_secret,
+          unsigned char const *transcript, size_t transcript_len,
+          mbedtls_ssl_tls1_3_application_secrets *derived_application_secrets );
+
+#if defined(MBEDTLS_SSL_NEW_SESSION_TICKET)
+int mbedtls_ssl_tls1_3_derive_resumption_master_secret(
+          mbedtls_md_type_t md_type,
+          unsigned char const *application_secret,
+          unsigned char const *transcript, size_t transcript_len,
+          mbedtls_ssl_tls1_3_application_secrets *derived_application_secrets );
+#endif /* MBEDTLS_SSL_NEW_SESSION_TICKET */
+
+
 /**
  * \brief Compute the next secret in the TLS 1.3 key schedule
  *
@@ -303,43 +337,48 @@ int mbedtls_ssl_tls1_3_evolve_secret(
                    const unsigned char *input, size_t input_len,
                    unsigned char *secret_new );
 
-int mbedtls_ssl_tls1_3_derive_early_secrets(
-          mbedtls_md_type_t md_type,
-          unsigned char const *early_secret,
-          unsigned char const *transcript, size_t transcript_len,
-          mbedtls_ssl_tls1_3_early_secrets *derived_early_secrets );
+/*
+ * TLS 1.3 key schedule evolutions
+ *
+ *   Early Data -> Handshake -> Application
+ *
+ * Small wrappers around mbedtls_ssl_tls1_3_evolve_secret().
+ */
 
-int mbedtls_ssl_tls1_3_derive_handshake_secrets(
-          mbedtls_md_type_t md_type,
-          unsigned char const *handshake_secret,
-          unsigned char const *transcript, size_t transcript_len,
-          mbedtls_ssl_tls1_3_handshake_secrets *derived_handshake_secrets );
+int mbedtls_ssl_tls1_3_key_schedule_stage_early_data(
+    mbedtls_ssl_context *ssl );
+int mbedtls_ssl_tls1_3_key_schedule_stage_handshake(
+    mbedtls_ssl_context *ssl );
+int mbedtls_ssl_tls1_3_key_schedule_stage_application(
+    mbedtls_ssl_context *ssl );
 
-int mbedtls_ssl_tls1_3_derive_application_secrets(
-          mbedtls_md_type_t md_type,
-          unsigned char const *application_secret,
-          unsigned char const *transcript, size_t transcript_len,
-          mbedtls_ssl_tls1_3_application_secrets *derived_application_secrets );
+/*
+ * Convenience functions combining
+ *
+ *    mbedtls_ssl_tls1_3_key_schedule_stage_xxx()
+ *
+ * with
+ *
+ *    mbedtls_ssl_tls1_3_make_traffic_keys()
+ *
+ * Those functions assume that the key schedule has been moved
+ * to the correct stage via
+ *
+ *    mbedtls_ssl_tls1_3_key_schedule_stage_xxx().
+ */
+int mbedtls_ssl_tls1_3_generate_early_data_keys(
+    mbedtls_ssl_context *ssl, mbedtls_ssl_key_set *traffic_keys );
+int mbedtls_ssl_tls1_3_generate_handshake_traffic_keys(
+    mbedtls_ssl_context* ssl, mbedtls_ssl_key_set *traffic_keys );
+int mbedtls_ssl_tls1_3_generate_application_traffic_keys(
+    mbedtls_ssl_context* ssl, mbedtls_ssl_key_set *traffic_keys );
 
-#if defined(MBEDTLS_SSL_NEW_SESSION_TICKET)
-int mbedtls_ssl_tls1_3_derive_resumption_master_secret(
-          mbedtls_md_type_t md_type,
-          unsigned char const *application_secret,
-          unsigned char const *transcript, size_t transcript_len,
-          mbedtls_ssl_tls1_3_application_secrets *derived_application_secrets );
-#endif /* MBEDTLS_SSL_NEW_SESSION_TICKET */
+/*
+ * TODO: Document
+ */
 
-/* TODO: Document */
-int mbedtls_ssl_generate_application_traffic_keys( mbedtls_ssl_context* ssl,
-                                                   mbedtls_ssl_key_set* traffic_keys );
-int mbedtls_ssl_generate_early_data_keys( mbedtls_ssl_context *ssl,
-                                          mbedtls_ssl_key_set *traffic_keys );
-int mbedtls_ssl_handshake_key_derivation( mbedtls_ssl_context* ssl,
-                                          mbedtls_ssl_key_set* traffic_keys );
-
-int mbedtls_ssl_generate_handshake_traffic_keys( mbedtls_ssl_context* ssl,
-                                                 mbedtls_ssl_key_set* traffic_keys );
-int mbedtls_ssl_generate_resumption_master_secret( mbedtls_ssl_context* ssl );
+int mbedtls_ssl_tls1_3_generate_resumption_master_secret(
+    mbedtls_ssl_context* ssl );
 
 int mbedtls_ssl_tls1_3_calc_finished( mbedtls_ssl_context* ssl,
                                       unsigned char* dst,
@@ -356,9 +395,5 @@ int mbedtls_ssl_tls1_3_create_psk_binder( mbedtls_ssl_context *ssl,
                                size_t transcript_len,
                                unsigned char *result );
 #endif /* MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED */
-
-int mbedtls_ssl_tls1_3_derive_master_secret( mbedtls_ssl_context *ssl,
-                                             unsigned char *ephemeral,
-                                             size_t ephemeral_len );
 
 #endif /* MBEDTLS_SSL_TLS1_3_KEYS_H */

--- a/library/ssl_tls13_keys.h
+++ b/library/ssl_tls13_keys.h
@@ -368,9 +368,9 @@ int mbedtls_ssl_tls1_3_key_schedule_stage_application(
  */
 int mbedtls_ssl_tls1_3_generate_early_data_keys(
     mbedtls_ssl_context *ssl, mbedtls_ssl_key_set *traffic_keys );
-int mbedtls_ssl_tls1_3_generate_handshake_traffic_keys(
+int mbedtls_ssl_tls1_3_generate_handshake_keys(
     mbedtls_ssl_context* ssl, mbedtls_ssl_key_set *traffic_keys );
-int mbedtls_ssl_tls1_3_generate_application_traffic_keys(
+int mbedtls_ssl_tls1_3_generate_application_keys(
     mbedtls_ssl_context* ssl, mbedtls_ssl_key_set *traffic_keys );
 
 /*

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -3017,7 +3017,8 @@ static int ssl_client_hello_postprocess( mbedtls_ssl_context* ssl,
     {
         MBEDTLS_SSL_DEBUG_MSG( 3, ( "Generate 0-RTT keys" ) );
 
-        ret = mbedtls_ssl_tls1_3_generate_early_data_keys( ssl, &traffic_keys );
+        ret = mbedtls_ssl_tls1_3_generate_early_data_keys(
+            ssl, &traffic_keys );
         if( ret != 0 )
         {
             MBEDTLS_SSL_DEBUG_RET( 1,
@@ -3026,11 +3027,9 @@ static int ssl_client_hello_postprocess( mbedtls_ssl_context* ssl,
         }
 
 #if !defined(MBEDTLS_SSL_USE_MPS)
-        ret = mbedtls_ssl_tls13_populate_transform( ssl->transform_earlydata,
-                                                    ssl->conf->endpoint,
-                                                    ssl->session_negotiate->ciphersuite,
-                                                    &traffic_keys,
-                                                    ssl );
+        ret = mbedtls_ssl_tls13_populate_transform(
+            ssl->transform_earlydata, ssl->conf->endpoint,
+            ssl->session_negotiate->ciphersuite, &traffic_keys, ssl );
         if( ret != 0 )
         {
             MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_tls13_populate_transform", ret );
@@ -3275,11 +3274,11 @@ static int ssl_encrypted_extensions_prepare( mbedtls_ssl_context* ssl )
     }
 
     /* Derive handshake key material */
-    ret = mbedtls_ssl_tls1_3_generate_handshake_traffic_keys( ssl, &traffic_keys );
+    ret = mbedtls_ssl_tls1_3_generate_handshake_keys( ssl, &traffic_keys );
     if( ret != 0 )
     {
         MBEDTLS_SSL_DEBUG_RET( 1,
-                "mbedtls_ssl_tls1_3_generate_handshake_traffic_keys", ret );
+                "mbedtls_ssl_tls1_3_generate_handshake_keys", ret );
         return( ret );
     }
 


### PR DESCRIPTION
This PR finishes preparing the remaining TLS 1.3 key schedule functions for upstreaming, building on #204 and #235.

It aims to find a high-level key schedule API which is close to the standard and easy to use and test.

Here's the key schedule from the standard annotated with functions from `ssl_tls13_keys.h` implementing the respective steps:
```
             0
             |
             v
   PSK ->  HKDF-Extract = Early Secret               <----- mbedtls_ssl_tls1_3_stage_early_data()
             |
             +-----> Derive-Secret(., "ext binder" | "res binder", "")           \
             |                     = binder_key                                   \
             |                                                                    | mbedtls_ssl_tls1_3_
             +-----> Derive-Secret(., "c e traffic", ClientHello)                 >    _derive_early_secrets()  /
             |                     = client_early_traffic_secret                  | mbedtls_ssl_tls1_3
             |                                                                    /    _generate_early_data_keys()
             +-----> Derive-Secret(., "e exp master", ClientHello)               /
             |                     = early_exporter_master_secret
             v
       Derive-Secret(., "derived", "")
             |
             v
   (EC)DHE -> HKDF-Extract = Handshake Secret        <----- mbedtls_ssl_tls1_3_stage_handshake()
             |
             +-----> Derive-Secret(., "c hs traffic",                            \
             |                     ClientHello...ServerHello)                    | mbedtls_ssl_tls1_3
             |                     = client_handshake_traffic_secret             |    _derive_handshake_secrets() /
             |                                                                   > mbedtls_ssl_tls1_3
             +-----> Derive-Secret(., "s hs traffic",                            |   _generate_handshake_keys()
             |                     ClientHello...ServerHello)                    |
             |                     = server_handshake_traffic_secret             /
             v
       Derive-Secret(., "derived", "")
             |
             v
   0 -> HKDF-Extract = Master Secret                 <----- mbedtls_ssl_tls1_3_stage_application()
             |
             +-----> Derive-Secret(., "c ap traffic",                           \
             |                     ClientHello...server Finished)               |
             |                     = client_application_traffic_secret_0        |
             |                                                                  | mbedtls_ssl_tls1_3
             +-----> Derive-Secret(., "s ap traffic",                           >        _derive_application_secrets() /
             |                     ClientHello...server Finished)               | mbedtls_ssl_tls1_3_
             |                     = server_application_traffic_secret_0        |        _generate_application_keys()
             |                                                                  |
             +-----> Derive-Secret(., "exp master",                             |
             |                     ClientHello...server Finished)               /
             |                     = exporter_master_secret
             |
             +-----> Derive-Secret(., "res master",                             mbedtls_ssl_tls1_3_derive_
                                   ClientHello...client Finished)                 _resumption_master_secret()
                                   = resumption_master_secret

```

Some comments:
* The functions `mbedtls_ssl_tls1_3_stage_{early_data,handshake,application}()` can be thought of as state machine transitions for the key schedule, moving through the states `initial -> early data -> handshake -> application`. 
* The functions `mbedtls_ssl_tls1_3_generate_xxx_keys()` are valid only in their respective key schedule stage, and generate the traffic keys (that is, `mbedtls_ssl_key_set` instances for key+iv pairs) for the stage.
* Internally, `mbedtls_ssl_tls1_3_generate_xxx_keys()` use standalone functions `mbedtls_ssl_tls1_3_derive_xxx_secrets()` (which wrap `mbedtls_ssl_tls1_3_derive_secret()`) for the secret derivation, and `mbedtls_ssl_tls1_3_make_traffic_keys()` for the [conversion](https://tools.ietf.org/html/rfc8446#section-7.1) of secrets into traffic keys. 
* `mbedtls_ssl_tls1_3_derive_xxx_secrets()` are standalone, accepting the hash algorithm and transcript as a parameter. This makes them suitable for unit testing.

In addition to those three classes of functions, we also have
* `mbedtls_ssl_tls1_3_create_psk_binder()` for PSK binder calculation
* `mbedtls_ssl_tls1_3_calc_finished()` for Finished payload calculation