### PR TITLE
Revert "Only use one single ciphersuite if 0-rtt is actually enabled"

### DIFF
--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -1752,10 +1752,9 @@ static int ssl_client_hello_write_partial( mbedtls_ssl_context* ssl,
 
         buflen -= 2;
 
-#if defined(MBEDTLS_ZERO_RTT) && defined(MBEDTLS_SSL_NEW_SESSION_TICKET)
-        /* For 0-RTT we only add a single ciphersuite. */
-        if( ssl->conf->early_data_enabled == MBEDTLS_SSL_EARLY_DATA_ENABLED)
-            break;
+#if defined(MBEDTLS_ZERO_RTT)
+        /* For ZeroRTT we only add a single ciphersuite. */
+        break;
 #endif /* MBEDTLS_ZERO_RTT */
     }
 

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -1499,7 +1499,7 @@ run_test    "TLS 1.3, TLS_AES_256_GCM_SHA384, ext PSK, early data" \
             "$P_SRV nbio=2 debug_level=5 force_version=tls1_3 early_data=-1 key_exchange_modes=psk psk=010203 psk_identity=0a0b0c" \
             "$P_CLI nbio=2 debug_level=5 force_version=tls1_3 force_ciphersuite=TLS_AES_256_GCM_SHA384 key_exchange_modes=psk early_data=1 psk=010203 psk_identity=0a0b0c" \
             0 \
-        -s "found early_data extension"                 \
+	    -s "found early_data extension"                 \
 	    -s "Derive Early Secret with 'ext binder'"      \
 	    -c "client hello, adding early_data extension"  \
             -c "Protocol is TLSv1.3"                        \
@@ -1576,27 +1576,6 @@ run_test    "TLS 1.3, TLS_AES_256_GCM_SHA384, ECDHE-ECDSA, client tries early da
       -c "Protocol is TLSv1.3"                                        \
       -c "Ciphersuite is TLS_AES_256_GCM_SHA384"                      \
       -c "early data status = 0"
-
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL
-requires_config_enabled MBEDTLS_DEBUG_C
-requires_config_disabled MBEDTLS_RSA_C
-requires_config_enabled MBEDTLS_ZERO_RTT
-run_test    "TLS 1.3, Multiple cipher suites, early data off" \
-            "$P_SRV nbio=2 debug_level=4 force_version=tls1_3" \
-            "$P_CLI nbio=2 debug_level=4 force_version=tls1_3 early_data=0" \
-            0 \
-        -c "client hello, add ciphersuite: 1302, TLS_AES_256_GCM_SHA384" \
-        -c "client hello, add ciphersuite: 1301, TLS_AES_128_GCM_SHA256"
-
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL
-requires_config_enabled MBEDTLS_DEBUG_C
-requires_config_disabled MBEDTLS_RSA_C
-requires_config_enabled MBEDTLS_ZERO_RTT
-run_test    "TLS 1.3, Single cipher suite, ext PSK, early data" \
-            "$P_SRV nbio=2 debug_level=5 force_version=tls1_3 early_data=-1 key_exchange_modes=psk psk=010203 psk_identity=0a0b0c" \
-            "$P_CLI nbio=2 debug_level=5 force_version=tls1_3 key_exchange_modes=psk early_data=1 psk=010203 psk_identity=0a0b0c" \
-            0 \
-        -c "client hello, got 1 ciphersuites"
 
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL
 requires_config_enabled MBEDTLS_DEBUG_C


### PR DESCRIPTION
Reverts hannestschofenig/mbedtls#281

We are seeing test failures from our internal tests. Currently I am not able to reproduce the test with `ssl_client2` yet. But the test failure is from the server when it tries to derive early secret, resulting in a `bad_record_mac` alert.

These are the scenario that passes:
  - One configures the client to use only one cipher suite;
  - One configures the client to use multiple cipher suite, and during resumption the previously negotiated cipher suite is the first one in the list;
 
The case where it fails is when in resumption there are multiple cipher suites and the previously negotiates cipher suite is not the first one. I am not sure what causes the failure but I suspect somewhere in the code we are making the assumption that the first cipher suite in the list is the one to use.