### PR TITLE
Move early_data config and report to reconnect.

### DIFF
--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -2633,10 +2633,6 @@ int main( int argc, char *argv[] )
 
 #endif /* MBEDTLS_X509_CRT_PARSE_C */
 
-#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && defined(MBEDTLS_ZERO_RTT)
-    mbedtls_ssl_conf_early_data( &conf, opt.early_data, early_data, strlen( early_data ), NULL );
-#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL && MBEDTLS_ZERO_RTT */
-
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && defined(MBEDTLS_ECP_C)
     mbedtls_ssl_conf_sig_hashes( &conf, ssl_sig_hashes_for_test_tls13 );
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL && MBEDTLS_ECP_C */
@@ -3095,11 +3091,6 @@ int main( int argc, char *argv[] )
 #endif /* MBEDTLS_SSL_PROTO_TLS1 || MBEDTLS_SSL_PROTO_TLS1_1 || \
           MBEDTLS_SSL_PROTO_TLS1_2 */
 #endif /* MBEDTLS_SSL_EXPORT_KEYS */
-
-#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && \
-    defined(MBEDTLS_ZERO_RTT) && defined(MBEDTLS_SSL_CLI_C)
-    mbedtls_printf( "early data status = %d\n", mbedtls_ssl_get_early_data_status( &ssl ) );
-#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL && MBEDTLS_ZERO_RTT && MBEDTLS_SSL_CLI_C */
 
 #if defined(MBEDTLS_X509_CRT_PARSE_C)
     /*
@@ -3814,6 +3805,10 @@ reconnect:
         }
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && defined(MBEDTLS_ZERO_RTT)
+    mbedtls_ssl_conf_early_data( &conf, opt.early_data, early_data, strlen( early_data ), NULL );
+#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL && MBEDTLS_ZERO_RTT */
+
         if( ( ret = mbedtls_net_connect( &server_fd,
                         opt.server_addr, opt.server_port,
                         opt.transport == MBEDTLS_SSL_TRANSPORT_STREAM ?
@@ -3848,7 +3843,10 @@ reconnect:
         }
 
         mbedtls_printf( " ok\n" );
-
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && \
+    defined(MBEDTLS_ZERO_RTT) && defined(MBEDTLS_SSL_CLI_C)
+    mbedtls_printf( "early data status = %d\n", mbedtls_ssl_get_early_data_status( &ssl ) );
+#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL && MBEDTLS_ZERO_RTT && MBEDTLS_SSL_CLI_C */
         goto send_request;
     }
 #endif /* MBEDTLS_SSL_NEW_SESSION_TICKET */


### PR DESCRIPTION
Notes:
* Pull requests cannot be accepted until the PR follows the [contributing guidelines](../CONTRIBUTING.md). In particular, each commit must have at least one `Signed-off-by:` line from the committer to certify that the contribution is made under the terms of the [Developer Certificate of Origin](../dco.txt).
* This is just a template, so feel free to use/remove the unnecessary things
## Description
Move the configuration of early_data and reporting of early_data to the reconnect part of the code. Since early_data is only supported with resumption, it only makes sense to configure and report early_data when we resume a previous session.


## Status
**READY**

## Requires Backporting
NO  

## Migrations
NO

## Additional comments
Any additional information that could be of interest

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported


## Steps to test or reproduce
```
./ssl_client2 server_name=localhost server_port=1234 auth_mode=none reconnect=1 force_ciphersuite=TLS_AES_128_GCM_SHA256 early_data=1

  . Seeding the random number generator... ok
  . Loading the CA root certificate ... ok (0 skipped)
  . Loading the client cert. and key... ok (key type: EC)
  . Connecting to tcp/localhost/1234... ok
  . Setting up the SSL/TLS structure... ok
  . Performing the SSL/TLS handshake... ok
    [ Protocol is TLSv1.3 ]
    [ Ciphersuite is TLS_AES_128_GCM_SHA256 ]
    [ Key Exchange Mode is ECDHE-ECDSA ]
    [ Record expansion is 5 ]
  . Verifying peer X.509 certificate... ok
  . Peer certificate information    ...

  > Write to server: 34 bytes written in 1 fragments

GET / HTTP/1.0
Extra-header:


  < Read from server: got ticket.
 got ticket.
 2 bytes read

a
  . Saving session for reuse... ok
    [ Saved 99 bytes of session data]
  . Closing the connection... done
  . Reconnecting with saved session... ok
early data status = 2
  > Write to server: 34 bytes written in 1 fragments

GET / HTTP/1.0
Extra-header:


  < Read from server: got ticket.
 2 bytes read

b
  . Closing the connection... done
```