### PR TITLE
MPS: Interpret ret val 0 from BIO as connection closure

### DIFF
--- a/include/mbedtls/mps/error.h
+++ b/include/mbedtls/mps/error.h
@@ -64,6 +64,8 @@
 /*! The underlying transport does not have enough incoming data available
  *  to perform the requested read operation. */
 #define MBEDTLS_ERR_MPS_WANT_READ             MBEDTLS_MPS_MAKE_ERROR( 0x10 )
+/*! The underlying transport has been closed. */
+#define MBEDTLS_ERR_MPS_CONN_EOF              MBEDTLS_MPS_MAKE_ERROR( 0x70 )
 /*! The underlying transport is unavailable perform the send operation. */
 #define MBEDTLS_ERR_MPS_WANT_WRITE            MBEDTLS_MPS_MAKE_ERROR( 0x11 )
 #define MBEDTLS_ERR_MPS_BAD_TRANSFORM         MBEDTLS_MPS_MAKE_ERROR( 0x12 )
@@ -230,6 +232,10 @@
             ( MBEDTLS_MPS_ERROR_FLAGS_EXTERNAL |                        \
               MBEDTLS_MPS_ERROR_FLAGS_FATAL ),                          \
             MBEDTLS_ERR_MPS_TOO_MANY_EPOCHS ) )                         \
+    MBEDTLS_MPS_ERROR_INFO_WRAP(                                        \
+        MBEDTLS_MPS_MAKE_ERROR_INFO(                                    \
+            ( MBEDTLS_MPS_ERROR_FLAGS_EXTERNAL ),                       \
+            MBEDTLS_ERR_MPS_CONN_EOF ) )                                \
     MBEDTLS_MPS_ERROR_INFO_WRAP(                                        \
         MBEDTLS_MPS_MAKE_ERROR_INFO(                                    \
             ( MBEDTLS_MPS_ERROR_FLAGS_EXTERNAL ),                       \

--- a/library/mps/layer1.c
+++ b/library/mps/layer1.c
@@ -270,6 +270,8 @@ int l1_fetch_stream( mps_l1_stream_read *p,
     {
         MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "attempt to receive %u", (unsigned) data_need );
         ret = recv( recv_ctx, read_ptr, data_need );
+        if( ret == 0 )
+            ret = MBEDTLS_ERR_MPS_CONN_EOF;
         if( ret < 0 )
             break;
         MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT, "got %u", (unsigned) ret );

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -6797,6 +6797,8 @@ int mbedtls_ssl_mps_remap_error( int ret )
         ret = MBEDTLS_ERR_SSL_WANT_READ;
     if( ret == MBEDTLS_ERR_MPS_WANT_WRITE )
         ret = MBEDTLS_ERR_SSL_WANT_WRITE;
+    if( ret == MBEDTLS_ERR_MPS_CONN_EOF )
+        ret = MBEDTLS_ERR_SSL_CONN_EOF;
     if( ret == MBEDTLS_ERR_MPS_RETRY )
         ret = MBEDTLS_ERR_SSL_WANT_READ;
 


### PR DESCRIPTION
MPS assumed that the underlying transport would return an error code on connection closure, which is not the case: It can also be signalled through return value `0`. This lead to MPS missing connection closure and looping indefinitely in the absence of explicit connection closure alerts, as noticed by @lhuang04 in #295. Fixes #295.