### PR TITLE
Rename mbedtls_ssl_conf_early_data() to mbedtls_ssl_set_early_data()

### DIFF
--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -1380,22 +1380,6 @@ struct mbedtls_ssl_config
                                      *   \c psk is not \c NULL or \c psk_opaque
                                      *   is not \c 0. */
 
-#if defined(MBEDTLS_ZERO_RTT)
-     /*!< Early data indication:
-      *   0  -- MBEDTLS_SSL_EARLY_DATA_DISABLED (for no early data), and
-      *   1  -- MBEDTLS_SSL_EARLY_DATA_ENABLED (for use early data)
-      */
-    int early_data;
-    // Pointer to early data buffer
-    char* early_data_buf;
-    // Length of early data
-    unsigned int early_data_len;
-#if defined(MBEDTLS_SSL_SRV_C)
-    // Callback function for early data processing is only used by the server-side
-    int(*early_data_callback)(mbedtls_ssl_context*, unsigned char*, size_t);
-#endif /* MBEDTLS_SSL_SRV_C */
-#endif /* MBEDTLS_ZERO_RTT */
-
 #endif /* MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED */
 
 #if defined(MBEDTLS_SSL_ALPN)
@@ -1753,6 +1737,22 @@ struct mbedtls_ssl_context
                             *   and #MBEDTLS_SSL_CID_DISABLED. */
 #endif /* MBEDTLS_SSL_DTLS_CONNECTION_ID */
 
+#if defined(MBEDTLS_ZERO_RTT)
+     /*!< Early data indication:
+      *   0  -- MBEDTLS_SSL_EARLY_DATA_DISABLED (for no early data), and
+      *   1  -- MBEDTLS_SSL_EARLY_DATA_ENABLED (for use early data)
+      */
+    int early_data_enabled;
+    // Pointer to early data buffer
+    char* early_data_buf;
+    // Length of early data
+    unsigned int early_data_len;
+#if defined(MBEDTLS_SSL_SRV_C)
+    // Callback function for early data processing is only used by the server-side
+    int(*early_data_callback)(mbedtls_ssl_context*, unsigned char*, size_t);
+#endif /* MBEDTLS_SSL_SRV_C */
+#endif /* MBEDTLS_ZERO_RTT */
+
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && \
     defined(MBEDTLS_ZERO_RTT) && defined(MBEDTLS_SSL_CLI_C)
     /*
@@ -1934,7 +1934,7 @@ void mbedtls_ssl_conf_authmode( mbedtls_ssl_config *conf, int authmode );
 * \brief          Set the early_data mode
 *                 Default: disabled on server and client
 *
-* \param conf     SSL configuration
+* \param ssl     SSL context
 * \param early_data can be:
 *
 *  MBEDTLS_SSL_EARLY_DATA_DISABLED:  early data functionality will not be used
@@ -1952,7 +1952,7 @@ void mbedtls_ssl_conf_authmode( mbedtls_ssl_config *conf, int authmode );
 * \param len     Length of early data
 */
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && defined(MBEDTLS_ZERO_RTT)
-void mbedtls_ssl_conf_early_data(mbedtls_ssl_config* conf, int early_data, char* buffer, unsigned int len, int(*early_data_callback)(mbedtls_ssl_context*,
+void mbedtls_ssl_set_early_data(mbedtls_ssl_context* ssl, int early_data, char* buffer, unsigned int len, int(*early_data_callback)(mbedtls_ssl_context*,
     unsigned char*, size_t));
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL && MBEDTLS_ZERO_RTT */
 

--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -1385,7 +1385,7 @@ static inline int mbedtls_ssl_tls13_key_exchange_with_psk( mbedtls_ssl_context *
 static inline int mbedtls_ssl_conf_tls13_0rtt_enabled( mbedtls_ssl_context *ssl )
 {
 #if defined(MBEDTLS_ZERO_RTT)
-    if( ssl->conf->early_data == MBEDTLS_SSL_EARLY_DATA_ENABLED )
+    if( ssl->early_data_enabled == MBEDTLS_SSL_EARLY_DATA_ENABLED )
         return( 1 );
 #else
     ((void) ssl);

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -283,23 +283,23 @@ static int ssl_write_early_data_write( mbedtls_ssl_context* ssl,
     size_t buflen,
     size_t* olen )
 {
-    if ( ssl->conf->early_data_len > buflen )
+    if ( ssl->early_data_len > buflen )
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "buffer too small" ) );
         return ( MBEDTLS_ERR_SSL_ALLOC_FAILED );
     }
     else
     {
-        memcpy( buf, ssl->conf->early_data_buf, ssl->conf->early_data_len );
+        memcpy( buf, ssl->early_data_buf, ssl->early_data_len );
 
 #if !defined(MBEDTLS_SSL_USE_MPS)
-        buf[ssl->conf->early_data_len] = MBEDTLS_SSL_MSG_APPLICATION_DATA;
-        *olen = ssl->conf->early_data_len + 1;
+        buf[ssl->early_data_len] = MBEDTLS_SSL_MSG_APPLICATION_DATA;
+        *olen = ssl->early_data_len + 1;
 
         MBEDTLS_SSL_DEBUG_BUF( 3, "Early Data", ssl->out_msg, *olen );
 #else
-        *olen = ssl->conf->early_data_len;
-        MBEDTLS_SSL_DEBUG_BUF( 3, "Early Data", buf, ssl->conf->early_data_len );
+        *olen = ssl->early_data_len;
+        MBEDTLS_SSL_DEBUG_BUF( 3, "Early Data", buf, ssl->early_data_len );
 #endif /* MBEDTLS_SSL_USE_MPS */
     }
 
@@ -426,11 +426,11 @@ static int ssl_write_end_of_early_data_postprocess( mbedtls_ssl_context* ssl )
 #if defined(MBEDTLS_SSL_TLS13_COMPATIBILITY_MODE)
     if( ssl_write_end_of_early_data_coordinate( ssl ) != SSL_END_OF_EARLY_DATA_WRITE )
     {
-        mbedtls_ssl_handshake_set_state( ssl, 
+        mbedtls_ssl_handshake_set_state( ssl,
                          MBEDTLS_SSL_CLIENT_CCS_AFTER_SERVER_FINISHED );
         return( 0 );
     }
-#endif /* MBEDTLS_SSL_TLS13_COMPATIBILITY_MODE */ 
+#endif /* MBEDTLS_SSL_TLS13_COMPATIBILITY_MODE */
     mbedtls_ssl_handshake_set_state( ssl, MBEDTLS_SSL_CLIENT_CERTIFICATE );
     return( 0 );
 }

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -2759,27 +2759,27 @@ static int ssl_finished_in_postprocess( mbedtls_ssl_context* ssl )
 }
 
 #if defined(MBEDTLS_ZERO_RTT)
-void mbedtls_ssl_conf_early_data( mbedtls_ssl_config *conf, int early_data,
-                        char *buffer, unsigned int len,
-                        int(*early_data_callback)( mbedtls_ssl_context *,
-                                                   unsigned char *, size_t ) )
+void mbedtls_ssl_set_early_data( mbedtls_ssl_context *ssl, int early_data,
+                                 char *buffer, unsigned int len,
+                                 int(*early_data_callback)( mbedtls_ssl_context *,
+                                                            unsigned char *, size_t ) )
 {
 #if !defined(MBEDTLS_SSL_SRV_C)
     ( (void ) early_data_callback );
 #endif /* !MBEDTLS_SSL_SRV_C */
 
-    if( conf != NULL )
+    if( ssl != NULL )
     {
-        conf->early_data = early_data;
+        ssl->early_data_enabled = early_data;
         if( buffer != NULL && len >0 && early_data==MBEDTLS_SSL_EARLY_DATA_ENABLED )
         {
-            conf->early_data_buf = buffer;
-            conf->early_data_len = len;
+            ssl->early_data_buf = buffer;
+            ssl->early_data_len = len;
 #if defined(MBEDTLS_SSL_SRV_C)
             /* Only the server uses the early data callback.
              * For the client this parameter is not used.
              */
-            conf->early_data_callback = early_data_callback;
+            ssl->early_data_callback = early_data_callback;
 #endif /* MBEDTLS_SSL_SRV_C */
         }
     }
@@ -3104,7 +3104,7 @@ int mbedtls_ssl_write_early_data_ext( mbedtls_ssl_context *ssl,
             return( 0 );
 
         if( ssl->conf->key_exchange_modes != MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_KE ||
-            ssl->conf->early_data == MBEDTLS_SSL_EARLY_DATA_DISABLED )
+            ssl->early_data_enabled == MBEDTLS_SSL_EARLY_DATA_DISABLED )
         {
             MBEDTLS_SSL_DEBUG_MSG( 2, ( "skip write early_data extension" ) );
             ssl->handshake->early_data = MBEDTLS_SSL_EARLY_DATA_OFF;
@@ -3117,7 +3117,7 @@ int mbedtls_ssl_write_early_data_ext( mbedtls_ssl_context *ssl,
     if( ssl->conf->endpoint == MBEDTLS_SSL_IS_CLIENT )
     {
         if( ssl->conf->key_exchange_modes == MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_ECDHE_ECDSA ||
-            ssl->conf->early_data == MBEDTLS_SSL_EARLY_DATA_DISABLED )
+            ssl->early_data_enabled == MBEDTLS_SSL_EARLY_DATA_DISABLED )
         {
             MBEDTLS_SSL_DEBUG_MSG( 2, ( "<= skip write early_data extension" ) );
             ssl->handshake->early_data = MBEDTLS_SSL_EARLY_DATA_OFF;

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -704,7 +704,7 @@ int mbedtls_ssl_parse_client_psk_identity_ext(
                     }
 
 #if defined(MBEDTLS_ZERO_RTT)
-                    if( ssl->conf->early_data == MBEDTLS_SSL_EARLY_DATA_ENABLED )
+                    if( ssl->early_data_enabled == MBEDTLS_SSL_EARLY_DATA_ENABLED )
                     {
                         if( diff <= MBEDTLS_SSL_EARLY_DATA_MAX_DELAY )
                         {
@@ -733,7 +733,7 @@ int mbedtls_ssl_parse_client_psk_identity_ext(
                     if( ret == MBEDTLS_ERR_SSL_SESSION_TICKET_EXPIRED )
                     {
 #if defined(MBEDTLS_ZERO_RTT)
-                        if( ssl->conf->early_data ==
+                        if( ssl->early_data_enabled ==
                             MBEDTLS_SSL_EARLY_DATA_ENABLED )
                         {
                             ssl->session_negotiate->process_early_data =
@@ -2016,21 +2016,21 @@ static int ssl_read_early_data_parse( mbedtls_ssl_context* ssl,
                                       size_t buflen )
 {
     /* Check whether we have enough buffer space. */
-    if( buflen <= ssl->conf->early_data_len )
+    if( buflen <= ssl->early_data_len )
     {
         /* TODO: We need to check that we're not receiving more 0-RTT
          * than what the ticket allows. */
 
         /* copy data to staging area */
-        memcpy( ssl->conf->early_data_buf, buf, buflen );
+        memcpy( ssl->early_data_buf, buf, buflen );
         /* execute callback to process application data */
-        ssl->conf->early_data_callback( ssl, (unsigned char*)ssl->conf->early_data_buf,
-                                        buflen );
+        ssl->early_data_callback( ssl, (unsigned char*)ssl->early_data_buf,
+                                  buflen );
     }
     else
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "Buffer too small (recv %d bytes, buffer %d bytes)",
-                                    buflen, ssl->conf->early_data_len ) );
+                                    buflen, ssl->early_data_len ) );
         return ( MBEDTLS_ERR_SSL_ALLOC_FAILED );
     }
 

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -2633,10 +2633,6 @@ int main( int argc, char *argv[] )
 
 #endif /* MBEDTLS_X509_CRT_PARSE_C */
 
-#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && defined(MBEDTLS_ZERO_RTT)
-    mbedtls_ssl_conf_early_data( &conf, opt.early_data, early_data, strlen( early_data ), NULL );
-#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL && MBEDTLS_ZERO_RTT */
-
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && defined(MBEDTLS_ECP_C)
     mbedtls_ssl_conf_sig_hashes( &conf, ssl_sig_hashes_for_test_tls13 );
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL && MBEDTLS_ECP_C */
@@ -3813,6 +3809,10 @@ reconnect:
             goto exit;
         }
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
+
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && defined(MBEDTLS_ZERO_RTT)
+    mbedtls_ssl_set_early_data( &ssl, opt.early_data, early_data, strlen( early_data ), NULL );
+#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL && MBEDTLS_ZERO_RTT */
 
         if( ( ret = mbedtls_net_connect( &server_fd,
                         opt.server_addr, opt.server_port,

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -3092,11 +3092,6 @@ int main( int argc, char *argv[] )
           MBEDTLS_SSL_PROTO_TLS1_2 */
 #endif /* MBEDTLS_SSL_EXPORT_KEYS */
 
-#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && \
-    defined(MBEDTLS_ZERO_RTT) && defined(MBEDTLS_SSL_CLI_C)
-    mbedtls_printf( "early data status = %d\n", mbedtls_ssl_get_early_data_status( &ssl ) );
-#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL && MBEDTLS_ZERO_RTT && MBEDTLS_SSL_CLI_C */
-
 #if defined(MBEDTLS_X509_CRT_PARSE_C)
     /*
      * 5. Verify the server certificate
@@ -3848,6 +3843,11 @@ reconnect:
         }
 
         mbedtls_printf( " ok\n" );
+
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && \
+    defined(MBEDTLS_ZERO_RTT) && defined(MBEDTLS_SSL_CLI_C)
+    mbedtls_printf( "early data status = %d\n", mbedtls_ssl_get_early_data_status( &ssl ) );
+#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL && MBEDTLS_ZERO_RTT && MBEDTLS_SSL_CLI_C */
 
         goto send_request;
     }

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -3439,7 +3439,7 @@ int main( int argc, char *argv[] )
 
 #if defined(MBEDTLS_ZERO_RTT)
     early_data_len = sizeof( early_data_buf )-1;
-    mbedtls_ssl_conf_early_data( &conf, opt.early_data, early_data_buf, early_data_len, early_data_callback );
+    mbedtls_ssl_set_early_data( &ssl, opt.early_data, early_data_buf, early_data_len, early_data_callback );
 #endif /* MBEDTLS_ZERO_RTT */
 
 #if defined(MBEDTLS_SSL_PROTO_DTLS)


### PR DESCRIPTION
Notes:
* Rename `mbedtls_ssl_conf_early_data()` to `mbedtls_ssl_set_early_data()` and move the data from `conf` to `context`.
* Move the enabling and reporting of early data to reconnect.

## Status
**READY**

## Requires Backporting
NO  

## Migrations
NO

## Additional comments
Any additional information that could be of interest

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported


## Steps to test or reproduce
```
./ssl_client2 server_name=localhost server_port=1234 auth_mode=none reconnect=1 force_ciphersuite=TLS_AES_128_GCM_SHA256 early_data=1

  . Seeding the random number generator... ok
  . Loading the CA root certificate ... ok (0 skipped)
  . Loading the client cert. and key... ok (key type: EC)
  . Connecting to tcp/localhost/1234... ok
  . Setting up the SSL/TLS structure... ok
  . Performing the SSL/TLS handshake... ok
    [ Protocol is TLSv1.3 ]
    [ Ciphersuite is TLS_AES_128_GCM_SHA256 ]
    [ Key Exchange Mode is ECDHE-ECDSA ]
    [ Record expansion is 5 ]
  . Verifying peer X.509 certificate... ok
  . Peer certificate information    ...

  > Write to server: 34 bytes written in 1 fragments

GET / HTTP/1.0
Extra-header:


  < Read from server: got ticket.
 got ticket.
 2 bytes read

a
  . Saving session for reuse... ok
    [ Saved 99 bytes of session data]
  . Closing the connection... done
  . Reconnecting with saved session... ok
early data status = 2
  > Write to server: 34 bytes written in 1 fragments

GET / HTTP/1.0
Extra-header:


  < Read from server: got ticket.
 2 bytes read

b
  . Closing the connection... done
```