### PR TITLE
fix namespace of extensions in ssl.h

### DIFF
--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -167,19 +167,19 @@
 #define MBEDTLS_ERR_LAST 0x7F80 /**< This definition points to the last error code to have a correct parsing in error.c */
 
  /* List of extensions used in ssl_internal.h / extensions_present in mbedtls_ssl_handshake_params */
-#define NO_EXTENSION 0
-#define PRE_SHARED_KEY_EXTENSION 1
-#define KEY_SHARE_EXTENSION 2
-#define SIGNATURE_ALGORITHM_EXTENSION 4
-#define SUPPORTED_GROUPS_EXTENSION 8
-#define MAX_FRAGMENT_LENGTH_EXTENSION 16
-#define ALPN_EXTENSION 32
-#define SUPPORTED_VERSION_EXTENSION 64
-#define PSK_KEY_EXCHANGE_MODES_EXTENSION 128
-#define EARLY_DATA_EXTENSION 256
-#define SERVERNAME_EXTENSION 512
-#define COOKIE_EXTENSION 1024
-#define CID_EXTENSION 2048
+#define MBEDTLS_SSL_EXT_NONE                      0
+#define MBEDTLS_SSL_EXT_PRE_SHARED_KEY            1
+#define MBEDTLS_SSL_EXT_KEY_SHARE                 2
+#define MBEDTLS_SSL_EXT_SIGNATURE_ALGORITHM       4
+#define MBEDTLS_SSL_EXT_SUPPORTED_GROUPS          8
+#define MBEDTLS_SSL_EXT_MAX_FRAGMENT_LENGTH       16
+#define MBEDTLS_SSL_EXT_ALPN                      32
+#define MBEDTLS_SSL_EXT_SUPPORTED_VERSION         64
+#define MBEDTLS_SSL_EXT_PSK_KEY_EXCHANGE_MODES    128
+#define MBEDTLS_SSL_EXT_EARLY_DATA                256
+#define MBEDTLS_SSL_EXT_SERVERNAME                512
+#define MBEDTLS_SSL_EXT_COOKIE                    1024
+#define MBEDTLS_SSL_EXT_CID                       2048
 
 
 /*

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -780,7 +780,7 @@ static int ssl_write_psk_key_exchange_modes_ext( mbedtls_ssl_context *ssl,
     buf[4] = num_modes;
 
     *olen = p - buf;
-    ssl->handshake->extensions_present |= PSK_KEY_EXCHANGE_MODES_EXTENSION;
+    ssl->handshake->extensions_present |= MBEDTLS_SSL_EXT_PSK_KEY_EXCHANGE_MODES;
     return ( 0 );
 }
 #endif /* MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED */
@@ -998,7 +998,7 @@ int mbedtls_ssl_write_pre_shared_key_ext( mbedtls_ssl_context *ssl,
         *bytes_written = ext_len_total - psk_binder_list_bytes;
         *total_ext_len = ext_len_total;
 
-        ssl->handshake->extensions_present |= PRE_SHARED_KEY_EXTENSION;
+        ssl->handshake->extensions_present |= MBEDTLS_SSL_EXT_PRE_SHARED_KEY;
     }
     else if( part == SSL_WRITE_PSK_EXT_ADD_PSK_BINDERS )
     {
@@ -1193,7 +1193,7 @@ static int ssl_write_supported_groups_ext( mbedtls_ssl_context *ssl,
 
     *olen = 6 + elliptic_curve_len;
 
-    ssl->handshake->extensions_present |= SUPPORTED_GROUPS_EXTENSION;
+    ssl->handshake->extensions_present |= MBEDTLS_SSL_EXT_SUPPORTED_GROUPS;
     return( 0 );
 }
 #endif /* defined(MBEDTLS_ECDH_C) */
@@ -1361,7 +1361,7 @@ static int ssl_write_key_shares_ext( mbedtls_ssl_context *ssl,
 
     *olen += 4; /* 4 bytes for fixed header */
 
-    ssl->handshake->extensions_present |= KEY_SHARE_EXTENSION;
+    ssl->handshake->extensions_present |= MBEDTLS_SSL_EXT_KEY_SHARE;
     return( 0 );
 }
 
@@ -1605,7 +1605,7 @@ static int ssl_client_hello_write_partial( mbedtls_ssl_context* ssl,
     size_t ciphersuite_count;
 
     /* Keeping track of the included extensions */
-    ssl->handshake->extensions_present = NO_EXTENSION;
+    ssl->handshake->extensions_present = MBEDTLS_SSL_EXT_NONE;
 
     rand_bytes_len = 32;
 
@@ -2046,7 +2046,7 @@ static int ssl_parse_server_psk_identity_ext( mbedtls_ssl_context *ssl,
         return( ret );
     }
 
-    ssl->handshake->extensions_present |= PRE_SHARED_KEY_EXTENSION;
+    ssl->handshake->extensions_present |= MBEDTLS_SSL_EXT_PRE_SHARED_KEY;
     return( 0 );
 }
 
@@ -2206,7 +2206,7 @@ static int ssl_parse_key_shares_ext( mbedtls_ssl_context *ssl,
         return( MBEDTLS_ERR_SSL_BAD_HS_SERVER_KEY_EXCHANGE );
     }
 
-    ssl->handshake->extensions_present |= KEY_SHARE_EXTENSION;
+    ssl->handshake->extensions_present |= MBEDTLS_SSL_EXT_KEY_SHARE;
     return( ret );
 }
 #endif /* MBEDTLS_ECDH_C || MBEDTLS_ECDSA_C */
@@ -3396,14 +3396,14 @@ static int ssl_server_hello_postprocess( mbedtls_ssl_context* ssl )
      *   ELSE unknown key exchange mechanism.
      */
 
-    if( ssl->handshake->extensions_present & PRE_SHARED_KEY_EXTENSION )
+    if( ssl->handshake->extensions_present & MBEDTLS_SSL_EXT_PRE_SHARED_KEY )
     {
-        if( ssl->handshake->extensions_present & KEY_SHARE_EXTENSION )
+        if( ssl->handshake->extensions_present & MBEDTLS_SSL_EXT_KEY_SHARE )
             ssl->session_negotiate->key_exchange = MBEDTLS_KEY_EXCHANGE_ECDHE_PSK;
         else
             ssl->session_negotiate->key_exchange = MBEDTLS_KEY_EXCHANGE_PSK;
     }
-    else if( ssl->handshake->extensions_present & KEY_SHARE_EXTENSION )
+    else if( ssl->handshake->extensions_present & MBEDTLS_SSL_EXT_KEY_SHARE )
         ssl->session_negotiate->key_exchange = MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA;
     else
     {
@@ -4010,7 +4010,7 @@ int mbedtls_ssl_handshake_client_step( mbedtls_ssl_context *ssl )
              *
              * Reset extensions we have seen so far.
              */
-            ssl->handshake->extensions_present = NO_EXTENSION;
+            ssl->handshake->extensions_present = MBEDTLS_SSL_EXT_NONE;
             ret = ssl_server_hello_process( ssl );
 
             if( ret != 0 )
@@ -4081,7 +4081,7 @@ int mbedtls_ssl_handshake_client_step( mbedtls_ssl_context *ssl )
              * message and not the HRR anymore.
              */
             /* reset extensions we have seen so far */
-            ssl->handshake->extensions_present = NO_EXTENSION;
+            ssl->handshake->extensions_present = MBEDTLS_SSL_EXT_NONE;
             ret = ssl_server_hello_process( ssl );
 
             if( ret != 0 )

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -396,7 +396,7 @@ int mbedtls_ssl_write_signature_algorithms_ext( mbedtls_ssl_context *ssl,
 
     *olen = 6 + sig_alg_len;
 
-    ssl->handshake->extensions_present |= SIGNATURE_ALGORITHM_EXTENSION;
+    ssl->handshake->extensions_present |= MBEDTLS_SSL_EXT_SIGNATURE_ALGORITHM;
     return( 0 );
 }
 
@@ -3099,7 +3099,7 @@ int mbedtls_ssl_write_early_data_ext( mbedtls_ssl_context *ssl,
 #if defined(MBEDTLS_SSL_SRV_C)
     if( ssl->conf->endpoint == MBEDTLS_SSL_IS_SERVER )
     {
-        if( ( ssl->handshake->extensions_present & EARLY_DATA_EXTENSION ) == 0 )
+        if( ( ssl->handshake->extensions_present & MBEDTLS_SSL_EXT_EARLY_DATA ) == 0 )
             return( 0 );
 
         if( ssl->conf->key_exchange_modes != 

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -73,7 +73,7 @@ static int ssl_write_sni_server_ext(
     unsigned char *p = buf;
     *olen = 0;
 
-    if( ( ssl->handshake->extensions_present & SERVERNAME_EXTENSION ) == 0 )
+    if( ( ssl->handshake->extensions_present & MBEDTLS_SSL_EXT_SERVERNAME ) == 0 )
     {
         return( 0 );
     }
@@ -2275,54 +2275,54 @@ static void ssl_debug_print_client_hello_exts( mbedtls_ssl_context *ssl )
 {
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "Supported Extensions:" ) );
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "- KEY_SHARE_EXTENSION ( %s )",
-                                ( ( ssl->handshake->extensions_present & KEY_SHARE_EXTENSION ) > 0 ) ?
+                                ( ( ssl->handshake->extensions_present & MBEDTLS_SSL_EXT_KEY_SHARE ) > 0 ) ?
                                 "TRUE" : "FALSE" ) );
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "- PSK_KEY_EXCHANGE_MODES_EXTENSION ( %s )",
-                                ( ( ssl->handshake->extensions_present & PSK_KEY_EXCHANGE_MODES_EXTENSION ) > 0 ) ?
+                                ( ( ssl->handshake->extensions_present & MBEDTLS_SSL_EXT_PSK_KEY_EXCHANGE_MODES ) > 0 ) ?
                                 "TRUE" : "FALSE" ) );
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "- PRE_SHARED_KEY_EXTENSION ( %s )",
-                                ( ( ssl->handshake->extensions_present & PRE_SHARED_KEY_EXTENSION ) > 0 ) ?
+                                ( ( ssl->handshake->extensions_present & MBEDTLS_SSL_EXT_PRE_SHARED_KEY ) > 0 ) ?
                                 "TRUE" : "FALSE" ) );
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "- SIGNATURE_ALGORITHM_EXTENSION ( %s )",
-                                ( ( ssl->handshake->extensions_present & SIGNATURE_ALGORITHM_EXTENSION ) > 0 ) ?
+                                ( ( ssl->handshake->extensions_present & MBEDTLS_SSL_EXT_SIGNATURE_ALGORITHM ) > 0 ) ?
                                 "TRUE" : "FALSE" ) );
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "- SUPPORTED_GROUPS_EXTENSION ( %s )",
-                                ( ( ssl->handshake->extensions_present & SUPPORTED_GROUPS_EXTENSION ) >0 ) ?
+                                ( ( ssl->handshake->extensions_present & MBEDTLS_SSL_EXT_SUPPORTED_GROUPS ) >0 ) ?
                                 "TRUE" : "FALSE" ) );
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "- SUPPORTED_VERSION_EXTENSION ( %s )",
-                                ( ( ssl->handshake->extensions_present & SUPPORTED_VERSION_EXTENSION ) > 0 ) ?
+                                ( ( ssl->handshake->extensions_present & MBEDTLS_SSL_EXT_SUPPORTED_VERSION ) > 0 ) ?
                                 "TRUE" : "FALSE" ) );
 #if defined ( MBEDTLS_SSL_SERVER_NAME_INDICATION )
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "- SERVERNAME_EXTENSION    ( %s )",
-                                ( ( ssl->handshake->extensions_present & SERVERNAME_EXTENSION ) > 0 ) ?
+                                ( ( ssl->handshake->extensions_present & MBEDTLS_SSL_EXT_SERVERNAME ) > 0 ) ?
                                 "TRUE" : "FALSE" ) );
 #endif /* MBEDTLS_SSL_SERVER_NAME_INDICATION */
 #if defined ( MBEDTLS_SSL_ALPN )
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "- ALPN_EXTENSION   ( %s )",
-                                ( ( ssl->handshake->extensions_present & ALPN_EXTENSION ) > 0 ) ?
+                                ( ( ssl->handshake->extensions_present & MBEDTLS_SSL_EXT_ALPN ) > 0 ) ?
                                 "TRUE" : "FALSE" ) );
 #endif /* MBEDTLS_SSL_ALPN */
 #if defined ( MBEDTLS_SSL_MAX_FRAGMENT_LENGTH )
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "- MAX_FRAGMENT_LENGTH_EXTENSION  ( %s )",
-                                ( ( ssl->handshake->extensions_present & MAX_FRAGMENT_LENGTH_EXTENSION ) > 0 ) ?
+                                ( ( ssl->handshake->extensions_present & MBEDTLS_SSL_EXT_MAX_FRAGMENT_LENGTH ) > 0 ) ?
                                 "TRUE" : "FALSE" ) );
 #endif /* MBEDTLS_SSL_MAX_FRAGMENT_LENGTH */
 #if defined ( MBEDTLS_SSL_COOKIE_C )
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "- COOKIE_EXTENSION ( %s )",
-                                ( ( ssl->handshake->extensions_present & COOKIE_EXTENSION ) >0 ) ?
+                                ( ( ssl->handshake->extensions_present & MBEDTLS_SSL_EXT_COOKIE ) >0 ) ?
                                 "TRUE" : "FALSE" ) );
 #endif /* MBEDTLS_SSL_COOKIE_C */
 #if defined(MBEDTLS_ZERO_RTT)
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "- EARLY_DATA_EXTENSION ( %s )",
-                                ( ( ssl->handshake->extensions_present & EARLY_DATA_EXTENSION ) > 0 ) ?
+                                ( ( ssl->handshake->extensions_present & MBEDTLS_SSL_EXT_EARLY_DATA ) > 0 ) ?
                                 "TRUE" : "FALSE" ) );
 #endif /* MBEDTLS_ZERO_RTT*/
 }
 
 static int ssl_client_hello_has_psk_extensions( mbedtls_ssl_context *ssl )
 {
-    if( ( ssl->handshake->extensions_present & PRE_SHARED_KEY_EXTENSION ) &&
-        ( ssl->handshake->extensions_present & PSK_KEY_EXCHANGE_MODES_EXTENSION ) )
+    if( ( ssl->handshake->extensions_present & MBEDTLS_SSL_EXT_PRE_SHARED_KEY ) &&
+        ( ssl->handshake->extensions_present & MBEDTLS_SSL_EXT_PSK_KEY_EXCHANGE_MODES ) )
     {
         return( 1 );
     }
@@ -2332,9 +2332,9 @@ static int ssl_client_hello_has_psk_extensions( mbedtls_ssl_context *ssl )
 
 static int ssl_client_hello_has_cert_extensions( mbedtls_ssl_context *ssl )
 {
-    if( ( ssl->handshake->extensions_present & SUPPORTED_GROUPS_EXTENSION )    &&
-        ( ssl->handshake->extensions_present & SIGNATURE_ALGORITHM_EXTENSION ) &&
-        ( ssl->handshake->extensions_present & KEY_SHARE_EXTENSION ) )
+    if( ( ssl->handshake->extensions_present & MBEDTLS_SSL_EXT_SUPPORTED_GROUPS )    &&
+        ( ssl->handshake->extensions_present & MBEDTLS_SSL_EXT_SIGNATURE_ALGORITHM ) &&
+        ( ssl->handshake->extensions_present & MBEDTLS_SSL_EXT_KEY_SHARE ) )
     {
         return( 1 );
     }
@@ -2412,7 +2412,7 @@ static int ssl_check_use_0rtt_handshake( mbedtls_ssl_context *ssl )
         return( 0 );
 
     /* Check if the client has indicated the use of 0-RTT */
-    if( ( ssl->handshake->extensions_present & EARLY_DATA_EXTENSION ) == 0 )
+    if( ( ssl->handshake->extensions_present & MBEDTLS_SSL_EXT_EARLY_DATA ) == 0 )
         return( 0 );
 
     /* If the client has indicated the use of 0-RTT but not sent
@@ -2448,7 +2448,7 @@ static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
     const int* ciphersuites;
     const mbedtls_ssl_ciphersuite_t* ciphersuite_info;
 
-    ssl->handshake->extensions_present = NO_EXTENSION;
+    ssl->handshake->extensions_present = MBEDTLS_SSL_EXT_NONE;
     ssl->session_negotiate->key_exchange = MBEDTLS_KEY_EXCHANGE_NONE;
 
     /* TBD: Refactor */
@@ -2635,7 +2635,7 @@ static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
                     MBEDTLS_SSL_DEBUG_RET( 1, "ssl_parse_servername_ext", ret );
                     return( MBEDTLS_ERR_SSL_BAD_HS_SERVERNAME_EXT );
                 }
-                ssl->handshake->extensions_present |= SERVERNAME_EXTENSION;
+                ssl->handshake->extensions_present |= MBEDTLS_SSL_EXT_SERVERNAME;
                 break;
 #endif /* MBEDTLS_SSL_SERVER_NAME_INDICATION */
 
@@ -2652,7 +2652,7 @@ static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
                 }
                 else if( ret == 0 ) /* cookie extension present and processed succesfully */
                 {
-                    ssl->handshake->extensions_present |= COOKIE_EXTENSION;
+                    ssl->handshake->extensions_present |= MBEDTLS_SSL_EXT_COOKIE;
                 }
                 break;
 #endif /* MBEDTLS_SSL_COOKIE_C  */
@@ -2667,7 +2667,7 @@ static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
                 ext_len_psk_ext = ext_size;
                 ext_psk_ptr = ext + 4;
 
-                ssl->handshake->extensions_present |= PRE_SHARED_KEY_EXTENSION;
+                ssl->handshake->extensions_present |= MBEDTLS_SSL_EXT_PRE_SHARED_KEY;
                 break;
 #endif /* MBEDTLS_KEY_EXCHANGE_PSK_ENABLED */
 
@@ -2683,7 +2683,7 @@ static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
                    return( MBEDTLS_ERR_SSL_BAD_HS_SUPPORTED_GROUPS );
                    }
                 */
-                ssl->handshake->extensions_present |= EARLY_DATA_EXTENSION;
+                ssl->handshake->extensions_present |= MBEDTLS_SSL_EXT_EARLY_DATA;
                 break;
 #endif /* MBEDTLS_ZERO_RTT */
 
@@ -2705,7 +2705,7 @@ static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
                     return( MBEDTLS_ERR_SSL_BAD_HS_SUPPORTED_GROUPS );
                 }
 
-                ssl->handshake->extensions_present |= SUPPORTED_GROUPS_EXTENSION;
+                ssl->handshake->extensions_present |= MBEDTLS_SSL_EXT_SUPPORTED_GROUPS;
                 break;
 #endif /* MBEDTLS_ECDH_C || MBEDTLS_ECDSA_C */
 
@@ -2720,7 +2720,7 @@ static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
                     return( MBEDTLS_ERR_SSL_BAD_HS_PSK_KEY_EXCHANGE_MODES_EXT );
                 }
 
-                ssl->handshake->extensions_present |= PSK_KEY_EXCHANGE_MODES_EXTENSION;
+                ssl->handshake->extensions_present |= MBEDTLS_SSL_EXT_PSK_KEY_EXCHANGE_MODES;
                 break;
 #endif /* MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED */
 
@@ -2744,10 +2744,10 @@ static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
                      *       the content of it.
                      */
                     final_ret = MBEDTLS_ERR_SSL_HRR_REQUIRED;
-                    ssl->handshake->extensions_present |= KEY_SHARE_EXTENSION;
+                    ssl->handshake->extensions_present |= MBEDTLS_SSL_EXT_KEY_SHARE;
                     break;
                 }
-                ssl->handshake->extensions_present |= KEY_SHARE_EXTENSION;
+                ssl->handshake->extensions_present |= MBEDTLS_SSL_EXT_KEY_SHARE;
                 break;
 #endif /* MBEDTLS_ECDH_C || MBEDTLS_ECDSA_C */
 
@@ -2774,7 +2774,7 @@ static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
                     MBEDTLS_SSL_DEBUG_RET( 1, ( "ssl_parse_supported_versions_ext" ), ret );
                     return( MBEDTLS_ERR_SSL_BAD_HS_SUPPORTED_VERSIONS_EXT );
                 }
-                ssl->handshake->extensions_present |= SUPPORTED_VERSION_EXTENSION;
+                ssl->handshake->extensions_present |= MBEDTLS_SSL_EXT_SUPPORTED_VERSION;
                 break;
 
 #if defined(MBEDTLS_SSL_ALPN)
@@ -2801,7 +2801,7 @@ static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
                     MBEDTLS_SSL_DEBUG_MSG( 1, ( "ssl_parse_supported_signature_algorithms_server_ext ( %d )", ret ) );
                     return( ret );
                 }
-                ssl->handshake->extensions_present |= SIGNATURE_ALGORITHM_EXTENSION;
+                ssl->handshake->extensions_present |= MBEDTLS_SSL_EXT_SIGNATURE_ALGORITHM;
                 break;
 #endif /* MBEDTLS_KEY_EXCHANGE_WITH_CERT_ENABLED */
 
@@ -2948,7 +2948,7 @@ static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
      * the verification check.
      */
     if( ( ssl->conf->rr_config == MBEDTLS_SSL_FORCE_RR_CHECK_ON ) &&
-        !( ssl->handshake->extensions_present & COOKIE_EXTENSION ) )
+        !( ssl->handshake->extensions_present & MBEDTLS_SSL_EXT_COOKIE ) )
     {
         MBEDTLS_SSL_DEBUG_MSG( 2, ( "Cookie extension missing. Need to send a HRR." ) );
         final_ret = MBEDTLS_ERR_SSL_HRR_REQUIRED;
@@ -3976,7 +3976,7 @@ static int ssl_server_hello_write( mbedtls_ssl_context* ssl,
     /* Only add the pre_shared_key extension if the client provided it in the ClientHello
      * and if the key exchange supports PSK
      */
-    if( ssl->handshake->extensions_present & PRE_SHARED_KEY_EXTENSION && (
+    if( ssl->handshake->extensions_present & MBEDTLS_SSL_EXT_PRE_SHARED_KEY && (
             ssl->session_negotiate->key_exchange == MBEDTLS_KEY_EXCHANGE_ECDHE_PSK ||
             ssl->session_negotiate->key_exchange == MBEDTLS_KEY_EXCHANGE_PSK ) )
     {
@@ -3998,7 +3998,7 @@ static int ssl_server_hello_write( mbedtls_ssl_context* ssl,
     /* Only add the key_share extension if the client provided it in the ClientHello
      * and if the appropriate key exchange mechanism was selected
      */
-    if( ssl->handshake->extensions_present & KEY_SHARE_EXTENSION && (
+    if( ssl->handshake->extensions_present & MBEDTLS_SSL_EXT_KEY_SHARE && (
             ssl->session_negotiate->key_exchange == MBEDTLS_KEY_EXCHANGE_ECDHE_PSK ||
             ssl->session_negotiate->key_exchange == MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA ) )
     {


### PR DESCRIPTION


## Description
This patch is to fix  #17


## Status
**READY**


## Migrations
 NO

## Todos
- [X] Tests
   - Test pass with `ssl-opt-in-docker.sh`


