### PR TITLE
Review fix for  #220 certificate request parsing

### DIFF
--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -262,6 +262,9 @@
 /* Maximum amount of early data to buffer on the server. */
 #define MBEDTLS_SSL_MAX_EARLY_DATA             1024
 
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+#define MBEDTLS_SIGNATURE_SCHEMES_SIZE         20
+#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 /*
  * Check that we obey the standard's message size bounds
  */
@@ -497,7 +500,7 @@ struct mbedtls_ssl_handshake_params
      */
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
 #if defined(MBEDTLS_X509_CRT_PARSE_C)
-    int *received_signature_schemes_list;              /*!<  Received signature algorithms */
+    int received_signature_schemes_list[MBEDTLS_SIGNATURE_SCHEMES_SIZE];              /*!<  Received signature algorithms */
 #endif /* MBEDTLS_X509_CRT_PARSE_C */
     mbedtls_ecp_curve_info server_preferred_curve; /*!<  Preferred curve requested by server (obtained in HelloRetryRequest  */
 #if defined(MBEDTLS_SSL_CLI_C)

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -7162,12 +7162,6 @@ void mbedtls_ssl_handshake_free( mbedtls_ssl_context *ssl )
     }
 #endif
 
-#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
-#if defined(MBEDTLS_X509_CRT_PARSE_C)
-    mbedtls_free( handshake->received_signature_schemes_list );
-#endif /* MBEDTLS_X509_CRT_PARSE_C */
-#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
-
 #if defined(MBEDTLS_X509_CRT_PARSE_C) && \
     defined(MBEDTLS_SSL_SERVER_NAME_INDICATION)
     /*

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -2574,8 +2574,8 @@ static int ssl_certificate_request_parse( mbedtls_ssl_context* ssl,
                 if( ( ret = mbedtls_ssl_parse_signature_algorithms_ext( ssl,
                         ext + 4, (size_t) ext_size ) ) != 0 )
                 {
-                    MBEDTLS_SSL_DEBUG_MSG( 1,
-                        ( "mbedtls_ssl_parse_signature_algorithms_ext" ) );
+                    MBEDTLS_SSL_DEBUG_RET( 1,
+                        "mbedtls_ssl_parse_signature_algorithms_ext", ret );
                     SSL_PEND_FATAL_ALERT( MBEDTLS_SSL_ALERT_MSG_DECODE_ERROR,
                         ret );
                     return( ret );

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -2468,15 +2468,19 @@ static int ssl_certificate_request_parse( mbedtls_ssl_context* ssl,
                                           const unsigned char* buf,
                                           size_t buflen )
 {
-
     int ret;
     const unsigned char* p;
-    unsigned char* ext;
+    const unsigned char* ext;
     size_t ext_len = 0;
-    int context_len = 0;
+    size_t context_len = 0;
 
-    /* TODO: Add bounds checks! Only then remove the next line. */
-    ((void) buflen);
+    if( buflen < 1 )
+    {
+        MBEDTLS_SSL_DEBUG_MSG( 1, ( "bad certificate request message" ) );
+        SSL_PEND_FATAL_ALERT( MBEDTLS_SSL_ALERT_MSG_DECODE_ERROR,
+                              MBEDTLS_ERR_SSL_BAD_HS_CERTIFICATE_REQUEST );
+        return( MBEDTLS_ERR_SSL_BAD_HS_CERTIFICATE_REQUEST );
+    }
 
     /*
      * struct {
@@ -2490,7 +2494,7 @@ static int ssl_certificate_request_parse( mbedtls_ssl_context* ssl,
     /*
      * Parse certificate_request_context
      */
-    context_len = p[0];
+    context_len = (size_t) p[0];
 
     /* skip context_len */
     p++;
@@ -2502,7 +2506,7 @@ static int ssl_certificate_request_parse( mbedtls_ssl_context* ssl,
      *    3 bytes
      */
 
-    if( buflen < (size_t)( 3 + context_len ) )
+    if( buflen < (size_t) ( 3 + context_len ) )
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "bad certificate request message" ) );
         SSL_PEND_FATAL_ALERT( MBEDTLS_SSL_ALERT_MSG_DECODE_ERROR,
@@ -2513,9 +2517,11 @@ static int ssl_certificate_request_parse( mbedtls_ssl_context* ssl,
     /* store context ( if necessary ) */
     if( context_len > 0 )
     {
-        MBEDTLS_SSL_DEBUG_BUF( 3, "Certificate Request Context", p, context_len );
+        MBEDTLS_SSL_DEBUG_BUF( 3, "Certificate Request Context",
+            p, context_len );
 
-        ssl->handshake->certificate_request_context = mbedtls_calloc( context_len, 1 );
+        ssl->handshake->certificate_request_context =
+          mbedtls_calloc( context_len, 1 );
         if( ssl->handshake->certificate_request_context == NULL )
         {
             MBEDTLS_SSL_DEBUG_MSG( 1, ( "buffer too small" ) );
@@ -2530,9 +2536,10 @@ static int ssl_certificate_request_parse( mbedtls_ssl_context* ssl,
     /*
      * Parse extensions
      */
-    ext_len = ( p[0] << 8 ) | ( p[1] );
+    ext_len = ( (size_t) p[0] << 8 ) | ( (size_t) p[1] );
 
-    /* At least one extension needs to be present, namely signature_algorithms ext. */
+    /* At least one extension needs to be present,
+     * namely signature_algorithms ext. */
     if( ext_len < 4 )
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "bad certificate request message" ) );
@@ -2544,11 +2551,11 @@ static int ssl_certificate_request_parse( mbedtls_ssl_context* ssl,
     /* skip total extension length */
     p += 2;
 
-    ext = (unsigned char*) p; /* jump to extensions */
+    ext = p; /* jump to extensions */
     while( ext_len )
     {
-        unsigned int ext_id = ( ( ext[0] << 8 ) | ( ext[1] ) );
-        unsigned int ext_size = ( ( ext[2] << 8 ) | ( ext[3] ) );
+        size_t ext_id = ( ( size_t ) ext[0] << 8 ) | ( ( size_t ) ext[1] );
+        size_t ext_size = ( ( size_t ) ext[2] << 8 ) | ( ( size_t ) ext[3] );
 
         if( ext_size + 4 > ext_len )
         {
@@ -2560,21 +2567,25 @@ static int ssl_certificate_request_parse( mbedtls_ssl_context* ssl,
 
         switch( ext_id )
         {
-
             case MBEDTLS_TLS_EXT_SIG_ALG:
-                MBEDTLS_SSL_DEBUG_MSG( 3, ( "found signature_algorithms extension" ) );
+                MBEDTLS_SSL_DEBUG_MSG( 3,
+                    ( "found signature_algorithms extension" ) );
 
-                if( ( ret = mbedtls_ssl_parse_signature_algorithms_ext( ssl, ext + 4, (size_t)ext_size ) ) != 0 )
+                if( ( ret = mbedtls_ssl_parse_signature_algorithms_ext( ssl,
+                        ext + 4, (size_t) ext_size ) ) != 0 )
                 {
-                    MBEDTLS_SSL_DEBUG_MSG( 1, ( "mbedtls_ssl_parse_signature_algorithms_ext" ) );
-                    SSL_PEND_FATAL_ALERT( MBEDTLS_SSL_ALERT_MSG_DECODE_ERROR, ret );
+                    MBEDTLS_SSL_DEBUG_MSG( 1,
+                        ( "mbedtls_ssl_parse_signature_algorithms_ext" ) );
+                    SSL_PEND_FATAL_ALERT( MBEDTLS_SSL_ALERT_MSG_DECODE_ERROR,
+                        ret );
                     return( ret );
                 }
                 break;
 
             default:
-                MBEDTLS_SSL_DEBUG_MSG( 3, ( "unknown extension found: %d ( ignoring )",
-                                            ext_id ) );
+                MBEDTLS_SSL_DEBUG_MSG( 3,
+                    ( "unknown extension found: %d ( ignoring )", ext_id ) );
+                break;
         }
 
         ext_len -= 4 + ext_size;

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -410,7 +410,7 @@ int mbedtls_ssl_parse_signature_algorithms_ext( mbedtls_ssl_context *ssl,
     const int *md_cur; /* iterate through configured signature schemes */
     int signature_scheme; /* store received signature algorithm scheme */
     size_t num_supported_hashes = 0;
-    uint32_t i = 0; /* iterate through received_signature_schemes_list */
+    uint32_t common_idx = 0; /* iterate through received_signature_schemes_list */
 
     if( buf_len < 2 )
     {
@@ -444,11 +444,11 @@ int mbedtls_ssl_parse_signature_algorithms_ext( mbedtls_ssl_context *ssl,
     if( ssl->handshake->received_signature_schemes_list == NULL )
     {
         MBEDTLS_SSL_DEBUG_MSG( 1,
-            ( "malloc failed in mbedtls_ssl_parse_signature_algorithms_ext( )" ) );
+            ( "mbedtls_calloc failed in mbedtls_ssl_parse_signature_algorithms_ext( )" ) );
         return( MBEDTLS_ERR_SSL_ALLOC_FAILED );
     }
 
-    for( p = buf + 2; p < end && i < num_supported_hashes; p += 2 )
+    for( p = buf + 2; p < end && common_idx < num_supported_hashes; p += 2 )
     {
         signature_scheme = ( (int) p[0] << 8 ) | ( ( int ) p[1] );
 
@@ -458,13 +458,13 @@ int mbedtls_ssl_parse_signature_algorithms_ext( mbedtls_ssl_context *ssl,
         {
             if( *md_cur == signature_scheme )
             {
-                ssl->handshake->received_signature_schemes_list[i] = signature_scheme;
-                i++;
+                ssl->handshake->received_signature_schemes_list[common_idx] = signature_scheme;
+                common_idx++;
             }
         }
     }
 
-    if( i == 0 )
+    if( common_idx == 0 )
     {
         MBEDTLS_SSL_DEBUG_MSG( 3, ( "no signature algorithm in common" ) );
         mbedtls_free( ssl->handshake->received_signature_schemes_list );
@@ -472,7 +472,7 @@ int mbedtls_ssl_parse_signature_algorithms_ext( mbedtls_ssl_context *ssl,
         return( MBEDTLS_ERR_SSL_NO_USABLE_CIPHERSUITE );
     }
 
-    ssl->handshake->received_signature_schemes_list[i] = SIGNATURE_NONE;
+    ssl->handshake->received_signature_schemes_list[common_idx] = SIGNATURE_NONE;
 
     return( 0 );
 }


### PR DESCRIPTION
#220. Review of the following functions:
* ssl_certificate_request_parse
* mbedtls_ssl_parse_signature_algorithms_ext