### PR TITLE
Key schedule rework: Add documentation

### DIFF
--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -812,12 +812,14 @@ struct mbedtls_ssl_handshake_params
     unsigned char* ptr_to_psk_ext;
 #endif /* MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED */
 
-    unsigned char early_secret[MBEDTLS_MD_MAX_SIZE];
-    unsigned char handshake_secret[MBEDTLS_MD_MAX_SIZE];
-    unsigned char master_secret[MBEDTLS_MD_MAX_SIZE];
+    union
+    {
+        unsigned char early    [MBEDTLS_MD_MAX_SIZE];
+        unsigned char handshake[MBEDTLS_MD_MAX_SIZE];
+        unsigned char app      [MBEDTLS_MD_MAX_SIZE];
+    } tls1_3_master_secrets;
 
     mbedtls_ssl_tls1_3_handshake_secrets hs_secrets;
-
 #if defined(MBEDTLS_ZERO_RTT)
     mbedtls_ssl_tls1_3_early_secrets early_secrets;
 

--- a/library/ssl_tls13_keys.c
+++ b/library/ssl_tls13_keys.c
@@ -578,7 +578,7 @@ int mbedtls_ssl_tls1_3_generate_early_data_keys(
     }
 
     ret = mbedtls_ssl_tls1_3_derive_early_secrets( md_type,
-                                   ssl->handshake->early_secret,
+                                   ssl->handshake->tls1_3_master_secrets.early,
                                    transcript, transcript_len,
                                    &ssl->handshake->early_secrets );
     if( ret != 0 )
@@ -656,9 +656,9 @@ int mbedtls_ssl_tls1_3_generate_handshake_keys(
     }
 
     ret = mbedtls_ssl_tls1_3_derive_handshake_secrets( md_type,
-                                         ssl->handshake->handshake_secret,
-                                         transcript, transcript_len,
-                                         &ssl->handshake->hs_secrets );
+                               ssl->handshake->tls1_3_master_secrets.handshake,
+                               transcript, transcript_len,
+                               &ssl->handshake->hs_secrets );
     if( ret != 0 )
     {
         MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_tls1_3_derive_early_secrets", ret );
@@ -778,9 +778,9 @@ int mbedtls_ssl_tls1_3_generate_application_keys(
     /* Compute application secrets from master secret and transcript hash. */
 
     ret = mbedtls_ssl_tls1_3_derive_application_secrets( md_type,
-                                                ssl->handshake->master_secret,
-                                                transcript, transcript_len,
-                                                app_secrets );
+                                   ssl->handshake->tls1_3_master_secrets.app,
+                                   transcript, transcript_len,
+                                   app_secrets );
     if( ret != 0 )
     {
         MBEDTLS_SSL_DEBUG_RET( 1,
@@ -894,9 +894,9 @@ int mbedtls_ssl_tls1_3_generate_resumption_master_secret(
         return( ret );
 
     ret = mbedtls_ssl_tls1_3_derive_resumption_master_secret( md_type,
-                                         ssl->handshake->master_secret,
-                                         transcript, transcript_len,
-                                         &ssl->session_negotiate->app_secrets );
+                              ssl->handshake->tls1_3_master_secrets.app,
+                              transcript, transcript_len,
+                              &ssl->session_negotiate->app_secrets );
     if( ret != 0 )
         return( ret );
 
@@ -986,9 +986,9 @@ int mbedtls_ssl_tls1_3_key_schedule_stage_handshake(
      */
 
     ret = mbedtls_ssl_tls1_3_evolve_secret( md_type,
-                              ssl->handshake->early_secret,
+                              ssl->handshake->tls1_3_master_secrets.early,
                               ephemeral, ephemeral_len,
-                              ssl->handshake->handshake_secret );
+                              ssl->handshake->tls1_3_master_secrets.handshake );
     if( ret != 0 )
     {
         MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_tls1_3_evolve_secret", ret );
@@ -996,7 +996,7 @@ int mbedtls_ssl_tls1_3_key_schedule_stage_handshake(
     }
 
     MBEDTLS_SSL_DEBUG_BUF( 4, "Handshake secret",
-                           ssl->handshake->handshake_secret, md_size );
+            ssl->handshake->tls1_3_master_secrets.handshake, md_size );
 
 #if defined(MBEDTLS_KEY_EXCHANGE_SOME_ECDHE_ENABLED)
     mbedtls_platform_zeroize( ecdhe, sizeof( ecdhe ) );
@@ -1019,9 +1019,9 @@ int mbedtls_ssl_tls1_3_key_schedule_stage_application(
      */
 
     ret = mbedtls_ssl_tls1_3_evolve_secret( md_type,
-                              ssl->handshake->handshake_secret,
-                              NULL, 0,
-                              ssl->handshake->master_secret );
+                    ssl->handshake->tls1_3_master_secrets.handshake,
+                    NULL, 0,
+                    ssl->handshake->tls1_3_master_secrets.app );
     if( ret != 0 )
     {
         MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_tls1_3_evolve_secret", ret );
@@ -1029,7 +1029,7 @@ int mbedtls_ssl_tls1_3_key_schedule_stage_application(
     }
 
     MBEDTLS_SSL_DEBUG_BUF( 4, "Master secret",
-                           ssl->handshake->master_secret, md_size );
+             ssl->handshake->tls1_3_master_secrets.app, md_size );
 
     return( 0 );
 }
@@ -1228,9 +1228,9 @@ int mbedtls_ssl_tls1_3_key_schedule_stage_early_data(
     mbedtls_ssl_get_psk( ssl, &psk, &psk_len );
 
     ret = mbedtls_ssl_tls1_3_evolve_secret( md_type,
-                                            NULL,          /* Old secret */
-                                            psk, psk_len,  /* Input      */
-                                            ssl->handshake->early_secret );
+                              NULL,          /* Old secret */
+                              psk, psk_len,  /* Input      */
+                              ssl->handshake->tls1_3_master_secrets.early );
     if( ret != 0 )
     {
         MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_tls1_3_evolve_secret", ret );

--- a/library/ssl_tls13_keys.h
+++ b/library/ssl_tls13_keys.h
@@ -425,10 +425,60 @@ int mbedtls_ssl_tls1_3_evolve_secret(
  * Small wrappers around mbedtls_ssl_tls1_3_evolve_secret().
  */
 
+/**
+ * \brief Begin TLS 1.3 key schedule by calculating early secret
+ *        from chosen PSK.
+ *
+ *        The TLS 1.3 key schedule can be viewed as a simple state machine
+ *        with states Initial -> Early -> Handshake -> Application, and
+ *        this function represents the Initial -> Early transition.
+ *
+ *        In the early stage, mbedtls_ssl_tls1_3_generate_early_data_keys()
+ *        can be used to derive the 0-RTT traffic keys.
+ *
+ * \param ssl  The SSL context to operate on.
+ *
+ * \returns    \c 0 on success.
+ * \returns    A negative error code on failure.
+ */
 int mbedtls_ssl_tls1_3_key_schedule_stage_early_data(
     mbedtls_ssl_context *ssl );
+
+/**
+ * \brief Transition into handshake stage of TLS 1.3 key schedule.
+ *
+ *        The TLS 1.3 key schedule can be viewed as a simple state machine
+ *        with states Initial -> Early -> Handshake -> Application, and
+ *        this function represents the Early -> Handshake transition.
+ *
+ *        In the handshake stage, mbedtls_ssl_tls1_3_generate_handshake_keys()
+ *        can be used to derive the handshake traffic keys.
+ *
+ * \param ssl  The SSL context to operate on. This must be in key schedule
+ *             stage \c Early.
+ *
+ * \returns    \c 0 on success.
+ * \returns    A negative error code on failure.
+ */
 int mbedtls_ssl_tls1_3_key_schedule_stage_handshake(
     mbedtls_ssl_context *ssl );
+
+/**
+ * \brief Transition into application stage of TLS 1.3 key schedule.
+ *
+ *        The TLS 1.3 key schedule can be viewed as a simple state machine
+ *        with states Initial -> Early -> Handshake -> Application, and
+ *        this function represents the Handshake -> Application transition.
+ *
+ *        In the handshake stage, mbedtls_ssl_tls1_3_generate_application_keys()
+ *        can be used to derive the handshake traffic keys.
+ *
+ * \param ssl  The SSL context to operate on. This must be in key schedule
+ *             stage \c Handshake.
+ *
+ * \returns    \c 0 on success.
+ * \returns    A negative error code on failure.
+ */
 int mbedtls_ssl_tls1_3_key_schedule_stage_application(
     mbedtls_ssl_context *ssl );
 
@@ -446,20 +496,85 @@ int mbedtls_ssl_tls1_3_key_schedule_stage_application(
  *
  *    mbedtls_ssl_tls1_3_key_schedule_stage_xxx().
  */
+
+/**
+ * \brief Compute traffic keys for 0-RTT.
+ *
+ * \param ssl  The SSL context to operate on. This must be in key schedule stage
+ *             \c Early, see mbedtls_ssl_tls1_3_key_schedule_stage_early_data().
+ * \param traffic_keys The address at which to store the 0-RTT traffic key
+ *                     keys. This must be writable but may be uninitialized.
+ *
+ * \returns    \c 0 on success.
+ * \returns    A negative error code on failure.
+ */
 int mbedtls_ssl_tls1_3_generate_early_data_keys(
     mbedtls_ssl_context *ssl, mbedtls_ssl_key_set *traffic_keys );
+
+/**
+ * \brief Compute TLS 1.3 handshake traffic keys.
+ *
+ * \param ssl  The SSL context to operate on. This must be in
+ *             key schedule stage \c Handshake, see
+ *             mbedtls_ssl_tls1_3_key_schedule_stage_handshake().
+ * \param traffic_keys The address at which to store the handshake traffic key
+ *                     keys. This must be writable but may be uninitialized.
+ *
+ * \returns    \c 0 on success.
+ * \returns    A negative error code on failure.
+ */
 int mbedtls_ssl_tls1_3_generate_handshake_keys(
     mbedtls_ssl_context* ssl, mbedtls_ssl_key_set *traffic_keys );
+
+/**
+ * \brief Compute TLS 1.3 application traffic keys.
+ *
+ * \param ssl  The SSL context to operate on. This must be in
+ *             key schedule stage \c Application, see
+ *             mbedtls_ssl_tls1_3_key_schedule_stage_application().
+ * \param traffic_keys The address at which to store the application traffic key
+ *                     keys. This must be writable but may be uninitialized.
+ *
+ * \returns    \c 0 on success.
+ * \returns    A negative error code on failure.
+ */
 int mbedtls_ssl_tls1_3_generate_application_keys(
     mbedtls_ssl_context* ssl, mbedtls_ssl_key_set *traffic_keys );
 
-/*
- * TODO: Document
+/**
+ * \brief Compute TLS 1.3 resumption master secret.
+ *
+ * \param ssl  The SSL context to operate on. This must be in
+ *             key schedule stage \c Application, see
+ *             mbedtls_ssl_tls1_3_key_schedule_stage_application().
+ *
+ * \returns    \c 0 on success.
+ * \returns    A negative error code on failure.
  */
-
 int mbedtls_ssl_tls1_3_generate_resumption_master_secret(
     mbedtls_ssl_context* ssl );
 
+/**
+ * \brief Calculate content of TLS 1.3 Finished message.
+ *
+ * \param ssl  The SSL context to operate on. This must be in
+ *             key schedule stage \c Handshake, see
+ *             mbedtls_ssl_tls1_3_key_schedule_stage_application().
+ * \param dst        The address at which to write the Finished content.
+ * \param dst_len    The size of \p dst in bytes.
+ * \param actual_len The address at which to store the amount of data
+ *                   actually written to \p dst upon success.
+ * \param from       The endpoint the Finished message originates from:
+ *                   - #MBEDTLS_SSL_IS_CLIENT for the Client's Finished message
+ *                   - #MBEDTLS_SSL_IS_SERVER for the Server's Finished message
+ *
+ * \note       Both client and server call this function twice, once to
+ *             generate their own Finished message, and once to verify the
+ *             peer's Finished message.
+
+ * \returns    \c 0 on success.
+ * \returns    A negative error code on failure.
+ */
 int mbedtls_ssl_tls1_3_calc_finished( mbedtls_ssl_context* ssl,
                                       unsigned char* dst,
                                       size_t dst_len,
@@ -467,6 +582,29 @@ int mbedtls_ssl_tls1_3_calc_finished( mbedtls_ssl_context* ssl,
                                       int from );
 
 #if defined(MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED)
+/**
+ * \brief Calculate a TLS 1.3 PSK binder
+ *
+ * \param ssl  The SSL context. This is used for debugging only and may
+ *             be \c NULL if MBEDTLS_DEBUG_C is disabled.
+ * \param psk         The buffer holding the PSK for which to create a binder.
+ * \param psk_len     The size of \p psk in bytes.
+ * \param md_type     The hash algorithm associated to the PSK \p psk.
+ * \param is_external This indicates whether the PSK \p psk is externally
+ *                    provisioned or a resumption PSK:
+ *                    - \c 1: Externally provisioned PSK
+ *                    - \c 0: Resumption PSK
+ * \param transcript  The handshake transcript up to the point where the
+ *                    PSK binder calculation happens. This must be readable,
+ *                    and its size must be equal to the digest size of
+ *                    the hash algorithm represented by \p md_type.
+ * \param result      The address at which to store the PSK binder on success.
+ *                    This must be writable, and its size must be equal to the
+ *                    digest size of  the hash algorithm represented by \p md_type.
+ *
+ * \returns    \c 0 on success.
+ * \returns    A negative error code on failure.
+ */
 int mbedtls_ssl_tls1_3_create_psk_binder( mbedtls_ssl_context *ssl,
                                unsigned char const *psk, size_t psk_len,
                                const mbedtls_md_type_t md_type,


### PR DESCRIPTION
This PR documents all TLS 1.3 key schedule functions from `ssl_tls13_keys.h`. It also saves a bit of RAM by using the same buffer to store 0-RTT, Handshake, and Application master secrets.