### PR TITLE
Assign minor_ver when loading session

### DIFF
--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -6499,6 +6499,7 @@ static int ssl_session_load( mbedtls_ssl_session *session,
 #if defined(MBEDTLS_SSL_NEW_SESSION_TICKET) && defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
 
     minor_ver = MBEDTLS_SSL_MINOR_VERSION_4; /* TBD: For testing only */
+    session->minor_ver = minor_ver;
 
     if( minor_ver == MBEDTLS_SSL_MINOR_VERSION_4 )
     {


### PR DESCRIPTION
This should fix the issue in https://github.com/hannestschofenig/mbedtls/issues/273.

The line above mentioned that setting `minor_ver` is for test-only, we might want to address the issue soon. 