### PR TITLE
Fix compiler warning for mps.c

### DIFF
--- a/library/mps/mps.c
+++ b/library/mps/mps.c
@@ -2255,6 +2255,7 @@ MBEDTLS_MPS_STATIC int mps_retransmission_timer_check( mbedtls_mps *mps )
                              mps,
                              MBEDTLS_MPS_FLIGHT_FINALIZE,
                              MBEDTLS_MPS_FLIGHT_DONE ) );
+                break;
 
             default:
                 break;


### PR DESCRIPTION
Note implicit fall-through is enabled [here](https://github.com/hannestschofenig/mbedtls/blob/ff1e8d690ca0acc02286ea132d1c7e57a3ca450f/CMakeLists.txt#L83).

/Users/zhih/github/mbedtls/library/mps/mps.c:2259:13: error: unannotated fall-through between switch labels
      [-Werror,-Wimplicit-fallthrough]
            default:
            ^
/Users/zhih/github/mbedtls/library/mps/mps.c:2259:13: note: insert 'break;' to avoid fall-through
            default:
            ^
            break;
1 error generated.