### PR TITLE
MFL API Fix

### DIFF
--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -5703,6 +5703,15 @@ size_t mbedtls_ssl_get_input_max_frag_len( const mbedtls_ssl_context *ssl )
     size_t max_len = MBEDTLS_SSL_MAX_CONTENT_LEN;
     size_t read_mfl;
 
+#if defined(MBEDTLS_SSL_PROTO_TLS1_2_OR_EARLIER)
+    /* Use the configured MFL for the client if we're past SERVER_HELLO_DONE */
+    if( ssl->conf->endpoint == MBEDTLS_SSL_IS_CLIENT &&
+        ssl->state >= MBEDTLS_SSL_SERVER_HELLO_DONE )
+    {
+        return ssl_mfl_code_to_length( ssl->conf->mfl_code );
+    }
+#endif /* MBEDTLS_SSL_PROTO_TLS1_2_OR_EARLIER */
+
     /* Check if a smaller max length was negotiated */
     if( ssl->session_out != NULL )
     {

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -5703,13 +5703,6 @@ size_t mbedtls_ssl_get_input_max_frag_len( const mbedtls_ssl_context *ssl )
     size_t max_len = MBEDTLS_SSL_MAX_CONTENT_LEN;
     size_t read_mfl;
 
-    /* Use the configured MFL for the client if we're past SERVER_HELLO_DONE */
-    if( ssl->conf->endpoint == MBEDTLS_SSL_IS_CLIENT &&
-        ssl->state >= MBEDTLS_SSL_SERVER_HELLO_DONE )
-    {
-        return ssl_mfl_code_to_length( ssl->conf->mfl_code );
-    }
-
     /* Check if a smaller max length was negotiated */
     if( ssl->session_out != NULL )
     {
@@ -5720,7 +5713,7 @@ size_t mbedtls_ssl_get_input_max_frag_len( const mbedtls_ssl_context *ssl )
         }
     }
 
-    // During a handshake, use the value being negotiated
+    /* During a handshake, use the value being negotiated */
     if( ssl->session_negotiate != NULL )
     {
         read_mfl = ssl_mfl_code_to_length( ssl->session_negotiate->mfl_code );

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -569,7 +569,7 @@ static int ssl_write_max_fragment_length_ext( mbedtls_ssl_context *ssl,
         return( MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL );
     }
 
-    MBEDTLS_SSL_DEBUG_MSG( 3, ( "client hello, adding max_fragment_length extension" ) );
+    MBEDTLS_SSL_DEBUG_MSG( 3, ( "adding max_fragment_length extension" ) );
 
     *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_MAX_FRAGMENT_LENGTH >> 8 ) & 0xFF );
     *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_MAX_FRAGMENT_LENGTH ) & 0xFF );
@@ -1754,7 +1754,13 @@ static int ssl_client_hello_write_partial( mbedtls_ssl_context* ssl,
 #endif /* MBEDTLS_SSL_ALPN */
 
 #if defined(MBEDTLS_SSL_MAX_FRAGMENT_LENGTH)
-    ssl_write_max_fragment_length_ext( ssl, buf, end, &cur_ext_len );
+    if( ( ret = ssl_write_max_fragment_length_ext( ssl, buf,
+                                                   end - buf, &cur_ext_len )  ) != 0 )
+    {
+        MBEDTLS_SSL_DEBUG_RET( 1, "ssl_write_max_fragment_length_ext", ret );
+        return( ret );
+    }
+
     total_ext_len += cur_ext_len;
     buf += cur_ext_len;
 #endif /* MBEDTLS_SSL_MAX_FRAGMENT_LENGTH */

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -1755,7 +1755,8 @@ static int ssl_client_hello_write_partial( mbedtls_ssl_context* ssl,
 
 #if defined(MBEDTLS_SSL_MAX_FRAGMENT_LENGTH)
     if( ( ret = ssl_write_max_fragment_length_ext( ssl, buf,
-                                                   end - buf, &cur_ext_len )  ) != 0 )
+                                                   (size_t)( end - buf ), 
+                                                   &cur_ext_len )  ) != 0 )
     {
         MBEDTLS_SSL_DEBUG_RET( 1, "ssl_write_max_fragment_length_ext", ret );
         return( ret );

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -3069,20 +3069,21 @@ static int ssl_client_hello_postprocess( mbedtls_ssl_context* ssl,
 #if defined(MBEDTLS_SSL_MAX_FRAGMENT_LENGTH)
 static int ssl_write_max_fragment_length_ext( mbedtls_ssl_context *ssl,
                                               unsigned char *buf,
-                                              const unsigned char *end,
+                                              size_t buflen,
                                               size_t *olen )
 {
     unsigned char *p = buf;
 
-    *olen = 0;
-
-    if( ssl->conf->mfl_code == MBEDTLS_SSL_MAX_FRAG_LEN_NONE )
+    if( ssl->session_negotiate->mfl_code == MBEDTLS_SSL_MAX_FRAG_LEN_NONE )
+    {
+        *olen = 0;
         return( 0 );
+    }
 
     MBEDTLS_SSL_DEBUG_MSG( 3,
-        ( "client hello, adding max_fragment_length extension" ) );
+        ( "adding max_fragment_length extension" ) );
 
-    MBEDTLS_SSL_CHK_BUF_PTR( p, end, 5 );
+    MBEDTLS_SSL_CHK_BUF_PTR( p, buf + buflen, 5 );
 
     *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_MAX_FRAGMENT_LENGTH >> 8 )
                             & 0xFF );
@@ -3392,12 +3393,9 @@ static int ssl_encrypted_extensions_write( mbedtls_ssl_context* ssl,
 #endif /* MBEDTLS_SSL_ALPN */
 
 #if defined(MBEDTLS_SSL_MAX_FRAGMENT_LENGTH)
-    if( ( ret = ssl_write_max_fragment_length_ext( ssl, p, 
-                                                   end - p, &n )  ) != 0 )
-    {
-        MBEDTLS_SSL_DEBUG_RET( 1, "ssl_write_max_fragment_length_ext", ret );
+    ret = ssl_write_max_fragment_length_ext( ssl, p, end - p, &n );
+    if( ret != 0 )
         return( ret );
-    }
     p += n;
 #endif /* MBEDTLS_SSL_MAX_FRAGMENT_LENGTH */
 

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -3074,9 +3074,16 @@ static int ssl_write_max_fragment_length_ext( mbedtls_ssl_context *ssl,
 {
     unsigned char *p = buf;
 
+    *olen = 0;
+	
+    if( ( ssl->handshake->extensions_present & MAX_FRAGMENT_LENGTH_EXTENSION )
+        == 0 )
+    {
+        return( 0 );
+    }
+
     if( ssl->session_negotiate->mfl_code == MBEDTLS_SSL_MAX_FRAG_LEN_NONE )
     {
-        *olen = 0;
         return( 0 );
     }
 


### PR DESCRIPTION
This PR addresses https://github.com/hannestschofenig/mbedtls/issues/209 

The goal was also to better align the API (as noted here https://github.com/hannestschofenig/mbedtls/issues/130). However, the upstream Mbed TLS code has no harmonized API signature for the extension handling between the client and the server code either. Hence, the currently used API signature is consistent with the approach selected for upstream Mbed TLS in the sense that it is equally inconsistent. 

In a future attempt to reduce the code size the extension handling code should be moved out of the client and server files. This would offer the possibility to do some harmonization. 