### PR TITLE
Restore mbedtls_ssl_conf_early_data() function.

### DIFF
--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -1431,9 +1431,9 @@ struct mbedtls_ssl_config
       */
     int early_data_enabled;
 #if defined(MBEDTLS_SSL_SRV_C)
-    // Max number of bytes of early data acceptable by the server.
+    /* Max number of bytes of early data acceptable by the server. */
     unsigned int max_early_data;
-    // Callback function for early data processing, only used by the server-side.
+    /* Callback function for early data processing (server only). */
     int(*early_data_callback)(mbedtls_ssl_context*, unsigned char*, size_t);
 #endif /* MBEDTLS_SSL_SRV_C */
 #endif /* MBEDTLS_ZERO_RTT */
@@ -1813,15 +1813,16 @@ struct mbedtls_ssl_context
 #if defined(MBEDTLS_ZERO_RTT)
 
 #if defined(MBEDTLS_SSL_SRV_C)
-    // Early data buffer allocated by the server.
-    char* early_data_server_buf;
+    /* Early data buffer allocated by the server. */
+    unsigned char* early_data_server_buf;
+    size_t early_data_server_buf_len;
 #endif /* MBEDTLS_SSL_SRV_C */
 
 #if defined(MBEDTLS_SSL_CLI_C)
-    // Pointer to early data buffer to send.
-    char* early_data_buf;
-    // Length of early data to send.
-    unsigned int early_data_len;
+    /* Pointer to early data buffer to send. */
+    unsigned char* early_data_buf;
+    /* Length of early data to send. */
+    size_t early_data_len;
 #endif /* MBEDTLS_SSL_CLI_C */
 #endif /* MBEDTLS_ZERO_RTT */
 
@@ -2020,15 +2021,19 @@ void mbedtls_ssl_conf_authmode( mbedtls_ssl_config *conf, int authmode );
 *                        payloads.
 *
 * \param max_early_data  Max number of bytes allowed for early data (server only).
-* \param early_data_callback Callback function when early data is received.
+* \param early_data_callback Callback function when early data is received (server
+                             only).
 */
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && defined(MBEDTLS_ZERO_RTT)
-void mbedtls_ssl_conf_early_data( mbedtls_ssl_config* conf, int early_data, unsigned int max_early_data,
+void mbedtls_ssl_conf_early_data( mbedtls_ssl_config* conf, int early_data,
+                                  unsigned int max_early_data,
                                   int(*early_data_callback)( mbedtls_ssl_context*,
-                                                             unsigned char*, size_t ));
+                                                             unsigned char*,
+                                                             size_t ) );
 
 #if defined(MBEDTLS_SSL_CLI_C)
-void mbedtls_ssl_set_early_data(mbedtls_ssl_context* ssl, char* buffer, unsigned int len);
+int mbedtls_ssl_set_early_data( mbedtls_ssl_context* ssl, unsigned char* buffer,
+                                unsigned int len );
 #endif /* MBEDTLS_SSL_CLI_C */
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL && MBEDTLS_ZERO_RTT */
 

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -1432,7 +1432,7 @@ struct mbedtls_ssl_config
     int early_data_enabled;
 #if defined(MBEDTLS_SSL_SRV_C)
     /* Max number of bytes of early data acceptable by the server. */
-    unsigned int max_early_data;
+    size_t max_early_data;
     /* Callback function for early data processing (server only). */
     int(*early_data_callback)(mbedtls_ssl_context*, unsigned char*, size_t);
 #endif /* MBEDTLS_SSL_SRV_C */
@@ -2026,14 +2026,14 @@ void mbedtls_ssl_conf_authmode( mbedtls_ssl_config *conf, int authmode );
 */
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && defined(MBEDTLS_ZERO_RTT)
 void mbedtls_ssl_conf_early_data( mbedtls_ssl_config* conf, int early_data,
-                                  unsigned int max_early_data,
+                                  size_t max_early_data,
                                   int(*early_data_callback)( mbedtls_ssl_context*,
                                                              unsigned char*,
                                                              size_t ) );
 
 #if defined(MBEDTLS_SSL_CLI_C)
 int mbedtls_ssl_set_early_data( mbedtls_ssl_context* ssl, unsigned char* buffer,
-                                unsigned int len );
+                                size_t len );
 #endif /* MBEDTLS_SSL_CLI_C */
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL && MBEDTLS_ZERO_RTT */
 

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -1426,15 +1426,15 @@ struct mbedtls_ssl_config
 
 #if defined(MBEDTLS_ZERO_RTT)
      /*!< Early data indication:
-      *   0  -- MBEDTLS_SSL_EARLY_DATA_DISABLED (for no early data), and
-      *   1  -- MBEDTLS_SSL_EARLY_DATA_ENABLED (for use early data)
+      *   - MBEDTLS_SSL_EARLY_DATA_DISABLED,
+      *   - MBEDTLS_SSL_EARLY_DATA_ENABLED
       */
     int early_data_enabled;
 #if defined(MBEDTLS_SSL_SRV_C)
     /* Max number of bytes of early data acceptable by the server. */
     size_t max_early_data;
     /* Callback function for early data processing (server only). */
-    int(*early_data_callback)(mbedtls_ssl_context*, unsigned char*, size_t);
+    int(*early_data_callback)(mbedtls_ssl_context*, const unsigned char*, size_t);
 #endif /* MBEDTLS_SSL_SRV_C */
 #endif /* MBEDTLS_ZERO_RTT */
 #endif /* MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED */
@@ -1820,7 +1820,7 @@ struct mbedtls_ssl_context
 
 #if defined(MBEDTLS_SSL_CLI_C)
     /* Pointer to early data buffer to send. */
-    unsigned char* early_data_buf;
+    const unsigned char* early_data_buf;
     /* Length of early data to send. */
     size_t early_data_len;
 #endif /* MBEDTLS_SSL_CLI_C */
@@ -2028,11 +2028,11 @@ void mbedtls_ssl_conf_authmode( mbedtls_ssl_config *conf, int authmode );
 void mbedtls_ssl_conf_early_data( mbedtls_ssl_config* conf, int early_data,
                                   size_t max_early_data,
                                   int(*early_data_callback)( mbedtls_ssl_context*,
-                                                             unsigned char*,
+                                                             const unsigned char*,
                                                              size_t ) );
 
 #if defined(MBEDTLS_SSL_CLI_C)
-int mbedtls_ssl_set_early_data( mbedtls_ssl_context* ssl, unsigned char* buffer,
+int mbedtls_ssl_set_early_data( mbedtls_ssl_context* ssl, const unsigned char* buffer,
                                 size_t len );
 #endif /* MBEDTLS_SSL_CLI_C */
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL && MBEDTLS_ZERO_RTT */

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -2022,7 +2022,7 @@ void mbedtls_ssl_conf_authmode( mbedtls_ssl_config *conf, int authmode );
 *
 * \param max_early_data  Max number of bytes allowed for early data (server only).
 * \param early_data_callback Callback function when early data is received (server
-                             only).
+*                            only).
 */
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && defined(MBEDTLS_ZERO_RTT)
 void mbedtls_ssl_conf_early_data( mbedtls_ssl_config* conf, int early_data,

--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -1390,7 +1390,7 @@ static inline int mbedtls_ssl_tls13_key_exchange_with_psk( mbedtls_ssl_context *
 static inline int mbedtls_ssl_conf_tls13_0rtt_enabled( mbedtls_ssl_context *ssl )
 {
 #if defined(MBEDTLS_ZERO_RTT)
-    if( ssl->early_data_enabled == MBEDTLS_SSL_EARLY_DATA_ENABLED )
+    if( ssl->conf->early_data_enabled == MBEDTLS_SSL_EARLY_DATA_ENABLED )
         return( 1 );
 #else
     ((void) ssl);

--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -259,6 +259,9 @@
 /* Maximum size in bytes of list in supported elliptic curve ext., RFC 4492 */
 #define MBEDTLS_SSL_MAX_CURVE_LIST_LEN         65535
 
+/* Maximum amount of early data to buffer on the server. */
+#define MBEDTLS_SSL_MAX_EARLY_DATA             1024
+
 /*
  * Check that we obey the standard's message size bounds
  */

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -8067,9 +8067,11 @@ void mbedtls_ssl_free( mbedtls_ssl_context *ssl )
 
 #if defined(MBEDTLS_ZERO_RTT) && defined(MBEDTLS_SSL_SRV_C)
     if( ssl->early_data_server_buf != NULL )
+    {
         mbedtls_platform_zeroize( ssl->early_data_server_buf,
                                   ssl->early_data_server_buf_len );
         mbedtls_free( ssl->early_data_server_buf );
+    }
 #endif /* MBEDTLS_ZERO_RTT && MBEDTLS_SSL_SRV_C */
 
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "<= free" ) );

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -4521,6 +4521,23 @@ int mbedtls_ssl_setup( mbedtls_ssl_context *ssl,
         goto error;
 #endif /* MBEDTLS_SSL_USE_MPS */
 
+#if defined(MBEDTLS_ZERO_RTT)
+#if defined(MBEDTLS_SSL_SRV_C)
+    if( conf->endpoint == MBEDTLS_SSL_IS_SERVER &&
+        conf->early_data_enabled == MBEDTLS_SSL_EARLY_DATA_ENABLED &&
+        conf->max_early_data > 0 )
+    {
+        ssl->early_data_server_buf = mbedtls_calloc( 1, conf->max_early_data );
+        if( ssl->early_data_server_buf == NULL )
+        {
+            MBEDTLS_SSL_DEBUG_MSG( 1, ( "alloc(%d bytes) failed", conf->max_early_data ) );
+            ret = MBEDTLS_ERR_SSL_ALLOC_FAILED;
+            goto error;
+        }
+    }
+#endif /* MBEDTLS_SSL_SRV_C */
+#endif /* MBEDTLS_ZERO_RTT */
+
     return( 0 );
 
 error:
@@ -4551,6 +4568,12 @@ error:
     ssl->out_msg = NULL;
 #endif /* MBEDTLS_SSL_USE_MPS */
 
+#if defined(MBEDTLS_ZERO_RTT) && defined(MBEDTLS_SSL_SRV_C)
+    if( conf->endpoint == MBEDTLS_SSL_IS_SERVER )
+    {
+        mbedtls_free( ssl->early_data_server_buf );
+    }
+#endif
     return( ret );
 }
 
@@ -4685,9 +4708,18 @@ int mbedtls_ssl_session_reset_int( mbedtls_ssl_context *ssl, int partial )
 #endif /* MBEDTLS_SSL_USE_MPS */
 
 #if defined(MBEDTLS_ZERO_RTT)
-    ssl->early_data_enabled = MBEDTLS_SSL_EARLY_DATA_DISABLED;
+#if defined(MBEDTLS_SSL_SRV_C)
+    if( ssl->early_data_server_buf != NULL &&
+        ssl->conf->max_early_data > 0 )
+    {
+        memset( ssl->early_data_server_buf, 0,  ssl->conf->max_early_data );
+    }
+#endif /* MBEDTLS_SSL_SRV_C */
+
+#if defined(MBEDTLS_SSL_CLI_C)
     ssl->early_data_buf = NULL;
     ssl->early_data_len = 0;
+#endif /* MBEDTLS_SSL_CLI_C */
 #endif /* MBEDTLS_ZERO_RTT */
 
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
@@ -8040,6 +8072,11 @@ void mbedtls_ssl_free( mbedtls_ssl_context *ssl )
     && defined(MBEDTLS_SSL_SRV_C)
     mbedtls_free( ssl->cli_id );
 #endif
+
+#if defined(MBEDTLS_ZERO_RTT) && defined(MBEDTLS_SSL_SRV_C)
+    if( ssl->early_data_server_buf != NULL )
+        mbedtls_free( ssl->early_data_server_buf );
+#endif /* MBEDTLS_ZERO_RTT && MBEDTLS_SSL_SRV_C */
 
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "<= free" ) );
 

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -2097,7 +2097,7 @@ int mbedtls_ssl_get_early_data_status( mbedtls_ssl_context *ssl )
 }
 
 int mbedtls_ssl_set_early_data( mbedtls_ssl_context *ssl,
-                                unsigned char *buffer, size_t len )
+                                const unsigned char *buffer, size_t len )
 {
     if( buffer == NULL || len == 0 )
         return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -2097,14 +2097,14 @@ int mbedtls_ssl_get_early_data_status( mbedtls_ssl_context *ssl )
 }
 
 int mbedtls_ssl_set_early_data( mbedtls_ssl_context *ssl,
-                                unsigned char *buffer, unsigned int len )
+                                unsigned char *buffer, size_t len )
 {
     if( buffer == NULL || len == 0 )
         return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
 
     ssl->early_data_buf = buffer;
     ssl->early_data_len = len;
-    return 0;
+    return( 0 );
 }
 #endif /* MBEDTLS_ZERO_RTT */
 

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -2096,17 +2096,15 @@ int mbedtls_ssl_get_early_data_status( mbedtls_ssl_context *ssl )
     return( ssl->early_data_status );
 }
 
-void mbedtls_ssl_set_early_data( mbedtls_ssl_context *ssl,
-                                 char *buffer, unsigned int len )
+int mbedtls_ssl_set_early_data( mbedtls_ssl_context *ssl,
+                                unsigned char *buffer, unsigned int len )
 {
-    if( ssl != NULL )
-    {
-        if( buffer != NULL && len > 0 )
-        {
-            ssl->early_data_buf = buffer;
-            ssl->early_data_len = len;
-        }
-    }
+    if( buffer == NULL || len == 0 )
+        return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
+
+    ssl->early_data_buf = buffer;
+    ssl->early_data_len = len;
+    return 0;
 }
 #endif /* MBEDTLS_ZERO_RTT */
 

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -2095,6 +2095,19 @@ int mbedtls_ssl_get_early_data_status( mbedtls_ssl_context *ssl )
 
     return( ssl->early_data_status );
 }
+
+void mbedtls_ssl_set_early_data( mbedtls_ssl_context *ssl,
+                                 char *buffer, unsigned int len )
+{
+    if( ssl != NULL )
+    {
+        if( buffer != NULL && len > 0 )
+        {
+            ssl->early_data_buf = buffer;
+            ssl->early_data_len = len;
+        }
+    }
+}
 #endif /* MBEDTLS_ZERO_RTT */
 
 #if ( defined(MBEDTLS_ECDH_C) || defined(MBEDTLS_ECDSA_C) )

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -2741,7 +2741,7 @@ static int ssl_finished_in_postprocess( mbedtls_ssl_context* ssl )
 
 #if defined(MBEDTLS_ZERO_RTT)
 void mbedtls_ssl_conf_early_data( mbedtls_ssl_config* conf, int early_data,
-                                  unsigned int max_early_data,
+                                  size_t max_early_data,
                                   int(*early_data_callback)( mbedtls_ssl_context*,
                                                              unsigned char*,
                                                              size_t ) )

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -2743,7 +2743,7 @@ static int ssl_finished_in_postprocess( mbedtls_ssl_context* ssl )
 void mbedtls_ssl_conf_early_data( mbedtls_ssl_config* conf, int early_data,
                                   size_t max_early_data,
                                   int(*early_data_callback)( mbedtls_ssl_context*,
-                                                             unsigned char*,
+                                                             const unsigned char*,
                                                              size_t ) )
 {
 #if !defined(MBEDTLS_SSL_SRV_C)

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -2740,29 +2740,31 @@ static int ssl_finished_in_postprocess( mbedtls_ssl_context* ssl )
 }
 
 #if defined(MBEDTLS_ZERO_RTT)
-void mbedtls_ssl_set_early_data( mbedtls_ssl_context *ssl, int early_data,
-                                 char *buffer, unsigned int len,
-                                 int(*early_data_callback)( mbedtls_ssl_context *,
-                                                            unsigned char *, size_t ) )
+void mbedtls_ssl_conf_early_data( mbedtls_ssl_config* conf, int early_data, unsigned int max_early_data,
+                                  int(*early_data_callback)( mbedtls_ssl_context*,
+                                                             unsigned char*, size_t ))
 {
 #if !defined(MBEDTLS_SSL_SRV_C)
     ( (void ) early_data_callback );
 #endif /* !MBEDTLS_SSL_SRV_C */
-
-    if( ssl != NULL )
+    if( conf != NULL )
     {
-        ssl->early_data_enabled = early_data;
-        if( buffer != NULL && len >0 && early_data==MBEDTLS_SSL_EARLY_DATA_ENABLED )
-        {
-            ssl->early_data_buf = buffer;
-            ssl->early_data_len = len;
+        conf->early_data_enabled = early_data;
+
 #if defined(MBEDTLS_SSL_SRV_C)
+        conf->max_early_data = max_early_data;
+        if( max_early_data > 0 && early_data == MBEDTLS_SSL_EARLY_DATA_ENABLED )
+        {
+            conf->early_data_callback = early_data_callback;
             /* Only the server uses the early data callback.
              * For the client this parameter is not used.
              */
-            ssl->early_data_callback = early_data_callback;
-#endif /* MBEDTLS_SSL_SRV_C */
         }
+        else
+        {
+            conf->early_data_callback = NULL;
+        }
+#endif
     }
 }
 #endif /* MBEDTLS_ZERO_RTT */
@@ -3085,7 +3087,7 @@ int mbedtls_ssl_write_early_data_ext( mbedtls_ssl_context *ssl,
             return( 0 );
 
         if( ssl->conf->key_exchange_modes != MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_KE ||
-            ssl->early_data_enabled == MBEDTLS_SSL_EARLY_DATA_DISABLED )
+            ssl->conf->early_data_enabled == MBEDTLS_SSL_EARLY_DATA_DISABLED )
         {
             MBEDTLS_SSL_DEBUG_MSG( 2, ( "skip write early_data extension" ) );
             ssl->handshake->early_data = MBEDTLS_SSL_EARLY_DATA_OFF;
@@ -3099,7 +3101,7 @@ int mbedtls_ssl_write_early_data_ext( mbedtls_ssl_context *ssl,
     {
         if( !mbedtls_ssl_conf_tls13_some_psk_enabled( ssl ) ||
             mbedtls_ssl_get_psk_to_offer( ssl, NULL, NULL, NULL, NULL ) != 0 ||
-            ssl->early_data_enabled == MBEDTLS_SSL_EARLY_DATA_DISABLED )
+            ssl->conf->early_data_enabled == MBEDTLS_SSL_EARLY_DATA_DISABLED )
         {
             MBEDTLS_SSL_DEBUG_MSG( 2, ( "<= skip write early_data extension" ) );
             ssl->handshake->early_data = MBEDTLS_SSL_EARLY_DATA_OFF;

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -2755,11 +2755,13 @@ void mbedtls_ssl_conf_early_data( mbedtls_ssl_config* conf, int early_data,
 
     if( early_data == MBEDTLS_SSL_EARLY_DATA_ENABLED )
     {
+        if( max_early_data > MBEDTLS_SSL_MAX_EARLY_DATA )
+            max_early_data = MBEDTLS_SSL_MAX_EARLY_DATA;
+
         conf->max_early_data = max_early_data;
         conf->early_data_callback = early_data_callback;
         /* Only the server uses the early data callback.
-         * For the client this parameter is not used.
-         */
+         * For the client this parameter is not used. */
     }
     else
     {

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -2740,32 +2740,32 @@ static int ssl_finished_in_postprocess( mbedtls_ssl_context* ssl )
 }
 
 #if defined(MBEDTLS_ZERO_RTT)
-void mbedtls_ssl_conf_early_data( mbedtls_ssl_config* conf, int early_data, unsigned int max_early_data,
+void mbedtls_ssl_conf_early_data( mbedtls_ssl_config* conf, int early_data,
+                                  unsigned int max_early_data,
                                   int(*early_data_callback)( mbedtls_ssl_context*,
-                                                             unsigned char*, size_t ))
+                                                             unsigned char*,
+                                                             size_t ) )
 {
 #if !defined(MBEDTLS_SSL_SRV_C)
-    ( (void ) early_data_callback );
+    ( ( void ) early_data_callback );
 #endif /* !MBEDTLS_SSL_SRV_C */
-    if( conf != NULL )
-    {
-        conf->early_data_enabled = early_data;
+    conf->early_data_enabled = early_data;
 
 #if defined(MBEDTLS_SSL_SRV_C)
+
+    if( early_data == MBEDTLS_SSL_EARLY_DATA_ENABLED )
+    {
         conf->max_early_data = max_early_data;
-        if( max_early_data > 0 && early_data == MBEDTLS_SSL_EARLY_DATA_ENABLED )
-        {
-            conf->early_data_callback = early_data_callback;
-            /* Only the server uses the early data callback.
-             * For the client this parameter is not used.
-             */
-        }
-        else
-        {
-            conf->early_data_callback = NULL;
-        }
-#endif
+        conf->early_data_callback = early_data_callback;
+        /* Only the server uses the early data callback.
+         * For the client this parameter is not used.
+         */
     }
+    else
+    {
+        conf->early_data_callback = NULL;
+    }
+#endif
 }
 #endif /* MBEDTLS_ZERO_RTT */
 

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -2011,7 +2011,7 @@ static int ssl_read_early_data_parse( mbedtls_ssl_context* ssl,
         /* copy data to staging area */
         memcpy( ssl->early_data_server_buf, buf, buflen );
         /* execute callback to process application data */
-        ssl->conf->early_data_callback( ssl, (unsigned char*)ssl->early_data_server_buf,
+        ssl->conf->early_data_callback( ssl, ssl->early_data_server_buf,
                                         buflen );
     }
     else

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -706,7 +706,7 @@ int mbedtls_ssl_parse_client_psk_identity_ext(
                     }
 
 #if defined(MBEDTLS_ZERO_RTT)
-                    if( ssl->early_data_enabled == MBEDTLS_SSL_EARLY_DATA_ENABLED )
+                    if( ssl->conf->early_data_enabled == MBEDTLS_SSL_EARLY_DATA_ENABLED )
                     {
                         if( diff <= MBEDTLS_SSL_EARLY_DATA_MAX_DELAY )
                         {
@@ -735,7 +735,7 @@ int mbedtls_ssl_parse_client_psk_identity_ext(
                     if( ret == MBEDTLS_ERR_SSL_SESSION_TICKET_EXPIRED )
                     {
 #if defined(MBEDTLS_ZERO_RTT)
-                        if( ssl->early_data_enabled ==
+                        if( ssl->conf->early_data_enabled ==
                             MBEDTLS_SSL_EARLY_DATA_ENABLED )
                         {
                             ssl->session_negotiate->process_early_data =
@@ -2003,16 +2003,16 @@ static int ssl_read_early_data_parse( mbedtls_ssl_context* ssl,
                                       size_t buflen )
 {
     /* Check whether we have enough buffer space. */
-    if( buflen <= ssl->early_data_len )
+    if( buflen <= ssl->conf->max_early_data )
     {
         /* TODO: We need to check that we're not receiving more 0-RTT
          * than what the ticket allows. */
 
         /* copy data to staging area */
-        memcpy( ssl->early_data_buf, buf, buflen );
+        memcpy( ssl->early_data_server_buf, buf, buflen );
         /* execute callback to process application data */
-        ssl->early_data_callback( ssl, (unsigned char*)ssl->early_data_buf,
-                                  buflen );
+        ssl->conf->early_data_callback( ssl, (unsigned char*)ssl->early_data_server_buf,
+                                        buflen );
     }
     else
     {

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -2017,7 +2017,7 @@ static int ssl_read_early_data_parse( mbedtls_ssl_context* ssl,
     else
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "Buffer too small (recv %d bytes, buffer %d bytes)",
-                                    buflen, ssl->early_data_len ) );
+                                    buflen, ssl->conf->max_early_data ) );
         return ( MBEDTLS_ERR_SSL_ALLOC_FAILED );
     }
 

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -3031,7 +3031,7 @@ int main( int argc, char *argv[] )
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && defined(MBEDTLS_ZERO_RTT)
     mbedtls_ssl_conf_early_data( &conf, opt.early_data, 0, NULL );
-    mbedtls_ssl_set_early_data( &ssl, early_data, strlen( early_data ) );
+    mbedtls_ssl_set_early_data( &ssl, (unsigned char*) early_data, strlen( early_data ) );
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL && MBEDTLS_ZERO_RTT */
 
     if( ( ret = mbedtls_ssl_setup( &ssl, &conf ) ) != 0 )
@@ -4043,7 +4043,7 @@ reconnect:
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && defined(MBEDTLS_ZERO_RTT)
-        mbedtls_ssl_set_early_data( &ssl, early_data, strlen( early_data ) );
+        mbedtls_ssl_set_early_data( &ssl, (unsigned char*) early_data, strlen( early_data ) );
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL && MBEDTLS_ZERO_RTT */
 
 

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -3029,6 +3029,11 @@ int main( int argc, char *argv[] )
         mbedtls_ssl_conf_fallback( &conf, opt.fallback );
 #endif
 
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && defined(MBEDTLS_ZERO_RTT)
+    mbedtls_ssl_conf_early_data( &conf, opt.early_data, 0, NULL );
+    mbedtls_ssl_set_early_data( &ssl, early_data, strlen( early_data ) );
+#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL && MBEDTLS_ZERO_RTT */
+
     if( ( ret = mbedtls_ssl_setup( &ssl, &conf ) ) != 0 )
     {
         mbedtls_printf( " failed\n  ! mbedtls_ssl_setup returned -0x%x\n\n",
@@ -3064,9 +3069,6 @@ int main( int argc, char *argv[] )
         mbedtls_ssl_set_verify( &ssl, my_verify, NULL );
 #endif /* MBEDTLS_X509_CRT_PARSE_C */
 
-#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && defined(MBEDTLS_ZERO_RTT)
-    mbedtls_ssl_set_early_data( &ssl, opt.early_data, early_data, strlen( early_data ), NULL );
-#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL && MBEDTLS_ZERO_RTT */
 
     io_ctx.ssl = &ssl;
     io_ctx.net = &server_fd;
@@ -4041,8 +4043,7 @@ reconnect:
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && defined(MBEDTLS_ZERO_RTT)
-        mbedtls_ssl_set_early_data( &ssl, opt.early_data, early_data, 
-                                    strlen( early_data ), NULL );
+        mbedtls_ssl_set_early_data( &ssl, early_data, strlen( early_data ) );
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL && MBEDTLS_ZERO_RTT */
 
 

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -3031,7 +3031,8 @@ int main( int argc, char *argv[] )
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && defined(MBEDTLS_ZERO_RTT)
     mbedtls_ssl_conf_early_data( &conf, opt.early_data, 0, NULL );
-    mbedtls_ssl_set_early_data( &ssl, (unsigned char*) early_data, strlen( early_data ) );
+    mbedtls_ssl_set_early_data( &ssl, (const unsigned char*) early_data,
+                                strlen( early_data ) );
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL && MBEDTLS_ZERO_RTT */
 
     if( ( ret = mbedtls_ssl_setup( &ssl, &conf ) ) != 0 )
@@ -4043,7 +4044,8 @@ reconnect:
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && defined(MBEDTLS_ZERO_RTT)
-        mbedtls_ssl_set_early_data( &ssl, (unsigned char*) early_data, strlen( early_data ) );
+        mbedtls_ssl_set_early_data( &ssl, (const unsigned char*) early_data,
+                                    strlen( early_data ) );
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL && MBEDTLS_ZERO_RTT */
 
 

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -2064,8 +2064,7 @@ int main( int argc, char *argv[] )
 #endif
 
 #if defined(MBEDTLS_ZERO_RTT)
-    char early_data_buf[50];
-    unsigned int early_data_len;
+    unsigned int max_early_data;
 #endif
 
 #if defined(MBEDTLS_SSL_DTLS_CONNECTION_ID)
@@ -3537,6 +3536,12 @@ int main( int argc, char *argv[] )
     if( opt.cert_req_ca_list != DFL_CERT_REQ_CA_LIST )
         mbedtls_ssl_conf_cert_req_ca_list( &conf, opt.cert_req_ca_list );
 
+#if defined(MBEDTLS_ZERO_RTT)
+    max_early_data = 50;
+    mbedtls_ssl_conf_early_data( &conf, opt.early_data,
+                                 max_early_data, early_data_callback );
+#endif /* MBEDTLS_ZERO_RTT */
+
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
     if( opt.hs_to_min != DFL_HS_TO_MIN || opt.hs_to_max != DFL_HS_TO_MAX )
         mbedtls_ssl_conf_handshake_timeout( &conf, opt.hs_to_min, opt.hs_to_max );
@@ -4136,13 +4141,6 @@ reset:
     mbedtls_net_free( &client_fd );
 
     mbedtls_ssl_session_reset( &ssl );
-
-
-#if defined(MBEDTLS_ZERO_RTT)
-    early_data_len = sizeof( early_data_buf ) - 1;
-    mbedtls_ssl_set_early_data( &ssl, opt.early_data, early_data_buf,
-                                early_data_len, early_data_callback );
-#endif /* MBEDTLS_ZERO_RTT */
 
     /*
      * 3. Wait until a client connects

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -493,8 +493,10 @@ int main( void )
 
 #if defined(MBEDTLS_ZERO_RTT)
 #define USAGE_EARLY_DATA \
-    "    early_data=%%d        default: 0 (disabled)\n"      \
-    "                        options: 0 (disabled), 1 (enabled)\n"
+    "    early_data=%%d        default: 0 (disabled)\n"             \
+    "                        options: 0     (disabled), "           \
+    "                                 -1    (enabled, unlimited), " \
+    "                                 n > 0 (enabled, max. number of bytes sent as 0-RTT = n)\n"
 #else
 #define USAGE_EARLY_DATA ""
 #endif /* MBEDTLS_ZERO_RTT */
@@ -745,6 +747,7 @@ struct options
     int reproducible;           /* make communication reproducible          */
     unsigned char key_exchange_modes; /* key exchange modes                 */
     int early_data;                   /* support for early data             */
+    int early_data_max;               /* maximum amount of early data       */
     const char *named_groups_string;  /* list of named groups               */
     const char *sig_algs;             /* supported signature algorithms     */
     int query_config_mode;      /* whether to read config                   */
@@ -2066,10 +2069,6 @@ int main( int argc, char *argv[] )
     unsigned char alloc_buf[MEMORY_HEAP_SIZE];
 #endif
 
-#if defined(MBEDTLS_ZERO_RTT)
-    unsigned int max_early_data;
-#endif
-
 #if defined(MBEDTLS_SSL_DTLS_CONNECTION_ID)
     unsigned char cid[MBEDTLS_SSL_CID_IN_LEN_MAX];
     unsigned char cid_renego[MBEDTLS_SSL_CID_IN_LEN_MAX];
@@ -2489,15 +2488,16 @@ int main( int argc, char *argv[] )
 #if defined(MBEDTLS_ZERO_RTT)
         else if( strcmp( p, "early_data" ) == 0 )
         {
-            switch( atoi( q ) )
+            int early_data_val = atoi( q );
+            switch( early_data_val )
             {
                 case 0:
                     opt.early_data = MBEDTLS_SSL_EARLY_DATA_DISABLED;
                     break;
-                case 1:
+                default:
                     opt.early_data = MBEDTLS_SSL_EARLY_DATA_ENABLED;
+                    opt.early_data_max = (size_t) early_data_val;
                     break;
-                default: goto usage;
             }
         }
 #endif /* MBEDTLS_ZERO_RTT */
@@ -3540,9 +3540,9 @@ int main( int argc, char *argv[] )
         mbedtls_ssl_conf_cert_req_ca_list( &conf, opt.cert_req_ca_list );
 
 #if defined(MBEDTLS_ZERO_RTT)
-    max_early_data = 50;
     mbedtls_ssl_conf_early_data( &conf, opt.early_data,
-                                 max_early_data, early_data_callback );
+                                 opt.early_data_max,
+                                 early_data_callback );
 #endif /* MBEDTLS_ZERO_RTT */
 
 #if defined(MBEDTLS_SSL_PROTO_DTLS)

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -1573,17 +1573,20 @@ int psk_callback( void *p_info, mbedtls_ssl_context *ssl,
 * Early data callback.
 */
 int early_data_callback( mbedtls_ssl_context *ssl,
-                     unsigned char *buffer, size_t len )
+                         const unsigned char *buffer, size_t len )
 {
     // In this example we don't need access to the SSL structure
     ((void) ssl);
-
+    char *buffer_to_print;
     if( len > 0 && buffer != NULL )
     {
-        buffer[len] = '\0';
-        mbedtls_printf( " %zu bytes early data received: %s\n", len, (char *) buffer ) ;
+        buffer_to_print = mbedtls_calloc( 1, len + 1 );
+        memcpy( buffer_to_print, buffer, len );
+        buffer_to_print[len] = '\0';
+        mbedtls_printf( " %zu bytes early data received: %s\n", len, buffer_to_print );
+        mbedtls_free( buffer_to_print );
     }
-    return(0);
+    return( 0 );
 }
 #endif /* MBEDTLS_ZERO_RTT */
 

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -1496,7 +1496,7 @@ requires_config_enabled MBEDTLS_DEBUG_C
 requires_config_disabled MBEDTLS_RSA_C
 requires_config_enabled MBEDTLS_ZERO_RTT
 run_test    "TLS 1.3, TLS_AES_256_GCM_SHA384, ext PSK, early data" \
-            "$P_SRV nbio=2 debug_level=5 force_version=tls1_3 early_data=1 key_exchange_modes=psk psk=010203 psk_identity=0a0b0c" \
+            "$P_SRV nbio=2 debug_level=5 force_version=tls1_3 early_data=-1 key_exchange_modes=psk psk=010203 psk_identity=0a0b0c" \
             "$P_CLI nbio=2 debug_level=5 force_version=tls1_3 force_ciphersuite=TLS_AES_256_GCM_SHA384 key_exchange_modes=psk early_data=1 psk=010203 psk_identity=0a0b0c" \
             0 \
 	    -s "found early_data extension"                 \
@@ -1514,7 +1514,7 @@ requires_config_enabled MBEDTLS_DEBUG_C
 requires_config_disabled MBEDTLS_RSA_C
 requires_config_enabled MBEDTLS_ZERO_RTT
 run_test    "TLS 1.3, TLS_AES_128_CCM_SHA256, ext PSK, early data" \
-            "$P_SRV nbio=2 debug_level=5 force_version=tls1_3 early_data=1 key_exchange_modes=psk psk=010203 psk_identity=0a0b0c" \
+            "$P_SRV nbio=2 debug_level=5 force_version=tls1_3 early_data=-1 key_exchange_modes=psk psk=010203 psk_identity=0a0b0c" \
             "$P_CLI nbio=2 debug_level=5 force_version=tls1_3 force_ciphersuite=TLS_AES_128_CCM_SHA256 key_exchange_modes=psk early_data=1 psk=010203 psk_identity=0a0b0c" \
             0 \
 	    -s "found early_data extension"                 \
@@ -1532,7 +1532,7 @@ requires_config_enabled MBEDTLS_DEBUG_C
 requires_config_disabled MBEDTLS_RSA_C
 requires_config_enabled MBEDTLS_ZERO_RTT
 run_test    "TLS 1.3, TLS_AES_128_GCM_SHA256, ext PSK, early data" \
-            "$P_SRV nbio=2 debug_level=5 force_version=tls1_3 early_data=1 key_exchange_modes=psk psk=010203 psk_identity=0a0b0c" \
+            "$P_SRV nbio=2 debug_level=5 force_version=tls1_3 early_data=-1 key_exchange_modes=psk psk=010203 psk_identity=0a0b0c" \
             "$P_CLI nbio=2 debug_level=5 force_version=tls1_3 force_ciphersuite=TLS_AES_128_GCM_SHA256 key_exchange_modes=psk early_data=1 psk=010203 psk_identity=0a0b0c" \
             0 \
 	    -s "found early_data extension"                 \
@@ -1550,7 +1550,7 @@ requires_config_enabled MBEDTLS_DEBUG_C
 requires_config_disabled MBEDTLS_RSA_C
 requires_config_enabled MBEDTLS_ZERO_RTT
 run_test    "TLS 1.3, TLS_AES_128_CCM_8_SHA256, ext PSK, early data" \
-            "$P_SRV nbio=2 debug_level=5 force_version=tls1_3 early_data=1 key_exchange_modes=psk psk=010203 psk_identity=0a0b0c" \
+            "$P_SRV nbio=2 debug_level=5 force_version=tls1_3 early_data=-1 key_exchange_modes=psk psk=010203 psk_identity=0a0b0c" \
             "$P_CLI nbio=2 debug_level=5 force_version=tls1_3 force_ciphersuite=TLS_AES_128_CCM_8_SHA256 key_exchange_modes=psk early_data=1 psk=010203 psk_identity=0a0b0c" \
             0 \
 	    -s "found early_data extension"                 \
@@ -1616,7 +1616,7 @@ requires_config_enabled MBEDTLS_DEBUG_C
 requires_config_enabled MBEDTLS_ZERO_RTT
 requires_config_disabled MBEDTLS_RSA_C
 run_test    "TLS 1.3, TLS_AES_256_GCM_SHA384, ext PSK, early data status - accepted" \
-            "$P_SRV nbio=2 debug_level=5 force_version=tls1_3 early_data=1 key_exchange_modes=psk psk=010203 psk_identity=0a0b0c" \
+            "$P_SRV nbio=2 debug_level=5 force_version=tls1_3 early_data=-1 key_exchange_modes=psk psk=010203 psk_identity=0a0b0c" \
             "$P_CLI nbio=2 debug_level=5 force_version=tls1_3 force_ciphersuite=TLS_AES_256_GCM_SHA384 key_exchange_modes=psk early_data=1 psk=010203 psk_identity=0a0b0c" \
             0 \
 	    -c "early data status = 2"  \


### PR DESCRIPTION
Restore `mbedtls_ssl_conf_early_data()` function. It will enable early data in either the server or the client. 
* For server, the user need to set `max_early_data` field and `early_data_callback` function
* For client, the user enables early data and then use `mbedtls_ssl_set_early_data()` function to set the early data to send.

## Status
**READY**

## Requires Backporting
NO  

## Migrations
NO

## Additional comments


## Steps to test or reproduce
Outline the steps to test or reproduce the PR here.
