### PR TITLE
MPS: Remove extended reader/writer from MPS, part 2

### DIFF
--- a/include/mbedtls/mps/common.h
+++ b/include/mbedtls/mps/common.h
@@ -290,8 +290,10 @@ typedef uint8_t mbedtls_mps_epoch_offset_t;
 
 #else /* MBEDTLS_MPS_ENABLE_ASSERTIONS */
 
-#define MBEDTLS_MPS_ASSERT( cond, string )     do {} while( 0 )
-#define MBEDTLS_MPS_ASSERT_RAW( cond, string ) do {} while( 0 )
+#define MBEDTLS_MPS_ASSERT( cond, string )              \
+    do { int val = (cond); ((void) val); } while( 0 )
+#define MBEDTLS_MPS_ASSERT_RAW( cond, string )          \
+    do { int val = (cond); ((void) val); } while( 0 )
 
 #endif /* MBEDTLS_MPS_ENABLE_ASSERTIONS */
 

--- a/include/mbedtls/mps/common.h
+++ b/include/mbedtls/mps/common.h
@@ -376,41 +376,29 @@ typedef uint8_t mbedtls_mps_transport_type;
  /* MBEDTLS_SSL_TRANSPORT_DATAGRAM */
 #define MBEDTLS_MPS_MODE_DATAGRAM ((mbedtls_mps_transport_type) 1)
 
+/* Helper macros to check whether TLS/DTLS are enabled. */
 #if defined(MBEDTLS_MPS_PROTO_TLS)
-
 #if defined(MBEDTLS_MPS_PROTO_BOTH)
-#define MBEDTLS_MPS_IS_TLS( mode )               \
-    ( (mode) == MBEDTLS_MPS_MODE_STREAM )
+#define MBEDTLS_MPS_IS_TLS(mode)         ((mode) == MBEDTLS_MPS_MODE_STREAM)
 #else
-/* Define `1` in a roundabout way using `mode` to avoid unused
- * variable warnings. */
-#define MBEDTLS_MPS_IS_TLS( mode ) ( ((void) mode), 1 )
+#define MBEDTLS_MPS_IS_TLS(mode)         (((void) mode), 1)
 #endif /* MBEDTLS_MPS_PROTO_BOTH */
-
-#define MBEDTLS_MPS_IF_TLS( mode ) if( MBEDTLS_MPS_IS_TLS( mode ) )
-
-#else /* MBEDTLS_MPS_PROTO_TLS */
-
-#define MBEDTLS_MPS_IS_TLS( mode ) 0
-
+#else  /* MBEDTLS_MPS_PROTO_TLS */
+#define MBEDTLS_MPS_IS_TLS(mode)         (((void) mode), 0)
 #endif /* MBEDTLS_MPS_PROTO_TLS  */
-
+#define MBEDTLS_MPS_IF_TLS(mode)         if( MBEDTLS_MPS_IS_TLS( mode ) )
 #if defined(MBEDTLS_MPS_PROTO_DTLS)
 #if defined(MBEDTLS_MPS_PROTO_BOTH)
-#define MBEDTLS_MPS_IS_DTLS( mode )               \
-    ( (mode) == MBEDTLS_MPS_MODE_DATAGRAM )
-#define MBEDTLS_MPS_ELSE_IF_DTLS( mode )         \
-    else if( ((void)mode), 1 )
-#else
-/* Define `1` in a roundabout way using `mode` to avoid unused
- * variable warnings. */
-#define MBEDTLS_MPS_IS_DTLS( mode ) ( ((void) mode), 1 )
-#define MBEDTLS_MPS_ELSE_IF_DTLS( mode )        \
-    if( MBEDTLS_MPS_IS_DTLS( mode ) )
+#define MBEDTLS_MPS_IS_DTLS(mode)        ((mode) == MBEDTLS_MPS_MODE_DATAGRAM)
+#define MBEDTLS_MPS_ELSE_IF_DTLS(mode)   else if(((void)mode), 1)
+#else /* MBEDTLS_MPS_PROTO_BOTH */
+#define MBEDTLS_MPS_IS_DTLS(mode)        (((void) mode), 1)
+#define MBEDTLS_MPS_ELSE_IF_DTLS( mode ) if( MBEDTLS_MPS_IS_DTLS( mode ) )
 #endif /* MBEDTLS_MPS_PROTO_BOTH */
-
-#define MBEDTLS_MPS_IF_DTLS( mode ) if( MBEDTLS_MPS_IS_DTLS( mode ) )
+#else  /* MBEDTLS_MPS_PROTO_DTLS  */
+#define MBEDTLS_MPS_IS_DTLS(mode)        (((void) mode), 0 )
 #endif /* MBEDTLS_MPS_PROTO_DTLS  */
+#define MBEDTLS_MPS_IF_DTLS( mode )      if(MBEDTLS_MPS_IS_DTLS(mode))
 
 /*! The enumeration of record content types recognized by MPS.
  *

--- a/include/mbedtls/mps/layer3.h
+++ b/include/mbedtls/mps/layer3.h
@@ -92,36 +92,28 @@ typedef enum mps_l3_hs_state
 } mps_l3_hs_state;
 
 /**
- * \brief    This structure represents handles to
- *           outgoing handshake messages.
+ * \brief    This structure represents handles to outgoing handshake messages.
  *
- *           It is used in the following way:
- *           When the user wants to prepare an outgoing
- *           handshake message, he creates an instance
- *           of this structure and sets fields indicating
- *           the intended epoch, handshake type, and
- *           handshake message length. The user then calls
- *           mps_l3_write_handshake() which, on success,
- *           sets the \c wr_ext within this struct to point
- *           to a valid writer that can be used to provide
- *           the actual message contents.
+ *           It is used in the following way: When users want to prepare
+ *           an outgoing handshake message, they create an instance of this
+ *           structure and set fields indicating the intended epoch,
+ *           handshake type, and handshake message length. They then call
+ *           mps_l3_write_handshake() which, on success, sets the \c wr
+ *           within this struct to point to a valid writer that can be used
+ *           to provide the actual message contents.
  *
- *           When the writing is done, the user calls
- *           mps_l3_dispatch() to prepare the message for
- *           delivery; if the writing cannot be completed
- *           because the provided writer does not provide
- *           enough space for outgoing data, the write can
- *           be paused via mps_l3_pause_handshake(), and
- *           subsequently be continued via another call to
- *           mps_l3_write_handshake() which must use the
- *           the same epoch, handshake type and length
- *           parameters as the initial one.
+ *           When the writing is done, users call mps_l3_dispatch() to prepare
+ *           the message for delivery; if the writing cannot be completed
+ *           because the provided writer does not provide enough space for
+ *           outgoing data, the write can be paused via mps_l3_pause_handshake()
+ *           and subsequently be continued via another call to
+ *           mps_l3_write_handshake() which must use the the same epoch,
+ *           handshake type and length parameters as the initial one.
  *
- *           The handshake message length must be known
- *           in advance if pausing is needed for the message.
- *           If pausing is not needed, the length field can
- *           be set to #MBEDTLS_MPS_SIZE_UNKNOWN and will be
- *           be determined automatically on closing.
+ *           The handshake message length must be known in advance if pausing
+ *           is needed for the message. If pausing is not needed, the length
+ *           field can be set to #MBEDTLS_MPS_SIZE_UNKNOWN and will be be
+ *           determined automatically on closing.
  */
 struct mps_l3_handshake_out
 {
@@ -152,11 +144,11 @@ struct mps_l3_handshake_out
       *  beginning of the handshake message.*/
     mbedtls_mps_stored_size_t frag_offset;
 
-    /*! The extended writer providing buffers to which the message
+    /*! The writer providing buffers to which the message
      *  contents can be written, and keeping track of message bounds.
      *  This must be \c NULL when the user calls mps_l3_write_handshake(), which
-     *  will modify it to point to a valid extended writer on success. */
-    mbedtls_writer_ext *wr_ext;
+     *  will modify it to point to a valid writer on success. */
+    mbedtls_writer *wr;
 };
 
 /**
@@ -205,9 +197,8 @@ struct mps_l3_handshake_in
     /*! The handshake sequence number.*/
     mbedtls_mps_stored_hs_seq_nr_t seq_nr;
 
-    /*!< The extended reader giving access to the message contents, and
-     *   keeping track of message bounds. */
-    mbedtls_mps_reader_ext *rd_ext;
+    /*!< The reader giving access to the message contents. */
+    mbedtls_mps_reader *rd;
 };
 
 /**
@@ -338,10 +329,6 @@ struct mps_l3_hs_in_internal
 
     /*!< The handshake sequence number. */
     mbedtls_mps_stored_hs_seq_nr_t seq_nr;
-
-    mbedtls_mps_reader_ext rd_ext;  /*!< The extended reader giving access to
-                                 *   the message contents, but also keeping
-                                 *   track of message bounds.                */
 };
 
 struct mps_l3_hs_out_internal
@@ -370,15 +357,6 @@ struct mps_l3_hs_out_internal
     mbedtls_mps_stored_size_t hdr_len;
 
     mbedtls_mps_stored_size_t hdr_offset;
-
-    /*! The extended writer providing buffers to which the message
-     *  contents can be written, and keeping track of message bounds. */
-
-    /* OPTIMIZATION:
-     * Consider removing the extended writer from Layer 3 and
-     * performing bounds checks for handshake messages at Layer 4.
-     * See the corresponding comment in mps.h. */
-    mbedtls_writer_ext wr_ext;
 
     /* DTLS-specific fields. */
 

--- a/include/mbedtls/mps/layer3.h
+++ b/include/mbedtls/mps/layer3.h
@@ -117,17 +117,6 @@ typedef enum mps_l3_hs_state
  */
 struct mps_l3_handshake_out
 {
-    /*! The epoch to use to protect the handshake message.
-     *  This must be set by the user before calling mps_l3_write_handshake(). */
-    mbedtls_mps_stored_epoch_id epoch;
-
-    /*! The handshake message type. This must be set by
-     *  the user before calling mps_l3_write_handshake().*/
-    mbedtls_mps_stored_hs_type type;
-
-    /*! The handshake sequence number. */
-    mbedtls_mps_stored_hs_seq_nr_t seq_nr;
-
     /*! The total length of the handshake message (regardless of fragmentation),
      *  or #MBEDTLS_MPS_SIZE_UNKNOWN if the length will be determined at
      *  write-time. In this case, pausing is not possible for the handshake
@@ -136,6 +125,18 @@ struct mps_l3_handshake_out
      *  before calling mps_l3_write_handshake(). */
     mbedtls_mps_stored_opt_size_t len;
 
+    /*! The epoch to use to protect the handshake message.
+     *  This must be set by the user before calling mps_l3_write_handshake(). */
+    mbedtls_mps_stored_epoch_id epoch;
+
+    /*! The handshake message type. This must be set by
+     *  the user before calling mps_l3_write_handshake().*/
+    mbedtls_mps_stored_hs_type type;
+
+#if defined(MBEDTLS_MPS_PROTO_DTLS)
+    /*! The handshake sequence number. */
+    mbedtls_mps_stored_hs_seq_nr_t seq_nr;
+
     /*! The length of the current handshake fragment, or
      *  #MBEDTLS_MPS_SIZE_UNKNOWN if the will be determined at write-time. */
     mbedtls_mps_stored_opt_size_t frag_len;
@@ -143,6 +144,7 @@ struct mps_l3_handshake_out
      /*! The offset of the current fragment from the
       *  beginning of the handshake message.*/
     mbedtls_mps_stored_size_t frag_offset;
+#endif /* MBEDTLS_MPS_PROTO_DTLS */
 
     /*! The writer providing buffers to which the message
      *  contents can be written, and keeping track of message bounds.

--- a/include/mbedtls/mps/layer3.h
+++ b/include/mbedtls/mps/layer3.h
@@ -369,6 +369,8 @@ struct mps_l3_hs_out_internal
     /*! The size of the header buffer. */
     mbedtls_mps_stored_size_t hdr_len;
 
+    mbedtls_mps_stored_size_t hdr_offset;
+
     /*! The extended writer providing buffers to which the message
      *  contents can be written, and keeping track of message bounds. */
 

--- a/include/mbedtls/mps/trace.h
+++ b/include/mbedtls/mps/trace.h
@@ -37,8 +37,6 @@
 #define mbedtls_vsnprintf vsnprintf
 #endif /* MBEDTLS_PLATFORM_C */
 
-#if defined(MBEDTLS_MPS_ENABLE_TRACE)
-
 /*
  * Adapt this to enable/disable tracing output
  * from the various layers of the MPS.
@@ -115,6 +113,8 @@ typedef enum
                                  MBEDTLS_MPS_TRACE_MASK_READER  |       \
                                  MBEDTLS_MPS_TRACE_MASK_WRITER )
 
+#if defined(MBEDTLS_MPS_ENABLE_TRACE)
+
 /* We have to avoid globals because E-ACSL chokes on them...
  * Wrap everything in stub functions. */
 int  mbedtls_mps_trace_get_depth( void );
@@ -163,8 +163,16 @@ void mbedtls_mps_trace_print_msg( int id, int line, const char *format, ... );
 
 #else /* MBEDTLS_MPS_TRACE */
 
-#define MBEDTLS_MPS_TRACE( type, ... ) do { } while( 0 )
-#define MBEDTLS_MPS_TRACE_INIT( ... )  do { } while( 0 )
+static inline void mps_trace_variable_sink( const char* fmt, ...)
+{
+    ((void) fmt);
+}
+
+/* Make sure to "use" arguments, to avoid unused variable warnings. */
+#define MBEDTLS_MPS_TRACE( type, ... ) \
+    do { ((void) type); mps_trace_variable_sink( __VA_ARGS__ ); } while( 0 )
+#define MBEDTLS_MPS_TRACE_INIT( ... )  \
+    do { mps_trace_variable_sink( __VA_ARGS__ ); } while( 0 )
 #define MBEDTLS_MPS_TRACE_END          do { } while( 0 )
 
 #define MBEDTLS_MPS_TRACE_RETURN( val ) return( val );

--- a/library/mps/layer2_internal.h
+++ b/library/mps/layer2_internal.h
@@ -249,7 +249,6 @@ MBEDTLS_MPS_STATIC int l2_type_ignore( mbedtls_mps_l2 *ctx,
 /* Print human-readable description of epoch usage flags. */
 MBEDTLS_MPS_STATIC void l2_print_usage( unsigned usage );
 
-#if defined(MBEDTLS_MPS_ENABLE_TRACE)
 static inline const char * l2_epoch_usage_to_string(
     mbedtls_mps_epoch_usage usage )
 {
@@ -265,7 +264,6 @@ static inline const char * l2_epoch_usage_to_string(
 
     return( "NONE" );
 }
-#endif /* MBEDTLS_MPS_ENABLE_TRACE */
 
 /* Internal macro used to indicate internal usage of an epoch,
  * e.g. because data it still pending to be dispatched.

--- a/library/mps/layer3.c
+++ b/library/mps/layer3.c
@@ -34,6 +34,61 @@ static int mbedtls_mps_trace_id = MBEDTLS_MPS_TRACE_BIT_LAYER_3;
 
 #include <stdlib.h>
 
+/*
+ * Some debug helpers, captured as macros to keep the code readable.
+ */
+
+#if defined(MBEDTLS_MPS_PROTO_TLS)
+#define L3_DEBUG_TLS_HS_HEADER( hdr )                                                    \
+    do                                                                                   \
+    {                                                                                    \
+        MBEDTLS_MPS_TRACE_COMMENT( "TLS handshake header" );                            \
+        MBEDTLS_MPS_TRACE_COMMENT( "* Type:        %u", (unsigned) (hdr)->type        ); \
+        MBEDTLS_MPS_TRACE_COMMENT( "* Length:      %u", (unsigned) (hdr)->len         ); \
+    } while( 0 )
+#else
+#define L3_DEBUG_TLS_HS_HEADER( hdr ) do {} while( 0 )
+#endif /* MBEDTLS_MPS_PROTO_TLS */
+
+#if defined(MBEDTLS_MPS_PROTO_DTLS)
+#define L3_DEBUG_DTLS_HS_HEADER( hdr )                                                   \
+    do                                                                                   \
+    {                                                                                    \
+        MBEDTLS_MPS_TRACE_COMMENT( "DTLS handshake header" );                            \
+        MBEDTLS_MPS_TRACE_COMMENT( "* Type:        %u", (unsigned) (hdr)->type        ); \
+        MBEDTLS_MPS_TRACE_COMMENT( "* Length:      %u", (unsigned) (hdr)->len         ); \
+        MBEDTLS_MPS_TRACE_COMMENT( "* Sequence Nr: %u", (unsigned) (hdr)->seq_nr      ); \
+        MBEDTLS_MPS_TRACE_COMMENT( "* Frag Offset: %u", (unsigned) (hdr)->frag_offset ); \
+        MBEDTLS_MPS_TRACE_COMMENT( "* Frag Length: %u", (unsigned) (hdr)->frag_len    ); \
+    } while( 0 )
+#else
+#define L3_DEBUG_DTLS_HS_HEADER( hdr ) do {} while( 0 )
+#endif /* MBEDTLS_MPS_PROTO_DTLS */
+
+#define L3_DEBUG_HS_HEADER( hdr, mode )                                                  \
+    do                                                                                   \
+    {                                                                                    \
+        if( MBEDTLS_MPS_IS_TLS( mode ) )                                                 \
+            L3_DEBUG_TLS_HS_HEADER(hdr);                                                 \
+        if( MBEDTLS_MPS_IS_DTLS( mode ) )                                                \
+            L3_DEBUG_DTLS_HS_HEADER(hdr);                                                \
+    } while( 0 )
+
+#define L3_DEBUG_ALERT( alert )                                                          \
+    do                                                                                   \
+    {                                                                                    \
+        MBEDTLS_MPS_TRACE_COMMENT( "Alert, level %u, type %u",                           \
+                                   (unsigned) (alert)->level, (alert)->type );           \
+    } while( 0 )
+
+#define L3_DEBUG_IN_STATE( l3 )                                                     \
+    do                                                                              \
+    {                                                                               \
+        MBEDTLS_MPS_TRACE_COMMENT( "* External state:  %u",                         \
+               (unsigned) l3->io.in.state );                                        \
+        MBEDTLS_MPS_TRACE_COMMENT( "* Handshake state: %u",                         \
+               (unsigned) l3->io.in.hs.state );                                     \
+    } while( 0 )
 
 /*
  * Constants and sizes from the [D]TLS standard
@@ -107,13 +162,10 @@ MBEDTLS_MPS_STATIC int l3_incomplete_header( mps_l3 *l3 )
 
     if( MBEDTLS_MPS_IS_TLS( mode ) )
     {
-        MBEDTLS_MPS_TRACE_COMMENT(
-              "Incomplete message header -- wait for more data" );
-
+        MBEDTLS_MPS_TRACE_COMMENT( "Incomplete message header" );
         ret = mps_l2_read_done( l2 );
         if( ret != 0 )
             MBEDTLS_MPS_TRACE_RETURN( ret );
-
         /* We could return WANT_READ here, because _currently_ no records are
          * buffered by Layer 2, hence progress depends on the availability of
          * the underlying transport. However, this would need to be reconsidered
@@ -128,16 +180,6 @@ MBEDTLS_MPS_STATIC int l3_incomplete_header( mps_l3 *l3 )
         return( MBEDTLS_ERR_MPS_INVALID_CONTENT );
     }
 }
-
-#define L3_DEBUG_IN_STATE( l3 )                                                     \
-    do                                                                              \
-    {                                                                               \
-        MBEDTLS_MPS_TRACE_COMMENT( "New state" );                                   \
-        MBEDTLS_MPS_TRACE_COMMENT( "* External state:  %u",                         \
-               (unsigned) l3->io.in.state );                                        \
-        MBEDTLS_MPS_TRACE_COMMENT( "* Handshake state: %u",                         \
-               (unsigned) l3->io.in.hs.state );                                     \
-    } while( 0 )
 
 /* Attempt to receive an incoming message from Layer 2. */
 int mps_l3_read( mps_l3 *l3 )
@@ -296,84 +338,44 @@ int mps_l3_read( mps_l3 *l3 )
     MBEDTLS_MPS_TRACE_RETURN( l3->io.in.state );
 }
 
-/* Mark an incoming message as fully processed. */
-int mps_l3_read_consume( mps_l3 *l3 )
+MBEDTLS_MPS_STATIC int l3_read_consume_core( mps_l3 *l3,
+                                             mps_l3_hs_state new_hs_state )
 {
     int res;
     mbedtls_mps_l2* const l2 = mbedtls_mps_l3_get_l2( l3 );
-    MBEDTLS_MPS_TRACE_INIT( "mps_l3_read_consume" );
-
-    switch( l3->io.in.state )
-    {
-        case MBEDTLS_MPS_MSG_HS:
-            MBEDTLS_MPS_TRACE_COMMENT(  "Finishing handshake message" );
-            /* See mps_l3_read for the general description
-             * of how the implementation uses extended readers
-             * to handle pausing of handshake messages. */
-            break;
-
-        case MBEDTLS_MPS_MSG_ALERT:
-        case MBEDTLS_MPS_MSG_ACK:
-        case MBEDTLS_MPS_MSG_CCS:
-        case MBEDTLS_MPS_MSG_APP:
-            /* All contents are already committed in parsing functions. */
-            break;
-
-        default:
-            MBEDTLS_MPS_STATE_VALIDATE_RAW( l3->io.in.state != MBEDTLS_MPS_MSG_NONE,
-                          "mps_l3_read_consume() called in unexpected state." );
-
-            MBEDTLS_MPS_ASSERT_RAW( 0,
-                       "Invalid message state in mps_l3_read_consume()." );
-            break;
-    }
 
     /* Remove reference to the raw reader borrowed from Layer 2
      * before calling mps_l2_read_done(), which invalidates it. */
     l3->io.in.raw_in = NULL;
-
     /* Signal that incoming data is fully processed. */
     res = mps_l2_read_done( l2 );
     if( res != 0 )
-        MBEDTLS_MPS_TRACE_RETURN( res );
+        return( res );
 
     /* Reset state */
     if( l3->io.in.state == MBEDTLS_MPS_MSG_HS )
-        l3->io.in.hs.state = MPS_L3_HS_NONE;
+        l3->io.in.hs.state = new_hs_state;
     l3->io.in.state = MBEDTLS_MPS_MSG_NONE;
-    MBEDTLS_MPS_TRACE_RETURN( 0 );
+    return( 0 );
+}
+
+/* Mark an incoming message as fully processed. */
+int mps_l3_read_consume( mps_l3 *l3 )
+{
+    MBEDTLS_MPS_TRACE_INIT( "mps_l3_read_consume" );
+    MBEDTLS_MPS_TRACE_RETURN( l3_read_consume_core( l3, MPS_L3_HS_NONE ) );
 }
 
 #if defined(MBEDTLS_MPS_PROTO_TLS)
 /* Pause the processing of an incoming handshake message. */
 int mps_l3_read_pause_handshake( mps_l3 *l3 )
 {
-    int res;
-    mbedtls_mps_l2* const l2 = mbedtls_mps_l3_get_l2( l3 );
     MBEDTLS_MPS_TRACE_INIT( "mps_l3_read_pause_handshake" );
-
-    /* See mps_l3_read() for the general description
-     * of how the implementation uses extended readers
-     * to handle pausing of handshake messages. */
-
     MBEDTLS_MPS_STATE_VALIDATE_RAW(
         l3->io.in.state    == MBEDTLS_MPS_MSG_HS &&
         l3->io.in.hs.state == MPS_L3_HS_ACTIVE,
         "mps_l3_read_pause_handshake() called in unexpected state." );
-
-    /* Remove reference to the raw reader borrowed from Layer 2
-     * before calling mps_l2_read_done(), which invalidates it. */
-    l3->io.in.raw_in = NULL;
-
-    /* Signal to Layer 2 that incoming data is fully processed. */
-    res = mps_l2_read_done( l2 );
-    if( res != 0 )
-        MBEDTLS_MPS_TRACE_RETURN( res );
-
-    /* Switch to paused state. */
-    l3->io.in.state    = MBEDTLS_MPS_MSG_NONE;
-    l3->io.in.hs.state = MPS_L3_HS_PAUSED;
-    MBEDTLS_MPS_TRACE_RETURN( 0 );
+    MBEDTLS_MPS_TRACE_RETURN( l3_read_consume_core( l3, MPS_L3_HS_PAUSED ) );
 }
 #endif /* MBEDTLS_MPS_PROTO_TLS */
 
@@ -384,7 +386,7 @@ int mps_l3_read_pause_handshake( mps_l3 *l3 )
 /* Handshake */
 
 MBEDTLS_MPS_STATIC int l3_parse_hs_header( uint8_t mode, mbedtls_mps_reader *rd,
-                               mps_l3_hs_in_internal *in )
+                                           mps_l3_hs_in_internal *in )
 {
     if( MBEDTLS_MPS_IS_TLS( mode ) )
         return( l3_parse_hs_header_tls( rd, in ) );
@@ -398,126 +400,75 @@ MBEDTLS_MPS_STATIC int l3_parse_hs_header_tls( mbedtls_mps_reader *rd,
 {
     int res;
     unsigned char *tmp;
-
     mbedtls_mps_size_t const tls_hs_hdr_len = 4;
-
     mbedtls_mps_size_t const tls_hs_type_offset   = 0;
     mbedtls_mps_size_t const tls_hs_length_offset = 1;
-
-    /*
-
-      From RFC 5246 (TLS 1.2):
-
-      enum {
-          ..., (255)
-      } HandshakeType;
-
-      struct {
-          HandshakeType msg_type;
-          uint24 length;
-          select (HandshakeType) {
-              case hello_request:       HelloRequest;
-              case client_hello:        ClientHello;
-              case server_hello:        ServerHello;
-              case certificate:         Certificate;
-              case server_key_exchange: ServerKeyExchange;
-              case certificate_request: CertificateRequest;
-              case server_hello_done:   ServerHelloDone;
-              case certificate_verify:  CertificateVerify;
-              case client_key_exchange: ClientKeyExchange;
-              case finished:            Finished;
-          } body;
-      } Handshake;
-
-    */
-
     MBEDTLS_MPS_TRACE_INIT( "l3_parse_hs_header_tls" );
 
-    /* This call might fail for handshake headers spanning
-     * multiple records. This will be caught in up in the
-     * call chain, and Layer 2 will remember the request
-     * in this case and ensure it can be satisfied the next
-     * time it signals incoming data of handshake content type.
-     * We therefore don't need to save state here. */
+    /* From RFC 5246 (TLS 1.2):
+     * enum {
+     *     ..., (255)
+     * } HandshakeType;
+     * struct {
+     *     HandshakeType msg_type;
+     *     uint24 length;
+     *     select (HandshakeType) {
+     *       ...
+     *     } body;
+     * } Handshake; */
+
+    /* This fails for handshake headers crossing record boundaries.
+     * It will be caught and handled by the caller. */
     res = mbedtls_mps_reader_get( rd, tls_hs_hdr_len, &tmp, NULL );
     if( res != 0 )
         MBEDTLS_MPS_TRACE_RETURN( res );
 
-    MPS_READ_UINT8_BE ( tmp + tls_hs_type_offset, &in->type );
+    MPS_READ_UINT8_BE ( tmp + tls_hs_type_offset,   &in->type );
     MPS_READ_UINT24_BE( tmp + tls_hs_length_offset, &in->len );
 
     res = mbedtls_mps_reader_commit( rd );
     if( res != 0 )
         MBEDTLS_MPS_TRACE_RETURN( res );
 
-    MBEDTLS_MPS_TRACE_COMMENT(  "Parsed handshake header" );
-    MBEDTLS_MPS_TRACE_COMMENT(  "* Type:   %u", (unsigned) in->type );
-    MBEDTLS_MPS_TRACE_COMMENT(  "* Length: %u", (unsigned) in->len );
+    L3_DEBUG_TLS_HS_HEADER(in);
     MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 #endif /* MBEDTLS_MPS_PROTO_TLS */
 
-#if defined(MBEDTLS_MPS_PROTO_DTLS)
-#define L3_DEBUG_DTLS_HEADER( hdr )                                                      \
-    do                                                                                   \
-    {                                                                                    \
-        MBEDTLS_MPS_TRACE_COMMENT( "DTLS handshake header" );                            \
-        MBEDTLS_MPS_TRACE_COMMENT( "* Type:        %u", (unsigned) (hdr)->type        ); \
-        MBEDTLS_MPS_TRACE_COMMENT( "* Length:      %u", (unsigned) (hdr)->len         ); \
-        MBEDTLS_MPS_TRACE_COMMENT( "* Sequence Nr: %u", (unsigned) (hdr)->seq_nr      ); \
-        MBEDTLS_MPS_TRACE_COMMENT( "* Frag Offset: %u", (unsigned) (hdr)->frag_offset ); \
-        MBEDTLS_MPS_TRACE_COMMENT( "* Frag Length: %u", (unsigned) (hdr)->frag_len    ); \
-    } while( 0 )
 
+#if defined(MBEDTLS_MPS_PROTO_DTLS)
 MBEDTLS_MPS_STATIC int l3_parse_hs_header_dtls( mbedtls_mps_reader *rd,
                                     mps_l3_hs_in_internal *in )
 {
     int res;
     unsigned char *tmp;
-
     mbedtls_mps_size_t const dtls_hs_hdr_len         = 13;
     mbedtls_mps_size_t const dtls_hs_type_offset     = 0;
     mbedtls_mps_size_t const dtls_hs_len_offset      = 1;
     mbedtls_mps_size_t const dtls_hs_seq_offset      = 4;
     mbedtls_mps_size_t const dtls_hs_frag_off_offset = 7;
     mbedtls_mps_size_t const dtls_hs_frag_len_offset = 10;
+    MBEDTLS_MPS_TRACE_INIT( "parse_hs_header_dtls" );
 
-    /*
-     *
-     * From RFC 6347 (DTLS 1.2):
-     *
+    /* From RFC 6347 (DTLS 1.2):
      *   struct {
      *     HandshakeType msg_type;
      *     uint24 length;
-     *     uint16 message_seq;                               // New field
-     *     uint24 fragment_offset;                           // New field
-     *     uint24 fragment_length;                           // New field
+     *     uint16 message_seq;
+     *     uint24 fragment_offset;
+     *     uint24 fragment_length;
      *     select (HandshakeType) {
-     *       case hello_request: HelloRequest;
-     *       case client_hello:  ClientHello;
-     *       case hello_verify_request: HelloVerifyRequest;  // New type
-     *       case server_hello:  ServerHello;
-     *       case certificate:Certificate;
-     *       case server_key_exchange: ServerKeyExchange;
-     *       case certificate_request: CertificateRequest;
-     *       case server_hello_done:ServerHelloDone;
-     *       case certificate_verify:  CertificateVerify;
-     *       case client_key_exchange: ClientKeyExchange;
-     *       case finished: Finished;
+     *       ...
      *     } body;
-     *   } Handshake;
-     *
-     */
-
-    MBEDTLS_MPS_TRACE_INIT( "parse_hs_header_dtls" );
+     *   } Handshake; */
 
     res = mbedtls_mps_reader_get( rd, dtls_hs_hdr_len, &tmp, NULL );
     if( res != 0 )
         MBEDTLS_MPS_TRACE_RETURN( res );
 
-    MPS_READ_UINT8_BE ( tmp + dtls_hs_type_offset, &in->type );
-    MPS_READ_UINT24_BE( tmp + dtls_hs_len_offset, &in->len );
-    MPS_READ_UINT16_BE( tmp + dtls_hs_seq_offset, &in->seq_nr );
+    MPS_READ_UINT8_BE ( tmp + dtls_hs_type_offset,     &in->type );
+    MPS_READ_UINT24_BE( tmp + dtls_hs_len_offset,      &in->len );
+    MPS_READ_UINT16_BE( tmp + dtls_hs_seq_offset,      &in->seq_nr );
     MPS_READ_UINT24_BE( tmp + dtls_hs_frag_off_offset, &in->frag_offset );
     MPS_READ_UINT24_BE( tmp + dtls_hs_frag_len_offset, &in->frag_len );
 
@@ -536,7 +487,7 @@ MBEDTLS_MPS_STATIC int l3_parse_hs_header_dtls( mbedtls_mps_reader *rd,
         MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_INVALID_CONTENT );
     }
 
-    L3_DEBUG_DTLS_HEADER(in);
+    L3_DEBUG_DTLS_HS_HEADER(in);
     MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 #endif /* MBEDTLS_MPS_PROTO_DTLS */
@@ -550,25 +501,16 @@ MBEDTLS_MPS_STATIC int l3_parse_alert( mbedtls_mps_reader *rd,
     unsigned char *tmp;
     MBEDTLS_MPS_TRACE_INIT( "l3_parse_alert" );
 
-    /*
+    /* From RFC 5246 (TLS 1.2):
+     * enum { warning(1), fatal(2), (255) } AlertLevel;
+     * enum { close_notify(0), ..., (255) } AlertDescription;
+     * struct {
+     *     AlertLevel level;
+     *     AlertDescription description;
+     * } Alert; */
 
-      From RFC 5246 (TLS 1.2):
-
-      enum { warning(1), fatal(2), (255) } AlertLevel;
-      enum { close_notify(0), ..., (255) } AlertDescription;
-      struct {
-          AlertLevel level;
-          AlertDescription description;
-      } Alert;
-
-    */
-
-    /* This call might fail for alert messages spanning
-     * two records. This will be caught higher up in the
-     * call chain, and Layer 2 will remember the request
-     * in this case and ensure it can be satisfied the next
-     * time it signals incoming data of alert content type.
-     * We therefore don't need to save state here. */
+    /* This may fail for an alert at record boundary. Needs to be
+     * re-entrant, so no state change before this call. */
     res = mbedtls_mps_reader_get( rd, MPS_TLS_ALERT_SIZE, &tmp, NULL );
     if( res != 0 )
         MBEDTLS_MPS_TRACE_RETURN( res );
@@ -580,9 +522,7 @@ MBEDTLS_MPS_STATIC int l3_parse_alert( mbedtls_mps_reader *rd,
     if( res != 0 )
         MBEDTLS_MPS_TRACE_RETURN( res );
 
-    MBEDTLS_MPS_TRACE_COMMENT(  "Parsed alert message" );
-    MBEDTLS_MPS_TRACE_COMMENT(  "* Level: %u", (unsigned) alert->level );
-    MBEDTLS_MPS_TRACE_COMMENT(  "* Type:  %u", (unsigned) alert->type );
+    L3_DEBUG_ALERT(alert);
 
     if( alert->level != MPS_TLS_ALERT_LEVEL_FATAL &&
         alert->level != MPS_TLS_ALERT_LEVEL_WARNING )
@@ -590,7 +530,6 @@ MBEDTLS_MPS_STATIC int l3_parse_alert( mbedtls_mps_reader *rd,
         MBEDTLS_MPS_TRACE_ERROR( "Alert level unknown" );
         MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_INVALID_CONTENT );
     }
-
     MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
@@ -603,22 +542,16 @@ MBEDTLS_MPS_STATIC int l3_parse_ccs( mbedtls_mps_reader *rd )
     uint8_t val;
     MBEDTLS_MPS_TRACE_INIT( "l3_parse_ccs" );
 
-    /*
-
-      From RFC 5246 (TLS 1.2):
-
-      struct {
-          enum { change_cipher_spec(1), (255) } type;
-      } ChangeCipherSpec;
-
-    */
+    /* From RFC 5246 (TLS 1.2):
+     * struct {
+     *   enum { change_cipher_spec(1), (255) } type;
+     * } ChangeCipherSpec; */
 
     res = mbedtls_mps_reader_get( rd, MPS_TLS_CCS_SIZE, &tmp, NULL );
     if( res != 0 )
         MBEDTLS_MPS_TRACE_RETURN( res );
 
     MPS_READ_UINT8_BE( tmp + 0, &val );
-
     res = mbedtls_mps_reader_commit( rd );
     if( res != 0 )
         MBEDTLS_MPS_TRACE_RETURN( res );
@@ -628,9 +561,6 @@ MBEDTLS_MPS_STATIC int l3_parse_ccs( mbedtls_mps_reader *rd )
         MBEDTLS_MPS_TRACE_ERROR( "Bad CCS value %u", (unsigned) val );
         MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_INVALID_CONTENT );
     }
-
-    MBEDTLS_MPS_TRACE_COMMENT(  "Parsed alert message" );
-    MBEDTLS_MPS_TRACE_COMMENT(  " * Value: %u", (unsigned) MPS_TLS_CCS_VALUE );
     MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
@@ -642,7 +572,6 @@ int mps_l3_read_handshake( mps_l3 *l3, mps_l3_handshake_in *hs )
 {
     mbedtls_mps_transport_type const mode =
         mbedtls_mps_l3_conf_get_mode( &l3->conf );
-
     MBEDTLS_MPS_TRACE_INIT( "mps_l3_read_handshake" );
 
     MBEDTLS_MPS_STATE_VALIDATE_RAW(
@@ -662,21 +591,15 @@ int mps_l3_read_handshake( mps_l3 *l3, mps_l3_handshake_in *hs )
         hs->frag_offset = l3->io.in.hs.frag_offset;
         hs->frag_len    = l3->io.in.hs.frag_len;
     }
-#else
-    ((void) mode);
 #endif /* MBEDTLS_MPS_PROTO_DTLS */
-
     MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 
 int mps_l3_read_app( mps_l3 *l3, mps_l3_app_in *app )
 {
     MBEDTLS_MPS_TRACE_INIT( "mps_l3_read_app" );
-
-    MBEDTLS_MPS_STATE_VALIDATE_RAW(
-        l3->io.in.state == MBEDTLS_MPS_MSG_APP,
-        "mps_l3_read_app() called in unexpected state." );
-
+    MBEDTLS_MPS_STATE_VALIDATE_RAW( l3->io.in.state == MBEDTLS_MPS_MSG_APP,
+                             "mps_l3_read_app() called in unexpected state." );
     app->epoch = l3->io.in.epoch;
     app->rd = l3->io.in.raw_in;
     MBEDTLS_MPS_TRACE_RETURN( 0 );
@@ -685,11 +608,8 @@ int mps_l3_read_app( mps_l3 *l3, mps_l3_app_in *app )
 int mps_l3_read_alert( mps_l3 *l3, mps_l3_alert_in *alert )
 {
     MBEDTLS_MPS_TRACE_INIT( "mps_l3_read_alert" );
-
-    MBEDTLS_MPS_STATE_VALIDATE_RAW(
-        l3->io.in.state == MBEDTLS_MPS_MSG_ALERT,
-        "mps_l3_read_alert() called in unexpected state." );
-
+    MBEDTLS_MPS_STATE_VALIDATE_RAW( l3->io.in.state == MBEDTLS_MPS_MSG_ALERT,
+                           "mps_l3_read_alert() called in unexpected state." );
     alert->epoch = l3->io.in.epoch;
     alert->type  = l3->io.in.alert.type;
     alert->level = l3->io.in.alert.level;
@@ -699,11 +619,8 @@ int mps_l3_read_alert( mps_l3 *l3, mps_l3_alert_in *alert )
 int mps_l3_read_ccs( mps_l3 *l3, mps_l3_ccs_in *ccs )
 {
     MBEDTLS_MPS_TRACE_INIT( "mps_l3_read_ccs" );
-
-    MBEDTLS_MPS_STATE_VALIDATE_RAW(
-        l3->io.in.state == MBEDTLS_MPS_MSG_CCS,
-        "mps_l3_read_appccs() called in unexpected state." );
-
+    MBEDTLS_MPS_STATE_VALIDATE_RAW( l3->io.in.state == MBEDTLS_MPS_MSG_CCS,
+                          "mps_l3_read_appccs() called in unexpected state." );
     ccs->epoch = l3->io.in.epoch;
     MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
@@ -724,18 +641,15 @@ MBEDTLS_MPS_STATIC int l3_check_write_hs_hdr_tls( mps_l3 *l3 )
 {
     int res;
     mps_l3_hs_out_internal *hs = &l3->io.out.hs;
-
     /* Skip HS header on continuations */
     if( hs->hdr == NULL )
         return( 0 );
 
     MBEDTLS_MPS_ASSERT_RAW( hs->len != MBEDTLS_MPS_SIZE_UNKNOWN,
                             "HS message length unknown" );
-
     res = l3_write_hs_header_tls( hs );
     if( res != 0 )
         return( res );
-
     hs->hdr     = NULL;
     hs->hdr_len = 0;
     return( 0 );
@@ -751,11 +665,9 @@ MBEDTLS_MPS_STATIC int l3_check_write_hs_hdr_dtls( mps_l3 *l3 )
                             hs->len      != MBEDTLS_MPS_SIZE_UNKNOWN &&
                             hs->frag_len != MBEDTLS_MPS_SIZE_UNKNOWN,
                             "Incomplete HS header data" );
-
     res = l3_write_hs_header_dtls( hs );
     if( res != 0 )
         return( res );
-
     hs->hdr     = NULL;
     hs->hdr_len = 0;
     return( 0 );
@@ -776,6 +688,35 @@ MBEDTLS_MPS_STATIC int l3_check_write_hs_hdr( mps_l3 *l3 )
 #endif /* MBEDTLS_MPS_PROTO_DTLS */
 }
 
+#if !defined(MBEDTLS_MPS_ENABLE_ASSERTIONS)
+#define L3_ASSERT_FRAG_BOUNDS(a,b,c) do {} while( 0 )
+#else
+#define L3_ASSERT_FRAG_BOUNDS(len,frag_offset, frag_len)                    \
+    do {                                                                    \
+        /* If the total length isn't specified, then                        \
+         * then the fragment offset must be 0, and the                      \
+         * fragment length must be unspecified, too. */                     \
+        MBEDTLS_MPS_ASSERT_RAW( len != MBEDTLS_MPS_SIZE_UNKNOWN ||          \
+                               ( frag_offset == 0 &&                        \
+                                 frag_len == MBEDTLS_MPS_SIZE_UNKNOWN ),    \
+                                "Invalid message bounds" );                 \
+                                                                            \
+        /* Check that fragment doesn't exceed the total message length. */  \
+        if( len      != MBEDTLS_MPS_SIZE_UNKNOWN &&                         \
+            frag_len != MBEDTLS_MPS_SIZE_UNKNOWN )                          \
+        {                                                                   \
+            mbedtls_mps_size_t total_len =                                  \
+                (mbedtls_mps_size_t) len;                                   \
+            mbedtls_mps_size_t end_of_fragment =                            \
+                (mbedtls_mps_size_t)( frag_offset + frag_len );             \
+                                                                            \
+            MBEDTLS_MPS_ASSERT_RAW( end_of_fragment >= frag_offset &&       \
+                                    end_of_fragment <= total_len,           \
+                                    "Invalid fragment bounds" );            \
+        }                                                                   \
+    } while( 0 )
+#endif /* MBEDTLS_MPS_ENABLE_ASSERTIONS */
+
 int mps_l3_write_handshake( mps_l3 *l3, mps_l3_handshake_out *out )
 {
     int res;
@@ -784,13 +725,7 @@ int mps_l3_write_handshake( mps_l3 *l3, mps_l3_handshake_out *out )
         mbedtls_mps_l3_conf_get_mode( &l3->conf );
 
     MBEDTLS_MPS_TRACE_INIT( "l3_write_handshake" );
-    MBEDTLS_MPS_TRACE_COMMENT(  "Parameters: " );
-    MBEDTLS_MPS_TRACE_COMMENT(  "* Seq Nr:   %u", (unsigned) out->seq_nr );
-    MBEDTLS_MPS_TRACE_COMMENT(  "* Epoch:    %u", (unsigned) out->epoch );
-    MBEDTLS_MPS_TRACE_COMMENT(  "* Type:     %u", (unsigned) out->type );
-    MBEDTLS_MPS_TRACE_COMMENT(  "* Length:   %u", (unsigned) out->len );
-    MBEDTLS_MPS_TRACE_COMMENT(  "* Frag Off: %u", (unsigned) out->frag_offset );
-    MBEDTLS_MPS_TRACE_COMMENT(  "* Frag Len: %u", (unsigned) out->frag_len );
+    L3_DEBUG_HS_HEADER(out,mode);
 
 #if defined(MBEDTLS_MPS_STATE_VALIDATION)
     if( l3->io.out.hs.state == MPS_L3_HS_PAUSED &&
@@ -821,43 +756,10 @@ int mps_l3_write_handshake( mps_l3 *l3, mps_l3_handshake_out *out )
         MBEDTLS_MPS_ELSE_IF_DTLS( mode )
         {
             l3->io.out.hs.hdr_len = MPS_DTLS_HS_HDR_SIZE;
-
             l3->io.out.hs.seq_nr      = out->seq_nr;
             l3->io.out.hs.frag_len    = out->frag_len;
             l3->io.out.hs.frag_offset = out->frag_offset;
-
-#if defined(MBEDTLS_MPS_ENABLE_ASSERTIONS)
-            /* If the total length isn't specified, then
-             * then the fragment offset must be 0, and the
-             * fragment length must be unspecified, too. */
-            if( out->len == MBEDTLS_MPS_SIZE_UNKNOWN &&
-                ( out->frag_offset != 0 ||
-                  out->frag_len    != MBEDTLS_MPS_SIZE_UNKNOWN ) )
-            {
-                MBEDTLS_MPS_TRACE_ERROR( "ASSERTION FAILURE!" );
-                MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_INTERNAL_ERROR );
-            }
-
-            /* Check that fragment doesn't exceed the total message length. */
-            if( out->len      != MBEDTLS_MPS_SIZE_UNKNOWN &&
-                out->frag_len != MBEDTLS_MPS_SIZE_UNKNOWN )
-            {
-                mbedtls_mps_size_t frag_len =
-                    (mbedtls_mps_size_t) out->frag_len;
-                mbedtls_mps_size_t total_len =
-                    (mbedtls_mps_size_t) out->len;
-
-                mbedtls_mps_size_t end_of_fragment =
-                    (mbedtls_mps_size_t)( out->frag_offset + frag_len );
-
-                if( end_of_fragment < out->frag_offset /* overflow */ ||
-                    end_of_fragment > total_len )
-                {
-                    MBEDTLS_MPS_TRACE_ERROR( "ASSERTION FAILURE!" );
-                    MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_INTERNAL_ERROR );
-                }
-            }
-#endif /* MBEDTLS_MPS_ENABLE_ASSERTIONS */
+            L3_ASSERT_FRAG_BOUNDS(out->len, out->frag_offset, out->frag_len);
         }
 #endif /* MBEDTLS_MPS_PROTO_DTLS */
 
@@ -866,14 +768,11 @@ int mps_l3_write_handshake( mps_l3 *l3, mps_l3_handshake_out *out )
                                   l3->io.out.hs.hdr_len,
                                   &l3->io.out.hs.hdr, NULL );
 
-        /* It might happen that we're at the end of a record
-         * and there's not enough space left to write the
-         * handshake header. In this case, abort the write
-         * and make sure Layer 2 is flushed before we attempt
-         * again. */
+        /* If we're at the end of a record and there's not enough space left for
+         * a handshake header, abort the write, flush L2, and retry. */
         if( res == MBEDTLS_ERR_WRITER_OUT_OF_DATA )
         {
-            MBEDTLS_MPS_TRACE_COMMENT(  "Not enough space to write handshake header - flush." );
+            MBEDTLS_MPS_TRACE_COMMENT( "Not enough space for HS header, flush" );
             /* Remember that we must flush. */
             l3->io.out.clearing = 1;
             l3->io.out.state = MBEDTLS_MPS_MSG_NONE;
@@ -881,9 +780,8 @@ int mps_l3_write_handshake( mps_l3 *l3, mps_l3_handshake_out *out )
             if( res != 0 )
                 MBEDTLS_MPS_TRACE_RETURN( res );
 
-            /* We could return WANT_WRITE here to indicate that
-             * progress hinges on the availability of the underlying
-             * transport. */
+            /* We could return WANT_WRITE here to indicate that progress hinges
+             * on the availability of the underlying transport. */
             MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_RETRY );
         }
         else if( res != 0 )
@@ -939,9 +837,8 @@ int mps_l3_write_alert( mps_l3 *l3, mps_l3_alert_out *alert )
         if( res != 0 )
             MBEDTLS_MPS_TRACE_RETURN( res );
 
-        /* We could return WANT_WRITE here to indicate that
-         * progress hinges on the availability of the underlying
-         * transport. */
+        /* We could return WANT_WRITE here to indicate that progress hinges
+         * on the availability of the underlying transport. */
         MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_RETRY );
     }
     else if( res != 0 )
@@ -973,9 +870,8 @@ int mps_l3_write_ccs( mps_l3 *l3, mps_l3_ccs_out *ccs )
         if( res != 0 )
             MBEDTLS_MPS_TRACE_RETURN( res );
 
-        /* We could return WANT_WRITE here to indicate that
-         * progress hinges on the availability of the underlying
-         * transport. */
+        /* We could return WANT_WRITE here to indicate that progress hinges
+         * on the availability of the underlying transport. */
         MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_RETRY );
     }
     else if( res != 0 )
@@ -1095,12 +991,9 @@ MBEDTLS_MPS_STATIC int l3_write_hs_header_tls( mps_l3_hs_out_internal *hs )
 
 {
     unsigned char *buf = hs->hdr;
-
     mbedtls_mps_size_t const tls_hs_hdr_len = 4;
-
     mbedtls_mps_size_t const tls_hs_type_offset   = 0;
     mbedtls_mps_size_t const tls_hs_length_offset = 1;
-
     MBEDTLS_MPS_ASSERT_RAW( buf != NULL, "Invalid buffer" );
     MBEDTLS_MPS_ASSERT_RAW( hs->hdr_len == tls_hs_hdr_len, "Invalid header" );
 
@@ -1112,26 +1005,14 @@ MBEDTLS_MPS_STATIC int l3_write_hs_header_tls( mps_l3_hs_out_internal *hs )
      *     HandshakeType msg_type;
      *     uint24 length;
      *     select (HandshakeType) {
-     *         case hello_request:       HelloRequest;
-     *         case client_hello:        ClientHello;
-     *         case server_hello:        ServerHello;
-     *         case certificate:         Certificate;
-     *         case server_key_exchange: ServerKeyExchange;
-     *         case certificate_request: CertificateRequest;
-     *         case server_hello_done:   ServerHelloDone;
-     *         case certificate_verify:  CertificateVerify;
-     *         case client_key_exchange: ClientKeyExchange;
-     *         case finished:            Finished;
+     *       ...
      *     } body;
      * } Handshake;
      */
-
-    MBEDTLS_MPS_TRACE_INIT( "l3_write_hs_hdr_tls, type %u, len %u",
-           (unsigned) hs->type, (unsigned) hs->len );
-
     MPS_WRITE_UINT8_BE ( &hs->type, buf + tls_hs_type_offset   );
     MPS_WRITE_UINT24_BE( &hs->len,  buf + tls_hs_length_offset );
 
+    L3_DEBUG_TLS_HS_HEADER(hs);
     MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 #endif /* MBEDTLS_MPS_PROTO_TLS */
@@ -1141,18 +1022,16 @@ MBEDTLS_MPS_STATIC int l3_write_hs_header_dtls( mps_l3_hs_out_internal *hs )
 
 {
     unsigned char *buf = hs->hdr;
-
     mbedtls_mps_size_t const dtls_hs_hdr_len         = 13;
     mbedtls_mps_size_t const dtls_hs_type_offset     = 0;
     mbedtls_mps_size_t const dtls_hs_len_offset      = 1;
     mbedtls_mps_size_t const dtls_hs_seq_offset      = 4;
     mbedtls_mps_size_t const dtls_hs_frag_off_offset = 7;
     mbedtls_mps_size_t const dtls_hs_frag_len_offset = 10;
+    MBEDTLS_MPS_ASSERT_RAW( buf != NULL, "Invalid buffer" );
+    MBEDTLS_MPS_ASSERT_RAW( hs->hdr_len == dtls_hs_hdr_len, "Invalid header" );
 
-    /*
-     *
-     * From RFC 6347 (DTLS 1.2):
-     *
+    /* From RFC 6347 (DTLS 1.2):
      *   struct {
      *     HandshakeType msg_type;
      *     uint24 length;
@@ -1160,32 +1039,16 @@ MBEDTLS_MPS_STATIC int l3_write_hs_header_dtls( mps_l3_hs_out_internal *hs )
      *     uint24 fragment_offset;                           // New field
      *     uint24 fragment_length;                           // New field
      *     select (HandshakeType) {
-     *       case hello_request: HelloRequest;
-     *       case client_hello:  ClientHello;
-     *       case hello_verify_request: HelloVerifyRequest;  // New type
-     *       case server_hello:  ServerHello;
-     *       case certificate:Certificate;
-     *       case server_key_exchange: ServerKeyExchange;
-     *       case certificate_request: CertificateRequest;
-     *       case server_hello_done:ServerHelloDone;
-     *       case certificate_verify:  CertificateVerify;
-     *       case client_key_exchange: ClientKeyExchange;
-     *       case finished: Finished;
+     *       ...
      *     } body;
-     *   } Handshake;
-     *
-     */
-
-    MBEDTLS_MPS_ASSERT_RAW( buf != NULL, "Invalid buffer" );
-    MBEDTLS_MPS_ASSERT_RAW( hs->hdr_len == dtls_hs_hdr_len, "Invalid header" );
-
+     *   } Handshake; */
     MPS_WRITE_UINT8_BE ( &hs->type,        buf + dtls_hs_type_offset     );
     MPS_WRITE_UINT24_BE( &hs->len,         buf + dtls_hs_len_offset      );
     MPS_WRITE_UINT16_BE( &hs->seq_nr,      buf + dtls_hs_seq_offset      );
     MPS_WRITE_UINT24_BE( &hs->frag_offset, buf + dtls_hs_frag_off_offset );
     MPS_WRITE_UINT24_BE( &hs->frag_len,    buf + dtls_hs_frag_len_offset );
 
-    L3_DEBUG_DTLS_HEADER(hs);
+    L3_DEBUG_DTLS_HS_HEADER(hs);
     MBEDTLS_MPS_TRACE_RETURN( 0 );
 }
 #endif /* MBEDTLS_MPS_PROTO_DTLS */
@@ -1211,7 +1074,6 @@ MBEDTLS_MPS_STATIC int l3_check_clear( mps_l3 *l3 )
 
 /*
  * Request a writer for the respective epoch and content type from Layer 2.
- *
  * This also keeps track of pursuing ongoing but not yet finished flush calls.
  */
 MBEDTLS_MPS_STATIC int l3_prepare_write( mps_l3 *l3, mbedtls_mps_msg_type_t port,

--- a/library/mps/mps.c
+++ b/library/mps/mps.c
@@ -3010,7 +3010,6 @@ MBEDTLS_MPS_STATIC int mps_request_resend( mbedtls_mps *mps )
                                      MPS_RETRANSMIT_ONLY_EMPTY_FRAGMENTS ) );
 }
 
-#if defined(MBEDTLS_MPS_ENABLE_TRACE)
 static inline const char * mps_flight_state_to_string(
     mbedtls_mps_flight_state_t state )
 {
@@ -3034,7 +3033,6 @@ static inline const char * mps_flight_state_to_string(
             return( "UNKNOWN" );
     }
 }
-#endif /* MBEDTLS_MPS_ENABLE_TRACE */
 
 MBEDTLS_MPS_INLINE
 /* Perform a retransmisison state machine transition and

--- a/library/mps/mps.c
+++ b/library/mps/mps.c
@@ -217,19 +217,11 @@ MBEDTLS_MPS_STATIC int mps_clear_pending( mbedtls_mps *mps,
  *    retransmission; in this case, the backup buffer functions as the
  *    queue, so that the user writing the message directly writes it
  *    it into the backup buffer, avoiding an unnecessary copy.
- *
- *  - #MPS_DTLS_FRAG_OUT_START_FROM_QUEUE
- *    This type is used if an entire message is already present
- *    in a contiguous buffer and solely needs to be dispatched
- *    to Layer 3, without any prior interaction with the user.
- *    In this case, \c queue specifies the message contents.
- *    This type is used for retransmission of messages via raw backups.
  */
 
 typedef uint8_t mps_dtls_outgoing_hs_msg_mode;
 #define MPS_DTLS_FRAG_OUT_START_USE_L3     ( (mps_dtls_outgoing_hs_msg_mode) 0 )
 #define MPS_DTLS_FRAG_OUT_START_QUEUE_ONLY ( (mps_dtls_outgoing_hs_msg_mode) 1 )
-#define MPS_DTLS_FRAG_OUT_START_FROM_QUEUE ( (mps_dtls_outgoing_hs_msg_mode) 2 )
 
 /*
  * The API between outgoing fragmentation and the rest of the MPS code.
@@ -251,8 +243,6 @@ typedef uint8_t mps_dtls_outgoing_hs_msg_mode;
  *    handshake message structure is in state #MBEDTLS_MPS_HS_PAUSED.
  *  - If \p mode is #MPS_DTLS_FRAG_OUT_START_QUEUE_ONLY, the outgoing
  *    handshake message structure is in state #MBEDTLS_MPS_HS_ACTIVE.
- *  - If \p mode is #MPS_DTLS_FRAG_OUT_START_FROM_QUEUE, the outgoing
- *    handshake message structure is in state #MBEDTLS_MPS_HS_PAUSED.
  */
 MBEDTLS_MPS_STATIC int mps_dtls_frag_out_start(
                                     mbedtls_mps_handshake_out_internal *hs,

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -1349,8 +1349,8 @@ static int ssl_client_hello_process( mbedtls_ssl_context* ssl )
                                                        &msg, NULL, NULL ) );
 
     /* Request write-buffer */
-    MBEDTLS_SSL_PROC_CHK( mbedtls_writer_get_ext( msg.handle, MBEDTLS_MPS_SIZE_MAX,
-                                                  &buf, &buf_len ) );
+    MBEDTLS_SSL_PROC_CHK( mbedtls_writer_get( msg.handle, MBEDTLS_MPS_SIZE_MAX,
+                                              &buf, &buf_len ) );
 
     MBEDTLS_SSL_PROC_CHK( ssl_client_hello_write_partial( ssl, buf, buf_len,
                                                   &len_without_binders,
@@ -1378,8 +1378,8 @@ static int ssl_client_hello_process( mbedtls_ssl_context* ssl )
 #endif /* MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED */
 
     /* Commit message */
-    MBEDTLS_SSL_PROC_CHK( mbedtls_writer_commit_partial_ext( msg.handle,
-                                                             buf_len - msg_len ) );
+    MBEDTLS_SSL_PROC_CHK( mbedtls_writer_commit_partial( msg.handle,
+                                                         buf_len - msg_len ) );
 
     MBEDTLS_SSL_PROC_CHK( mbedtls_mps_dispatch( &ssl->mps.l4 ) );
 
@@ -2873,7 +2873,7 @@ static int ssl_server_hello_process( mbedtls_ssl_context* ssl )
         mbedtls_ssl_add_hs_msg_to_checksum( ssl, MBEDTLS_SSL_HS_SERVER_HELLO,
                                             buf, buflen );
 
-        MBEDTLS_SSL_PROC_CHK( mbedtls_mps_reader_commit_ext( msg.handle ) );
+        MBEDTLS_SSL_PROC_CHK( mbedtls_mps_reader_commit( msg.handle ) );
         MBEDTLS_SSL_PROC_CHK( mbedtls_mps_read_consume( &ssl->mps.l4  ) );
 #endif /* MBEDTLS_SSL_USE_MPS */
 
@@ -2884,7 +2884,7 @@ static int ssl_server_hello_process( mbedtls_ssl_context* ssl )
         MBEDTLS_SSL_PROC_CHK( ssl_hrr_parse( ssl, buf, buflen ) );
 
 #if defined(MBEDTLS_SSL_USE_MPS)
-        MBEDTLS_SSL_PROC_CHK( mbedtls_mps_reader_commit_ext( msg.handle ) );
+        MBEDTLS_SSL_PROC_CHK( mbedtls_mps_reader_commit( msg.handle ) );
         MBEDTLS_SSL_PROC_CHK( mbedtls_mps_read_consume( &ssl->mps.l4  ) );
 #endif /* MBEDTLS_SSL_USE_MPS */
 
@@ -2960,7 +2960,7 @@ static int ssl_server_hello_coordinate( mbedtls_ssl_context* ssl,
     if( msg->type != MBEDTLS_SSL_HS_SERVER_HELLO )
         return( MBEDTLS_ERR_SSL_UNEXPECTED_MESSAGE );
 
-    ret = mbedtls_mps_reader_get_ext( msg->handle,
+    ret = mbedtls_mps_reader_get( msg->handle,
                                   msg->length,
                                   &peak,
                                   NULL );

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -76,7 +76,7 @@ int mbedtls_ssl_mps_fetch_full_hs_msg( mbedtls_ssl_context *ssl,
     if( msg.type != hs_type )
         return( MBEDTLS_ERR_SSL_UNEXPECTED_MESSAGE );
 
-    ret = mbedtls_mps_reader_get_ext( msg.handle,
+    ret = mbedtls_mps_reader_get( msg.handle,
                                   msg.length,
                                   buf,
                                   NULL );
@@ -90,7 +90,7 @@ int mbedtls_ssl_mps_fetch_full_hs_msg( mbedtls_ssl_context *ssl,
     {
         MBEDTLS_SSL_PROC_CHK( ret );
 
-        /* *buf already set in mbedtls_mps_reader_get_ext() */
+        /* *buf already set in mbedtls_mps_reader_get() */
         *buflen = msg.length;
     }
 
@@ -107,7 +107,7 @@ int mbedtls_ssl_mps_hs_consume_full_hs_msg( mbedtls_ssl_context *ssl )
     MBEDTLS_SSL_PROC_CHK( mbedtls_mps_read_handshake( &ssl->mps.l4,
                                                       &msg ) );
 
-    MBEDTLS_SSL_PROC_CHK( mbedtls_mps_reader_commit_ext( msg.handle ) );
+    MBEDTLS_SSL_PROC_CHK( mbedtls_mps_reader_commit( msg.handle ) );
     MBEDTLS_SSL_PROC_CHK( mbedtls_mps_read_consume( &ssl->mps.l4 ) );
 
 cleanup:
@@ -582,7 +582,7 @@ int mbedtls_ssl_write_certificate_verify_process( mbedtls_ssl_context* ssl )
                                                            &msg, NULL, NULL ) );
 
         /* Request write-buffer */
-        MBEDTLS_SSL_PROC_CHK( mbedtls_writer_get_ext( msg.handle, MBEDTLS_MPS_SIZE_MAX,
+        MBEDTLS_SSL_PROC_CHK( mbedtls_writer_get( msg.handle, MBEDTLS_MPS_SIZE_MAX,
                                                       &buf, &buf_len ) );
 
         MBEDTLS_SSL_PROC_CHK( ssl_certificate_verify_write(
@@ -592,7 +592,7 @@ int mbedtls_ssl_write_certificate_verify_process( mbedtls_ssl_context* ssl )
                                             buf, msg_len );
 
         /* Commit message */
-        MBEDTLS_SSL_PROC_CHK( mbedtls_writer_commit_partial_ext( msg.handle,
+        MBEDTLS_SSL_PROC_CHK( mbedtls_writer_commit_partial( msg.handle,
                                                                  buf_len - msg_len ) );
 
         MBEDTLS_SSL_PROC_CHK( mbedtls_mps_dispatch( &ssl->mps.l4 ) );
@@ -1296,7 +1296,7 @@ int mbedtls_ssl_write_certificate_process( mbedtls_ssl_context* ssl )
                                                            &msg, NULL, NULL ) );
 
         /* Request write-buffer */
-        MBEDTLS_SSL_PROC_CHK( mbedtls_writer_get_ext( msg.handle, MBEDTLS_MPS_SIZE_MAX,
+        MBEDTLS_SSL_PROC_CHK( mbedtls_writer_get( msg.handle, MBEDTLS_MPS_SIZE_MAX,
                                                       &buf, &buf_len ) );
 
         MBEDTLS_SSL_PROC_CHK( ssl_write_certificate_write(
@@ -1306,8 +1306,8 @@ int mbedtls_ssl_write_certificate_process( mbedtls_ssl_context* ssl )
                                             buf, msg_len );
 
         /* Commit message */
-        MBEDTLS_SSL_PROC_CHK( mbedtls_writer_commit_partial_ext( msg.handle,
-                                                                 buf_len - msg_len ) );
+        MBEDTLS_SSL_PROC_CHK( mbedtls_writer_commit_partial( msg.handle,
+                                                             buf_len - msg_len ) );
 
         MBEDTLS_SSL_PROC_CHK( mbedtls_mps_dispatch( &ssl->mps.l4 ) );
 
@@ -2287,7 +2287,7 @@ int mbedtls_ssl_finished_out_process( mbedtls_ssl_context* ssl )
                                                        &msg, NULL, NULL ) );
 
     /* Request write-buffer */
-    MBEDTLS_SSL_PROC_CHK( mbedtls_writer_get_ext( msg.handle, MBEDTLS_MPS_SIZE_MAX,
+    MBEDTLS_SSL_PROC_CHK( mbedtls_writer_get( msg.handle, MBEDTLS_MPS_SIZE_MAX,
                                                   &buf, &buf_len ) );
 
     MBEDTLS_SSL_PROC_CHK( ssl_finished_out_write(
@@ -2297,7 +2297,7 @@ int mbedtls_ssl_finished_out_process( mbedtls_ssl_context* ssl )
                                         buf, msg_len );
 
     /* Commit message */
-    MBEDTLS_SSL_PROC_CHK( mbedtls_writer_commit_partial_ext( msg.handle,
+    MBEDTLS_SSL_PROC_CHK( mbedtls_writer_commit_partial( msg.handle,
                                                              buf_len - msg_len ) );
 
     MBEDTLS_SSL_PROC_CHK( mbedtls_mps_dispatch( &ssl->mps.l4 ) );
@@ -2801,7 +2801,7 @@ int mbedtls_ssl_write_early_data_ext( mbedtls_ssl_context *ssl,
         if( ( ssl->handshake->extensions_present & MBEDTLS_SSL_EXT_EARLY_DATA ) == 0 )
             return( 0 );
 
-        if( ssl->conf->key_exchange_modes != 
+        if( ssl->conf->key_exchange_modes !=
                    MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_KE ||
             ssl->conf->early_data_enabled == MBEDTLS_SSL_EARLY_DATA_DISABLED )
         {

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -1405,16 +1405,16 @@ static int ssl_write_new_session_ticket_process( mbedtls_ssl_context *ssl )
                                                            &msg, NULL, NULL ) );
 
         /* Request write-buffer */
-        MBEDTLS_SSL_PROC_CHK( mbedtls_writer_get_ext( msg.handle,
-                                                      MBEDTLS_MPS_SIZE_MAX,
-                                                      &buf, &buf_len ) );
+        MBEDTLS_SSL_PROC_CHK( mbedtls_writer_get( msg.handle,
+                                                  MBEDTLS_MPS_SIZE_MAX,
+                                                  &buf, &buf_len ) );
 
         MBEDTLS_SSL_PROC_CHK( ssl_write_new_session_ticket_write(
                                   ssl, buf, buf_len, &msg_len ) );
 
         /* Commit message */
-        MBEDTLS_SSL_PROC_CHK( mbedtls_writer_commit_partial_ext( msg.handle,
-                                                         buf_len - msg_len ) );
+        MBEDTLS_SSL_PROC_CHK( mbedtls_writer_commit_partial( msg.handle,
+                                                             buf_len - msg_len ) );
 
         MBEDTLS_SSL_PROC_CHK( mbedtls_mps_dispatch( &ssl->mps.l4 ) );
 
@@ -3192,8 +3192,8 @@ static int ssl_encrypted_extensions_process( mbedtls_ssl_context* ssl )
                                                        &msg, NULL, NULL ) );
 
     /* Request write-buffer */
-    MBEDTLS_SSL_PROC_CHK( mbedtls_writer_get_ext( msg.handle, MBEDTLS_MPS_SIZE_MAX,
-                                                  &buf, &buf_len ) );
+    MBEDTLS_SSL_PROC_CHK( mbedtls_writer_get( msg.handle, MBEDTLS_MPS_SIZE_MAX,
+                                              &buf, &buf_len ) );
 
     MBEDTLS_SSL_PROC_CHK( ssl_encrypted_extensions_write(
                               ssl, buf, buf_len, &msg_len ) );
@@ -3202,8 +3202,8 @@ static int ssl_encrypted_extensions_process( mbedtls_ssl_context* ssl )
                                         buf, msg_len );
 
     /* Commit message */
-    MBEDTLS_SSL_PROC_CHK( mbedtls_writer_commit_partial_ext( msg.handle,
-                                                             buf_len - msg_len ) );
+    MBEDTLS_SSL_PROC_CHK( mbedtls_writer_commit_partial( msg.handle,
+                                                         buf_len - msg_len ) );
 
     MBEDTLS_SSL_PROC_CHK( mbedtls_mps_dispatch( &ssl->mps.l4 ) );
 
@@ -3461,8 +3461,8 @@ static int ssl_write_hello_retry_request_process( mbedtls_ssl_context *ssl )
                                                        &msg, NULL, NULL ) );
 
     /* Request write-buffer */
-    MBEDTLS_SSL_PROC_CHK( mbedtls_writer_get_ext( msg.handle, MBEDTLS_MPS_SIZE_MAX,
-                                                  &buf, &buf_len ) );
+    MBEDTLS_SSL_PROC_CHK( mbedtls_writer_get( msg.handle, MBEDTLS_MPS_SIZE_MAX,
+                                              &buf, &buf_len ) );
 
     MBEDTLS_SSL_PROC_CHK( ssl_write_hello_retry_request_write(
                               ssl, buf, buf_len, &msg_len ) );
@@ -3471,8 +3471,8 @@ static int ssl_write_hello_retry_request_process( mbedtls_ssl_context *ssl )
                                         buf, msg_len );
 
     /* Commit message */
-    MBEDTLS_SSL_PROC_CHK( mbedtls_writer_commit_partial_ext( msg.handle,
-                                                             buf_len - msg_len ) );
+    MBEDTLS_SSL_PROC_CHK( mbedtls_writer_commit_partial( msg.handle,
+                                                         buf_len - msg_len ) );
 
     MBEDTLS_SSL_PROC_CHK( mbedtls_mps_dispatch( &ssl->mps.l4 ) );
 
@@ -3793,8 +3793,8 @@ static int ssl_server_hello_process( mbedtls_ssl_context* ssl ) {
                                                        &msg, NULL, NULL ) );
 
     /* Request write-buffer */
-    MBEDTLS_SSL_PROC_CHK( mbedtls_writer_get_ext( msg.handle, MBEDTLS_MPS_SIZE_MAX,
-                                                  &buf, &buf_len ) );
+    MBEDTLS_SSL_PROC_CHK( mbedtls_writer_get( msg.handle, MBEDTLS_MPS_SIZE_MAX,
+                                              &buf, &buf_len ) );
 
     MBEDTLS_SSL_PROC_CHK( ssl_server_hello_write( ssl, buf, buf_len,
                                                   &msg_len ) );
@@ -3803,8 +3803,8 @@ static int ssl_server_hello_process( mbedtls_ssl_context* ssl ) {
                                         buf, msg_len );
 
     /* Commit message */
-    MBEDTLS_SSL_PROC_CHK( mbedtls_writer_commit_partial_ext( msg.handle,
-                                                             buf_len - msg_len ) );
+    MBEDTLS_SSL_PROC_CHK( mbedtls_writer_commit_partial( msg.handle,
+                                                         buf_len - msg_len ) );
 
     MBEDTLS_SSL_PROC_CHK( mbedtls_mps_dispatch( &ssl->mps.l4 ) );
 
@@ -4099,7 +4099,7 @@ static int ssl_certificate_request_process( mbedtls_ssl_context* ssl )
                                                            &msg, NULL, NULL ) );
 
         /* Request write-buffer */
-        MBEDTLS_SSL_PROC_CHK( mbedtls_writer_get_ext( msg.handle, MBEDTLS_MPS_SIZE_MAX,
+        MBEDTLS_SSL_PROC_CHK( mbedtls_writer_get( msg.handle, MBEDTLS_MPS_SIZE_MAX,
                                                       &buf, &buf_len ) );
 
         MBEDTLS_SSL_PROC_CHK( ssl_certificate_request_write(
@@ -4109,8 +4109,8 @@ static int ssl_certificate_request_process( mbedtls_ssl_context* ssl )
                                             buf, msg_len );
 
         /* Commit message */
-        MBEDTLS_SSL_PROC_CHK( mbedtls_writer_commit_partial_ext( msg.handle,
-                                                                 buf_len - msg_len ) );
+        MBEDTLS_SSL_PROC_CHK( mbedtls_writer_commit_partial( msg.handle,
+                                                             buf_len - msg_len ) );
 
         MBEDTLS_SSL_PROC_CHK( mbedtls_mps_dispatch( &ssl->mps.l4 ) );
 

--- a/tests/suites/test_suite_mps.function
+++ b/tests/suites/test_suite_mps.function
@@ -1169,7 +1169,7 @@ typedef struct
 } dummy_cb_ctx;
 
 int mps_l4_dummy_callback( mbedtls_mps_write_cb_ctx_t const *ctx,
-                           mbedtls_writer_ext *writer )
+                           mbedtls_writer *writer )
 {
     int ret;
     dummy_cb_ctx *dummy_ctx = ( (dummy_cb_ctx*) ctx );
@@ -1185,8 +1185,8 @@ int mps_l4_dummy_callback( mbedtls_mps_write_cb_ctx_t const *ctx,
     if( bytes_in_chunk > dummy_ctx->max_bytes_per_chunk )
         bytes_in_chunk = dummy_ctx->max_bytes_per_chunk;
 
-    ret = mbedtls_writer_get_ext( writer, bytes_in_chunk,
-                                  &chunk, NULL );
+    ret = mbedtls_writer_get( writer, bytes_in_chunk,
+                              &chunk, NULL );
     if( ret == MBEDTLS_ERR_WRITER_OUT_OF_DATA )
         return( MBEDTLS_MPS_RETRANSMISSION_CALLBACK_PAUSE );
     else if( ret != 0 )
@@ -1198,7 +1198,7 @@ int mps_l4_dummy_callback( mbedtls_mps_write_cb_ctx_t const *ctx,
             ( dummy_ctx->bytes_written + idx );
     }
 
-    ret = mbedtls_writer_commit_ext( writer );
+    ret = mbedtls_writer_commit( writer );
     if( ret != 0 )
         return( ret );
 
@@ -6459,21 +6459,21 @@ void mbedtls_mps_l3_basic_handshake(
 
     if( multiple_fetch )
     {
-        TEST_ASSERT( mbedtls_writer_get_ext( hs_out.wr_ext, 10, &tmp, NULL ) == 0 );
+        TEST_ASSERT( mbedtls_writer_get( hs_out.wr, 10, &tmp, NULL ) == 0 );
         for( size_t idx=0; idx<10; idx++ )
             tmp[idx] = (unsigned char) idx;
 
         if( intermediate_commit )
-            TEST_ASSERT( mbedtls_writer_commit_ext( hs_out.wr_ext )  == 0 );
+            TEST_ASSERT( mbedtls_writer_commit( hs_out.wr )  == 0 );
 
-        TEST_ASSERT( mbedtls_writer_get_ext( hs_out.wr_ext, 10 + additional_fetch,
+        TEST_ASSERT( mbedtls_writer_get( hs_out.wr, 10 + additional_fetch,
                                              &tmp, NULL ) == 0 );
         for( size_t idx=0; idx< 10 + additional_fetch ; idx++ )
             tmp[idx] = (unsigned char) ( 10 + idx );
     }
     else
     {
-        TEST_ASSERT( mbedtls_writer_get_ext( hs_out.wr_ext,
+        TEST_ASSERT( mbedtls_writer_get( hs_out.wr,
                                              20 + additional_fetch,
                                              &tmp, NULL ) == 0 );
         for( size_t idx=0; idx<20 + additional_fetch; idx++ )
@@ -6483,12 +6483,12 @@ void mbedtls_mps_l3_basic_handshake(
     if( !partial_commit )
     {
         /* Commit and update state */
-        TEST_ASSERT( mbedtls_writer_commit_ext( hs_out.wr_ext ) == 0 );
+        TEST_ASSERT( mbedtls_writer_commit( hs_out.wr ) == 0 );
     }
     else
     {
         /* Commit and update state */
-        TEST_ASSERT( mbedtls_writer_commit_partial_ext( hs_out.wr_ext,
+        TEST_ASSERT( mbedtls_writer_commit_partial( hs_out.wr,
                                                     additional_fetch ) == 0 );
     }
 
@@ -6527,14 +6527,14 @@ void mbedtls_mps_l3_basic_handshake(
     }
 
     /* Fetch next chunk of incoming data */
-    TEST_ASSERT( mbedtls_mps_reader_get_ext( hs_in.rd_ext, 20, &tmp, NULL ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_get( hs_in.rd, 20, &tmp, NULL ) == 0 );
 
     /* Process incoming data */
     for( size_t idx=0; idx<10; idx++ )
         TEST_ASSERT( tmp[idx] == (unsigned char) idx );
 
     /* Commit last incoming chunk and update state */
-    TEST_ASSERT( mbedtls_mps_reader_commit_ext( hs_in.rd_ext ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_commit( hs_in.rd ) == 0 );
 
     /* Signal that message has been processed. */
     TEST_ASSERT( mps_l3_read_consume( &srv_l3 ) == 0 );
@@ -6866,7 +6866,7 @@ fallback:
                 case 1:
 
                     /* Ask for outbuffer to write next chunk of data */
-                    res = mbedtls_writer_get_ext( hs_out.wr_ext, 4, &tmp, NULL );
+                    res = mbedtls_writer_get( hs_out.wr, 4, &tmp, NULL );
                     TEST_ASSERT( res == 0 ||
                                  res == MBEDTLS_ERR_WRITER_OUT_OF_DATA );
                     if( res == MBEDTLS_ERR_WRITER_OUT_OF_DATA )
@@ -6880,15 +6880,9 @@ fallback:
                         tmp[idx] = (unsigned char)( msgs_remaining + idx );
 
                     /* Commit and update state */
-                    TEST_ASSERT( mbedtls_writer_commit_ext(
-                                     hs_out.wr_ext ) == 0 );
+                    TEST_ASSERT( mbedtls_writer_commit(
+                                     hs_out.wr ) == 0 );
                     send_state = 2;
-
-                    /* Attempt to finish the writing -- should give an error
-                     * because we have initially specified how much we intend
-                     * to write. */
-                    TEST_ASSERT( mps_l3_dispatch( &cli_l3 ) ==
-                                 MBEDTLS_ERR_MPS_UNFINISHED_HS_MSG );
 
                     goto fallback;
                     break;
@@ -6896,7 +6890,7 @@ fallback:
                 case 2:
 
                     /* Ask for outbuffer to write next chunk of data */
-                    res = mbedtls_writer_get_ext( hs_out.wr_ext, 4,
+                    res = mbedtls_writer_get( hs_out.wr, 4,
                                                   &tmp, NULL );
                     TEST_ASSERT( res == 0 ||
                                  res == MBEDTLS_ERR_WRITER_OUT_OF_DATA );
@@ -6911,8 +6905,8 @@ fallback:
                         tmp[idx] = (unsigned char)( 4 + msgs_remaining + idx );
 
                     /* Commit and update state */
-                    TEST_ASSERT( mbedtls_writer_commit_ext(
-                                     hs_out.wr_ext ) == 0 );
+                    TEST_ASSERT( mbedtls_writer_commit(
+                                     hs_out.wr ) == 0 );
                     send_state = 3;
 
                     goto fallback;
@@ -6994,7 +6988,7 @@ repeat:
                 case 0:
 
                     /* Fetch next chunk of incoming data */
-                    res = mbedtls_mps_reader_get_ext( hs_in.rd_ext, 4, &tmp, NULL );
+                    res = mbedtls_mps_reader_get( hs_in.rd, 4, &tmp, NULL );
                     TEST_ASSERT( res == 0 ||
                                  res == MBEDTLS_ERR_MPS_READER_OUT_OF_DATA );
                     if( res == MBEDTLS_ERR_MPS_READER_OUT_OF_DATA )
@@ -7009,14 +7003,9 @@ repeat:
                                      (uint8_t)( msgs_remaining + idx ) );
 
                     /* Commit last incoming chunk and update state */
-                    TEST_ASSERT( mbedtls_mps_reader_commit_ext(
-                                     hs_in.rd_ext ) == 0 );
+                    TEST_ASSERT( mbedtls_mps_reader_commit(
+                                     hs_in.rd ) == 0 );
                     recv_state = 1;
-
-                    /* Attempt to finish the reading -- should give an error because
-                     * we know how large the message is in total.. */
-                    TEST_ASSERT( mps_l3_read_consume( &srv_l3 ) ==
-                                 MBEDTLS_ERR_MPS_UNFINISHED_HS_MSG );
 
                     goto repeat;
                     break;
@@ -7024,7 +7013,7 @@ repeat:
                 case 1:
 
                     /* Fetch next chunk of incoming data */
-                    res = mbedtls_mps_reader_get_ext( hs_in.rd_ext, 4,
+                    res = mbedtls_mps_reader_get( hs_in.rd, 4,
                                                   &tmp, NULL );
                     TEST_ASSERT( res == 0 ||
                                  res == MBEDTLS_ERR_MPS_READER_OUT_OF_DATA );
@@ -7040,8 +7029,8 @@ repeat:
                                      (uint8_t) ( 4 + msgs_remaining + idx ) );
 
                     /* Commit last incoming chunk and update state */
-                    TEST_ASSERT( mbedtls_mps_reader_commit_ext(
-                                     hs_in.rd_ext ) == 0 );
+                    TEST_ASSERT( mbedtls_mps_reader_commit(
+                                     hs_in.rd ) == 0 );
                     recv_state = 2;
 
                     goto repeat;
@@ -7553,7 +7542,7 @@ send_start:
                 case 0:
 
                     /* Ask for outbuffer to write next chunk of data */
-                    res = mbedtls_writer_get_ext( hs_out.wr_ext,
+                    res = mbedtls_writer_get( hs_out.wr,
                                                   4,
                                                   &tmp, NULL );
                     TEST_ASSERT( res == 0 ||
@@ -7569,15 +7558,9 @@ send_start:
                         tmp[idx] = (unsigned char)( msgs_remaining + idx );
 
                     /* Commit and update state */
-                    TEST_ASSERT( mbedtls_writer_commit_ext(
-                                     hs_out.wr_ext ) == 0 );
+                    TEST_ASSERT( mbedtls_writer_commit(
+                                     hs_out.wr ) == 0 );
                     send_state = 1;
-
-                    /* Attempt to finish the writing -- should give an error
-                     * because we have initially specified how much we intend
-                     * to write. */
-                    TEST_ASSERT( mps_l3_dispatch( &cli_l3 ) ==
-                                 MBEDTLS_ERR_MPS_UNFINISHED_HS_MSG );
 
                     goto send_start;
                     break;
@@ -7585,7 +7568,7 @@ send_start:
                 case 1:
 
                     /* Ask for outbuffer to write next chunk of data */
-                    res = mbedtls_writer_get_ext( hs_out.wr_ext, 4,
+                    res = mbedtls_writer_get( hs_out.wr, 4,
                                                   &tmp, NULL );
                     TEST_ASSERT( res == 0 ||
                                  res == MBEDTLS_ERR_WRITER_OUT_OF_DATA );
@@ -7600,8 +7583,8 @@ send_start:
                         tmp[idx] = (unsigned char)( 4 + msgs_remaining + idx );
 
                     /* Commit and update state */
-                    TEST_ASSERT( mbedtls_writer_commit_ext(
-                                     hs_out.wr_ext ) == 0 );
+                    TEST_ASSERT( mbedtls_writer_commit(
+                                     hs_out.wr ) == 0 );
                     send_state = 2;
 
                     goto send_start;
@@ -7736,7 +7719,7 @@ recv_start:
                 case 0:
 
                     /* Fetch next chunk of incoming data */
-                    res = mbedtls_mps_reader_get_ext( hs_in.rd_ext, 3,
+                    res = mbedtls_mps_reader_get( hs_in.rd, 3,
                                                   &tmp, NULL );
                     TEST_ASSERT( res == 0 ||
                                  res == MBEDTLS_ERR_MPS_READER_OUT_OF_DATA );
@@ -7752,14 +7735,9 @@ recv_start:
                                      (uint8_t)( msgs_remaining + idx ) );
 
                     /* Commit last incoming chunk and update state */
-                    TEST_ASSERT( mbedtls_mps_reader_commit_ext(
-                                     hs_in.rd_ext ) == 0 );
+                    TEST_ASSERT( mbedtls_mps_reader_commit(
+                                     hs_in.rd ) == 0 );
                     recv_state = 1;
-
-                    /* Attempt to finish the reading -- should give an error because
-                     * we know how large the message is in total.. */
-                    TEST_ASSERT( mps_l3_read_consume( &srv_l3 ) ==
-                                 MBEDTLS_ERR_MPS_UNFINISHED_HS_MSG );
 
                     goto recv_start;
                     break;
@@ -7767,7 +7745,7 @@ recv_start:
                 case 1:
 
                     /* Fetch next chunk of incoming data */
-                    res = mbedtls_mps_reader_get_ext( hs_in.rd_ext, 5,
+                    res = mbedtls_mps_reader_get( hs_in.rd, 5,
                                                   &tmp, NULL );
                     TEST_ASSERT( res == 0 ||
                                  res == MBEDTLS_ERR_MPS_READER_OUT_OF_DATA );
@@ -7783,8 +7761,8 @@ recv_start:
                                      (uint8_t) ( 3 + msgs_remaining + idx ) );
 
                     /* Commit last incoming chunk and update state */
-                    TEST_ASSERT( mbedtls_mps_reader_commit_ext(
-                                     hs_in.rd_ext ) == 0 );
+                    TEST_ASSERT( mbedtls_mps_reader_commit(
+                                     hs_in.rd ) == 0 );
                     recv_state = 2;
 
                     goto recv_start;
@@ -8127,14 +8105,14 @@ void mbedtls_mps_l3_random( int allocator_buffer_sz,
                     ret = mps_l3_read_handshake( endpoint[self], &hs_in );
                     TEST_ASSERT( ret == 0 );
 
-                    ret = mbedtls_mps_reader_get_ext( hs_in.rd_ext ,
+                    ret = mbedtls_mps_reader_get( hs_in.rd ,
                                                   data_requested, &buf,
                                                   &data_obtained );
                     TEST_ASSERT( ret == 0 );
                     TEST_ASSERT( memcmp( buf, chunk->data.hs.buf +
                                          chunk->data.hs.read_progress,
                                          data_obtained ) == 0 );
-                    TEST_ASSERT( mbedtls_mps_reader_commit_ext( hs_in.rd_ext ) == 0 );
+                    TEST_ASSERT( mbedtls_mps_reader_commit( hs_in.rd ) == 0 );
 
                     chunk->data.hs.read_progress += data_obtained;
 
@@ -8336,7 +8314,7 @@ void mbedtls_mps_l3_random( int allocator_buffer_sz,
                     data_remaining = chunk->data.hs.len - chunk->data.hs.send_progress;
                     data_requested = data_remaining;
 
-                    ret = mbedtls_writer_get_ext( hs_out.wr_ext, data_requested,
+                    ret = mbedtls_writer_get( hs_out.wr, data_requested,
                                                   &buf, &data_obtained );
                     TEST_ASSERT( ret == 0 );
 
@@ -8345,7 +8323,7 @@ void mbedtls_mps_l3_random( int allocator_buffer_sz,
                             data_obtained );
                     chunk->data.hs.send_progress += data_obtained;
 
-                    ret = mbedtls_writer_commit_ext( hs_out.wr_ext );
+                    ret = mbedtls_writer_commit( hs_out.wr );
                     TEST_ASSERT( ret == 0 );
 
                     if( chunk->data.hs.send_progress == chunk->data.hs.len )
@@ -8577,15 +8555,15 @@ void mbedtls_mps_l4_basic_handshake(
 
     if( multiple_fetch )
     {
-        TEST_ASSERT( mbedtls_writer_get_ext( hs_out.handle, 10,
+        TEST_ASSERT( mbedtls_writer_get( hs_out.handle, 10,
                                              &tmp, NULL ) == 0 );
         for( size_t idx=0; idx<10; idx++ )
             tmp[idx] = (unsigned char) idx;
 
         if( intermediate_commit )
-            TEST_ASSERT( mbedtls_writer_commit_ext( hs_out.handle )  == 0 );
+            TEST_ASSERT( mbedtls_writer_commit( hs_out.handle )  == 0 );
 
-        TEST_ASSERT( mbedtls_writer_get_ext( hs_out.handle,
+        TEST_ASSERT( mbedtls_writer_get( hs_out.handle,
                                              10 + additional_fetch,
                                              &tmp, NULL ) == 0 );
         for( size_t idx=0; idx< 10 + additional_fetch ; idx++ )
@@ -8593,7 +8571,7 @@ void mbedtls_mps_l4_basic_handshake(
     }
     else
     {
-        TEST_ASSERT( mbedtls_writer_get_ext( hs_out.handle,
+        TEST_ASSERT( mbedtls_writer_get( hs_out.handle,
                                              20 + additional_fetch,
                                              &tmp, NULL ) == 0 );
         for( size_t idx=0; idx<20 + additional_fetch; idx++ )
@@ -8603,12 +8581,12 @@ void mbedtls_mps_l4_basic_handshake(
     if( !partial_commit )
     {
         /* Commit and update state */
-        TEST_ASSERT( mbedtls_writer_commit_ext( hs_out.handle ) == 0 );
+        TEST_ASSERT( mbedtls_writer_commit( hs_out.handle ) == 0 );
     }
     else
     {
         /* Commit and update state */
-        TEST_ASSERT( mbedtls_writer_commit_partial_ext( hs_out.handle,
+        TEST_ASSERT( mbedtls_writer_commit_partial( hs_out.handle,
                                                     additional_fetch ) == 0 );
     }
 
@@ -8627,14 +8605,14 @@ void mbedtls_mps_l4_basic_handshake(
     TEST_ASSERT( hs_in.length == 20 );
 
     /* Fetch next chunk of incoming data */
-    TEST_ASSERT( mbedtls_mps_reader_get_ext( hs_in.handle, 20, &tmp, NULL ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_get( hs_in.handle, 20, &tmp, NULL ) == 0 );
 
     /* Process incoming data */
     for( size_t idx=0; idx<10; idx++ )
         TEST_ASSERT( tmp[idx] == (unsigned char) idx );
 
     /* Commit last incoming chunk and update state */
-    TEST_ASSERT( mbedtls_mps_reader_commit_ext( hs_in.handle ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_commit( hs_in.handle ) == 0 );
 
     /* Signal that message has been processed. */
     TEST_ASSERT( mbedtls_mps_read_consume( &srv_l4 ) == 0 );
@@ -8978,11 +8956,11 @@ void mbedtls_mps_l4_hs_inconsistent_continuation( int variant )
 
     TEST_ASSERT( mps_l3_write_handshake( &cli_l3, &hs_out_cli ) == 0 );
 
-    TEST_ASSERT( mbedtls_writer_get_ext( hs_out_cli.wr_ext,
+    TEST_ASSERT( mbedtls_writer_get( hs_out_cli.wr,
                                          hs_out_cli.frag_len,
                                          &tmp, NULL ) == 0 );
     memset( tmp, 42, hs_out_cli.frag_len );
-    TEST_ASSERT( mbedtls_writer_commit_ext( hs_out_cli.wr_ext ) == 0 );
+    TEST_ASSERT( mbedtls_writer_commit( hs_out_cli.wr ) == 0 );
     TEST_ASSERT( mps_l3_dispatch( &cli_l3 ) == 0 );
     TEST_ASSERT( mps_l3_flush( &cli_l3 ) == 0 );
 
@@ -8994,9 +8972,9 @@ void mbedtls_mps_l4_hs_inconsistent_continuation( int variant )
     TEST_ASSERT( mbedtls_mps_read_handshake( &srv_l4, &hs_in_srv ) == 0 );
     TEST_ASSERT( mbedtls_mps_read_set_flags( &srv_l4,
                                  MBEDTLS_MPS_FLIGHT_END ) == 0 );
-    TEST_ASSERT( mbedtls_mps_reader_get_ext( hs_in_srv.handle, 10,
+    TEST_ASSERT( mbedtls_mps_reader_get( hs_in_srv.handle, 10,
                                          &tmp, NULL ) == 0 );
-    TEST_ASSERT( mbedtls_mps_reader_commit_ext( hs_in_srv.handle ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_commit( hs_in_srv.handle ) == 0 );
     TEST_ASSERT( mbedtls_mps_read_consume( &srv_l4 ) == 0 );
 
     hs_out_srv.type = 0;
@@ -9006,11 +8984,11 @@ void mbedtls_mps_l4_hs_inconsistent_continuation( int variant )
     TEST_ASSERT( mbedtls_mps_write_set_flags( &srv_l4,
                              MBEDTLS_MPS_FLIGHT_END ) == 0 );
 
-    TEST_ASSERT( mbedtls_writer_get_ext( hs_out_srv.handle,
+    TEST_ASSERT( mbedtls_writer_get( hs_out_srv.handle,
                                          hs_out_srv.length,
                                          &tmp, NULL ) == 0 );
     memset( tmp, 0, hs_out_srv.length );
-    TEST_ASSERT( mbedtls_writer_commit_ext( hs_out_srv.handle ) == 0 );
+    TEST_ASSERT( mbedtls_writer_commit( hs_out_srv.handle ) == 0 );
     TEST_ASSERT( mbedtls_mps_dispatch( &srv_l4 ) == 0 );
 
     /* Switch incoming epoch on the server.
@@ -9046,11 +9024,11 @@ void mbedtls_mps_l4_hs_inconsistent_continuation( int variant )
 
     TEST_ASSERT( mps_l3_write_handshake( &cli_l3, &hs_out_cli ) == 0 );
 
-    TEST_ASSERT( mbedtls_writer_get_ext( hs_out_cli.wr_ext,
+    TEST_ASSERT( mbedtls_writer_get( hs_out_cli.wr,
                                          hs_out_cli.frag_len,
                                          &tmp, NULL ) == 0 );
     memset( tmp, 42, hs_out_cli.frag_len );
-    TEST_ASSERT( mbedtls_writer_commit_ext( hs_out_cli.wr_ext ) == 0 );
+    TEST_ASSERT( mbedtls_writer_commit( hs_out_cli.wr ) == 0 );
     TEST_ASSERT( mps_l3_dispatch( &cli_l3 ) == 0 );
 
     if( variant == 4 )
@@ -9064,11 +9042,11 @@ void mbedtls_mps_l4_hs_inconsistent_continuation( int variant )
 
         hs_out_cli.epoch = cli_epoch[0];
         TEST_ASSERT( mps_l3_write_handshake( &cli_l3, &hs_out_cli ) == 0 );
-        TEST_ASSERT( mbedtls_writer_get_ext( hs_out_cli.wr_ext,
+        TEST_ASSERT( mbedtls_writer_get( hs_out_cli.wr,
                                              hs_out_cli.frag_len,
                                              &tmp, NULL ) == 0 );
         memset( tmp, 42, hs_out_cli.frag_len );
-        TEST_ASSERT( mbedtls_writer_commit_ext( hs_out_cli.wr_ext ) == 0 );
+        TEST_ASSERT( mbedtls_writer_commit( hs_out_cli.wr ) == 0 );
         TEST_ASSERT( mps_l3_dispatch( &cli_l3 ) == 0 );
     }
 
@@ -9100,11 +9078,11 @@ void mbedtls_mps_l4_hs_inconsistent_continuation( int variant )
 
         TEST_ASSERT( mps_l3_write_handshake( &cli_l3, &hs_out_cli ) == 0 );
 
-        TEST_ASSERT( mbedtls_writer_get_ext( hs_out_cli.wr_ext,
+        TEST_ASSERT( mbedtls_writer_get( hs_out_cli.wr,
                                              hs_out_cli.frag_len,
                                              &tmp, NULL ) == 0 );
         memset( tmp, 42, hs_out_cli.frag_len );
-        TEST_ASSERT( mbedtls_writer_commit_ext( hs_out_cli.wr_ext ) == 0 );
+        TEST_ASSERT( mbedtls_writer_commit( hs_out_cli.wr ) == 0 );
 
         TEST_ASSERT( mps_l3_dispatch( &cli_l3 ) == 0 );
     }
@@ -9126,9 +9104,9 @@ void mbedtls_mps_l4_hs_inconsistent_continuation( int variant )
     {
         TEST_ASSERT( mbedtls_mps_read( &srv_l4 ) == MBEDTLS_MPS_MSG_HS );
         TEST_ASSERT( mbedtls_mps_read_handshake( &srv_l4, &hs_in_srv ) == 0 );
-        TEST_ASSERT( mbedtls_mps_reader_get_ext( hs_in_srv.handle, 20,
+        TEST_ASSERT( mbedtls_mps_reader_get( hs_in_srv.handle, 20,
                                              &tmp, NULL ) == 0 );
-        TEST_ASSERT( mbedtls_mps_reader_commit_ext( hs_in_srv.handle ) == 0 );
+        TEST_ASSERT( mbedtls_mps_reader_commit( hs_in_srv.handle ) == 0 );
         TEST_ASSERT( mbedtls_mps_read_consume( &srv_l4 ) == 0 );
 
         TEST_ASSERT( mbedtls_mps_set_incoming_keys( &srv_l4, srv_epoch[1] ) == 0 );
@@ -9220,14 +9198,14 @@ void mbedtls_mps_l4_disruption( int mode,
                                      MBEDTLS_MPS_FLIGHT_FINISHED ) == 0 );
     }
 
-    TEST_ASSERT( mbedtls_writer_get_ext( hs_out.handle,
+    TEST_ASSERT( mbedtls_writer_get( hs_out.handle,
                                          20,
                                          &tmp, NULL ) == 0 );
     for( size_t idx=0; idx<20; idx++ )
         tmp[idx] = (unsigned char) idx;
 
     /* Commit and update state */
-    TEST_ASSERT( mbedtls_writer_commit_ext( hs_out.handle ) == 0 );
+    TEST_ASSERT( mbedtls_writer_commit( hs_out.handle ) == 0 );
 
     /* Dispatch handshake message */
     TEST_ASSERT( mbedtls_mps_dispatch( &cli_l4 ) == 0 );
@@ -9268,14 +9246,14 @@ void mbedtls_mps_l4_disruption( int mode,
     TEST_ASSERT( hs_in.length == 20 );
 
     /* Fetch next chunk of incoming data */
-    TEST_ASSERT( mbedtls_mps_reader_get_ext( hs_in.handle, 20, &tmp, NULL ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_get( hs_in.handle, 20, &tmp, NULL ) == 0 );
 
     /* Process incoming data */
     for( size_t idx=0; idx<10; idx++ )
         TEST_ASSERT( tmp[idx] == (unsigned char) idx );
 
     /* Commit last incoming chunk and update state */
-    TEST_ASSERT( mbedtls_mps_reader_commit_ext( hs_in.handle ) == 0 );
+    TEST_ASSERT( mbedtls_mps_reader_commit( hs_in.handle ) == 0 );
 
     /* An orderly shutdown cannot happen in the middle of a handshake. */
     TEST_ASSERT( mbedtls_mps_read_set_flags( &srv_l4,
@@ -9310,14 +9288,14 @@ void mbedtls_mps_l4_disruption( int mode,
         TEST_ASSERT( mbedtls_mps_write_handshake( &srv_l4, &hs_out,
                                                   NULL, NULL ) == 0 );
 
-        TEST_ASSERT( mbedtls_writer_get_ext( hs_out.handle,
+        TEST_ASSERT( mbedtls_writer_get( hs_out.handle,
                                              20,
                                              &tmp, NULL ) == 0 );
         for( size_t idx=0; idx<20; idx++ )
             tmp[idx] = (unsigned char) idx;
 
         /* Commit and update state */
-        TEST_ASSERT( mbedtls_writer_commit_ext( hs_out.handle ) == 0 );
+        TEST_ASSERT( mbedtls_writer_commit( hs_out.handle ) == 0 );
 
         /* Dispatch handshake message */
         TEST_ASSERT( mbedtls_mps_dispatch( &srv_l4 ) == 0 );
@@ -9338,14 +9316,14 @@ void mbedtls_mps_l4_disruption( int mode,
         TEST_ASSERT( hs_in.length == 20 );
 
         /* Fetch next chunk of incoming data */
-        TEST_ASSERT( mbedtls_mps_reader_get_ext( hs_in.handle, 20, &tmp, NULL ) == 0 );
+        TEST_ASSERT( mbedtls_mps_reader_get( hs_in.handle, 20, &tmp, NULL ) == 0 );
 
         /* Process incoming data */
         for( size_t idx=0; idx<10; idx++ )
             TEST_ASSERT( tmp[idx] == (unsigned char) idx );
 
         /* Commit last incoming chunk and update state */
-        TEST_ASSERT( mbedtls_mps_reader_commit_ext( hs_in.handle ) == 0 );
+        TEST_ASSERT( mbedtls_mps_reader_commit( hs_in.handle ) == 0 );
 
         /* An orderly shutdown cannot happen in the middle of a handshake. */
         TEST_ASSERT( mbedtls_mps_read_set_flags( &cli_l4,
@@ -9452,13 +9430,13 @@ void mbedtls_mps_l4_dtls_fragmentation( int allocator_buffer_sz,
                                                       NULL ) == 0 );
         }
 
-        TEST_ASSERT( mbedtls_writer_get_ext( hs_out.handle, hs_len + iteration,
+        TEST_ASSERT( mbedtls_writer_get( hs_out.handle, hs_len + iteration,
                                              &tmp, NULL ) == 0 );
         for( size_t idx=0; idx<(unsigned) ( hs_len + iteration ); idx++ )
             tmp[idx] = (unsigned char) idx;
 
         /* Commit and update state */
-        TEST_ASSERT( mbedtls_writer_commit_ext( hs_out.handle ) == 0 );
+        TEST_ASSERT( mbedtls_writer_commit( hs_out.handle ) == 0 );
 
         /* Dispatch handshake message */
         TEST_ASSERT( mbedtls_mps_dispatch( &cli_l4 ) == 0 );
@@ -9485,14 +9463,14 @@ void mbedtls_mps_l4_dtls_fragmentation( int allocator_buffer_sz,
             TEST_ASSERT( hs_in.len         == ( hs_len + iteration) );
             TEST_ASSERT( hs_in.seq_nr      == iteration             );
 
-            TEST_ASSERT( mbedtls_mps_reader_get_ext( hs_in.rd_ext ,
+            TEST_ASSERT( mbedtls_mps_reader_get( hs_in.rd,
                                                  hs_in.frag_len,
                                                  &tmp, NULL ) == 0 );
             for( size_t idx=0; idx<(unsigned) hs_in.frag_len; idx++ )
                 TEST_ASSERT( tmp[idx] == (unsigned char)( hs_offset + idx ) );
 
             /* Commit last incoming chunk and update state */
-            TEST_ASSERT( mbedtls_mps_reader_commit_ext( hs_in.rd_ext ) == 0 );
+            TEST_ASSERT( mbedtls_mps_reader_commit( hs_in.rd ) == 0 );
 
             /* Signal that message fragment has been processed. */
             TEST_ASSERT( mps_l3_read_consume( &srv_l3 ) == 0 );
@@ -9597,13 +9575,13 @@ void mbedtls_mps_l4_dtls_reassembly( int allocator_buffer_sz,
             if( ret != 0 )
                 continue;
 
-            TEST_ASSERT( mbedtls_writer_get_ext( hs_out.handle,
+            TEST_ASSERT( mbedtls_writer_get( hs_out.handle,
                                                  hs_len, &tmp, NULL ) == 0 );
 
             for( size_t idx=0; idx<(unsigned) ( hs_len ); idx++ )
                 tmp[idx] = (unsigned char) idx;
 
-            TEST_ASSERT( mbedtls_writer_commit_ext( hs_out.handle ) == 0 );
+            TEST_ASSERT( mbedtls_writer_commit( hs_out.handle ) == 0 );
 
             /* Dispatch handshake message */
             TEST_ASSERT( mbedtls_mps_dispatch( &cli_l4 ) == 0 );
@@ -9640,13 +9618,13 @@ void mbedtls_mps_l4_dtls_reassembly( int allocator_buffer_sz,
             }
             else
             {
-                TEST_ASSERT( mbedtls_writer_get_ext( hs_out.handle,
+                TEST_ASSERT( mbedtls_writer_get( hs_out.handle,
                                                      hs_len, &tmp, NULL ) == 0 );
 
                 for( size_t idx=0; idx<(unsigned) ( hs_len ); idx++ )
                     tmp[idx] = (unsigned char) idx;
 
-                TEST_ASSERT( mbedtls_writer_commit_ext( hs_out.handle ) == 0 );
+                TEST_ASSERT( mbedtls_writer_commit( hs_out.handle ) == 0 );
 
                 /* Dispatch handshake message */
                 TEST_ASSERT( mbedtls_mps_dispatch( &cli_l4 ) == 0 );
@@ -9701,11 +9679,11 @@ void mbedtls_mps_l4_dtls_reassembly( int allocator_buffer_sz,
         TEST_ASSERT( hs_in.length == hs_len    );
         TEST_ASSERT( hs_in.type   == iteration );
 
-        TEST_ASSERT( mbedtls_mps_reader_get_ext( hs_in.handle, hs_in.length,
+        TEST_ASSERT( mbedtls_mps_reader_get( hs_in.handle, hs_in.length,
                                              &tmp, NULL ) == 0 );
         for( size_t idx=0; idx<(unsigned) ( hs_len ); idx++ )
             TEST_ASSERT( tmp[idx] == (unsigned char) idx );
-        TEST_ASSERT( mbedtls_mps_reader_commit_ext( hs_in.handle ) == 0 );
+        TEST_ASSERT( mbedtls_mps_reader_commit( hs_in.handle ) == 0 );
         TEST_ASSERT( mbedtls_mps_read_consume( &srv_l4 ) == 0 );
 
     }
@@ -10033,13 +10011,13 @@ void mbedtls_mps_l4_flight_exchange( int mode,
 
             if( retransmission_callback == 0 )
             {
-                TEST_ASSERT( mbedtls_writer_get_ext( hs_out.handle, hs_len + iteration,
+                TEST_ASSERT( mbedtls_writer_get( hs_out.handle, hs_len + iteration,
                                                      &tmp, NULL ) == 0 );
                 for( size_t idx=0; idx<(unsigned) ( hs_len + iteration ); idx++ )
                     tmp[idx] = (unsigned char) idx;
 
                 /* Commit and update state */
-                TEST_ASSERT( mbedtls_writer_commit_ext( hs_out.handle ) == 0 );
+                TEST_ASSERT( mbedtls_writer_commit( hs_out.handle ) == 0 );
 
                 /* Dispatch handshake message */
                 TEST_ASSERT( mbedtls_mps_dispatch( sender ) == 0 );
@@ -10271,7 +10249,7 @@ void mbedtls_mps_l4_flight_exchange( int mode,
             TEST_ASSERT( hs_in.length == hs_len + iteration );
             TEST_ASSERT( hs_in.type   == iteration );
 
-            ret = mbedtls_mps_reader_get_ext( hs_in.handle, hs_in.length,
+            ret = mbedtls_mps_reader_get( hs_in.handle, hs_in.length,
                                           &tmp, NULL );
             if( ret == MBEDTLS_ERR_MPS_READER_OUT_OF_DATA )
             {
@@ -10282,7 +10260,7 @@ void mbedtls_mps_l4_flight_exchange( int mode,
 
             for( size_t idx=0; idx<(unsigned) ( hs_len + iteration ); idx++ )
                 TEST_ASSERT( tmp[idx] == (unsigned char) idx );
-            TEST_ASSERT( mbedtls_mps_reader_commit_ext( hs_in.handle ) == 0 );
+            TEST_ASSERT( mbedtls_mps_reader_commit( hs_in.handle ) == 0 );
 
             if( iteration == (unsigned) ( num_hs - 1 ) )
             {


### PR DESCRIPTION
This PR removes all uses of extended reader/writer from MPS.

While reader/writer provide a layer of abstraction preventing buffer overflows and pointer arithmetic failures, extended reader/writers are primarily a means to track logical bounds, such as the bounds of a HS message spread over multiple physical buffers, or the bounds of substructures such as extensions in a `ClientHello`. 

Bounds checks as performed by the extended reader/writer are necessary at some point in the stack. However, the previous design choice of incorporating them already at MPS Layer 3 caused significant technical difficulties. 

For now, this PR removes extended reader/writers altogether, from both Layer 3 and Layer 4. 

It will need to be reconsidered if/where we want to re-introduce extended readers/writers at a later point: Either at the handshake layer, or at the very boundary of MPS Layer 4 -- but not within MPS itself.