### PR TITLE
Pr/fix two errors

### DIFF
--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -2405,8 +2405,8 @@ static int ssl_certificate_request_coordinate( mbedtls_ssl_context* ssl )
 {
     int ret;
 
-    if( ssl->session_negotiate->key_exchange == MBEDTLS_KEY_EXCHANGE_PSK ||
-        ssl->session_negotiate->key_exchange == MBEDTLS_KEY_EXCHANGE_ECDHE_PSK )
+    if( ssl->handshake->key_exchange == MBEDTLS_KEY_EXCHANGE_PSK ||
+        ssl->handshake->key_exchange == MBEDTLS_KEY_EXCHANGE_ECDHE_PSK )
     {
         MBEDTLS_SSL_DEBUG_MSG( 3, ( "<= skip parse certificate request" ) );
         return( SSL_CERTIFICATE_REQUEST_SKIP );

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -1610,8 +1610,7 @@ run_test    "TLS 1.3, TLS_AES_128_CCM_SHA256 with ECDHE-ECDSA, SRV auth, HRR enf
             -c "received HelloRetryRequest message"     \
             -c "Protocol is TLSv1.3"                    \
             -c "Ciphersuite is TLS_AES_128_CCM_SHA256"  \
-            -c "Verifying peer X.509 certificate... ok" \
-            -c "Key Exchange Mode is ECDHE-ECDSA"
+            -c "Verifying peer X.509 certificate... ok"
 
 # test early data status - not sent
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL


### PR DESCRIPTION
1. Without mps, it report key_exchange not defined error. That's missing when move key_exchange to handshake
2. get_exchange_name was removed. But test case 33 still check exchange name. 
