### PR TITLE
Some small refactor and style fixes for 0-RTT code

### DIFF
--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -1523,10 +1523,11 @@ static inline int mbedtls_ssl_get_psk( const mbedtls_ssl_context *ssl,
     return( 0 );
 }
 
-/* Check if we have any PSK to offer, and if so, return the first. */
+/* Check if we have any PSK to offer, returns 0 if PSK is available. Assign the
+   psk and ticket if pointers are present.  */
 static inline int mbedtls_ssl_get_psk_to_offer( const mbedtls_ssl_context *ssl,
-                     const unsigned char **psk, size_t *psk_len,
-                     const unsigned char **psk_identity, size_t *psk_identity_len )
+    const unsigned char **psk, size_t *psk_len,
+    const unsigned char **psk_identity, size_t *psk_identity_len )
 {
     int ptrs_present = 0;
 
@@ -1536,7 +1537,7 @@ static inline int mbedtls_ssl_get_psk_to_offer( const mbedtls_ssl_context *ssl,
         ptrs_present = 1;
     }
 
-    /* Check if a ticket has been configuredd. */
+    /* Check if a ticket has been configured. */
     if( ssl->session_negotiate != NULL         &&
         ssl->session_negotiate->ticket != NULL )
     {

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -5196,7 +5196,9 @@ int mbedtls_ssl_set_hs_psk( mbedtls_ssl_context *ssl,
 
     if( psk_len > MBEDTLS_PSK_MAX_LEN )
     {
-        MBEDTLS_SSL_DEBUG_MSG( 1, ( "PSK length has exceeded MBEDTLS_PSK_MAX_LEN" ) );
+        MBEDTLS_SSL_DEBUG_MSG( 1, 
+            ( "PSK length has exceeded MBEDTLS_PSK_MAX_LEN (%u)",
+              (unsigned) MBEDTLS_PSK_MAX_LEN ) );
         return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
     }
 

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -5195,7 +5195,10 @@ int mbedtls_ssl_set_hs_psk( mbedtls_ssl_context *ssl,
         return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
 
     if( psk_len > MBEDTLS_PSK_MAX_LEN )
+    {
+        MBEDTLS_SSL_DEBUG_MSG( 1, ( "PSK length has exceeded MBEDTLS_PSK_MAX_LEN" ) );
         return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
+    }
 
     mbedtls_ssl_remove_hs_psk( ssl );
 

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -2801,7 +2801,7 @@ static int ssl_encrypted_extensions_parse( mbedtls_ssl_context* ssl,
 
 #if defined(MBEDTLS_ZERO_RTT)
             case MBEDTLS_TLS_EXT_EARLY_DATA:
-                MBEDTLS_SSL_DEBUG_MSG(3, ( "found early data extension" ));
+                MBEDTLS_SSL_DEBUG_MSG(3, ( "found early_data extension" ));
 
                 ret = ssl_parse_encrypted_extensions_early_data_ext(
                     ssl, ext + 4, ext_size );

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -211,10 +211,10 @@ static int ssl_write_early_data_prepare( mbedtls_ssl_context* ssl )
     int ret;
     mbedtls_ssl_key_set traffic_keys;
 
-    unsigned char const *psk_identity;
-    size_t psk_identity_len;
-    unsigned char const *psk;
+    const unsigned char *psk;
     size_t psk_len;
+    const unsigned char *psk_identity;
+    size_t psk_identity_len;
 
     /* From RFC 8446:
      * "The PSK used to encrypt the
@@ -829,10 +829,10 @@ int mbedtls_ssl_write_pre_shared_key_ext( mbedtls_ssl_context *ssl,
     const mbedtls_ssl_ciphersuite_t *suite_info;
     const int *ciphersuites;
     int hash_len;
-    unsigned char const *psk_identity;
-    size_t psk_identity_len;
-    unsigned char const *psk;
+    const unsigned char *psk;
     size_t psk_len;
+    const unsigned char *psk_identity;
+    size_t psk_identity_len;
 
     *total_ext_len = 0;
     *bytes_written = 0;
@@ -1987,10 +1987,11 @@ static int ssl_parse_server_psk_identity_ext( mbedtls_ssl_context *ssl,
     int ret = 0;
     size_t selected_identity;
 
-    unsigned char const *psk_identity;
-    size_t psk_identity_len;
-    unsigned char const *psk;
+    const unsigned char *psk;
     size_t psk_len;
+    const unsigned char *psk_identity;
+    size_t psk_identity_len;
+
 
     /* Check which PSK we've offered.
      *

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -268,6 +268,8 @@ static int ssl_write_early_data_prepare( mbedtls_ssl_context* ssl )
                               ssl->session_negotiate->ciphersuite,
                               &traffic_keys,
                               ssl );
+        if( ret != 0 )
+            return( ret );
 
         /* Register transform with MPS. */
         ret = mbedtls_mps_add_key_material( &ssl->mps.l4,
@@ -320,14 +322,14 @@ static int ssl_write_early_data_write( mbedtls_ssl_context* ssl,
     {
         memcpy( buf, ssl->early_data_buf, ssl->early_data_len );
 
-#if !defined(MBEDTLS_SSL_USE_MPS)
+#if defined(MBEDTLS_SSL_USE_MPS)
+        *olen = ssl->early_data_len;
+        MBEDTLS_SSL_DEBUG_BUF( 3, "Early Data", buf, ssl->early_data_len );
+#else
         buf[ssl->early_data_len] = MBEDTLS_SSL_MSG_APPLICATION_DATA;
         *olen = ssl->early_data_len + 1;
 
         MBEDTLS_SSL_DEBUG_BUF( 3, "Early Data", ssl->out_msg, *olen );
-#else
-        *olen = ssl->early_data_len;
-        MBEDTLS_SSL_DEBUG_BUF( 3, "Early Data", buf, ssl->early_data_len );
 #endif /* MBEDTLS_SSL_USE_MPS */
     }
 

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -3102,7 +3102,8 @@ int mbedtls_ssl_write_early_data_ext( mbedtls_ssl_context *ssl,
         if( ( ssl->handshake->extensions_present & EARLY_DATA_EXTENSION ) == 0 )
             return( 0 );
 
-        if( ssl->conf->key_exchange_modes != MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_KE ||
+        if( ssl->conf->key_exchange_modes != 
+                   MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_KE ||
             ssl->conf->early_data_enabled == MBEDTLS_SSL_EARLY_DATA_DISABLED )
         {
             MBEDTLS_SSL_DEBUG_MSG( 2, ( "<= skip write early_data extension" ) );

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -3105,7 +3105,7 @@ int mbedtls_ssl_write_early_data_ext( mbedtls_ssl_context *ssl,
         if( ssl->conf->key_exchange_modes != MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_KE ||
             ssl->conf->early_data_enabled == MBEDTLS_SSL_EARLY_DATA_DISABLED )
         {
-            MBEDTLS_SSL_DEBUG_MSG( 2, ( "skip write early_data extension" ) );
+            MBEDTLS_SSL_DEBUG_MSG( 2, ( "<= skip write early_data extension" ) );
             ssl->handshake->early_data = MBEDTLS_SSL_EARLY_DATA_OFF;
             return( 0 );
         }

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -3082,6 +3082,20 @@ int mbedtls_ssl_write_early_data_ext( mbedtls_ssl_context *ssl,
 
     *olen = 0;
 
+#if defined(MBEDTLS_SSL_CLI_C)
+    if( ssl->conf->endpoint == MBEDTLS_SSL_IS_CLIENT )
+    {
+        if( !mbedtls_ssl_conf_tls13_some_psk_enabled( ssl ) ||
+            mbedtls_ssl_get_psk_to_offer( ssl, NULL, NULL, NULL, NULL ) != 0 ||
+            ssl->conf->early_data_enabled == MBEDTLS_SSL_EARLY_DATA_DISABLED )
+        {
+            MBEDTLS_SSL_DEBUG_MSG( 2, ( "<= skip write early_data extension" ) );
+            ssl->handshake->early_data = MBEDTLS_SSL_EARLY_DATA_OFF;
+            return( 0 );
+        }
+    }
+#endif /* MBEDTLS_SSL_CLI_C */
+
 #if defined(MBEDTLS_SSL_SRV_C)
     if( ssl->conf->endpoint == MBEDTLS_SSL_IS_SERVER )
     {
@@ -3097,20 +3111,6 @@ int mbedtls_ssl_write_early_data_ext( mbedtls_ssl_context *ssl,
         }
     }
 #endif /* MBEDTLS_SSL_SRV_C */
-
-#if defined(MBEDTLS_SSL_CLI_C)
-    if( ssl->conf->endpoint == MBEDTLS_SSL_IS_CLIENT )
-    {
-        if( !mbedtls_ssl_conf_tls13_some_psk_enabled( ssl ) ||
-            mbedtls_ssl_get_psk_to_offer( ssl, NULL, NULL, NULL, NULL ) != 0 ||
-            ssl->conf->early_data_enabled == MBEDTLS_SSL_EARLY_DATA_DISABLED )
-        {
-            MBEDTLS_SSL_DEBUG_MSG( 2, ( "<= skip write early_data extension" ) );
-            ssl->handshake->early_data = MBEDTLS_SSL_EARLY_DATA_OFF;
-            return( 0 );
-        }
-    }
-#endif /* MBEDTLS_SSL_CLI_C */
 
     if( buflen < 4 )
     {

--- a/library/ssl_tls13_keys.c
+++ b/library/ssl_tls13_keys.c
@@ -299,7 +299,7 @@ int mbedtls_ssl_tls1_3_evolve_secret(
                    const unsigned char *input, size_t input_len,
                    unsigned char *secret_new )
 {
-    int ret = MBEDTLS_ERR_SSL_INTERNAL_ERROR;
+    int ret = 0;
     size_t hlen, ilen;
     unsigned char tmp_secret[ MBEDTLS_MD_MAX_SIZE ] = { 0 };
     unsigned char tmp_input [ MBEDTLS_SSL_TLS1_3_MAX_IKM_SIZE ] = { 0 };
@@ -314,17 +314,14 @@ int mbedtls_ssl_tls1_3_evolve_secret(
     /* For non-initial runs, call Derive-Secret( ., "derived", "")
      * on the old secret. */
     if( secret_old != NULL )
-    {
-        ret = mbedtls_ssl_tls1_3_derive_secret(
-                   hash_alg,
-                   secret_old, hlen,
-                   MBEDTLS_SSL_TLS1_3_LBL_WITH_LEN( derived ),
-                   NULL, 0, /* context */
-                   MBEDTLS_SSL_TLS1_3_CONTEXT_UNHASHED,
-                   tmp_secret, hlen );
-        if( ret != 0 )
-            goto cleanup;
-    }
+        MBEDTLS_SSL_PROC_CHK(
+            mbedtls_ssl_tls1_3_derive_secret(
+                hash_alg,
+                secret_old, hlen,
+                MBEDTLS_SSL_TLS1_3_LBL_WITH_LEN( derived ),
+                NULL, 0, /* context */
+                MBEDTLS_SSL_TLS1_3_CONTEXT_UNHASHED,
+                tmp_secret, hlen ) );
 
     if( input != NULL )
     {
@@ -339,14 +336,10 @@ int mbedtls_ssl_tls1_3_evolve_secret(
     /* HKDF-Extract takes a salt and input key material.
      * The salt is the old secret, and the input key material
      * is the input secret (PSK / ECDHE). */
-    ret = mbedtls_hkdf_extract( md,
-                    tmp_secret, hlen,
-                    tmp_input, ilen,
-                    secret_new );
-    if( ret != 0 )
-        goto cleanup;
-
-    ret = 0;
+    MBEDTLS_SSL_PROC_CHK( mbedtls_hkdf_extract( md,
+        tmp_secret, hlen,
+        tmp_input, ilen,
+        secret_new ) );
 
  cleanup:
 

--- a/library/ssl_tls13_keys.c
+++ b/library/ssl_tls13_keys.c
@@ -314,6 +314,7 @@ int mbedtls_ssl_tls1_3_evolve_secret(
     /* For non-initial runs, call Derive-Secret( ., "derived", "")
      * on the old secret. */
     if( secret_old != NULL )
+    {
         MBEDTLS_SSL_PROC_CHK(
             mbedtls_ssl_tls1_3_derive_secret(
                 hash_alg,
@@ -322,6 +323,7 @@ int mbedtls_ssl_tls1_3_evolve_secret(
                 NULL, 0, /* context */
                 MBEDTLS_SSL_TLS1_3_CONTEXT_UNHASHED,
                 tmp_secret, hlen ) );
+    }
 
     if( input != NULL )
     {

--- a/library/ssl_tls13_keys.c
+++ b/library/ssl_tls13_keys.c
@@ -299,7 +299,7 @@ int mbedtls_ssl_tls1_3_evolve_secret(
                    const unsigned char *input, size_t input_len,
                    unsigned char *secret_new )
 {
-    int ret = 0;
+    int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     size_t hlen, ilen;
     unsigned char tmp_secret[ MBEDTLS_MD_MAX_SIZE ] = { 0 };
     unsigned char tmp_input [ MBEDTLS_SSL_TLS1_3_MAX_IKM_SIZE ] = { 0 };
@@ -342,6 +342,8 @@ int mbedtls_ssl_tls1_3_evolve_secret(
         tmp_secret, hlen,
         tmp_input, ilen,
         secret_new ) );
+
+    ret = 0;
 
  cleanup:
 

--- a/library/ssl_tls13_keys.c
+++ b/library/ssl_tls13_keys.c
@@ -299,7 +299,7 @@ int mbedtls_ssl_tls1_3_evolve_secret(
                    const unsigned char *input, size_t input_len,
                    unsigned char *secret_new )
 {
-    int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
+    int ret = MBEDTLS_ERR_SSL_INTERNAL_ERROR;
     size_t hlen, ilen;
     unsigned char tmp_secret[ MBEDTLS_MD_MAX_SIZE ] = { 0 };
     unsigned char tmp_input [ MBEDTLS_SSL_TLS1_3_MAX_IKM_SIZE ] = { 0 };


### PR DESCRIPTION
Some small fixes (typos, spaces, etc).

Change `char const` to `const char` so it is consistent in both the header and the implementation.

Also use `MBEDTLS_SSL_PROC_CHK` to replace a block of code.

Change the order of code blocks so it is consistent within the function.

Use the phrase 'early_data extension' in debug logs consistently.