### PR TITLE
Don't maintain {early,hs,app}_transform in SSL context if MPS used

### DIFF
--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -4087,7 +4087,8 @@ static int ssl_handshake_init( mbedtls_ssl_context *ssl )
     }
 #endif /* MBEDTLS_SSL_PROTO_TLS1_2_OR_EARLIER */
 
-#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && \
+    !defined(MBEDTLS_SSL_USE_MPS)
     ssl->transform_handshake   = mbedtls_calloc( 1, sizeof(mbedtls_ssl_transform) );
     ssl->transform_earlydata   = mbedtls_calloc( 1, sizeof(mbedtls_ssl_transform) );
     ssl->transform_application = mbedtls_calloc( 1, sizeof(mbedtls_ssl_transform) );
@@ -4169,7 +4170,8 @@ static int ssl_handshake_init( mbedtls_ssl_context *ssl )
 #if defined(MBEDTLS_SSL_PROTO_TLS1_2_OR_EARLIER)
         ssl->transform_negotiate == NULL ||
 #endif
-#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && \
+    !defined(MBEDTLS_SSL_USE_MPS)
         ssl->transform_handshake   == NULL ||
         ssl->transform_earlydata   == NULL ||
         ssl->transform_application == NULL ||
@@ -4186,7 +4188,8 @@ static int ssl_handshake_init( mbedtls_ssl_context *ssl )
         ssl->transform_negotiate = NULL;
 #endif
 
-#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && \
+    !defined(MBEDTLS_SSL_USE_MPS)
         mbedtls_ssl_transform_free( ssl->transform_handshake   );
         mbedtls_ssl_transform_free( ssl->transform_earlydata   );
         mbedtls_ssl_transform_free( ssl->transform_application );
@@ -4212,7 +4215,8 @@ static int ssl_handshake_init( mbedtls_ssl_context *ssl )
     mbedtls_ssl_transform_init( ssl->transform_negotiate );
 #endif
 
-#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && \
+    !defined(MBEDTLS_SSL_USE_MPS)
     mbedtls_ssl_transform_init( ssl->transform_handshake   );
     mbedtls_ssl_transform_init( ssl->transform_earlydata   );
     mbedtls_ssl_transform_init( ssl->transform_application );
@@ -4653,6 +4657,7 @@ int mbedtls_ssl_session_reset_int( mbedtls_ssl_context *ssl, int partial )
 #endif /* MBEDTLS_SSL_PROTO_TLS1_2_OR_EARLIER */
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+#if !defined(MBEDTLS_SSL_USE_MPS)
     mbedtls_ssl_transform_free( ssl->transform_handshake   );
     mbedtls_ssl_transform_free( ssl->transform_earlydata   );
     mbedtls_ssl_transform_free( ssl->transform_application );
@@ -4662,8 +4667,7 @@ int mbedtls_ssl_session_reset_int( mbedtls_ssl_context *ssl, int partial )
     ssl->transform_handshake   = NULL;
     ssl->transform_earlydata   = NULL;
     ssl->transform_application = NULL;
-
-#if defined(MBEDTLS_SSL_USE_MPS)
+#else
     ssl_mps_free( ssl );
     ssl_mps_init( ssl );
 #endif /* MBEDTLS_SSL_USE_MPS */
@@ -7879,7 +7883,8 @@ void mbedtls_ssl_free( mbedtls_ssl_context *ssl )
     }
 #endif
 
-#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && \
+    !defined(MBEDTLS_SSL_USE_MPS)
     mbedtls_ssl_transform_free( ssl->transform_handshake   );
     mbedtls_ssl_transform_free( ssl->transform_earlydata   );
     mbedtls_ssl_transform_free( ssl->transform_application );

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -3321,6 +3321,8 @@ static int ssl_server_hello_postprocess( mbedtls_ssl_context* ssl )
         return( ret );
     }
 
+#if !defined(MBEDTLS_SSL_USE_MPS)
+
     ret = mbedtls_ssl_tls13_populate_transform(
                               ssl->transform_handshake,
                               ssl->conf->endpoint,
@@ -3333,10 +3335,8 @@ static int ssl_server_hello_postprocess( mbedtls_ssl_context* ssl )
         return( ret );
     }
 
-#if defined(MBEDTLS_SSL_USE_MPS)
-    /* We're not yet using MPS for all outgoing encrypted handshake messages,
-     * so we cannot yet remove the old transform generation code in case
-     * MBEDTLS_SSL_USE_MPS is set. */
+#else /* MBEDTLS_SSL_USE_MPS */
+
     {
         mbedtls_ssl_transform *transform_handshake =
             mbedtls_calloc( 1, sizeof( mbedtls_ssl_transform ) );

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -2421,6 +2421,8 @@ static int ssl_finished_out_postprocess( mbedtls_ssl_context* ssl )
             return( ret );
         }
 
+#if !defined(MBEDTLS_SSL_USE_MPS)
+
         ret = mbedtls_ssl_tls13_populate_transform( ssl->transform_application,
                                                ssl->conf->endpoint,
                                                ssl->session_negotiate->ciphersuite,
@@ -2432,7 +2434,7 @@ static int ssl_finished_out_postprocess( mbedtls_ssl_context* ssl )
             return( ret );
         }
 
-#if defined(MBEDTLS_SSL_USE_MPS)
+#else /* MBEDTLS_SSL_USE_MPS */
         {
             mbedtls_ssl_transform *transform_application =
                 mbedtls_calloc( 1, sizeof( mbedtls_ssl_transform ) );
@@ -2678,6 +2680,7 @@ static int ssl_finished_in_postprocess_cli( mbedtls_ssl_context *ssl )
         return( ret );
     }
 
+#if !defined(MBEDTLS_SSL_USE_MPS)
     ret = mbedtls_ssl_tls13_populate_transform(
                                     ssl->transform_application,
                                     ssl->conf->endpoint,
@@ -2690,7 +2693,8 @@ static int ssl_finished_in_postprocess_cli( mbedtls_ssl_context *ssl )
         return( ret );
     }
 
-#if defined(MBEDTLS_SSL_USE_MPS)
+#else /* MBEDTLS_SSL_USE_MPS */
+
     {
         mbedtls_ssl_transform *transform_application =
             mbedtls_calloc( 1, sizeof( mbedtls_ssl_transform ) );

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -3021,6 +3021,7 @@ static int ssl_client_hello_postprocess( mbedtls_ssl_context* ssl,
             return( ret );
         }
 
+#if !defined(MBEDTLS_SSL_USE_MPS)
         ret = mbedtls_ssl_tls13_populate_transform( ssl->transform_earlydata,
                                                     ssl->conf->endpoint,
                                                     ssl->session_negotiate->ciphersuite,
@@ -3032,7 +3033,8 @@ static int ssl_client_hello_postprocess( mbedtls_ssl_context* ssl,
             return( ret );
         }
 
-#if defined(MBEDTLS_SSL_USE_MPS)
+#else /* MBEDTLS_SSL_USE_MPS */
+
         {
             mbedtls_ssl_transform *transform_earlydata =
                 mbedtls_calloc( 1, sizeof( mbedtls_ssl_transform ) );
@@ -3268,6 +3270,8 @@ static int ssl_encrypted_extensions_prepare( mbedtls_ssl_context* ssl )
         return( ret );
     }
 
+#if !defined(MBEDTLS_SSL_USE_MPS)
+
     /* Setup transform from handshake key material */
     ret = mbedtls_ssl_tls13_populate_transform(
                                ssl->transform_handshake,
@@ -3281,7 +3285,10 @@ static int ssl_encrypted_extensions_prepare( mbedtls_ssl_context* ssl )
         return( ret );
     }
 
-#if defined(MBEDTLS_SSL_USE_MPS)
+    mbedtls_ssl_set_outbound_transform( ssl, ssl->transform_handshake );
+
+#else /* MBEDTLS_SSL_USE_MPS */
+
     /* We're not yet using MPS for all outgoing encrypted handshake messages,
      * so we cannot yet remove the old transform generation code in case
      * MBEDTLS_SSL_USE_MPS is set. */
@@ -3311,8 +3318,6 @@ static int ssl_encrypted_extensions_prepare( mbedtls_ssl_context* ssl )
         if( ret != 0 )
             return( ret );
     }
-#else
-    mbedtls_ssl_set_outbound_transform( ssl, ssl->transform_handshake );
 #endif /* MBEDTLS_SSL_USE_MPS */
 
     /*


### PR DESCRIPTION
If MPS is used, SSL transforms are tracked and owned by MPS, and there's no need to also store them within the SSL context.

Signed-off-by: Hanno Becker <hanno.becker@arm.com>