### PR TITLE
Swap two statements in sending end-of-early-data

### DIFF
--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -419,11 +419,11 @@ int ssl_write_end_of_early_data_process( mbedtls_ssl_context* ssl )
         ssl->out_msg[0]  = MBEDTLS_SSL_HS_END_OF_EARLY_DATA;
         ssl->out_msglen  = 4;
 
-        /* Update state */
-        MBEDTLS_SSL_PROC_CHK( ssl_write_end_of_early_data_postprocess( ssl ) );
-
         /* Dispatch message */
         MBEDTLS_SSL_PROC_CHK( mbedtls_ssl_write_handshake_msg( ssl ) );
+
+        /* Update state */
+        MBEDTLS_SSL_PROC_CHK( ssl_write_end_of_early_data_postprocess( ssl ) );
 
 #endif /* MBEDTLS_SSL_USE_MPS */
 


### PR DESCRIPTION
Not sure if this is a typo. But it looks like we should call `post_process` after sending end_of_early_data.