### PR TITLE
Fix session minor ver

### DIFF
--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -163,6 +163,7 @@
 #define MBEDTLS_ERR_SSL_BAD_HS_MISSING_EXTENSION_EXT      -0x6795  /**< Missing extension. */
 #define MBEDTLS_ERR_SSL_RECEIVED_NEW_SESSION_TICKET       -0x6796  /**< Received NewSessionTicket Post Handshake Message */
 #define MBEDTLS_ERR_SSL_BAD_HS_CID_EXT                    -0x6797  /**< Received invalid CID extension */
+#define MBEDTLS_ERR_SSL_HANDSHAKE_EARLY_RETURN            -0x6798  /**< Early return when the client is ready to send early data */
 
 #define MBEDTLS_ERR_LAST 0x7F80 /**< This definition points to the last error code to have a correct parsing in error.c */
 
@@ -298,8 +299,9 @@
 #define MBEDTLS_SSL_EARLY_DATA_DISABLED        0
 #define MBEDTLS_SSL_EARLY_DATA_ENABLED         1
 
-#define MBEDTLS_SSL_EARLY_DATA_OFF        0
-#define MBEDTLS_SSL_EARLY_DATA_ON         1
+#define MBEDTLS_SSL_EARLY_DATA_STATE_DISABLED        0
+#define MBEDTLS_SSL_EARLY_DATA_STATE_OFF             1   /* early_data extension sent, cannot send early_data */
+#define MBEDTLS_SSL_EARLY_DATA_STATE_ON              2   /* early_data extension sent, can send early_data */
 
 #define MBEDTLS_SSL_FORCE_RR_CHECK_OFF      0
 #define MBEDTLS_SSL_FORCE_RR_CHECK_ON       1
@@ -1818,12 +1820,6 @@ struct mbedtls_ssl_context
     size_t early_data_server_buf_len;
 #endif /* MBEDTLS_SSL_SRV_C */
 
-#if defined(MBEDTLS_SSL_CLI_C)
-    /* Pointer to early data buffer to send. */
-    const unsigned char* early_data_buf;
-    /* Length of early data to send. */
-    size_t early_data_len;
-#endif /* MBEDTLS_SSL_CLI_C */
 #endif /* MBEDTLS_ZERO_RTT */
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && \

--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -828,9 +828,10 @@ struct mbedtls_ssl_handshake_params
 #if defined(MBEDTLS_ZERO_RTT)
     mbedtls_ssl_tls1_3_early_secrets early_secrets;
 
-    /*!< Early data indication:
-    0  -- MBEDTLS_SSL_EARLY_DATA_DISABLED (for no early data), and
-    1  -- MBEDTLS_SSL_EARLY_DATA_ENABLED (for use early data)
+    /*!< Early data state
+       MBEDTLS_SSL_EARLY_DATA_STATE_DISABLED
+       MBEDTLS_SSL_EARLY_DATA_STATE_ON
+       MBEDTLS_SSL_EARLY_DATA_STATE_OFF
     */
     int early_data;
 #endif /* MBEDTLS_ZERO_RTT */

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -6494,6 +6494,7 @@ static int ssl_session_load( mbedtls_ssl_session *session,
 #if defined(MBEDTLS_SSL_NEW_SESSION_TICKET) && defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
 
     minor_ver = MBEDTLS_SSL_MINOR_VERSION_4; /* TBD: For testing only */
+    session->minor_ver = minor_ver;
 
     if( minor_ver == MBEDTLS_SSL_MINOR_VERSION_4 )
     {

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -4709,11 +4709,6 @@ int mbedtls_ssl_session_reset_int( mbedtls_ssl_context *ssl, int partial )
     ssl_mps_init( ssl );
 #endif /* MBEDTLS_SSL_USE_MPS */
 
-#if defined(MBEDTLS_ZERO_RTT) && defined(MBEDTLS_SSL_CLI_C)
-    ssl->early_data_buf = NULL;
-    ssl->early_data_len = 0;
-#endif /* MBEDTLS_ZERO_RTT && MBEDTLS_SSL_CLI_C */
-
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 
     if( ssl->session )

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -3090,7 +3090,7 @@ int mbedtls_ssl_write_early_data_ext( mbedtls_ssl_context *ssl,
             ssl->conf->early_data_enabled == MBEDTLS_SSL_EARLY_DATA_DISABLED )
         {
             MBEDTLS_SSL_DEBUG_MSG( 2, ( "skip write early_data extension" ) );
-            ssl->handshake->early_data = MBEDTLS_SSL_EARLY_DATA_OFF;
+            ssl->handshake->early_data = MBEDTLS_SSL_EARLY_DATA_STATE_DISABLED;
             return( 0 );
         }
     }
@@ -3104,7 +3104,7 @@ int mbedtls_ssl_write_early_data_ext( mbedtls_ssl_context *ssl,
             ssl->conf->early_data_enabled == MBEDTLS_SSL_EARLY_DATA_DISABLED )
         {
             MBEDTLS_SSL_DEBUG_MSG( 2, ( "<= skip write early_data extension" ) );
-            ssl->handshake->early_data = MBEDTLS_SSL_EARLY_DATA_OFF;
+            ssl->handshake->early_data = MBEDTLS_SSL_EARLY_DATA_STATE_DISABLED;
             return( 0 );
         }
     }
@@ -3133,7 +3133,7 @@ int mbedtls_ssl_write_early_data_ext( mbedtls_ssl_context *ssl,
     }
 #endif /* MBEDTLS_SSL_SRV_C */
 
-    ssl->handshake->early_data = MBEDTLS_SSL_EARLY_DATA_ON;
+    ssl->handshake->early_data = MBEDTLS_SSL_EARLY_DATA_STATE_ON;
 
     /* Write extension header */
     *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_EARLY_DATA >> 8 ) & 0xFF );

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -1792,7 +1792,7 @@ static int ssl_read_end_of_early_data_coordinate( mbedtls_ssl_context* ssl )
 #else /* MBEDTLS_ZERO_RTT */
 static int ssl_read_end_of_early_data_coordinate( mbedtls_ssl_context* ssl )
 {
-    if( ssl->handshake->early_data != MBEDTLS_SSL_EARLY_DATA_ON )
+    if( ssl->handshake->early_data != MBEDTLS_SSL_EARLY_DATA_STATE_ON )
         return( SSL_END_OF_EARLY_DATA_SKIP );
 
     return( SSL_END_OF_EARLY_DATA_EXPECT );
@@ -1961,7 +1961,7 @@ static int ssl_read_early_data_coordinate( mbedtls_ssl_context* ssl )
 {
     int ret;
 
-    if( ssl->handshake->early_data != MBEDTLS_SSL_EARLY_DATA_ON )
+    if( ssl->handshake->early_data != MBEDTLS_SSL_EARLY_DATA_STATE_ON )
         return( SSL_EARLY_DATA_SKIP );
 
     /* Activate early data transform */
@@ -2022,7 +2022,7 @@ static int ssl_read_early_data_parse( mbedtls_ssl_context* ssl,
     else
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "Buffer too small (recv %d bytes, buffer %d bytes)",
-                                    buflen, ssl->early_data_len ) );
+                                    buflen, ssl->early_data_server_buf ) );
         return ( MBEDTLS_ERR_SSL_ALLOC_FAILED );
     }
 
@@ -2426,7 +2426,7 @@ static int ssl_check_use_0rtt_handshake( mbedtls_ssl_context *ssl )
     }
 
     /* Accept 0-RTT */
-    ssl->handshake->early_data = MBEDTLS_SSL_EARLY_DATA_ON;
+    ssl->handshake->early_data = MBEDTLS_SSL_EARLY_DATA_STATE_ON;
     return( 0 );
 }
 #endif /* MBEDTLS_ZERO_RTT*/
@@ -3004,7 +3004,7 @@ static int ssl_client_hello_postprocess( mbedtls_ssl_context* ssl,
     }
 
 #if defined(MBEDTLS_ZERO_RTT)
-    if( ssl->handshake->early_data == MBEDTLS_SSL_EARLY_DATA_ON )
+    if( ssl->handshake->early_data == MBEDTLS_SSL_EARLY_DATA_STATE_ON )
     {
         MBEDTLS_SSL_DEBUG_MSG( 3, ( "Generate 0-RTT keys" ) );
 


### PR DESCRIPTION
This should fix https://github.com/hannestschofenig/mbedtls/issues/273

It looks the current implementation hard-coded the minor version when loading the ssl session. I think it should read the minor version field from the saved data. But I would defer that to a later PR. This small change makes it consistent with the prototype code (the statement above the change).