### PR TITLE
TLS 1.3 Key schedule, pt4: Share code between PSK binder and Finished calculation

### DIFF
--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -790,7 +790,7 @@ int mbedtls_ssl_write_pre_shared_key_ext( mbedtls_ssl_context *ssl,
     int hash_len;
     unsigned char *psk_identity;
     size_t psk_identity_len;
-    unsigned char *psk;
+    unsigned char const *psk;
     size_t psk_len;
 
     *total_ext_len = 0;
@@ -986,14 +986,13 @@ int mbedtls_ssl_write_pre_shared_key_ext( mbedtls_ssl_context *ssl,
             return( ret );
 
         ret = mbedtls_ssl_tls1_3_create_psk_binder( ssl,
-                  external_psk,
-                  psk, psk_len,
-                  suite_info->mac,
-                  transcript, transcript_len, p );
-
+                                                    psk, psk_len,
+                                                    suite_info->mac,
+                                                    external_psk,
+                                                    transcript, p );
         if( ret != 0 )
         {
-            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_write_pre_shared_key_ext()", ret );
+            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_tls1_3_create_psk_binder", ret );
             return( MBEDTLS_ERR_SSL_BAD_HS_CLIENT_HELLO );
         }
 

--- a/library/ssl_tls13_keys.c
+++ b/library/ssl_tls13_keys.c
@@ -1175,7 +1175,7 @@ int mbedtls_ssl_tls1_3_create_psk_binder( mbedtls_ssl_context *ssl,
     if( !is_external )
     {
         ret = mbedtls_ssl_tls1_3_derive_secret( md_type,
-                            ssl->handshake->early_secret, md_size,
+                            early_secret, md_size,
                             MBEDTLS_SSL_TLS1_3_LBL_WITH_LEN( res_binder ),
                             NULL, 0, MBEDTLS_SSL_TLS1_3_CONTEXT_UNHASHED,
                             binder_key, md_size );
@@ -1184,7 +1184,7 @@ int mbedtls_ssl_tls1_3_create_psk_binder( mbedtls_ssl_context *ssl,
     else
     {
         ret = mbedtls_ssl_tls1_3_derive_secret( md_type,
-                            ssl->handshake->early_secret, md_size,
+                            early_secret, md_size,
                             MBEDTLS_SSL_TLS1_3_LBL_WITH_LEN( ext_binder ),
                             NULL, 0, MBEDTLS_SSL_TLS1_3_CONTEXT_UNHASHED,
                             binder_key, md_size );

--- a/library/ssl_tls13_keys.c
+++ b/library/ssl_tls13_keys.c
@@ -1034,6 +1034,54 @@ int mbedtls_ssl_tls1_3_key_schedule_stage_application(
     return( 0 );
 }
 
+static int ssl_tls1_3_calc_finished_core( mbedtls_md_type_t md_type,
+                                          unsigned char const *base_key,
+                                          unsigned char const *transcript,
+                                          unsigned char *dst,
+                                          size_t *actual_len )
+{
+    const mbedtls_md_info_t* const md = mbedtls_md_info_from_type( md_type );
+    size_t const md_size = mbedtls_md_get_size( md );
+    unsigned char finished_key[MBEDTLS_MD_MAX_SIZE];
+    int ret;
+
+    /* TLS 1.3 Finished message
+     *
+     * struct {
+     *     opaque verify_data[Hash.length];
+     * } Finished;
+     *
+     * verify_data =
+     *     HMAC( finished_key,
+     *            Hash( Handshake Context +
+     *                  Certificate*      +
+     *                  CertificateVerify* )
+     *    )
+     *
+     * finished_key =
+     *    HKDF-Expand-Label( BaseKey, "finished", "", Hash.length )
+     */
+
+    ret = mbedtls_ssl_tls1_3_hkdf_expand_label(
+                                 md_type, base_key, md_size,
+                                 MBEDTLS_SSL_TLS1_3_LBL_WITH_LEN( finished ),
+                                 NULL, 0,
+                                 finished_key, md_size );
+    if( ret != 0 )
+        goto exit;
+
+    ret = mbedtls_md_hmac( md, finished_key, md_size, transcript, md_size, dst );
+    if( ret != 0 )
+        goto exit;
+
+    *actual_len = md_size;
+
+exit:
+
+    mbedtls_platform_zeroize( finished_key, sizeof( finished_key ) );
+    return( ret );
+}
+
 int mbedtls_ssl_tls1_3_calc_finished( mbedtls_ssl_context* ssl,
                                       unsigned char* dst,
                                       size_t dst_len,
@@ -1045,7 +1093,6 @@ int mbedtls_ssl_tls1_3_calc_finished( mbedtls_ssl_context* ssl,
     unsigned char transcript[MBEDTLS_MD_MAX_SIZE];
     size_t transcript_len;
 
-    unsigned char finished_key[MBEDTLS_MD_MAX_SIZE];
     unsigned char const *base_key = NULL;
 
     mbedtls_md_type_t const md_type = ssl->handshake->ciphersuite_info->mac;
@@ -1067,63 +1114,20 @@ int mbedtls_ssl_tls1_3_calc_finished( mbedtls_ssl_context* ssl,
     }
     MBEDTLS_SSL_DEBUG_BUF( 4, "handshake hash", transcript, transcript_len );
 
-    /* TLS 1.3 Finished message
-     *
-     * struct {
-     *     opaque verify_data[Hash.length];
-     * } Finished;
-     *
-     * verify_data =
-     *     HMAC( finished_key,
-     *            Hash( Handshake Context +
-     *                  Certificate*      +
-     *                  CertificateVerify* )
-     *    )
-     *
-     * finished_key =
-     *    HKDF-Expand-Label( BaseKey, "finished", "", Hash.length )
-     *
-     * The binding_value is computed in the same way as the Finished message
-     * but with the BaseKey being the binder_key.
-     */
-
     if( from == MBEDTLS_SSL_IS_CLIENT )
         base_key = ssl->handshake->hs_secrets.client_handshake_traffic_secret;
     else
         base_key = ssl->handshake->hs_secrets.server_handshake_traffic_secret;
 
-    ret = mbedtls_ssl_tls1_3_hkdf_expand_label(
-                                 md_type, base_key, md_size,
-                                 MBEDTLS_SSL_TLS1_3_LBL_WITH_LEN( finished ),
-                                 NULL, 0,
-                                 finished_key, md_size );
+    ret = ssl_tls1_3_calc_finished_core( md_type, base_key, transcript,
+                                         dst, actual_len );
     if( ret != 0 )
-    {
-        MBEDTLS_SSL_DEBUG_RET( 2, "Creating the client_finished_key failed", ret );
-        goto exit;
-    }
-    MBEDTLS_SSL_DEBUG_BUF( 3, "finished_key", finished_key, md_size );
+        return( ret );
 
-    /* Compute verify_data */
-    ret = mbedtls_md_hmac( md, finished_key, md_size, transcript, md_size, dst );
-    if( ret != 0 )
-    {
-        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_md_hmac", ret );
-        goto exit;
-    }
-    *actual_len = md_size;
-
-    MBEDTLS_SSL_DEBUG_MSG( 3, ( "verify_data of Finished message" ) );
-    MBEDTLS_SSL_DEBUG_BUF( 3, "Input",  transcript, md_size );
-    MBEDTLS_SSL_DEBUG_BUF( 3, "Key",    finished_key, md_size );
-    MBEDTLS_SSL_DEBUG_BUF( 3, "Output", dst, md_size );
-
-exit:
-    mbedtls_platform_zeroize( transcript, sizeof( transcript ) );
-    mbedtls_platform_zeroize( finished_key, sizeof( finished_key ) );
+    MBEDTLS_SSL_DEBUG_BUF( 3, "verify_data for finished message", dst, md_size );
 
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "<= mbedtls_ssl_tls1_3_calc_finished" ) );
-    return( ret );
+    return( 0 );
 }
 
 #if defined(MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED)
@@ -1152,10 +1156,12 @@ int mbedtls_ssl_tls1_3_create_psk_binder( mbedtls_ssl_context *ssl,
 {
     int ret = 0;
     unsigned char binder_key[MBEDTLS_MD_MAX_SIZE];
-    unsigned char finished_key[MBEDTLS_MD_MAX_SIZE];
     unsigned char early_secret[MBEDTLS_MD_MAX_SIZE];
     mbedtls_md_info_t const *md_info = mbedtls_md_info_from_type( md_type );
     size_t const md_size = mbedtls_md_get_size( md_info );
+
+    size_t result_len;
+    ((void) transcript_len);
 
     ret = mbedtls_ssl_tls1_3_evolve_secret( md_type,
                                             NULL,          /* Old secret */
@@ -1164,7 +1170,7 @@ int mbedtls_ssl_tls1_3_create_psk_binder( mbedtls_ssl_context *ssl,
     if( ret != 0 )
     {
         MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_tls1_3_evolve_secret", ret );
-        return( ret );
+        goto exit;
     }
 
     /*
@@ -1180,7 +1186,7 @@ int mbedtls_ssl_tls1_3_create_psk_binder( mbedtls_ssl_context *ssl,
                             MBEDTLS_SSL_TLS1_3_LBL_WITH_LEN( res_binder ),
                             NULL, 0, MBEDTLS_SSL_TLS1_3_CONTEXT_UNHASHED,
                             binder_key, md_size );
-        MBEDTLS_SSL_DEBUG_MSG( 5, ( "Derive Early Secret with 'res binder'" ) );
+        MBEDTLS_SSL_DEBUG_MSG( 3, ( "Derive Early Secret with 'res binder'" ) );
     }
     else
     {
@@ -1189,56 +1195,29 @@ int mbedtls_ssl_tls1_3_create_psk_binder( mbedtls_ssl_context *ssl,
                             MBEDTLS_SSL_TLS1_3_LBL_WITH_LEN( ext_binder ),
                             NULL, 0, MBEDTLS_SSL_TLS1_3_CONTEXT_UNHASHED,
                             binder_key, md_size );
-        MBEDTLS_SSL_DEBUG_MSG( 5, ( "Derive Early Secret with 'ext binder'" ) );
+        MBEDTLS_SSL_DEBUG_MSG( 3, ( "Derive Early Secret with 'ext binder'" ) );
     }
 
     if( ret != 0 )
     {
         MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_tls1_3_derive_secret", ret );
-        return( ret );
+        goto exit;
     }
 
     /*
-     * finished_key =
-     *    HKDF-Expand-Label( BaseKey, "finished", "", Hash.length )
-     *
      * The binding_value is computed in the same way as the Finished message
      * but with the BaseKey being the binder_key.
      */
 
-    ret = mbedtls_ssl_tls1_3_hkdf_expand_label( md_type, binder_key,
-                            md_size,
-                            MBEDTLS_SSL_TLS1_3_LBL_WITH_LEN( finished ),
-                            NULL, 0,
-                            finished_key, md_size );
-
+    ret = ssl_tls1_3_calc_finished_core( md_type, binder_key, transcript,
+                                         result, &result_len );
     if( ret != 0 )
-    {
-        MBEDTLS_SSL_DEBUG_RET( 2, "Creating the finished_key", ret );
         goto exit;
-    }
 
-    MBEDTLS_SSL_DEBUG_BUF( 3, "finished_key", finished_key, md_size );
-
-    /* compute mac and write it into the buffer */
-    ret = mbedtls_md_hmac( md_info, finished_key, md_size,
-                           transcript, transcript_len,
-                           result );
-
-    if( ret != 0 )
-    {
-        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_md_hmac", ret );
-        goto exit;
-    }
-
-    MBEDTLS_SSL_DEBUG_MSG( 3, ( "verify_data of psk binder" ) );
-    MBEDTLS_SSL_DEBUG_BUF( 3, "Input", transcript, md_size );
-    MBEDTLS_SSL_DEBUG_BUF( 3, "Key", finished_key, md_size );
-    MBEDTLS_SSL_DEBUG_BUF( 3, "Output", result, md_size );
+    MBEDTLS_SSL_DEBUG_BUF( 3, "psk binder", result, md_size );
 
 exit:
 
-    mbedtls_platform_zeroize( finished_key, sizeof( finished_key ) );
     mbedtls_platform_zeroize( early_secret, sizeof( early_secret ) );
     mbedtls_platform_zeroize( binder_key,   sizeof( binder_key ) );
     return( ret );

--- a/library/ssl_tls13_keys.h
+++ b/library/ssl_tls13_keys.h
@@ -388,11 +388,10 @@ int mbedtls_ssl_tls1_3_calc_finished( mbedtls_ssl_context* ssl,
 
 #if defined(MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED)
 int mbedtls_ssl_tls1_3_create_psk_binder( mbedtls_ssl_context *ssl,
-                               int is_external,
-                               unsigned char *psk, size_t psk_len,
+                               unsigned char const *psk, size_t psk_len,
                                const mbedtls_md_type_t md_type,
+                               int is_external,
                                unsigned char const *transcript,
-                               size_t transcript_len,
                                unsigned char *result );
 #endif /* MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED */
 

--- a/library/ssl_tls13_keys.h
+++ b/library/ssl_tls13_keys.h
@@ -229,39 +229,119 @@ int mbedtls_ssl_tls1_3_derive_secret(
                    int ctx_hashed,
                    unsigned char *dstbuf, size_t buflen );
 
-/*
- * TLS 1.3 key schedule secret derivations
+/**
+ * \brief Derive TLS 1.3 early data key material from early secret.
  *
- * Standalone unit-testable wrappers around mbedtls_ssl_tls1_3_derive_secret().
+ *        This is a small wrapper invoking mbedtls_ssl_tls1_3_derive_secret()
+ *        with the appropriate labels.
  *
+ * \param md_type      The hash algorithm associated with the PSK for which
+ *                     early data key material is being derived.
+ * \param early_secret The early secret from which the early data key material
+ *                     should be derived. This must be a readable buffer whose
+ *                     length is the digest size of the hash algorithm
+ *                     represented by \p md_size.
+ * \param transcript   The transcript of the handshake so far, calculated with
+ *                     respect to \p md_type. This must be a readable buffer
+ *                     whose length is the digest size of the hash algorithm
+ *                     represented by \p md_size.
+ * \param derived_early_secrets The address of the structure in which to store
+ *                              the early data key material.
+ *
+ * \returns        \c 0 on success.
+ * \returns        A negative error code on failure.
  */
-
 int mbedtls_ssl_tls1_3_derive_early_secrets(
           mbedtls_md_type_t md_type,
           unsigned char const *early_secret,
           unsigned char const *transcript, size_t transcript_len,
           mbedtls_ssl_tls1_3_early_secrets *derived_early_secrets );
 
+/**
+ * \brief Derive TLS 1.3 handshake key material from handshake secret.
+ *
+ *        This is a small wrapper invoking mbedtls_ssl_tls1_3_derive_secret()
+ *        with the appropriate labels.
+ *
+ * \param md_type           The hash algorithm used in the handshake for which
+ *                          key material is being derived.
+ * \param handshake_secret  The handshake secret from which the handshake key
+ *                          material should be derived. This must be a readable
+ *                          buffer whose length is the digest size of the hash
+ *                          algorithm represented by \p md_size.
+ * \param transcript        The transcript of the handshake so far, calculated
+ *                          with respect to \p md_type. This must be a readable
+ *                          buffer whose length is the digest size of the hash
+ *                          algorithm represented by \p md_size.
+ * \param derived_handshake_secrets The address of the structure in which to
+ *                                  store the handshake key material.
+ *
+ * \returns        \c 0 on success.
+ * \returns        A negative error code on failure.
+ */
 int mbedtls_ssl_tls1_3_derive_handshake_secrets(
           mbedtls_md_type_t md_type,
           unsigned char const *handshake_secret,
           unsigned char const *transcript, size_t transcript_len,
           mbedtls_ssl_tls1_3_handshake_secrets *derived_handshake_secrets );
 
+/**
+ * \brief Derive TLS 1.3 application key material from master secret.
+ *
+ *        This is a small wrapper invoking mbedtls_ssl_tls1_3_derive_secret()
+ *        with the appropriate labels.
+ *
+ * \param md_type           The hash algorithm used in the application for which
+ *                          key material is being derived.
+ * \param master_secret     The master secret from which the application key
+ *                          material should be derived. This must be a readable
+ *                          buffer whose length is the digest size of the hash
+ *                          algorithm represented by \p md_size.
+ * \param transcript        The transcript of the application so far, calculated
+ *                          with respect to \p md_type. This must be a readable
+ *                          buffer whose length is the digest size of the hash
+ *                          algorithm represented by \p md_size.
+ * \param derived_application_secrets The address of the structure in which to
+ *                                    store the application key material.
+ *
+ * \returns        \c 0 on success.
+ * \returns        A negative error code on failure.
+ */
 int mbedtls_ssl_tls1_3_derive_application_secrets(
           mbedtls_md_type_t md_type,
-          unsigned char const *application_secret,
+          unsigned char const *master_secret,
           unsigned char const *transcript, size_t transcript_len,
           mbedtls_ssl_tls1_3_application_secrets *derived_application_secrets );
 
 #if defined(MBEDTLS_SSL_NEW_SESSION_TICKET)
+/**
+ * \brief Derive TLS 1.3 resumption master secret.
+ *
+ *        This is a small wrapper invoking mbedtls_ssl_tls1_3_derive_secret()
+ *        with the appropriate label.
+ *
+ * \param md_type           The hash algorithm used in the application for which
+ *                          key material is being derived.
+ * \param master_secret     The master secret from which the resumption master
+ *                          secret should be derived. This must be a readable
+ *                          buffer whose length is the digest size of the hash
+ *                          algorithm represented by \p md_size.
+ * \param transcript        The transcript of the application so far, calculated
+ *                          with respect to \p md_type. This must be a readable
+ *                          buffer whose length is the digest size of the hash
+ *                          algorithm represented by \p md_size.
+ * \param derived_application_secrets The address of the structure in which to
+ *                                    store the resumption master secret.
+ *
+ * \returns        \c 0 on success.
+ * \returns        A negative error code on failure.
+ */
 int mbedtls_ssl_tls1_3_derive_resumption_master_secret(
           mbedtls_md_type_t md_type,
           unsigned char const *application_secret,
           unsigned char const *transcript, size_t transcript_len,
           mbedtls_ssl_tls1_3_application_secrets *derived_application_secrets );
 #endif /* MBEDTLS_SSL_NEW_SESSION_TICKET */
-
 
 /**
  * \brief Compute the next secret in the TLS 1.3 key schedule

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -839,11 +839,10 @@ psk_parsing_successful:
         }
 
         ret = mbedtls_ssl_tls1_3_create_psk_binder( ssl,
-                 !( ssl->handshake->resume == 1 ) /* external PSK */,
-                 (unsigned char *) psk, psk_len,
+                 psk, psk_len,
                  ssl->handshake->ciphersuite_info->mac,
-                 transcript, transcript_len,
-                 server_computed_binder );
+                 !( ssl->handshake->resume == 1 ) /* external PSK */,
+                 transcript, server_computed_binder );
 
         /* We do not check for multiple binders */
         if( ret != 0 )


### PR DESCRIPTION
The PSK binder is calculated in the same way as the Finished message, but based on a different key. Quoting RFC 8446:
```
   The PskBinderEntry is computed in the same way as the Finished
   message (Section 4.4.4) but with the BaseKey being the binder_key
   derived via the key schedule from the corresponding PSK which is
   being offered (see Section 7.1).
```
This PR extracts this common core of `mbedtls_ssl_tls1_3_calc_finished()` and `mbedtls_ssl_tls1_3_create_psk_binder()` into a static helper function.

It also adds some documentation to TLS 1.3 key schedule functions and streamlines their signatures.