### PR TITLE
Fix client-side behaviour if PSK is offered but rejected by the server

### DIFF
--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -1679,6 +1679,7 @@ void mbedtls_ssl_write_version( int major, int minor, int transport,
 void mbedtls_ssl_read_version( int *major, int *minor, int transport,
                        const unsigned char ver[2] );
 
+void mbedtls_ssl_remove_hs_psk( mbedtls_ssl_context *ssl );
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
 static inline size_t mbedtls_ssl_hdr_len(const mbedtls_ssl_context* ssl)

--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -1520,6 +1520,50 @@ static inline int mbedtls_ssl_get_psk( const mbedtls_ssl_context *ssl,
     return( 0 );
 }
 
+/* Check if we have any PSK to offer, and if so, return the first. */
+static inline int mbedtls_ssl_get_psk_to_offer( const mbedtls_ssl_context *ssl,
+                     const unsigned char **psk, size_t *psk_len,
+                     const unsigned char **psk_identity, size_t *psk_identity_len )
+{
+    int ptrs_present = 0;
+
+    if( psk != NULL && psk_len != NULL &&
+        psk_identity != NULL && psk_identity_len != NULL )
+    {
+        ptrs_present = 1;
+    }
+
+    /* Check if a ticket has been configuredd. */
+    if( ssl->session_negotiate != NULL         &&
+        ssl->session_negotiate->ticket != NULL )
+    {
+        if( ptrs_present )
+        {
+            *psk = ssl->session_negotiate->key;
+            *psk_len = ssl->session_negotiate->resumption_key_len;
+            *psk_identity = ssl->session_negotiate->ticket;
+            *psk_identity_len = ssl->session_negotiate->ticket_len;
+        }
+        return( 0 );
+    }
+
+    /* Check if an external PSK has been configured. */
+    if( ssl->conf->psk != NULL )
+    {
+        if( ptrs_present )
+        {
+            *psk = ssl->conf->psk;
+            *psk_len = ssl->conf->psk_len;
+            *psk_identity = ssl->conf->psk_identity;
+            *psk_identity_len = ssl->conf->psk_identity_len;
+        }
+        return( 0 );
+    }
+
+    return( 1 );
+}
+
+
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
 /**
  * Get the first defined opaque PSK by order of precedence:

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -4871,17 +4871,6 @@ int mbedtls_ssl_set_session( mbedtls_ssl_context *ssl, const mbedtls_ssl_session
         return( ret );
 
     ssl->handshake->resume = 1;
-
-#if defined(MBEDTLS_SSL_NEW_SESSION_TICKET) && defined(MBEDTLS_SSL_CLI_C)
-    if( ssl->conf->endpoint == MBEDTLS_SSL_IS_CLIENT )
-    {
-        mbedtls_ssl_set_hs_psk( ssl, ssl->session_negotiate->key,
-                                     ssl->session_negotiate->resumption_key_len );
-        MBEDTLS_SSL_DEBUG_BUF( 4, "ticket: key", ssl->session_negotiate->key,
-                                     ssl->session_negotiate->resumption_key_len );
-    }
-#endif /* MBEDTLS_SSL_NEW_SESSION_TICKET && MBEDTLS_SSL_CLI_C */
-
     return( 0 );
 }
 #endif /* MBEDTLS_SSL_CLI_C && MBEDTLS_SSL_NEW_SESSION_TICKET */

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -5139,7 +5139,7 @@ int mbedtls_ssl_conf_tls13_key_exchange( mbedtls_ssl_config* conf,
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 
 
-static void ssl_remove_psk( mbedtls_ssl_context* ssl )
+void mbedtls_ssl_remove_hs_psk( mbedtls_ssl_context* ssl )
 {
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
     if( ! mbedtls_svc_key_id_is_null( ssl->handshake->psk_opaque ) )
@@ -5154,6 +5154,7 @@ static void ssl_remove_psk( mbedtls_ssl_context* ssl )
                                   ssl->handshake->psk_len );
         mbedtls_free( ssl->handshake->psk );
         ssl->handshake->psk_len = 0;
+        ssl->handshake->psk = NULL;
     }
 }
 
@@ -5166,7 +5167,7 @@ int mbedtls_ssl_set_hs_psk( mbedtls_ssl_context *ssl,
     if( psk_len > MBEDTLS_PSK_MAX_LEN )
         return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
 
-    ssl_remove_psk( ssl );
+    mbedtls_ssl_remove_hs_psk( ssl );
 
     if( ( ssl->handshake->psk = mbedtls_calloc( 1, psk_len ) ) == NULL )
         return( MBEDTLS_ERR_SSL_ALLOC_FAILED );
@@ -5185,7 +5186,7 @@ int mbedtls_ssl_conf_psk_opaque( mbedtls_ssl_config *conf,
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     /* Clear opaque/raw PSK + PSK Identity, if present. */
-    ssl_conf_remove_psk( conf );
+    mbedtls_ssl_remove_hs_psk( ssl );
 
     /* Check and set opaque PSK */
     if( mbedtls_svc_key_id_is_null( psk ) )
@@ -5208,7 +5209,7 @@ int mbedtls_ssl_set_hs_psk_opaque( mbedtls_ssl_context *ssl,
         ( ssl->handshake == NULL ) )
         return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
 
-    ssl_remove_psk( ssl );
+    mbedtls_ssl_remove_hs_psk( ssl );
     ssl->handshake->psk_opaque = psk;
     return( 0 );
 }

--- a/library/ssl_tls13_keys.c
+++ b/library/ssl_tls13_keys.c
@@ -1222,14 +1222,10 @@ int mbedtls_ssl_tls1_3_key_schedule_stage_early_data(
     int ret = 0;
     mbedtls_md_type_t const md_type = ssl->handshake->ciphersuite_info->mac;
 
-    unsigned char const *psk;
-    size_t psk_len;
-
-    mbedtls_ssl_get_psk( ssl, &psk, &psk_len );
-
     ret = mbedtls_ssl_tls1_3_evolve_secret( md_type,
                               NULL,          /* Old secret */
-                              psk, psk_len,  /* Input      */
+                              ssl->handshake->psk,
+                              ssl->handshake->psk_len,
                               ssl->handshake->tls1_3_master_secrets.early );
     if( ret != 0 )
     {

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -601,7 +601,6 @@ int mbedtls_ssl_parse_client_psk_identity_ext(
                 /* TBD: Process obfuscated ticket age ( zero for externally configured PSKs?! ) */
                 buf = buf + item_length + 4; /* 4 for obfuscated ticket age */;
 
-                MBEDTLS_SSL_DEBUG_MSG( 1, ( "STATIC PSK" ));
                 mbedtls_ssl_set_hs_psk( ssl, ssl->conf->psk, ssl->conf->psk_len );
                 goto psk_parsing_successful;
 

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -908,7 +908,6 @@ static int ssl_write_server_pre_shared_key_ext( mbedtls_ssl_context *ssl,
     {
         /* We shouldn't have called this extension writer unless we've
          * chosen to use a PSK. */
-        MBEDTLS_SSL_DEBUG_MSG(1, ( "Shouldn't write PSK extension without having chosen a PSK") );
         return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
     }
 


### PR DESCRIPTION
As spotted and described by @lhuang04 in #260, the client behaves wrongly if the server doesn't accept the PSK the client has offered. This PR aims to fix this. See the commit description for details of the cause of the problem and the proposed fix.