### PR TITLE
Add conditional compilation for  mbedtls_ssl_conf_dtls_cookies

### DIFF
--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -720,6 +720,10 @@
 #error "MBEDTLS_SSL_DTLS_HELLO_VERIFY  defined, but not all prerequisites"
 #endif
 
+#if defined(MBEDTLS_SSL_DTLS_HELLO_VERIFY) && !defined(MBEDTLS_SSL_SRV_C)
+#error "MBEDTLS_SSL_DTLS_HELLO_VERIFY  defined, but not all prerequisites"
+#endif
+
 #if defined(MBEDTLS_SSL_DTLS_CLIENT_PORT_REUSE) && \
     !defined(MBEDTLS_SSL_DTLS_HELLO_VERIFY)
 #error "MBEDTLS_SSL_DTLS_CLIENT_PORT_REUSE  defined, but not all prerequisites"

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -2775,7 +2775,9 @@ void mbedtls_ssl_conf_cookies(mbedtls_ssl_config* conf,
     mbedtls_ssl_cookie_check_t* f_cookie_check,
     void* p_cookie,
     unsigned int rr_conf);
-#else
+#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
+
+#if defined(MBEDTLS_SSL_DTLS_HELLO_VERIFY)
 /**
  * \brief           Register callbacks for DTLS cookies
  *                  (Server only. DTLS only.)
@@ -2808,7 +2810,7 @@ void mbedtls_ssl_conf_dtls_cookies( mbedtls_ssl_config *conf,
                            mbedtls_ssl_cookie_write_t *f_cookie_write,
                            mbedtls_ssl_cookie_check_t *f_cookie_check,
                            void *p_cookie );
-#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
+#endif /* defined(MBEDTLS_SSL_DTLS_HELLO_VERIFY) */
 
 /**
  * \brief          Set client's transport-level identification info.

--- a/programs/fuzz/fuzz_dtlsserver.c
+++ b/programs/fuzz/fuzz_dtlsserver.c
@@ -89,8 +89,9 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
 
     if( mbedtls_ssl_cookie_setup( &cookie_ctx, dummy_random, &ctr_drbg ) != 0 )
         goto exit;
-
+#if defined(MBEDTLS_SSL_DTLS_HELLO_VERIFY)
     mbedtls_ssl_conf_dtls_cookies( &conf, mbedtls_ssl_cookie_write, mbedtls_ssl_cookie_check, &cookie_ctx );
+#endif /* defined(MBEDTLS_SSL_DTLS_HELLO_VERIFY) */
 
     if( mbedtls_ssl_setup( &ssl, &conf ) != 0 )
         goto exit;

--- a/programs/ssl/dtls_server.c
+++ b/programs/ssl/dtls_server.c
@@ -244,8 +244,10 @@ int main( void )
         goto exit;
     }
 
+#if defined(MBEDTLS_SSL_DTLS_HELLO_VERIFY)
     mbedtls_ssl_conf_dtls_cookies( &conf, mbedtls_ssl_cookie_write, mbedtls_ssl_cookie_check,
                                &cookie_ctx );
+#endif
 
     if( ( ret = mbedtls_ssl_setup( &ssl, &conf ) ) != 0 )
     {

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -3781,9 +3781,10 @@ int main( int argc, char *argv[] )
                 mbedtls_printf( " failed\n  ! mbedtls_ssl_cookie_setup returned %d\n\n", ret );
                 goto exit;
             }
-
+#if defined(MBEDTLS_SSL_DTLS_HELLO_VERIFY)
             mbedtls_ssl_conf_dtls_cookies( &conf, mbedtls_ssl_cookie_write, mbedtls_ssl_cookie_check,
                                        &cookie_ctx );
+#endif /* defined(MBEDTLS_SSL_DTLS_HELLO_VERIFY) */
         }
         else
 #endif /* MBEDTLS_SSL_COOKIE_C */

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -939,10 +939,10 @@ int mbedtls_endpoint_init( mbedtls_endpoint *ep, int endpoint_type, int pk_alg,
     ret = mbedtls_ssl_setup( &( ep->ssl ), &( ep->conf ) );
     TEST_ASSERT( ret == 0 );
 
-#if defined(MBEDTLS_SSL_PROTO_DTLS) && defined(MBEDTLS_SSL_SRV_C)
+#if defined(MBEDTLS_SSL_DTLS_HELLO_VERIFY)
     if( endpoint_type == MBEDTLS_SSL_IS_SERVER && dtls_context != NULL )
          mbedtls_ssl_conf_dtls_cookies( &( ep->conf ), NULL, NULL, NULL );
-#endif
+#endif /* defined(MBEDTLS_SSL_DTLS_HELLO_VERIFY) */
 
     ret = mbedtls_endpoint_certificate_init( ep, pk_alg );
     TEST_ASSERT( ret == 0 );


### PR DESCRIPTION
mbedtls_ssl_conf_dtls_cookies depends on MBEDTLS_SSL_DTLS_HELLO_VERIFY.
Not all place is wrapped with it.

issues: #297