### PR TITLE
move key_exchange members to handshake structure

### DIFF
--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -1177,10 +1177,7 @@ struct mbedtls_ssl_session
 #endif /* MBEDTLS_X509_CRT_PARSE_C */
     uint32_t verify_result;          /*!<  verification result     */
 
-#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
-    unsigned int key_exchange; /* Indication of the key exchange algorithm being negotiated*/
-    unsigned char key_exchange_modes; /*!< psk key exchange modes */
-#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
+
 #if ( defined(MBEDTLS_SSL_SESSION_TICKETS) || defined(MBEDTLS_SSL_NEW_SESSION_TICKET) ) && defined(MBEDTLS_SSL_CLI_C)
     unsigned char *ticket;      /*!< RFC 5077 session ticket */
     size_t ticket_len;          /*!< session ticket length   */

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -4378,16 +4378,6 @@ const char *mbedtls_ssl_get_ciphersuite( const mbedtls_ssl_context *ssl );
 */
 mbedtls_key_exchange_type_t mbedtls_ssl_get_key_exchange(const mbedtls_ssl_context* ssl);
 
-/**
-* \brief          Return the string identifying the negotiated key exchange mode
-*
-* \param ssl      SSL context
-*
-* \return         string identifying the key exchange mode
-*/
-
-const char* mbedtls_ssl_get_key_exchange_name(const mbedtls_ssl_context* ssl);
-
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 
 /**

--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -496,6 +496,8 @@ struct mbedtls_ssl_handshake_params
      * Handshake specific crypto variables
      */
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+    unsigned int key_exchange; /* Indication of the key exchange algorithm being negotiated*/
+    unsigned char key_exchange_modes; /*!< psk key exchange modes */
 #if defined(MBEDTLS_X509_CRT_PARSE_C)
     int *received_signature_schemes_list;              /*!<  Received signature algorithms */
 #endif /* MBEDTLS_X509_CRT_PARSE_C */
@@ -1376,8 +1378,8 @@ static inline int mbedtls_ssl_conf_tls13_pure_ecdhe_enabled( mbedtls_ssl_context
 
 static inline int mbedtls_ssl_tls13_key_exchange_with_psk( mbedtls_ssl_context *ssl )
 {
-    if( ssl->session_negotiate->key_exchange == MBEDTLS_KEY_EXCHANGE_PSK ||
-        ssl->session_negotiate->key_exchange == MBEDTLS_KEY_EXCHANGE_ECDHE_PSK )
+    if( ssl->handshake->key_exchange == MBEDTLS_KEY_EXCHANGE_PSK ||
+        ssl->handshake->key_exchange == MBEDTLS_KEY_EXCHANGE_ECDHE_PSK )
     {
         return( 1 );
     }

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -5782,31 +5782,6 @@ const char *mbedtls_ssl_get_version( const mbedtls_ssl_context *ssl )
 }
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
-const char* mbedtls_ssl_get_key_exchange_name( const mbedtls_ssl_context* ssl ) {
-
-    if( ssl == NULL || ssl->handshake == NULL )
-        return( NULL );
-
-    switch( ssl->handshake->key_exchange ) {
-
-    case MBEDTLS_KEY_EXCHANGE_PSK:
-        return ( "PSK" );
-        break;
-
-    case MBEDTLS_KEY_EXCHANGE_ECDHE_PSK:
-        return ( "ECDHE-PSK" );
-        break;
-
-    case MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA:
-        return ( "ECDHE-ECDSA" );
-        break;
-
-    default:
-        return ( "Unknown" );
-    }
-
-}
-
 mbedtls_key_exchange_type_t mbedtls_ssl_get_key_exchange( const mbedtls_ssl_context* ssl )
 {
     if( ssl == NULL || ssl->session == NULL )

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -5784,10 +5784,10 @@ const char *mbedtls_ssl_get_version( const mbedtls_ssl_context *ssl )
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
 const char* mbedtls_ssl_get_key_exchange_name( const mbedtls_ssl_context* ssl ) {
 
-    if( ssl == NULL || ssl->session == NULL )
+    if( ssl == NULL || ssl->handshake == NULL )
         return( NULL );
 
-    switch( ssl->session->key_exchange ) {
+    switch( ssl->handshake->key_exchange ) {
 
     case MBEDTLS_KEY_EXCHANGE_PSK:
         return ( "PSK" );
@@ -5812,7 +5812,7 @@ mbedtls_key_exchange_type_t mbedtls_ssl_get_key_exchange( const mbedtls_ssl_cont
     if( ssl == NULL || ssl->session == NULL )
         return( MBEDTLS_KEY_EXCHANGE_NONE );
 
-    return ( ssl->session->key_exchange );
+    return ( ssl->handshake->key_exchange );
 }
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 #if defined(MBEDTLS_SSL_MAX_FRAGMENT_LENGTH)

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -2372,8 +2372,8 @@ static int ssl_certificate_request_coordinate( mbedtls_ssl_context* ssl )
     int ret;
     mbedtls_mps_handshake_in msg;
 
-    if( ssl->session_negotiate->key_exchange == MBEDTLS_KEY_EXCHANGE_PSK ||
-        ssl->session_negotiate->key_exchange == MBEDTLS_KEY_EXCHANGE_ECDHE_PSK )
+    if( ssl->handshake->key_exchange == MBEDTLS_KEY_EXCHANGE_PSK ||
+        ssl->handshake->key_exchange == MBEDTLS_KEY_EXCHANGE_ECDHE_PSK )
     {
         MBEDTLS_SSL_DEBUG_MSG( 3, ( "<= skip parse certificate request" ) );
         return( SSL_CERTIFICATE_REQUEST_SKIP );
@@ -3399,12 +3399,12 @@ static int ssl_server_hello_postprocess( mbedtls_ssl_context* ssl )
     if( ssl->handshake->extensions_present & MBEDTLS_SSL_EXT_PRE_SHARED_KEY )
     {
         if( ssl->handshake->extensions_present & MBEDTLS_SSL_EXT_KEY_SHARE )
-            ssl->session_negotiate->key_exchange = MBEDTLS_KEY_EXCHANGE_ECDHE_PSK;
+            ssl->handshake->key_exchange = MBEDTLS_KEY_EXCHANGE_ECDHE_PSK;
         else
-            ssl->session_negotiate->key_exchange = MBEDTLS_KEY_EXCHANGE_PSK;
+            ssl->handshake->key_exchange = MBEDTLS_KEY_EXCHANGE_PSK;
     }
     else if( ssl->handshake->extensions_present & MBEDTLS_SSL_EXT_KEY_SHARE )
-        ssl->session_negotiate->key_exchange = MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA;
+        ssl->handshake->key_exchange = MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA;
     else
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "Unknown key exchange." ) );

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -1050,7 +1050,7 @@ cleanup:
 
 static int ssl_read_certificate_verify_coordinate( mbedtls_ssl_context* ssl )
 {
-    if( ssl->session_negotiate->key_exchange != MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA )
+    if( ssl->handshake->key_exchange != MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA )
     {
         return( SSL_CERTIFICATE_VERIFY_SKIP );
     }
@@ -1395,8 +1395,8 @@ static int ssl_write_certificate_coordinate( mbedtls_ssl_context* ssl )
 #endif /* MBEDTLS_SSL_CLI_C */
 
     /* For PSK and ECDHE-PSK ciphersuites there is no certificate to exchange. */
-    if( ssl->session_negotiate->key_exchange == MBEDTLS_KEY_EXCHANGE_PSK ||
-        ssl->session_negotiate->key_exchange == MBEDTLS_KEY_EXCHANGE_ECDHE_PSK )
+    if( ssl->handshake->key_exchange == MBEDTLS_KEY_EXCHANGE_PSK ||
+        ssl->handshake->key_exchange == MBEDTLS_KEY_EXCHANGE_ECDHE_PSK )
     {
         MBEDTLS_SSL_DEBUG_MSG( 2, ( "<= skip write certificate" ) );
         return( SSL_WRITE_CERTIFICATE_SKIP );
@@ -1738,8 +1738,8 @@ static int ssl_read_certificate_coordinate( mbedtls_ssl_context* ssl )
     }
 #endif /* MBEDTLS_SSL_SRV_C */
 
-    if( ssl->session_negotiate->key_exchange == MBEDTLS_KEY_EXCHANGE_PSK ||
-        ssl->session_negotiate->key_exchange == MBEDTLS_KEY_EXCHANGE_ECDHE_PSK )
+    if( ssl->handshake->key_exchange == MBEDTLS_KEY_EXCHANGE_PSK ||
+        ssl->handshake->key_exchange == MBEDTLS_KEY_EXCHANGE_ECDHE_PSK )
     {
         return( SSL_CERTIFICATE_SKIP );
     }
@@ -2039,7 +2039,7 @@ static int ssl_read_certificate_validate( mbedtls_ssl_context* ssl )
 #endif /* MBEDTLS_ECP_C */
 
     if( mbedtls_ssl_check_cert_usage( ssl->session_negotiate->peer_cert,
-                                      ssl->session_negotiate->key_exchange,/*		ciphersuite_info, */
+                                      ssl->handshake->key_exchange,     /*		ciphersuite_info, */
                                       !ssl->conf->endpoint,
                                       &ssl->session_negotiate->verify_result ) != 0 )
     {

--- a/library/ssl_tls13_keys.c
+++ b/library/ssl_tls13_keys.c
@@ -926,9 +926,9 @@ static int ssl_tls1_3_complete_ephemeral_secret( mbedtls_ssl_context *ssl,
      * Compute ECDHE secret for second stage of secret evolution.
      */
 #if defined(MBEDTLS_KEY_EXCHANGE_SOME_ECDHE_ENABLED)
-    if( ssl->session_negotiate->key_exchange ==
+    if( ssl->handshake->key_exchange ==
           MBEDTLS_KEY_EXCHANGE_ECDHE_PSK ||
-        ssl->session_negotiate->key_exchange ==
+        ssl->handshake->key_exchange ==
           MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA )
     {
 

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -3170,16 +3170,9 @@ int main( int argc, char *argv[] )
         }
     }
 
-#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
-    mbedtls_printf(" ok\n    [ Protocol is %s ]\n    [ Ciphersuite is %s ]\n    [ Key Exchange Mode is %s ]\n",
-                    mbedtls_ssl_get_version(&ssl),
-                    mbedtls_ssl_get_ciphersuite(&ssl),
-                    mbedtls_ssl_get_key_exchange_name(&ssl));
-#else
     mbedtls_printf( " ok\n    [ Protocol is %s ]\n    [ Ciphersuite is %s ]\n",
                     mbedtls_ssl_get_version( &ssl ),
                     mbedtls_ssl_get_ciphersuite( &ssl ) );
-#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 
     if( ( ret = mbedtls_ssl_get_record_expansion( &ssl ) ) >= 0 )
         mbedtls_printf( "    [ Record expansion is %d ]\n", ret );


### PR DESCRIPTION
Key_exchange and key_exchange_modes should be part
of mbedtls_ssl_handshake_params.

fix #13,#14

Change-Id: I6c028765487e30f56f18a643795b2b3bde8583c8
Signed-off-by: Jerry Yu <jerry.h.yu@arm.com>

Notes:

## Status
**READY

## Requires Backporting

Yes



## Additional comments



## Todos
- [X] Tests
   - `ssl-opt-in-docker.sh` pass

## Steps to test or reproduce
Outline the steps to test or reproduce the PR here.
