### PR TITLE
Compile when few options are set

### DIFF
--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -124,11 +124,12 @@ static int ssl_write_early_data_postprocess( mbedtls_ssl_context* ssl );
 int ssl_write_early_data_process( mbedtls_ssl_context* ssl )
 {
     int ret;
-#if defined(MBEDTLS_SSL_USE_MPS)
+#if defined(MBEDTLS_SSL_USE_MPS) & defined(MBEDTLS_ZERO_RTT)
     mbedtls_writer *msg;
     unsigned char *buf;
     mbedtls_mps_size_t buf_len, msg_len;
-#endif /* MBEDTLS_SSL_USE_MPS */
+#endif /* MBEDTLS_SSL_USE_MPS & MBEDTLS_ZERO_RTT */
+    
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> write early data" ) );
 
     MBEDTLS_SSL_PROC_CHK_NEG( ssl_write_early_data_coordinate( ssl ) );
@@ -176,13 +177,7 @@ int ssl_write_early_data_process( mbedtls_ssl_context* ssl )
 #endif /* MBEDTLS_SSL_USE_MPS */
 
 #else /* MBEDTLS_ZERO_RTT */
-#if defined(MBEDTLS_SSL_USE_MPS)
-        ((void) buf);
-        ((void) buf_len);
-        ((void) msg);
-        ((void) msg_len);
-#endif /* MBEDTLS_SSL_USE_MPS */
-        
+      
         /* Should never happen */
         return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
 

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -176,10 +176,13 @@ int ssl_write_early_data_process( mbedtls_ssl_context* ssl )
 #endif /* MBEDTLS_SSL_USE_MPS */
 
 #else /* MBEDTLS_ZERO_RTT */
+#if defined(MBEDTLS_SSL_USE_MPS)
         ((void) buf);
         ((void) buf_len);
         ((void) msg);
         ((void) msg_len);
+#endif /* MBEDTLS_SSL_USE_MPS */
+        
         /* Should never happen */
         return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
 
@@ -2725,6 +2728,9 @@ static int ssl_encrypted_extensions_parse( mbedtls_ssl_context* ssl,
     size_t ext_len;
     const unsigned char *ext;
 
+    /* ssl structure is not used when ALPN, 0RTT, and MFL extensions are not used. */
+    ((void*) ssl);
+    
     if( buflen < 2 )
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "EncryptedExtension message too short" ) );

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -2723,7 +2723,8 @@ static int ssl_encrypted_extensions_parse( mbedtls_ssl_context* ssl,
     size_t ext_len;
     const unsigned char *ext;
 
-#if !( defined(MBEDTLS_SSL_ALPN) || defined(MBEDTLS_ZERO_RTT) || defined(MBEDTLS_SSL_MAX_FRAGMENT_LENGTH) )
+#if !( defined(MBEDTLS_SSL_ALPN) || defined(MBEDTLS_ZERO_RTT) || \
+       defined(MBEDTLS_SSL_MAX_FRAGMENT_LENGTH) )
     ((void) ssl);
 #endif /* ! (MBEDTLS_SSL_ALPN || MBEDTLS_ZERO_RTT || MBEDTLS_SSL_MAX_FRAGMENT_LENGTH) */
     

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -2723,8 +2723,9 @@ static int ssl_encrypted_extensions_parse( mbedtls_ssl_context* ssl,
     size_t ext_len;
     const unsigned char *ext;
 
-    /* ssl structure is not used when ALPN, 0RTT, and MFL extensions are not used. */
+#if !( defined(MBEDTLS_SSL_ALPN) || defined(MBEDTLS_ZERO_RTT) || defined(MBEDTLS_SSL_MAX_FRAGMENT_LENGTH) )
     ((void) ssl);
+#endif /* ! (MBEDTLS_SSL_ALPN || MBEDTLS_ZERO_RTT || MBEDTLS_SSL_MAX_FRAGMENT_LENGTH) */
     
     if( buflen < 2 )
     {

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -2729,7 +2729,7 @@ static int ssl_encrypted_extensions_parse( mbedtls_ssl_context* ssl,
     const unsigned char *ext;
 
     /* ssl structure is not used when ALPN, 0RTT, and MFL extensions are not used. */
-    ((void*) ssl);
+    ((void) ssl);
     
     if( buflen < 2 )
     {

--- a/library/ssl_tls13_keys.c
+++ b/library/ssl_tls13_keys.c
@@ -887,7 +887,7 @@ int mbedtls_ssl_tls1_3_generate_resumption_master_secret(
 #if defined(MBEDTLS_DEBUG_C)
     md_info = mbedtls_md_info_from_type( md_type );
     md_size = mbedtls_md_get_size( md_info );
-#endif
+#endif /* MBEDTLS_DEBUG_C */
     
     ret = mbedtls_ssl_get_handshake_transcript( ssl, md_type,
                                                 transcript, sizeof( transcript ),

--- a/library/ssl_tls13_keys.c
+++ b/library/ssl_tls13_keys.c
@@ -1160,7 +1160,7 @@ int mbedtls_ssl_tls1_3_create_psk_binder( mbedtls_ssl_context *ssl,
 
 #if !defined(MBEDTLS_DEBUG_C)
     ((void) ssl);
-#endif
+#endif /* MBEDTLS_DEBUG_C */
     
     ret = mbedtls_ssl_tls1_3_evolve_secret( md_type,
                                             NULL,          /* Old secret */

--- a/library/ssl_tls13_keys.c
+++ b/library/ssl_tls13_keys.c
@@ -871,8 +871,12 @@ int mbedtls_ssl_tls1_3_generate_resumption_master_secret(
     int ret = 0;
 
     mbedtls_md_type_t md_type;
+    
+#if defined(MBEDTLS_DEBUG_C)  
     mbedtls_md_info_t const *md_info;
-
+    size_t md_size;
+#endif
+    
     unsigned char transcript[MBEDTLS_MD_MAX_SIZE];
     size_t transcript_len;
 
@@ -880,8 +884,11 @@ int mbedtls_ssl_tls1_3_generate_resumption_master_secret(
           ( "=> mbedtls_ssl_tls1_3_generate_resumption_master_secret" ) );
 
     md_type = ssl->handshake->ciphersuite_info->mac;
+#if defined(MBEDTLS_DEBUG_C)
     md_info = mbedtls_md_info_from_type( md_type );
-
+    md_size = mbedtls_md_get_size( md_info );
+#endif
+    
     ret = mbedtls_ssl_get_handshake_transcript( ssl, md_type,
                                                 transcript, sizeof( transcript ),
                                                 &transcript_len );
@@ -897,7 +904,7 @@ int mbedtls_ssl_tls1_3_generate_resumption_master_secret(
 
     MBEDTLS_SSL_DEBUG_BUF( 4, "Resumption master secret",
              ssl->session_negotiate->app_secrets.resumption_master_secret,
-             mbedtls_md_get_size( md_info ) );
+             md_size );
 
     MBEDTLS_SSL_DEBUG_MSG( 2,
           ( "<= mbedtls_ssl_tls1_3_generate_resumption_master_secret" ) );
@@ -1152,7 +1159,7 @@ int mbedtls_ssl_tls1_3_create_psk_binder( mbedtls_ssl_context *ssl,
     size_t const md_size = mbedtls_md_get_size( md_info );
 
 #if !defined(MBEDTLS_DEBUG_C)
-    ((void)) ssl);
+    ((void) ssl);
 #endif
     
     ret = mbedtls_ssl_tls1_3_evolve_secret( md_type,

--- a/library/ssl_tls13_keys.c
+++ b/library/ssl_tls13_keys.c
@@ -1151,6 +1151,10 @@ int mbedtls_ssl_tls1_3_create_psk_binder( mbedtls_ssl_context *ssl,
     mbedtls_md_info_t const *md_info = mbedtls_md_info_from_type( md_type );
     size_t const md_size = mbedtls_md_get_size( md_info );
 
+#if !defined(MBEDTLS_DEBUG_C)
+    ((void)) ssl);
+#endif
+    
     ret = mbedtls_ssl_tls1_3_evolve_secret( md_type,
                                             NULL,          /* Old secret */
                                             psk, psk_len,  /* Input      */

--- a/library/ssl_tls13_keys.c
+++ b/library/ssl_tls13_keys.c
@@ -872,7 +872,6 @@ int mbedtls_ssl_tls1_3_generate_resumption_master_secret(
 
     mbedtls_md_type_t md_type;
     mbedtls_md_info_t const *md_info;
-    size_t md_size;
 
     unsigned char transcript[MBEDTLS_MD_MAX_SIZE];
     size_t transcript_len;
@@ -882,7 +881,6 @@ int mbedtls_ssl_tls1_3_generate_resumption_master_secret(
 
     md_type = ssl->handshake->ciphersuite_info->mac;
     md_info = mbedtls_md_info_from_type( md_type );
-    md_size = mbedtls_md_get_size( md_info );
 
     ret = mbedtls_ssl_get_handshake_transcript( ssl, md_type,
                                                 transcript, sizeof( transcript ),
@@ -899,7 +897,7 @@ int mbedtls_ssl_tls1_3_generate_resumption_master_secret(
 
     MBEDTLS_SSL_DEBUG_BUF( 4, "Resumption master secret",
              ssl->session_negotiate->app_secrets.resumption_master_secret,
-             md_size );
+             mbedtls_md_get_size( md_info ) );
 
     MBEDTLS_SSL_DEBUG_MSG( 2,
           ( "<= mbedtls_ssl_tls1_3_generate_resumption_master_secret" ) );

--- a/library/ssl_tls13_keys.c
+++ b/library/ssl_tls13_keys.c
@@ -875,7 +875,7 @@ int mbedtls_ssl_tls1_3_generate_resumption_master_secret(
 #if defined(MBEDTLS_DEBUG_C)  
     mbedtls_md_info_t const *md_info;
     size_t md_size;
-#endif
+#endif /* MBEDTLS_DEBUG_C */
     
     unsigned char transcript[MBEDTLS_MD_MAX_SIZE];
     size_t transcript_len;

--- a/library/ssl_tls13_keys.c
+++ b/library/ssl_tls13_keys.c
@@ -1159,6 +1159,7 @@ int mbedtls_ssl_tls1_3_create_psk_binder( mbedtls_ssl_context *ssl,
     size_t const md_size = mbedtls_md_get_size( md_info );
 
 #if !defined(MBEDTLS_DEBUG_C)
+    ssl = NULL;
     ((void) ssl);
 #endif /* MBEDTLS_DEBUG_C */
     

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -2269,6 +2269,10 @@ static int ssl_client_hello_fetch( mbedtls_ssl_context* ssl,
 
 static void ssl_debug_print_client_hello_exts( mbedtls_ssl_context *ssl )
 {
+#if !defined(MBEDTLS_DEBUG_C)
+    ((void) ssl);
+#endif
+
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "Supported Extensions:" ) );
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "- KEY_SHARE_EXTENSION ( %s )",
                                 ( ( ssl->handshake->extensions_present & MBEDTLS_SSL_EXT_KEY_SHARE ) > 0 ) ?

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -2267,12 +2267,14 @@ static int ssl_client_hello_fetch( mbedtls_ssl_context* ssl,
 
 #endif /* MBEDTLS_SSL_USE_MPS */
 
+#if !defined(MBEDTLS_DEBUG_C)
 static void ssl_debug_print_client_hello_exts( mbedtls_ssl_context *ssl )
 {
-#if !defined(MBEDTLS_DEBUG_C)
     ((void) ssl);
-#endif
-
+}
+#else
+static void ssl_debug_print_client_hello_exts( mbedtls_ssl_context *ssl )
+{
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "Supported Extensions:" ) );
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "- KEY_SHARE_EXTENSION ( %s )",
                                 ( ( ssl->handshake->extensions_present & MBEDTLS_SSL_EXT_KEY_SHARE ) > 0 ) ?
@@ -2318,6 +2320,7 @@ static void ssl_debug_print_client_hello_exts( mbedtls_ssl_context *ssl )
                                 "TRUE" : "FALSE" ) );
 #endif /* MBEDTLS_ZERO_RTT*/
 }
+#endif /* !MBEDTLS_DEBUG_C */
 
 static int ssl_client_hello_has_psk_extensions( mbedtls_ssl_context *ssl )
 {


### PR DESCRIPTION
## Description
When the stack is compiled with minimal extensions (without 0RTT, ALPN, MFL, and MPS) then compilation errors occur due to unused variables. 

## Status
**DONE**

## Requires Backporting
NO

## Migrations
NO

## Additional comments

## Todos
- [x] Tests

## Steps to test or reproduce
To reproduce the errors, use the config.h file from the EEMBC benchmark here: 
https://raw.githubusercontent.com/eembc/mbedtls/eembc-setup/include/mbedtls/config.h
