### PR TITLE
Add options test script

### DIFF
--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -2151,7 +2151,10 @@ int main( int argc, char *argv[] )
         mbedtls_printf( "Warning: event-driven IO mandates nbio=1 - overwrite\n" );
         opt.nbio = 1;
     }
-
+#if defined(MBEDTLS_DISABLE_NONBLOCK_IO)
+    // TODO: if #238 is fixed , This should be removed
+    opt.nbio = 0;
+#endif
 #if defined(MBEDTLS_DEBUG_C)
     mbedtls_debug_set_threshold( opt.debug_level );
 #endif

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -2850,7 +2850,10 @@ int main( int argc, char *argv[] )
         mbedtls_printf( "Warning: event-driven IO mandates nbio=1 - overwrite\n" );
         opt.nbio = 1;
     }
-
+#if defined(MBEDTLS_DISABLE_NONBLOCK_IO)
+    // TODO: if #238 is fixed , This should be removed
+    opt.nbio = 0;
+#endif
 #if defined(MBEDTLS_DEBUG_C)
     mbedtls_debug_set_threshold( opt.debug_level );
 #endif

--- a/tests/include/test/check_options.h
+++ b/tests/include/test/check_options.h
@@ -1,0 +1,109 @@
+/**
+ * Below part is to fix different options
+ * should be removed after merged
+ **/
+#if defined(MBEDTLS_TMP_TEST_CASE_1)
+        // issue #238
+        #define MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL
+        #undef MBEDTLS_SSL_PROTO_TLS1_2
+        #undef MBEDTLS_DISABLE_NONBLOCK_IO
+        #undef MBEDTLS_SSL_USE_MPS
+#endif
+
+#if defined(MBEDTLS_TMP_TEST_CASE_2)
+        // issue not created
+        #undef MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL
+        #define MBEDTLS_SSL_PROTO_TLS1_2
+        #undef MBEDTLS_DISABLE_NONBLOCK_IO
+        #undef MBEDTLS_SSL_USE_MPS
+#endif
+
+#if defined(MBEDTLS_TMP_TEST_CASE_3)
+        // issue not created
+        #define MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL
+        #define MBEDTLS_SSL_PROTO_TLS1_2
+        #undef MBEDTLS_DISABLE_NONBLOCK_IO
+        #undef MBEDTLS_SSL_USE_MPS
+#endif
+
+#if defined(MBEDTLS_TMP_TEST_CASE_5)
+        // issue not created
+        #define MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL
+        #undef MBEDTLS_SSL_PROTO_TLS1_2
+        #define MBEDTLS_DISABLE_NONBLOCK_IO
+        #undef MBEDTLS_SSL_USE_MPS
+#endif
+
+#if defined(MBEDTLS_TMP_TEST_CASE_6)
+        // issue #298
+        #undef MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL
+        #define MBEDTLS_SSL_PROTO_TLS1_2
+        #define MBEDTLS_DISABLE_NONBLOCK_IO
+        #undef MBEDTLS_SSL_USE_MPS
+#endif
+
+#if defined(MBEDTLS_TMP_TEST_CASE_7)
+        // issue #297
+        #define MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL
+        #define MBEDTLS_SSL_PROTO_TLS1_2
+        #define MBEDTLS_DISABLE_NONBLOCK_IO
+        #undef MBEDTLS_SSL_USE_MPS
+#endif
+
+#if defined(MBEDTLS_TMP_TEST_CASE_9)
+        // issue not created
+        #define MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL
+        #undef MBEDTLS_SSL_PROTO_TLS1_2
+        #undef MBEDTLS_DISABLE_NONBLOCK_IO
+        #define MBEDTLS_SSL_USE_MPS
+#endif
+
+#if defined(MBEDTLS_TMP_TEST_CASE_10)
+        // issue not created
+        #undef MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL
+        #define MBEDTLS_SSL_PROTO_TLS1_2
+        #undef MBEDTLS_DISABLE_NONBLOCK_IO
+        #define MBEDTLS_SSL_USE_MPS
+#endif
+
+#if defined(MBEDTLS_TMP_TEST_CASE_11)
+        // issue not created
+        #define MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL
+        #define MBEDTLS_SSL_PROTO_TLS1_2
+        #undef MBEDTLS_DISABLE_NONBLOCK_IO
+        #define MBEDTLS_SSL_USE_MPS
+#endif
+
+#if defined(MBEDTLS_TMP_TEST_CASE_13)
+        // issue not created
+        #define MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL
+        #undef MBEDTLS_SSL_PROTO_TLS1_2
+        #define MBEDTLS_DISABLE_NONBLOCK_IO
+        #define MBEDTLS_SSL_USE_MPS
+#endif
+
+#if defined(MBEDTLS_TMP_TEST_CASE_14)
+        // issue not created
+        #undef MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL
+        #define MBEDTLS_SSL_PROTO_TLS1_2
+        #define MBEDTLS_DISABLE_NONBLOCK_IO
+        #define MBEDTLS_SSL_USE_MPS
+#endif
+
+#if defined(MBEDTLS_TMP_TEST_CASE_15)
+        // issue not created
+        #define MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL
+        #define MBEDTLS_SSL_PROTO_TLS1_2
+        #define MBEDTLS_DISABLE_NONBLOCK_IO
+        #define MBEDTLS_SSL_USE_MPS
+#endif
+
+#if !defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+#undef MBEDTLS_SSL_TLS13_COMPATIBILITY_MODE
+#endif
+
+
+/**
+ * above part is to fix different options
+ * should be removed after merged
+ **/

--- a/tests/scripts/check-options.sh
+++ b/tests/scripts/check-options.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+
+print_usage() {
+    echo "Usage: $0 [options]"
+    printf "  -c|--check\tExit on error\n"
+    printf "  -f|--full\ttest_all\n"
+    printf "  -F|--fail\ttest unkown status test cases\n"
+    printf "  -h|--help\tPrint this help.\n"
+ }
+pass_cases="9 13 5"
+test_cases=""
+fail_cases="3 1 2 6 7 10 11 14 15"
+mbedtls_user_config="\\<test/check_options.h\\>"
+while [ $# -gt 0 ]; do
+        case "$1" in
+            -c|--check)
+                set -ex
+                ;;
+            -f|--full)
+                test_cases="${fail_cases} ${pass_cases} ${test_cases}"
+                ;;
+            -F|--fail)
+                test_cases="${fail_cases}"
+                ;;
+            -n|--number)
+                shift ;test_cases="${test_cases} $1"
+                ;;
+            -h|--help)
+                print_usage
+                exit 0
+                ;;
+            *)
+                echo "Unknown argument: '$1'"
+                print_usage
+                exit 1
+                ;;
+        esac
+        shift
+    done
+result=" "
+config_1="|ENABLE|DISABLE|DISABLE|DISABLE|#238|"
+config_2="|DISABLE|ENABLE|DISABLE|DISABLE|unkown|"
+config_3="|ENABLE|ENABLE|DISABLE|DISABLE|#297|"
+config_5="|ENABLE|DISABLE|ENABLE|DISABLE|pass|"
+config_6="|DISABLE|ENABLE|ENABLE|DISABLE|#298|"
+config_7="|ENABLE|ENABLE|ENABLE|DISABLE|unkown|"
+config_9="|ENABLE|DISABLE|DISABLE|ENABLE|pass|"
+config_10="|DISABLE|ENABLE|DISABLE|ENABLE|unkown|"
+config_11="|ENABLE|ENABLE|DISABLE|ENABLE|unkown|"
+config_13="|ENABLE|DISABLE|ENABLE|ENABLE|pass|"
+config_14="|DISABLE|ENABLE|ENABLE|ENABLE|unkown|"
+config_15="|ENABLE|ENABLE|ENABLE|ENABLE|unkown|"
+title="|No.|MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL|MBEDTLS_SSL_PROTO_TLS1_2|MBEDTLS_DISABLE_BLOCK_IO|MBEDTLS_SSL_USE_MPS|comment|status|cmd|"
+separated_line="|--------|--------|--------|--------|--------|--------|--------|-------|"
+
+
+
+
+
+
+ret=0
+fail_result=" "
+pass_result=" "
+test_cases=$(echo $test_cases | sort -u)
+if [ -z "$test_cases" ]
+then
+    test_cases=$pass_cases
+fi
+
+echo $title
+echo $separated_line
+
+for i in ${test_cases}
+do
+    test_case=config_$i
+    printf "|${i} ${!test_case}"
+    make clean  && \
+    make CFLAGS="-g -Werror -DMBEDTLS_TMP_TEST_CASE_${i} -I../tests/include -DMBEDTLS_USER_CONFIG_FILE=${mbedtls_user_config}" -j20 >/dev/null 2>&1 && \
+    ./tests/ssl-opt.sh -s  >/dev/null 2>&1
+    
+    if [ $? != 0 ]; then
+        printf "FAIL"
+        ret=$i
+    else
+        printf "PASS"
+    fi
+    printf  "|%s|\n" "make clean  && make CFLAGS=\"-g -Werror -I../tests/include -DMBEDTLS_TMP_TEST_CASE_${i} -DMBEDTLS_USER_CONFIG_FILE=${mbedtls_user_config}\" -j20 && ./tests/ssl-opt.sh -s"
+done
+
+exit $ret
+


### PR DESCRIPTION
Build and test with different options report error . 
This script is to test the status with/without MPS ,Non block io , TLS1_2 and TLS1_3.

Now, 9 cases fail . That is list in #301. 

It should be considered merged as a common script or left here. I need suggestion
