### PR TITLE
[Review 0-RTT write] Reuse the _coordinate function to in postprocess function.

### DIFF
--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -423,12 +423,13 @@ static int ssl_write_end_of_early_data_coordinate( mbedtls_ssl_context* ssl )
 
 static int ssl_write_end_of_early_data_postprocess( mbedtls_ssl_context* ssl )
 {
+#if defined(MBEDTLS_SSL_TLS13_COMPATIBILITY_MODE)
     if( ssl_write_end_of_early_data_coordinate( ssl ) != SSL_END_OF_EARLY_DATA_WRITE )
     {
         mbedtls_ssl_handshake_set_state( ssl, MBEDTLS_SSL_CLIENT_CCS_AFTER_SERVER_FINISHED ); 
         return( 0 );
     }
-
+#endif /* MBEDTLS_SSL_TLS13_COMPATIBILITY_MODE */ 
     mbedtls_ssl_handshake_set_state( ssl, MBEDTLS_SSL_CLIENT_CERTIFICATE );
     return( 0 );
 }

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -423,18 +423,14 @@ static int ssl_write_end_of_early_data_coordinate( mbedtls_ssl_context* ssl )
 
 static int ssl_write_end_of_early_data_postprocess( mbedtls_ssl_context* ssl )
 {
-#if defined(MBEDTLS_SSL_TLS13_COMPATIBILITY_MODE)
-#if defined(MBEDTLS_ZERO_RTT)
-    if( ssl->handshake->early_data != MBEDTLS_SSL_EARLY_DATA_ON )
-#endif /* MBEDTLS_ZERO_RTT */
+    if( ssl_write_end_of_early_data_coordinate( ssl ) != SSL_END_OF_EARLY_DATA_WRITE )
     {
-        mbedtls_ssl_handshake_set_state( ssl, MBEDTLS_SSL_CLIENT_CCS_AFTER_SERVER_FINISHED );
+        mbedtls_ssl_handshake_set_state( ssl, MBEDTLS_SSL_CLIENT_CCS_AFTER_SERVER_FINISHED ); 
         return( 0 );
     }
-#endif /* MBEDTLS_SSL_TLS13_COMPATIBILITY_MODE */
 
     mbedtls_ssl_handshake_set_state( ssl, MBEDTLS_SSL_CLIENT_CERTIFICATE );
-    return ( 0 );
+    return( 0 );
 }
 
 

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -426,7 +426,8 @@ static int ssl_write_end_of_early_data_postprocess( mbedtls_ssl_context* ssl )
 #if defined(MBEDTLS_SSL_TLS13_COMPATIBILITY_MODE)
     if( ssl_write_end_of_early_data_coordinate( ssl ) != SSL_END_OF_EARLY_DATA_WRITE )
     {
-        mbedtls_ssl_handshake_set_state( ssl, MBEDTLS_SSL_CLIENT_CCS_AFTER_SERVER_FINISHED ); 
+        mbedtls_ssl_handshake_set_state( ssl, 
+                         MBEDTLS_SSL_CLIENT_CCS_AFTER_SERVER_FINISHED );
         return( 0 );
     }
 #endif /* MBEDTLS_SSL_TLS13_COMPATIBILITY_MODE */ 

--- a/library/ssl_tls13_keys.h
+++ b/library/ssl_tls13_keys.h
@@ -322,11 +322,14 @@ int mbedtls_ssl_tls1_3_derive_application_secrets(
  *
  * \param md_type           The hash algorithm used in the application for which
  *                          key material is being derived.
+ * \param master_secret     The master secret from which the resumption master
+ *                          secret should be derived. This must be a readable
+ *                          buffer whose length is the digest size of the hash
+ *                          algorithm represented by \p md_size.
  * \param transcript        The transcript of the application so far, calculated
  *                          with respect to \p md_type. This must be a readable
  *                          buffer whose length is the digest size of the hash
  *                          algorithm represented by \p md_size.
- * \param transcript_len    The length of \p transcript in Bytes.
  * \param derived_application_secrets The address of the structure in which to
  *                                    store the resumption master secret.
  *

--- a/library/ssl_tls13_keys.h
+++ b/library/ssl_tls13_keys.h
@@ -330,7 +330,7 @@ int mbedtls_ssl_tls1_3_derive_application_secrets(
  *                          with respect to \p md_type. This must be a readable
  *                          buffer whose length is the digest size of the hash
  *                          algorithm represented by \p md_size.
- * \param transcript_len The length of \p transcript in Bytes.
+ * \param transcript_len    The length of \p transcript in Bytes.
  * \param derived_application_secrets The address of the structure in which to
  *                                    store the resumption master secret.
  *

--- a/library/ssl_tls13_keys.h
+++ b/library/ssl_tls13_keys.h
@@ -330,6 +330,7 @@ int mbedtls_ssl_tls1_3_derive_application_secrets(
  *                          with respect to \p md_type. This must be a readable
  *                          buffer whose length is the digest size of the hash
  *                          algorithm represented by \p md_size.
+ * \param transcript_len The length of \p transcript in Bytes.
  * \param derived_application_secrets The address of the structure in which to
  *                                    store the resumption master secret.
  *


### PR DESCRIPTION
Notes:
* Pull requests cannot be accepted until the PR follows the [contributing guidelines](../CONTRIBUTING.md). In particular, each commit must have at least one `Signed-off-by:` line from the committer to certify that the contribution is made under the terms of the [Developer Certificate of Origin](../dco.txt).
* This is just a template, so feel free to use/remove the unnecessary things
## Description
`ssl_write_end_of_early_data_coordinate` is a helper function to decide whether to write EndOfEarlyData extension. The logic in `_postprocess` is duplication of the same logic. Instead of repeating it we should just reuse.

## Status
**READY**

## Requires Backporting
No


## Migrations
If there is any API change, what's the incentive and logic for it.

NO

## Additional comments
Any additional information that could be of interest

## Steps to test or reproduce
Outline the steps to test or reproduce the PR here.

