### PR TITLE
Reset messaging layer and key shares upon dispatch/receipt of HRR

### DIFF
--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -65,6 +65,11 @@
 #define inline __inline
 #endif
 
+#if defined(MBEDTLS_SSL_PROTO_TLS1_2) || \
+    ( defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && !defined(MBEDTLS_SSL_USE_MPS) )
+#define MBEDTLS_SSL_LEGACY_MSG_LAYER_REQUIRED
+#endif
+
 /* Legacy minor version numbers as defined by:
  * - RFC 2246: ProtocolVersion version = { 3, 1 };     // TLS v1.0
  * - RFC 4346: ProtocolVersion version = { 3, 2 };     // TLS v1.1
@@ -1359,7 +1364,7 @@ void mbedtls_ssl_add_hs_hdr_to_checksum( mbedtls_ssl_context *ssl,
                                          unsigned hs_type,
                                          size_t total_hs_len );
 
-int mbedtls_ssl_hash_transcript( mbedtls_ssl_context *ssl );
+int mbedtls_ssl_reset_transcript_for_hrr( mbedtls_ssl_context *ssl );
 
 void mbedtls_ssl_set_inbound_transform( mbedtls_ssl_context *ssl,
                                         mbedtls_ssl_transform *transform );
@@ -1766,6 +1771,7 @@ void mbedtls_ssl_update_out_pointers( mbedtls_ssl_context *ssl,
 void mbedtls_ssl_update_in_pointers( mbedtls_ssl_context *ssl );
 
 int mbedtls_ssl_session_reset_int( mbedtls_ssl_context *ssl, int partial );
+void mbedtls_ssl_session_reset_msg_layer( mbedtls_ssl_context *ssl, int partial );
 
 #if defined(MBEDTLS_SSL_DTLS_ANTI_REPLAY)
 void mbedtls_ssl_dtls_replay_reset( mbedtls_ssl_context *ssl );

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -217,6 +217,8 @@ static int ssl_write_early_data_prepare( mbedtls_ssl_context* ssl )
     const unsigned char *psk_identity;
     size_t psk_identity_len;
 
+    mbedtls_ssl_transform *transform_earlydata;
+
     /* From RFC 8446:
      * "The PSK used to encrypt the
      *  early data MUST be the first PSK listed in the client's
@@ -256,52 +258,38 @@ static int ssl_write_early_data_prepare( mbedtls_ssl_context* ssl )
         return( ret );
     }
 
-#if defined(MBEDTLS_SSL_USE_MPS)
-    {
-        mbedtls_ssl_transform *transform_earlydata =
-            mbedtls_calloc( 1, sizeof( mbedtls_ssl_transform ) );
-        if( transform_earlydata == NULL )
-            return( MBEDTLS_ERR_SSL_ALLOC_FAILED );
-
-        ret = mbedtls_ssl_tls13_populate_transform(
-                              transform_earlydata,
-                              ssl->conf->endpoint,
-                              ssl->session_negotiate->ciphersuite,
-                              &traffic_keys,
-                              ssl );
-        if( ret != 0 )
-            return( ret );
-
-        /* Register transform with MPS. */
-        ret = mbedtls_mps_add_key_material( &ssl->mps->l4,
-                                            transform_earlydata,
-                                            &ssl->epoch_earlydata );
-        if( ret != 0 )
-            return( ret );
-
-        /* Use new transform for outgoing data. */
-        ret = mbedtls_mps_set_outgoing_keys( &ssl->mps->l4,
-                                             ssl->epoch_earlydata );
-        if( ret != 0 )
-            return( ret );
-    }
-
-#else /* MBEDTLS_SSL_USE_MPS */
+    transform_earlydata =
+        mbedtls_calloc( 1, sizeof( mbedtls_ssl_transform ) );
+    if( transform_earlydata == NULL )
+        return( MBEDTLS_ERR_SSL_ALLOC_FAILED );
 
     ret = mbedtls_ssl_tls13_populate_transform(
-                              ssl->transform_earlydata,
-                              ssl->conf->endpoint,
-                              ssl->session_negotiate->ciphersuite,
-                              &traffic_keys,
-                              ssl );
+                          transform_earlydata,
+                          ssl->conf->endpoint,
+                          ssl->session_negotiate->ciphersuite,
+                          &traffic_keys,
+                          ssl );
     if( ret != 0 )
-    {
-        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_tls13_populate_transform", ret );
         return( ret );
-    }
+
+#if defined(MBEDTLS_SSL_USE_MPS)
+    /* Register transform with MPS. */
+    ret = mbedtls_mps_add_key_material( &ssl->mps->l4,
+                                        transform_earlydata,
+                                        &ssl->epoch_earlydata );
+    if( ret != 0 )
+        return( ret );
+
+    /* Use new transform for outgoing data. */
+    ret = mbedtls_mps_set_outgoing_keys( &ssl->mps->l4,
+                                         ssl->epoch_earlydata );
+    if( ret != 0 )
+        return( ret );
+#else /* MBEDTLS_SSL_USE_MPS */
 
     /* Activate transform */
     MBEDTLS_SSL_DEBUG_MSG( 1, ( "Switch to 0-RTT keys for outbound traffic" ) );
+    ssl->transform_earlydata = transform_earlydata;
     mbedtls_ssl_set_outbound_transform( ssl, ssl->transform_earlydata );
 
 #endif /* MBEDTLS_SSL_USE_MPS */
@@ -1663,7 +1651,7 @@ static int ssl_client_hello_write_partial( mbedtls_ssl_context* ssl,
 
 #if defined(MBEDTLS_SSL_MAX_FRAGMENT_LENGTH)
     if( ( ret = ssl_write_max_fragment_length_ext( ssl, buf,
-                                                   (size_t)( end - buf ), 
+                                                   (size_t)( end - buf ),
                                                    &cur_ext_len )  ) != 0 )
     {
         MBEDTLS_SSL_DEBUG_RET( 1, "ssl_write_max_fragment_length_ext", ret );
@@ -2641,9 +2629,7 @@ static int ssl_hrr_parse( mbedtls_ssl_context* ssl,
                           const unsigned char* buf,
                           size_t buflen );
 
-static int ssl_hrr_postprocess( mbedtls_ssl_context* ssl,
-                                const unsigned char* buf,
-                                size_t buflen );
+static int ssl_hrr_postprocess( mbedtls_ssl_context* ssl );
 
 /*
  * Implementation
@@ -2699,13 +2685,17 @@ static int ssl_server_hello_process( mbedtls_ssl_context* ssl )
     else
     {
         MBEDTLS_SSL_PROC_CHK( ssl_hrr_parse( ssl, buf, buflen ) );
+        MBEDTLS_SSL_PROC_CHK( mbedtls_ssl_reset_transcript_for_hrr( ssl ) );
+
+        mbedtls_ssl_add_hs_msg_to_checksum( ssl, MBEDTLS_SSL_HS_SERVER_HELLO,
+                                            buf, buflen );
 
 #if defined(MBEDTLS_SSL_USE_MPS)
         MBEDTLS_SSL_PROC_CHK( mbedtls_mps_reader_commit( msg.handle ) );
         MBEDTLS_SSL_PROC_CHK( mbedtls_mps_read_consume( &ssl->mps->l4  ) );
 #endif /* MBEDTLS_SSL_USE_MPS */
 
-        MBEDTLS_SSL_PROC_CHK( ssl_hrr_postprocess( ssl, buf, buflen ) );
+        MBEDTLS_SSL_PROC_CHK( ssl_hrr_postprocess( ssl ) );
     }
 
 
@@ -3133,6 +3123,7 @@ static int ssl_server_hello_postprocess( mbedtls_ssl_context* ssl )
 {
     int ret;
     mbedtls_ssl_key_set traffic_keys;
+    mbedtls_ssl_transform *transform_handshake;
 
     /* We need to set the key exchange algorithm based on the
      * following rules:
@@ -3193,10 +3184,13 @@ static int ssl_server_hello_postprocess( mbedtls_ssl_context* ssl )
         return( ret );
     }
 
-#if !defined(MBEDTLS_SSL_USE_MPS)
+    transform_handshake =
+        mbedtls_calloc( 1, sizeof( mbedtls_ssl_transform ) );
+    if( transform_handshake == NULL )
+        return( MBEDTLS_ERR_SSL_ALLOC_FAILED );
 
     ret = mbedtls_ssl_tls13_populate_transform(
-                              ssl->transform_handshake,
+                              transform_handshake,
                               ssl->conf->endpoint,
                               ssl->session_negotiate->ciphersuite,
                               &traffic_keys,
@@ -3207,42 +3201,24 @@ static int ssl_server_hello_postprocess( mbedtls_ssl_context* ssl )
         return( ret );
     }
 
+#if !defined(MBEDTLS_SSL_USE_MPS)
+    ssl->transform_handshake = transform_handshake;
+    mbedtls_ssl_set_inbound_transform( ssl, ssl->transform_handshake );
 #else /* MBEDTLS_SSL_USE_MPS */
+    ret = mbedtls_mps_add_key_material( &ssl->mps->l4,
+                                        transform_handshake,
+                                        &ssl->epoch_handshake );
+    if( ret != 0 )
+        return( ret );
 
-    {
-        mbedtls_ssl_transform *transform_handshake =
-            mbedtls_calloc( 1, sizeof( mbedtls_ssl_transform ) );
-        if( transform_handshake == NULL )
-            return( MBEDTLS_ERR_SSL_ALLOC_FAILED );
-
-        ret = mbedtls_ssl_tls13_populate_transform(
-                              transform_handshake,
-                              ssl->conf->endpoint,
-                              ssl->session_negotiate->ciphersuite,
-                              &traffic_keys,
-                              ssl );
-
-        /* Register transform with MPS. */
-        ret = mbedtls_mps_add_key_material( &ssl->mps->l4,
-                                            transform_handshake,
-                                            &ssl->epoch_handshake );
-        if( ret != 0 )
-            return( ret );
-    }
-#endif /* MBEDTLS_SSL_USE_MPS */
-
-    /* Switch to new keys for inbound traffic. */
-    MBEDTLS_SSL_DEBUG_MSG( 1, ( "Switch to handshake keys for inbound traffic" ) );
-    ssl->session_in = ssl->session_negotiate;
-
-#if defined(MBEDTLS_SSL_USE_MPS)
     ret = mbedtls_mps_set_incoming_keys( &ssl->mps->l4,
                                          ssl->epoch_handshake );
     if( ret != 0 )
         return( ret );
-#else
-    mbedtls_ssl_set_inbound_transform( ssl, ssl->transform_handshake );
 #endif /* MBEDTLS_SSL_USE_MPS */
+
+    MBEDTLS_SSL_DEBUG_MSG( 1, ( "Switch to handshake keys for inbound traffic" ) );
+    ssl->session_in = ssl->session_negotiate;
 
     /*
      * State machine update
@@ -3562,12 +3538,8 @@ static int ssl_hrr_parse( mbedtls_ssl_context* ssl,
     return( 0 );
 }
 
-static int ssl_hrr_postprocess( mbedtls_ssl_context* ssl,
-                                const unsigned char* orig_buf,
-                                size_t orig_msg_len )
+static int ssl_hrr_postprocess( mbedtls_ssl_context* ssl )
 {
-    int ret = 0;
-
     if( ssl->handshake->hello_retry_requests_received > 0 )
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "Multiple HRRs received" ) );
@@ -3578,17 +3550,6 @@ static int ssl_hrr_postprocess( mbedtls_ssl_context* ssl,
 
     ssl->handshake->hello_retry_requests_received++;
 
-    MBEDTLS_SSL_DEBUG_MSG( 4, ( "Compress transcript hash for stateless HRR" ) );
-    ret = mbedtls_ssl_hash_transcript( ssl );
-    if( ret != 0 )
-    {
-        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_hash_transcript", ret );
-        return( ret );
-    }
-
-    mbedtls_ssl_add_hs_msg_to_checksum( ssl, MBEDTLS_SSL_HS_SERVER_HELLO,
-                                        orig_buf, orig_msg_len );
-
 #if defined(MBEDTLS_SSL_TLS13_COMPATIBILITY_MODE)
     /* If not offering early data, the client sends a dummy CCS record
      * immediately before its second flight. This may either be before
@@ -3598,6 +3559,7 @@ static int ssl_hrr_postprocess( mbedtls_ssl_context* ssl,
     mbedtls_ssl_handshake_set_state( ssl, MBEDTLS_SSL_CLIENT_HELLO );
 #endif /* MBEDTLS_SSL_TLS13_COMPATIBILITY_MODE */
 
+    mbedtls_ssl_session_reset_msg_layer( ssl, 0 );
     return( 0 );
 }
 


### PR DESCRIPTION
Proof-of-concept. Not ready to commit yet. 

When `HRR` is received, reset the `SSL context` and restore a few states before sending the second `ClientHello`. This fix is only for `MPS` disabled case.

## Status
**IN DEVELOPMENT**

## Test
Follow the steps of https://github.com/hannestschofenig/mbedtls/issues/255.