### PR TITLE
MPS Layer 3: Remove unused handshake abort function

### DIFF
--- a/include/mbedtls/mps/layer3.h
+++ b/include/mbedtls/mps/layer3.h
@@ -783,21 +783,6 @@ MBEDTLS_MPS_INTERNAL_API int mps_l3_pause_handshake( mps_l3 *l3 );
 #endif /* MBEDTLS_MPS_PROTO_TLS */
 
 /**
- * \brief           Abort the writing of an outgoing handshake message.
- *
- *                  After the writing of a handshake message has commenced
- *                  through a successful call to mps_l3_write_handshake(),
- *                  this function can be used to abort the write, as long
- *                  as no data has been committed.
- *
- * \param l3        The pointer to Layer 3 context.
- *
- * \return          0 on success, a negative error code on failure.
- *
- */
-MBEDTLS_MPS_INTERNAL_API int mps_l3_write_abort_handshake( mps_l3 *l3 );
-
-/**
  * \brief         Conclude the writing of the current outgoing message.
  *
  *                This function must be called after the user has requested

--- a/tests/suites/test_suite_mps.data
+++ b/tests/suites/test_suite_mps.data
@@ -423,166 +423,157 @@ depends_on:MBEDTLS_MPS_PROTO_TLS
 mbedtls_mps_l2_random:1000:1:5:5:10:1000:1:50:50:100
 
 MPS Layer 3 TLS: HS, fake transform, unknown length #0
-mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_STREAM:0:0:0:0:0:0
+mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_STREAM:0:0:0:0:0
 
 MPS Layer 3 TLS: HS, fake transform, unknown length #1
-mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_STREAM:0:0:0:0:0:1
+mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_STREAM:0:0:0:0:1
 
 MPS Layer 3 TLS: HS, fake transform, unknown length #2
-mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_STREAM:0:0:0:1:0:0
+mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_STREAM:0:0:1:0:0
 
 MPS Layer 3 TLS: HS, fake transform, unknown length #3
-mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_STREAM:0:0:0:1:0:1
+mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_STREAM:0:0:1:0:1
 
 MPS Layer 3 TLS: HS, fake transform, unknown length #4
-mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_STREAM:0:0:0:1:1:0
+mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_STREAM:0:0:1:1:0
 
 MPS Layer 3 TLS: HS, fake transform, unknown length #5
-mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_STREAM:0:0:0:1:1:1
+mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_STREAM:0:0:1:1:1
 
 MPS Layer 3 TLS: HS, fake transform, known length #0
-mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_STREAM:0:0:1:0:0:0
+mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_STREAM:0:1:0:0:0
 
 MPS Layer 3 TLS: HS, fake transform, known length #1
-mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_STREAM:0:0:1:1:0:0
+mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_STREAM:0:1:1:0:0
 
 MPS Layer 3 TLS: HS, fake transform, known length #2
-mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_STREAM:0:0:1:1:1:0
+mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_STREAM:0:1:1:1:0
 
 MPS Layer 3 TLS: HS, real transform, unknown length #0
-mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_STREAM:0:1:0:0:0:0
+mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_STREAM:1:0:0:0:0
 
 MPS Layer 3 TLS: HS, real transform, unknown length #1
-mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_STREAM:0:1:0:0:0:1
+mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_STREAM:1:0:0:0:1
 
 MPS Layer 3 TLS: HS, real transform, unknown length #2
-mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_STREAM:0:1:0:1:0:0
+mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_STREAM:1:0:1:0:0
 
 MPS Layer 3 TLS: HS, real transform, unknown length #3
-mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_STREAM:0:1:0:1:0:1
+mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_STREAM:1:0:1:0:1
 
 MPS Layer 3 TLS: HS, real transform, unknown length #4
-mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_STREAM:0:1:0:1:1:0
+mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_STREAM:1:0:1:1:0
 
 MPS Layer 3 TLS: HS, real transform, unknown length #5
-mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_STREAM:0:1:0:1:1:1
+mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_STREAM:1:0:1:1:1
 
 MPS Layer 3 TLS: HS, real transform, known length #0
-mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_STREAM:0:1:1:0:0:0
+mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_STREAM:1:1:0:0:0
 
 MPS Layer 3 TLS: HS, real transform, known length #1
-mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_STREAM:0:1:1:1:0:0
+mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_STREAM:1:1:1:0:0
 
 MPS Layer 3 TLS: HS, real transform, known length #2
-mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_STREAM:0:1:1:1:1:0
+mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_STREAM:1:1:1:1:0
 
 MPS Layer 3 TLS: HS, fake transform, unknown length, with abort
-mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_STREAM:1:0:0:0:0:0
+mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_STREAM:0:0:0:0:0
 
 MPS Layer 3 TLS: HS, fake transform, known length, with abort
-mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_STREAM:1:0:0:0:0:0
+mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_STREAM:0:0:0:0:0
 
 MPS Layer 3 TLS: HS, abort after commit
-mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_STREAM:2:0:0:0:0:0
+mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_STREAM:0:0:0:0:0
 
 MPS Layer 3 DTLS: HS, fake transform, unknown length #0
-mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:0:0:0:0:0
+mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:0:0:0:0
 
 MPS Layer 3 DTLS: HS, fake transform, unknown length #1
-mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:0:0:0:0:1
+mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:0:0:0:1
 
 MPS Layer 3 DTLS: HS, fake transform, unknown length #2
-mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:0:0:1:0:0
+mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:0:1:0:0
 
 MPS Layer 3 DTLS: HS, fake transform, unknown length #3
-mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:0:0:1:0:1
+mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:0:1:0:1
 
 MPS Layer 3 DTLS: HS, fake transform, unknown length #4
-mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:0:0:1:1:0
+mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:0:1:1:0
 
 MPS Layer 3 DTLS: HS, fake transform, unknown length #5
-mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:0:0:1:1:1
+mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:0:1:1:1
 
 MPS Layer 3 DTLS: HS, fake transform, unknown length #6
-mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:0:1:0:0:0
+mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:1:0:0:0
 
 MPS Layer 3 DTLS: HS, fake transform, unknown length #7
-mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:0:1:0:0:1
+mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:1:0:0:1
 
 MPS Layer 3 DTLS: HS, fake transform, unknown length #8
-mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:0:1:1:0:0
+mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:1:1:0:0
 
 MPS Layer 3 DTLS: HS, fake transform, unknown length #9
-mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:0:1:1:0:1
+mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:1:1:0:1
 
 MPS Layer 3 DTLS: HS, fake transform, unknown length #10
-mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:0:1:1:1:0
+mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:1:1:1:0
 
 MPS Layer 3 DTLS: HS, fake transform, unknown length #11
-mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:0:1:1:1:1
+mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:1:1:1:1
 
 MPS Layer 3 DTLS: HS, fake transform, known length #0
-mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:0:2:0:0:0
+mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:2:0:0:0
 
 MPS Layer 3 DTLS: HS, fake transform, known length #1
-mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:0:2:1:0:0
+mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:2:1:0:0
 
 MPS Layer 3 DTLS: HS, fake transform, known length #2
-mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:0:2:1:1:0
+mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:2:1:1:0
 
 MPS Layer 3 DTLS: HS, real transform, unknown length #0
-mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:1:0:0:0:0
+mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:1:0:0:0:0
 
 MPS Layer 3 DTLS: HS, real transform, unknown length #1
-mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:1:0:0:0:1
+mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:1:0:0:0:1
 
 MPS Layer 3 DTLS: HS, real transform, unknown length #2
-mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:1:0:1:0:0
+mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:1:0:1:0:0
 
 MPS Layer 3 DTLS: HS, real transform, unknown length #3
-mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:1:0:1:0:1
+mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:1:0:1:0:1
 
 MPS Layer 3 DTLS: HS, real transform, unknown length #4
-mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:1:0:1:1:0
+mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:1:0:1:1:0
 
 MPS Layer 3 DTLS: HS, real transform, unknown length #5
-mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:1:0:1:1:1
+mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:1:0:1:1:1
 
 MPS Layer 3 DTLS: HS, real transform, unknown length #6
-mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:1:1:0:0:0
+mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:1:1:0:0:0
 
 MPS Layer 3 DTLS: HS, real transform, unknown length #7
-mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:1:1:0:0:1
+mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:1:1:0:0:1
 
 MPS Layer 3 DTLS: HS, real transform, unknown length #8
-mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:1:1:1:0:0
+mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:1:1:1:0:0
 
 MPS Layer 3 DTLS: HS, real transform, unknown length #9
-mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:1:1:1:0:1
+mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:1:1:1:0:1
 
 MPS Layer 3 DTLS: HS, real transform, unknown length #10
-mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:1:1:1:1:0
+mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:1:1:1:1:0
 
 MPS Layer 3 DTLS: HS, real transform, unknown length #11
-mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:1:1:1:1:1
+mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:1:1:1:1:1
 
 MPS Layer 3 DTLS: HS, real transform, known length #0
-mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:1:2:0:0:0
+mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:1:2:0:0:0
 
 MPS Layer 3 DTLS: HS, real transform, known length #1
-mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:1:2:1:0:0
+mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:1:2:1:0:0
 
 MPS Layer 3 DTLS: HS, real transform, known length #2
-mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:0:1:2:1:1:0
-
-MPS Layer 3 DTLS: HS, fake transform, unknown length, with abort
-mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:1:0:0:0:0:0
-
-MPS Layer 3 DTLS: HS, fake transform, known length, with abort
-mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:1:0:0:0:0:0
-
-MPS Layer 3 DTLS: HS, abort after commit
-mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:2:0:0:0:0:0
+mbedtls_mps_l3_basic_handshake:MBEDTLS_MPS_MODE_DATAGRAM:1:2:1:1:0
 
 MPS Layer 3 DTLS: HS, incomplete header
 depends_on:MBEDTLS_MPS_PROTO_DTLS

--- a/tests/suites/test_suite_mps.function
+++ b/tests/suites/test_suite_mps.function
@@ -6351,7 +6351,6 @@ exit:
 /* BEGIN_CASE depends_on:TEST_SUITE_MPS_L3 */
 void mbedtls_mps_l3_basic_handshake(
           int mode,
-          int aborted_before,
           int real_transforms,
           int length_known,
           int multiple_fetch,
@@ -6410,79 +6409,6 @@ void mbedtls_mps_l3_basic_handshake(
     TEST_ASSERT( mps_l3_epoch_add( &srv_l3, dummy_s, &srv_epoch ) == 0 );
     TEST_ASSERT( mps_l3_epoch_usage( &srv_l3, srv_epoch,
                                      0, MPS_EPOCH_USAGE_READ( 0 ) ) == 0 );
-
-    /*
-     * Client: Start but abort writing handshake message, if requested
-     */
-
-    if( aborted_before != 0)
-    {
-        hs_out.epoch = 0;
-        hs_out.type = 12;
-
-        if( mode == MBEDTLS_MPS_MODE_STREAM )
-        {
-            if( length_known == 0 )
-            {
-                hs_out.frag_offset = 0;
-                hs_out.frag_len    = 10;
-                hs_out.len         = 20;
-            }
-            else
-            {
-                hs_out.frag_offset = 0;
-                hs_out.frag_len    = MBEDTLS_MPS_SIZE_UNKNOWN;
-                hs_out.len         = MBEDTLS_MPS_SIZE_UNKNOWN;
-            }
-        }
-        else
-        {
-            if( length_known == 2 )
-            {
-                hs_out.frag_offset = 10;
-                hs_out.frag_len    = 20;
-                hs_out.len         = 40;
-            }
-            else if( length_known == 1 )
-            {
-                hs_out.frag_offset = 10;
-                hs_out.frag_len    = MBEDTLS_MPS_SIZE_UNKNOWN;
-                hs_out.len         = 40;
-            }
-            else
-            {
-                hs_out.frag_offset = 0;
-                hs_out.frag_len    = MBEDTLS_MPS_SIZE_UNKNOWN;
-                hs_out.len         = MBEDTLS_MPS_SIZE_UNKNOWN;
-            }
-        }
-
-        TEST_ASSERT( mps_l3_write_handshake( &cli_l3,
-                                             &hs_out ) == 0 );
-
-        if( aborted_before == 1 )
-        {
-            TEST_ASSERT( mbedtls_writer_get_ext( hs_out.wr_ext, 10,
-                                                 &tmp, NULL ) == 0 );
-
-            TEST_ASSERT( mps_l3_write_abort_handshake( &cli_l3 ) == 0 );
-        }
-        else if( aborted_before == 2 )
-        {
-            TEST_ASSERT( mbedtls_writer_get_ext( hs_out.wr_ext, 10,
-                                                 &tmp, NULL ) == 0 );
-            TEST_ASSERT( mbedtls_writer_commit_ext( hs_out.wr_ext ) == 0 );
-
-#if defined(MBEDTLS_MPS_ENABLE_ASSERTIONS)
-            /* We shouldn't be allowed to abort once we have
-             * committed something. */
-            TEST_ASSERT( mps_l3_write_abort_handshake( &cli_l3 ) ==
-                         MBEDTLS_ERR_MPS_INTERNAL_ERROR );
-#endif /* MBEDTLS_MPS_ENABLE_ASSERTIONS */
-
-            goto exit;
-        }
-    }
 
     /*
      * Client: Write handshake message to server


### PR DESCRIPTION
Previously, MPS offered a function to abort the writing of handshake messages at Layer 3, but from all I can see, this is not used. Remove it for now.