### PR TITLE
fix mbedtls_ssl_check_cert_usage compile fail

### DIFF
--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -1137,9 +1137,6 @@ struct mbedtls_ssl_session
     mbedtls_time_t start;       /*!< starting time      */
 #endif /* MBEDTLS_HAVE_TIME */
     int ciphersuite;            /*!< chosen ciphersuite */
-#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
-    const mbedtls_ssl_ciphersuite_t* ciphersuite_info;
-#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
     int compression;            /*!< chosen compression */
     size_t id_len;              /*!< session id length  */
     unsigned char id[32];       /*!< session identifier */

--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -1652,17 +1652,10 @@ static inline mbedtls_x509_crt *mbedtls_ssl_own_cert( mbedtls_ssl_context *ssl )
  * Return 0 if everything is OK, -1 if not.
  */
 
-#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
 int mbedtls_ssl_check_cert_usage(const mbedtls_x509_crt* cert,
     const mbedtls_key_exchange_type_t key_exchange,
     int cert_endpoint,
     uint32_t* flags);
-#else
-int mbedtls_ssl_check_cert_usage( const mbedtls_x509_crt *cert,
-                          const mbedtls_ssl_ciphersuite_t *ciphersuite,
-                          int cert_endpoint,
-                          uint32_t *flags );
-#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 
 #endif /* MBEDTLS_X509_CRT_PARSE_C */
 

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -974,7 +974,7 @@ static int ssl_pick_cert( mbedtls_ssl_context *ssl,
          * different uses based on keyUsage, eg if they want to avoid signing
          * and decrypting with the same RSA key.
          */
-        if( mbedtls_ssl_check_cert_usage( cur->cert, ciphersuite_info,
+        if( mbedtls_ssl_check_cert_usage( cur->cert, ciphersuite_info->key_exchange,
                                   MBEDTLS_SSL_IS_SERVER, &flags ) != 0 )
         {
             MBEDTLS_SSL_DEBUG_MSG( 3, ( "certificate mismatch: "

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -2795,7 +2795,7 @@ static int ssl_parse_certificate_verify( mbedtls_ssl_context *ssl,
 #endif /* MBEDTLS_ECP_C */
 
     if( mbedtls_ssl_check_cert_usage( chain,
-                                      ciphersuite_info,
+                                      ciphersuite_info->key_exchange,
                                       ! ssl->conf->endpoint,
                                       &ssl->session_negotiate->verify_result ) != 0 )
     {
@@ -8560,17 +8560,10 @@ int mbedtls_ssl_check_sig_hash( const mbedtls_ssl_context *ssl,
 #endif /* MBEDTLS_KEY_EXCHANGE_WITH_CERT_ENABLED */
 
 #if defined(MBEDTLS_X509_CRT_PARSE_C)
-#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
 int mbedtls_ssl_check_cert_usage( const mbedtls_x509_crt* cert,
     const mbedtls_key_exchange_type_t key_exchange,
     int cert_endpoint,
     uint32_t* flags )
-#else
-int mbedtls_ssl_check_cert_usage( const mbedtls_x509_crt* cert,
-    const mbedtls_ssl_ciphersuite_t* ciphersuite,
-    int cert_endpoint,
-    uint32_t* flags )
-#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 {
     int ret = 0;
 #if defined(MBEDTLS_X509_CHECK_KEY_USAGE)
@@ -8592,11 +8585,7 @@ int mbedtls_ssl_check_cert_usage( const mbedtls_x509_crt* cert,
     if( cert_endpoint == MBEDTLS_SSL_IS_SERVER )
     {
         /* Server part of the key exchange */
-#if defined(MBEDTLS_SSL_PROTO_TLS1_2_OR_EARLIER)
-        switch( ciphersuite->key_exchange )
-#else   /* defined(MBEDTLS_SSL_PROTO_TLS1_2_OR_EARLIER) */
         switch( key_exchange )
-#endif /* !defined(MBEDTLS_SSL_PROTO_TLS1_2_OR_EARLIER) */
         {
             case MBEDTLS_KEY_EXCHANGE_RSA:
             case MBEDTLS_KEY_EXCHANGE_RSA_PSK:


### PR DESCRIPTION
`mbedtls_ssl_check_cert_usage` is redefined in TLS1.3.
That's due to different of `key_exchange` field. The function
only use `key_exchange` field of `ciphersuite_info`.
To keep consistency, we change the prototype of it.

issue: #297 