### PR TITLE
Fix misplaced 0-RTT configuration call in ssl_server2

### DIFF
--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -3537,11 +3537,6 @@ int main( int argc, char *argv[] )
     if( opt.cert_req_ca_list != DFL_CERT_REQ_CA_LIST )
         mbedtls_ssl_conf_cert_req_ca_list( &conf, opt.cert_req_ca_list );
 
-#if defined(MBEDTLS_ZERO_RTT)
-    early_data_len = sizeof( early_data_buf )-1;
-    mbedtls_ssl_set_early_data( &ssl, opt.early_data, early_data_buf, early_data_len, early_data_callback );
-#endif /* MBEDTLS_ZERO_RTT */
-
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
     if( opt.hs_to_min != DFL_HS_TO_MIN || opt.hs_to_max != DFL_HS_TO_MAX )
         mbedtls_ssl_conf_handshake_timeout( &conf, opt.hs_to_min, opt.hs_to_max );
@@ -4141,6 +4136,13 @@ reset:
     mbedtls_net_free( &client_fd );
 
     mbedtls_ssl_session_reset( &ssl );
+
+
+#if defined(MBEDTLS_ZERO_RTT)
+    early_data_len = sizeof( early_data_buf ) - 1;
+    mbedtls_ssl_set_early_data( &ssl, opt.early_data, early_data_buf,
+                                early_data_len, early_data_callback );
+#endif /* MBEDTLS_ZERO_RTT */
 
     /*
      * 3. Wait until a client connects


### PR DESCRIPTION
Previously, 0-RTT configuration happened as part of the SSL config.
Now, it's part of the SSL context configuration, which must come
after the context has been reset with `mbedtls_ssl_reset()`.
