### PR TITLE
Accepting records with a v1.1 version number

### DIFF
--- a/library/mps/layer2.c
+++ b/library/mps/layer2.c
@@ -1956,10 +1956,17 @@ int l2_in_fetch_protected_record_tls( mbedtls_mps_l2 *ctx, mps_rec *rec )
      * MBEDTLS_MPS_L2_VERSION_UNSPECIFIED.
      *
      * Also, for TLS 1.3, the wire-version is still TLS 1.2.
+     * For backwards compatibility reasons, the wire-version may also be set 
+     * to TLS 1.1 for the ClientHello.     
      *
      * We capture both special cases in a helper function checking whether the
      * wire-version matches the configured logical version. */
-    if( l2_version_wire_matches_logical( minor_ver,
+    if( minor_ver == MBEDTLS_SSL_MINOR_VERSION_1 )
+    { 
+        /* Backwards compatibility case */
+        MBEDTLS_MPS_TRACE_COMMENT( "Record with TLS 1.1 version number received" );
+    }
+    else if( l2_version_wire_matches_logical( minor_ver,
                   mbedtls_mps_l2_conf_get_version( &ctx->conf ) ) != 1 )
     {
         MBEDTLS_MPS_TRACE_ERROR( "Invalid minor record version %u received, expected %u",

--- a/library/mps/layer2.c
+++ b/library/mps/layer2.c
@@ -1867,6 +1867,17 @@ MBEDTLS_MPS_ALWAYS_INLINE
 int l2_version_wire_matches_logical( uint8_t wire_version,
                                      int logical_version )
 {
+
+    /* TODO: Since MBEDTLS_MPS_L2_VERSION_UNSPECIFIED is not 
+     * yet implemented we include this special handling.
+     */
+    if( wire_version == MBEDTLS_SSL_MINOR_VERSION_1 )
+    { 
+        /* Backwards compatibility case */
+        MBEDTLS_MPS_TRACE_COMMENT( "Record with TLS 1.1 version number received" );
+        return( 1 );
+    }
+        
     switch( logical_version )
     {
         case MBEDTLS_MPS_L2_VERSION_UNSPECIFIED:
@@ -1961,12 +1972,7 @@ int l2_in_fetch_protected_record_tls( mbedtls_mps_l2 *ctx, mps_rec *rec )
      *
      * We capture both special cases in a helper function checking whether the
      * wire-version matches the configured logical version. */
-    if( minor_ver == MBEDTLS_SSL_MINOR_VERSION_1 )
-    { 
-        /* Backwards compatibility case */
-        MBEDTLS_MPS_TRACE_COMMENT( "Record with TLS 1.1 version number received" );
-    }
-    else if( l2_version_wire_matches_logical( minor_ver,
+    if( l2_version_wire_matches_logical( minor_ver,
                   mbedtls_mps_l2_conf_get_version( &ctx->conf ) ) != 1 )
     {
         MBEDTLS_MPS_TRACE_ERROR( "Invalid minor record version %u received, expected %u",


### PR DESCRIPTION
## Description

compat.sh failed with GnuTLS because GnuTLS sets the minor version of the ClientHello record layer packet to v1.1. 

According to the spec this is allowed: 

>    legacy_record_version:  MUST be set to 0x0303 for all records
>       generated by a TLS 1.3 implementation other than an initial
>       ClientHello (i.e., one not generated after a HelloRetryRequest),
>       where it MAY also be 0x0301 for compatibility purposes.  This
>       field is deprecated and MUST be ignored for all purposes.
>       Previous versions of TLS would use other values in this field
>       under some circumstances.

What the PR does not do is to check whether this is this version number was only set for the ClientHello because at this layer we do not do deep packet inspection.

## Status
**READY**

Tested against compat.sh and ssl-opt.sh


## Requires Backporting
NO  

## Migrations
NO

## Additional comments
Any additional information that could be of interest

## Todos
- [x] Tests
- [x] Documentation

## Steps to test or reproduce
Run compat.sh with this fix enabled and without it. 
