### PR TITLE
Clean up 0-RTT, fix compiler error when MBEDTLS_ZERO_RTT is disabled

### DIFF
--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -176,7 +176,10 @@ int ssl_write_early_data_process( mbedtls_ssl_context* ssl )
 #endif /* MBEDTLS_SSL_USE_MPS */
 
 #else /* MBEDTLS_ZERO_RTT */
-
+        ((void) buf);
+        ((void) buf_len);
+        ((void) msg);
+        ((void) msg_len);
         /* Should never happen */
         return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
 
@@ -3403,7 +3406,7 @@ static int ssl_server_hello_postprocess( mbedtls_ssl_context* ssl )
     ret = mbedtls_ssl_tls1_3_key_schedule_stage_early_data( ssl );
     if( ret != 0 )
     {
-        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_tls1_3_establish_early_secret",
+        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_tls1_3_key_schedule_stage_early_data",
                                ret );
         return( ret );
     }

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -1672,7 +1672,9 @@ int ssl_read_end_of_early_data_process( mbedtls_ssl_context* ssl );
 
 static int ssl_read_end_of_early_data_coordinate( mbedtls_ssl_context* ssl );
 
+#if defined(MBEDTLS_ZERO_RTT)
 static int ssl_end_of_early_data_fetch( mbedtls_ssl_context* ssl );
+#endif /* MBEDTLS_ZERO_RTT */
 
 /* Update the state after handling the incoming end of early data message. */
 static int ssl_read_end_of_early_data_postprocess( mbedtls_ssl_context* ssl );
@@ -1819,6 +1821,7 @@ int ssl_read_early_data_process( mbedtls_ssl_context* ssl );
 #define SSL_EARLY_DATA_SKIP   0
 #define SSL_EARLY_DATA_EXPECT 1
 
+#if defined(MEDTLS_ZERO_RTT)
 #if defined(MBEDTLS_SSL_USE_MPS)
 static int ssl_early_data_fetch( mbedtls_ssl_context* ssl,
                                  mbedtls_mps_reader **reader );
@@ -1827,6 +1830,7 @@ static int ssl_early_data_fetch( mbedtls_ssl_context* ssl,
                                  unsigned char** buf,
                                  size_t* buflen );
 #endif /* MBEDTLS_SSL_USE_MPS */
+#endif /* MEDTLS_ZERO_RTT */
 
 static int ssl_read_early_data_coordinate( mbedtls_ssl_context* ssl );
 
@@ -1898,6 +1902,7 @@ cleanup:
     return( ret );
 }
 
+#if defined(MBEDTLS_ZERO_RTT)
 #if defined(MBEDTLS_SSL_USE_MPS)
 static int ssl_early_data_fetch( mbedtls_ssl_context *ssl,
                                  mbedtls_mps_reader **rd )
@@ -1943,7 +1948,7 @@ cleanup:
     return( ret );
 }
 #endif /* MBEDTLS_SSL_USE_MPS */
-
+#endif /* MBEDTLS_ZERO_RTT */
 
 #if !defined(MBEDTLS_ZERO_RTT)
 static int ssl_read_early_data_coordinate( mbedtls_ssl_context* ssl )

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -1821,7 +1821,7 @@ int ssl_read_early_data_process( mbedtls_ssl_context* ssl );
 #define SSL_EARLY_DATA_SKIP   0
 #define SSL_EARLY_DATA_EXPECT 1
 
-#if defined(MEDTLS_ZERO_RTT)
+#if defined(MBEDTLS_ZERO_RTT)
 #if defined(MBEDTLS_SSL_USE_MPS)
 static int ssl_early_data_fetch( mbedtls_ssl_context* ssl,
                                  mbedtls_mps_reader **reader );
@@ -1830,7 +1830,7 @@ static int ssl_early_data_fetch( mbedtls_ssl_context* ssl,
                                  unsigned char** buf,
                                  size_t* buflen );
 #endif /* MBEDTLS_SSL_USE_MPS */
-#endif /* MEDTLS_ZERO_RTT */
+#endif /* MBEDTLS_ZERO_RTT */
 
 static int ssl_read_early_data_coordinate( mbedtls_ssl_context* ssl );
 


### PR DESCRIPTION
- Fix a typo.
- Make sure mbedtls compiles when `MBEDTLS_ZERO_RTT` is disabled in `config.h`.

## Status
**READY**

## Requires Backporting
 NO  

## Migrations
NO

## Additional comments

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported


## Steps to test or reproduce
Outline the steps to test or reproduce the PR here.

Passed `ssl-opt.sh` test.