### PR TITLE
Allow integration of libOQS

### DIFF
--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -1,5 +1,11 @@
-execute_process(COMMAND ${MBEDTLS_PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/../scripts/config.py -f ${CMAKE_CURRENT_SOURCE_DIR}/../include/mbedtls/mbedtls_config.h get MBEDTLS_ECDH_VARIANT_EVEREST_ENABLED RESULT_VARIABLE result)
+execute_process(COMMAND ${MBEDTLS_PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/../scripts/config.py -f ${CMAKE_CURRENT_SOURCE_DIR}/../include/mbedtls/mbedtls_config.h get MBEDTLS_ECDH_VARIANT_EVEREST_ENABLED RESULT_VARIABLE result_everest)
 
-if(${result} EQUAL 0)
+if(${result_everest} EQUAL 0)
     add_subdirectory(everest)
+endif()
+
+execute_process(COMMAND ${MBEDTLS_PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/../scripts/config.py -f ${CMAKE_CURRENT_SOURCE_DIR}/../include/mbedtls/mbedtls_config.h get MBEDTLS_LIBOQS_ENABLE RESULT_VARIABLE result_liboqs)
+
+if(${result_liboqs} EQUAL 0)
+    add_subdirectory(liboqs)
 endif()

--- a/3rdparty/liboqs/CMakeLists.txt
+++ b/3rdparty/liboqs/CMakeLists.txt
@@ -3,4 +3,5 @@ ExternalProject_Add(liboqs
 	GIT_REPOSITORY             https://github.com/open-quantum-safe/liboqs
 	GIT_TAG                    main
 	CMAKE_CACHE_ARGS           -DOQS_ENABLE_KEM_CLASSIC_MCELIECE:BOOL=OFF -DOQS_USE_OPENSSL:BOOL=OFF -DCMAKE_INSTALL_PREFIX:PATH=${CMAKE_BINARY_DIR}
+	UPDATE_COMMAND             ""
 	)

--- a/3rdparty/liboqs/CMakeLists.txt
+++ b/3rdparty/liboqs/CMakeLists.txt
@@ -1,0 +1,6 @@
+include(ExternalProject)
+ExternalProject_Add(liboqs
+	GIT_REPOSITORY             https://github.com/open-quantum-safe/liboqs
+	GIT_TAG                    main
+	CMAKE_CACHE_ARGS           -DOQS_ENABLE_KEM_CLASSIC_MCELIECE:BOOL=OFF -DOQS_USE_OPENSSL:BOOL=OFF -DCMAKE_INSTALL_PREFIX:PATH=${CMAKE_BINARY_DIR}
+	)

--- a/README.md
+++ b/README.md
@@ -60,9 +60,13 @@ MPS is controlled by the configuration option `MBEDTLS_SSL_USE_MPS`, which is en
 
 ## Post-Quantum Cryptography
 
-We're in the early stages of experimenting with PQC support in Mbed TLS on the basis of the [libOQS](...) post-quantum
-cryptography library. You can enable libOQS via `MBEDTLS_LIBOQS_ENABLE` in `include/mbedtls/mbedtls_config.h`, which
-will make header files and library of libOQS available to the Mbed TLS compilation units.
+We're in the early stages of experimenting with PQC support in Mbed TLS on the basis of the [libOQS](https://openquantumsafe.org/liboqs/) post-quantum
+cryptography library.  To enable libOQS, you have to set `MBEDTLS_LIBOQS_ENABLE` in `include/mbedtls/mbedtls_config.h`
+and build Mbed TLS via `cmake`. Any change in `MBEDTLS_LIBOQS_ENABLE` currently demands a re-build of the `cmake`
+makefiles. You can check that the build was successful by checking for and running the libOQS unit test `./tests/test_suite_liboqs`.
+
+The actual integration PQC KEMs and their hybrids into Mbed TLS is still ongoing. Please reach out to @brett-warren-arm
+or @hanno-arm, or open an issue, if have questions or would like to contribute.
 
 # Known limitations
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ Implementation](https://github.com/hannestschofenig/mbedtls/tree/tls13-prototype
 
 MPS is controlled by the configuration option `MBEDTLS_SSL_USE_MPS`, which is enabled by default.
 
+## Post-Quantum Cryptography
+
+We're in the early stages of experimenting with PQC support in Mbed TLS on the basis of the [libOQS](...) post-quantum
+cryptography library. You can enable libOQS via `MBEDTLS_LIBOQS_ENABLE` in `include/mbedtls/mbedtls_config.h`, which
+will make header files and library of libOQS available to the Mbed TLS compilation units.
+
 # Known limitations
 
 Please consult the [issues](https://github.com/hannestschofenig/mbedtls/issues) for a complete list of issues. Here we

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -3354,6 +3354,6 @@
  * If this is enabled, libOQS will be built in 3rdparty/liboqs
  * and made available to Mbed TLS compilation units.
  */
-#define MBEDTLS_LIBOQS_ENABLE
+//#define MBEDTLS_LIBOQS_ENABLE
 
 /* \} name SECTION: Customisation configuration options */

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -3349,7 +3349,10 @@
 //#define MBEDTLS_ECDH_VARIANT_EVEREST_ENABLED
 
 /**
- * Enable liboqs post-quantum cryptography
+ * Enable the libOQS Post-Quantum Cryptography library
+ *
+ * If this is enabled, libOQS will be built in 3rdparty/liboqs
+ * and made available to Mbed TLS compilation units.
  */
 #define MBEDTLS_LIBOQS_ENABLE
 

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -3348,4 +3348,9 @@
  */
 //#define MBEDTLS_ECDH_VARIANT_EVEREST_ENABLED
 
+/**
+ * Enable liboqs post-quantum cryptography
+ */
+#define MBEDTLS_LIBOQS_ENABLE
+
 /* \} name SECTION: Customisation configuration options */

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -206,6 +206,11 @@ if(USE_SHARED_MBEDTLS_LIBRARY)
         target_link_libraries(${mbedcrypto_target} PUBLIC everest)
     endif()
 
+    if(TARGET liboqs)
+        add_dependencies(${mbedcrypto_target} PUBLIC liboqs)
+	target_link_libraries(${mbedcrypto_target} PUBLIC ${CMAKE_BINARY_DIR}/lib/liboqs.a)
+    endif()
+
     add_library(${mbedx509_target} SHARED ${src_x509})
     set_target_properties(${mbedx509_target} PROPERTIES VERSION 3.0.0 SOVERSION 4)
     target_link_libraries(${mbedx509_target} PUBLIC ${libs} ${mbedcrypto_target})
@@ -221,6 +226,7 @@ foreach(target IN LISTS target_libraries)
     # from /library and others declared by /3rdparty/**/CMakeLists.txt.
     # /library needs to be listed explicitly when building .c files outside
     # of /library (which currently means: under /3rdparty).
+    add_dependencies(${target} liboqs)
     target_include_directories(${target}
         PUBLIC $<BUILD_INTERFACE:${MBEDTLS_DIR}/include/>
                $<INSTALL_INTERFACE:include/>

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -188,6 +188,11 @@ if(USE_STATIC_MBEDTLS_LIBRARY)
         target_link_libraries(${mbedcrypto_static_target} PUBLIC everest)
     endif()
 
+    if(TARGET liboqs)
+        add_dependencies(${mbedcrypto_target} liboqs)
+	target_link_libraries(${mbedcrypto_target} PUBLIC ${CMAKE_BINARY_DIR}/lib/liboqs.a)
+    endif()
+
     add_library(${mbedx509_static_target} STATIC ${src_x509})
     set_target_properties(${mbedx509_static_target} PROPERTIES OUTPUT_NAME mbedx509)
     target_link_libraries(${mbedx509_static_target} PUBLIC ${libs} ${mbedcrypto_static_target})
@@ -207,7 +212,7 @@ if(USE_SHARED_MBEDTLS_LIBRARY)
     endif()
 
     if(TARGET liboqs)
-        add_dependencies(${mbedcrypto_target} PUBLIC liboqs)
+        add_dependencies(${mbedcrypto_target} liboqs)
 	target_link_libraries(${mbedcrypto_target} PUBLIC ${CMAKE_BINARY_DIR}/lib/liboqs.a)
     endif()
 
@@ -226,7 +231,6 @@ foreach(target IN LISTS target_libraries)
     # from /library and others declared by /3rdparty/**/CMakeLists.txt.
     # /library needs to be listed explicitly when building .c files outside
     # of /library (which currently means: under /3rdparty).
-    add_dependencies(${target} liboqs)
     target_include_directories(${target}
         PUBLIC $<BUILD_INTERFACE:${MBEDTLS_DIR}/include/>
                $<INSTALL_INTERFACE:include/>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -40,11 +40,17 @@ function(add_test_suite suite_name)
 
     add_executable(test_suite_${data_name} test_suite_${data_name}.c $<TARGET_OBJECTS:mbedtls_test>)
     target_link_libraries(test_suite_${data_name} ${libs})
+
+    if (TARGET liboqs)
+        target_link_libraries(test_suite_${data_name} ${CMAKE_BINARY_DIR}/lib/liboqs.a)
+    endif()
+
     # Include test-specific header files from ./include and private header
     # files (used by some invasive tests) from ../library. Public header
     # files are automatically included because the library targets declare
     # them as PUBLIC.
     target_include_directories(test_suite_${data_name}
+	PRIVATE ${CMAKE_BINARY_DIR}/include
         PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
         PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../library)
 
@@ -158,6 +164,7 @@ add_test_suite(ssl)
 add_test_suite(version)
 add_test_suite(x509parse)
 add_test_suite(x509write)
+add_test_suite(liboqs)
 
 # Make scripts and data files needed for testing available in an
 # out-of-source build.

--- a/tests/suites/test_suite_liboqs.data
+++ b/tests/suites/test_suite_liboqs.data
@@ -1,3 +1,3 @@
-Dummy test
+Build and link test: Example run of BIKE L1
 depends_on:MBEDTLS_LIBOQS_ENABLE
-dummy_test
+build_and_link_test

--- a/tests/suites/test_suite_liboqs.data
+++ b/tests/suites/test_suite_liboqs.data
@@ -1,0 +1,3 @@
+Dummy test
+depends_on:MBEDTLS_LIBOQS_ENABLE
+dummy_test

--- a/tests/suites/test_suite_liboqs.function
+++ b/tests/suites/test_suite_liboqs.function
@@ -16,8 +16,6 @@ void dummy_test()
     unsigned char ss0[OQS_KEM_bike_l1_length_shared_secret];
     unsigned char ss1[OQS_KEM_bike_l1_length_shared_secret];
 
-    OQS_KEM_bike_l1_new();
-
     OQS_KEM_bike_l1_keypair(pk,sk);
     OQS_KEM_bike_l1_encaps(cc,ss0,pk);
     OQS_KEM_bike_l1_decaps(ss1,cc,sk);

--- a/tests/suites/test_suite_liboqs.function
+++ b/tests/suites/test_suite_liboqs.function
@@ -10,8 +10,19 @@
 /* BEGIN_CASE */
 void dummy_test()
 {
+    unsigned char sk[OQS_KEM_bike_l1_length_secret_key];
+    unsigned char pk[OQS_KEM_bike_l1_length_public_key];
+    unsigned char cc[OQS_KEM_bike_l1_length_ciphertext];
+    unsigned char ss0[OQS_KEM_bike_l1_length_shared_secret];
+    unsigned char ss1[OQS_KEM_bike_l1_length_shared_secret];
+
     OQS_KEM_bike_l1_new();
-    /* This goto is added to avoid warnings from the generated code. */
-    goto exit;
+
+    OQS_KEM_bike_l1_keypair(pk,sk);
+    OQS_KEM_bike_l1_encaps(cc,ss0,pk);
+    OQS_KEM_bike_l1_decaps(ss1,cc,sk);
+
+    ASSERT_COMPARE(ss0, sizeof(ss0), ss1, sizeof(ss1));
+    TEST_ASSERT(1);
 }
 /* END_CASE */

--- a/tests/suites/test_suite_liboqs.function
+++ b/tests/suites/test_suite_liboqs.function
@@ -1,0 +1,17 @@
+/* BEGIN_HEADER */
+#include "oqs/kem_bike.h"
+/* END_HEADER */
+
+/* BEGIN_DEPENDENCIES
+ * depends_on:MBEDTLS_LIBOQS_ENABLE
+ * END_DEPENDENCIES
+ */
+
+/* BEGIN_CASE */
+void dummy_test()
+{
+    OQS_KEM_bike_l1_new();
+    /* This goto is added to avoid warnings from the generated code. */
+    goto exit;
+}
+/* END_CASE */

--- a/tests/suites/test_suite_liboqs.function
+++ b/tests/suites/test_suite_liboqs.function
@@ -8,7 +8,7 @@
  */
 
 /* BEGIN_CASE */
-void dummy_test()
+void build_and_link_test()
 {
     unsigned char sk[OQS_KEM_bike_l1_length_secret_key];
     unsigned char pk[OQS_KEM_bike_l1_length_public_key];


### PR DESCRIPTION
This PR adds the configuration flag `MBEDTLS_LIBOQS_ENABLE` which controls the integration of the libOQS post-quantum cryptography library into Mbed TLS.