### PR TITLE
Add signature_algorithms field to mbedtls_ssl_config 

### DIFF
--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -1356,8 +1356,16 @@ struct mbedtls_ssl_config
 #endif /* MBEDTLS_SSL_ASYNC_PRIVATE */
 
 #if defined(MBEDTLS_KEY_EXCHANGE_WITH_CERT_ENABLED)
-    const int *MBEDTLS_PRIVATE(sig_hashes);          /*!< allowed signature hashes           */
-#endif
+
+#if defined(MBEDTLS_SSL_PROTO_TLS1_2)
+    const int *MBEDTLS_PRIVATE(sig_hashes);             /*!< allowed signature hashes           */
+#endif /* MBEDTLS_SSL_PROTO_TLS1_2 */
+
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+    const int* MBEDTLS_PRIVATE(tls13_sig_algs);   /*!< allowed signature algorithms in TLS 1.3 */
+#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
+
+#endif /* MBEDTLS_KEY_EXCHANGE_WITH_CERT_ENABLED */
 
 #if defined(MBEDTLS_ECP_C)
     const mbedtls_ecp_group_id *MBEDTLS_PRIVATE(curve_list); /*!< allowed curves             */
@@ -1987,7 +1995,7 @@ void mbedtls_ssl_conf_verify( mbedtls_ssl_config *conf,
                      void *p_vrfy );
 #endif /* MBEDTLS_X509_CRT_PARSE_C */
 
-#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && defined(MBEDTLS_X509_CRT_PARSE_C)
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && defined(MBEDTLS_KEY_EXCHANGE_WITH_CERT_ENABLED)
 /**
  * \brief          Configure signature algorithms (Optional).
  *
@@ -2003,7 +2011,7 @@ void mbedtls_ssl_conf_verify( mbedtls_ssl_config *conf,
  */
 void mbedtls_ssl_conf_signature_algorithms( mbedtls_ssl_config *conf,
                      const int* sig_algs );
-#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL && MBEDTLS_X509_CRT_PARSE_C */
+#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL && MBEDTLS_KEY_EXCHANGE_WITH_CERT_ENABLED */
 
 /**
  * \brief          Set the random number generator callback
@@ -3507,7 +3515,7 @@ void mbedtls_ssl_conf_key_share_curves(mbedtls_ssl_config* conf,
     const mbedtls_ecp_group_id* curve_list);
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL && MBEDTLS_SSL_CLI_C && MBEDTLS_ECP_C */
 
-#if defined(MBEDTLS_KEY_EXCHANGE_WITH_CERT_ENABLED)
+#if defined(MBEDTLS_KEY_EXCHANGE_WITH_CERT_ENABLED) && defined(MBEDTLS_SSL_PROTO_TLS1_2)
 /**
  * \brief          Set the allowed hashes for signatures during the handshake.
  *
@@ -3539,7 +3547,7 @@ void mbedtls_ssl_conf_key_share_curves(mbedtls_ssl_config* conf,
  */
 void mbedtls_ssl_conf_sig_hashes( mbedtls_ssl_config *conf,
                                   const int *hashes );
-#endif /* MBEDTLS_KEY_EXCHANGE_WITH_CERT_ENABLED */
+#endif /* MBEDTLS_KEY_EXCHANGE_WITH_CERT_ENABLED && MBEDTLS_SSL_PROTO_TLS1_2 */
 
 #if defined(MBEDTLS_X509_CRT_PARSE_C)
 /**

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -2111,7 +2111,7 @@ static int ssl_client_hello_fetch( mbedtls_ssl_context* ssl,
                 return( MBEDTLS_ERR_SSL_DECODE_ERROR );
             }
 
-            MBEDTLS_SSL_DEBUG_MSG( 3, ( "CCS, message len.: %d", msg_len ) );
+            MBEDTLS_SSL_DEBUG_MSG( 3, ( "CCS, message len.: %" MBEDTLS_PRINTF_SIZET , msg_len ) );
 
             if( ( ret = mbedtls_ssl_fetch_input( ssl,
                             mbedtls_ssl_hdr_len( ssl ) + msg_len ) ) != 0 )

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -607,7 +607,7 @@ static int my_verify( void *data, mbedtls_x509_crt *crt,
 #endif /* MBEDTLS_X509_CRT_PARSE_C */
 
 #if defined(MBEDTLS_ECP_C) && defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
-static int ssl_sig_hashes_for_test_tls13[] = {
+static int ssl_tls13_sig_algs_for_test[] = {
 #if defined(MBEDTLS_SHA256_C) && defined(MBEDTLS_ECDSA_C) && defined(MBEDTLS_ECP_DP_SECP256R1_ENABLED)
     SIGNATURE_ECDSA_SECP256r1_SHA256,
 #endif
@@ -1965,7 +1965,9 @@ int main( int argc, char *argv[] )
     {
         crt_profile_for_test.allowed_mds |= MBEDTLS_X509_ID_FLAG( MBEDTLS_MD_SHA1 );
         mbedtls_ssl_conf_cert_profile( &conf, &crt_profile_for_test );
+#if defined(MBEDTLS_SSL_PROTO_TLS1_2)
         mbedtls_ssl_conf_sig_hashes( &conf, ssl_sig_hashes_for_test );
+#endif /* MBEDTLS_SSL_PROTO_TLS1_2 */
     }
 
     if( opt.context_crt_cb == 0 )
@@ -1975,9 +1977,9 @@ int main( int argc, char *argv[] )
 
 #endif /* MBEDTLS_X509_CRT_PARSE_C */
 
-#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && defined(MBEDTLS_ECP_C)
-    mbedtls_ssl_conf_sig_hashes( &conf, ssl_sig_hashes_for_test_tls13 );
-#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL && MBEDTLS_ECP_C */
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && defined(MBEDTLS_KEY_EXCHANGE_WITH_CERT_ENABLED)
+    mbedtls_ssl_conf_signature_algorithms( &conf, ssl_tls13_sig_algs_for_test );
+#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL && MBEDTLS_KEY_EXCHANGE_WITH_CERT_ENABLED */
 
 #if defined(MBEDTLS_SSL_DTLS_CONNECTION_ID)
     if( opt.cid_enabled == 1 || opt.cid_enabled_renego == 1 )


### PR DESCRIPTION
Supported signature algorithms structures are different between
TLS1.2 and TLS1.3. Origin `sig_hashes` represents hash field defined
in RFC5246, but TLS1.3 does not define the field. TLS1.3 define an enum
to represent signaure/hash pairs, and the enum is not compatible with
TLS1.2.

So, a new field is needed for supported signature algorthms of TLS1.3.

References:
- [RFC8446 Section 4.2.3](https://datatracker.ietf.org/doc/html/rfc8446#section-4.2.3)
- [RFC5246 Section 7.4.1.4.1](https://datatracker.ietf.org/doc/html/rfc5246#section-7.4.1.4.1)


