### PR TITLE
MPS: Remove extended reader/writer from Layer 3, part 1

### DIFF
--- a/include/mbedtls/mps/layer3.h
+++ b/include/mbedtls/mps/layer3.h
@@ -369,6 +369,8 @@ struct mps_l3_hs_out_internal
     /*! The size of the header buffer. */
     mbedtls_mps_stored_size_t hdr_len;
 
+    mbedtls_mps_stored_size_t hdr_offset;
+
     /*! The extended writer providing buffers to which the message
      *  contents can be written, and keeping track of message bounds. */
 


### PR DESCRIPTION
This is the first step in a series of PRs aiming to remove extended reader/writer from Layer 3 of MPS, hopefully simplifying the code and reducing its size.