### PR TITLE
Don't use TLS 1.2 key exchange identifiers in TLS 1.3 code

### DIFF
--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -186,6 +186,8 @@
                                                   MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_ECDHE_ECDSA )
 #define MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_ALL ( MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_KE     | \
                                                       MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_DHE_KE )
+#define MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_ECDHE_ALL ( MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_ECDHE_ECDSA     | \
+                                                      MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_DHE_KE )
 
 /*
  * Constants from RFC 8446 for TLS 1.3 PSK modes

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -1253,76 +1253,54 @@ int ssl_parse_encrypted_extensions_early_data_ext( mbedtls_ssl_context *ssl,
 /*
  * Helper functions around key exchange modes.
  */
-static inline unsigned mbedtls_ssl_conf_tls13_get_key_exchange_modes( mbedtls_ssl_context *ssl )
+static inline unsigned mbedtls_ssl_conf_tls13_kex_modes_check( mbedtls_ssl_context *ssl,
+                                                               int kex_mode_mask )
 {
-    return( ssl->conf->key_exchange_modes );
+    return( ( ssl->conf->key_exchange_modes & kex_mode_mask ) != 0 );
 }
 
 static inline int mbedtls_ssl_conf_tls13_pure_psk_enabled( mbedtls_ssl_context *ssl )
 {
-    if( ( mbedtls_ssl_conf_tls13_get_key_exchange_modes( ssl ) &
-          MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_KE ) != 0 )
-    {
-        return( 1 );
-    }
-
-    return( 0 );
+    return( mbedtls_ssl_conf_tls13_kex_modes_check( ssl,
+                   MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_KE ) );
 }
-
 static inline int mbedtls_ssl_conf_tls13_psk_ecdhe_enabled( mbedtls_ssl_context *ssl )
 {
-    if( ( mbedtls_ssl_conf_tls13_get_key_exchange_modes( ssl ) &
-          MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_DHE_KE ) != 0 )
-    {
-        return( 1 );
-    }
-
-    return( 0 );
+    return( mbedtls_ssl_conf_tls13_kex_modes_check( ssl,
+                   MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_DHE_KE ) );
 }
-
 static inline int mbedtls_ssl_conf_tls13_some_ecdhe_enabled( mbedtls_ssl_context *ssl )
 {
-    if( ( mbedtls_ssl_conf_tls13_get_key_exchange_modes( ssl ) &
-          ( MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_DHE_KE | \
-            MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_ECDHE_ECDSA ) ) != 0 )
-    {
-        return( 1 );
-    }
-
-    return( 0 );
+    return( mbedtls_ssl_conf_tls13_kex_modes_check( ssl,
+                   MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_ECDHE_ALL ) );
 }
-
 static inline int mbedtls_ssl_conf_tls13_some_psk_enabled( mbedtls_ssl_context *ssl )
 {
-    if( ( mbedtls_ssl_conf_tls13_get_key_exchange_modes( ssl ) &
-          MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_ALL ) != 0 )
-    {
-        return( 1 );
-    }
-
-    return( 0 );
+    return( mbedtls_ssl_conf_tls13_kex_modes_check( ssl,
+                   MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_ALL ) );
 }
-
 static inline int mbedtls_ssl_conf_tls13_pure_ecdhe_enabled( mbedtls_ssl_context *ssl )
 {
-    if( ( mbedtls_ssl_conf_tls13_get_key_exchange_modes( ssl ) &
-          MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_ECDHE_ECDSA ) != 0 )
-    {
-        return( 1 );
-    }
-
-    return( 0 );
+    return( mbedtls_ssl_conf_tls13_kex_modes_check( ssl,
+                   MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_ECDHE_ECDSA ) );
 }
 
-static inline int mbedtls_ssl_tls13_key_exchange_with_psk( mbedtls_ssl_context *ssl )
+static inline int mbedtls_ssl_tls13_kex_check( mbedtls_ssl_context *ssl,
+                                      int kex_mask )
 {
-    if( ssl->handshake->key_exchange == MBEDTLS_KEY_EXCHANGE_PSK ||
-        ssl->handshake->key_exchange == MBEDTLS_KEY_EXCHANGE_ECDHE_PSK )
-    {
-        return( 1 );
-    }
+    return( ( ssl->handshake->key_exchange & kex_mask ) != 0 );
+}
 
-    return( 0 );
+static inline int mbedtls_ssl_tls13_kex_with_psk( mbedtls_ssl_context *ssl )
+{
+    return( mbedtls_ssl_tls13_kex_check( ssl,
+                   MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_ALL ) );
+}
+
+static inline int mbedtls_ssl_tls13_kex_with_ecdhe( mbedtls_ssl_context *ssl )
+{
+    return( mbedtls_ssl_tls13_kex_check( ssl,
+                   MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_ECDHE_ALL ) );
 }
 
 /*

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -2281,8 +2281,7 @@ static int ssl_certificate_request_coordinate( mbedtls_ssl_context* ssl )
     int ret;
     mbedtls_mps_handshake_in msg;
 
-    if( ssl->handshake->key_exchange == MBEDTLS_KEY_EXCHANGE_PSK ||
-        ssl->handshake->key_exchange == MBEDTLS_KEY_EXCHANGE_ECDHE_PSK )
+    if( mbedtls_ssl_tls13_kex_with_psk( ssl ) )
     {
         MBEDTLS_SSL_DEBUG_MSG( 3, ( "<= skip parse certificate request" ) );
         return( SSL_CERTIFICATE_REQUEST_SKIP );
@@ -2314,8 +2313,7 @@ static int ssl_certificate_request_coordinate( mbedtls_ssl_context* ssl )
 {
     int ret;
 
-    if( ssl->handshake->key_exchange == MBEDTLS_KEY_EXCHANGE_PSK ||
-        ssl->handshake->key_exchange == MBEDTLS_KEY_EXCHANGE_ECDHE_PSK )
+    if( mbedtls_ssl_tls13_kex_with_psk( ssl ) )
     {
         MBEDTLS_SSL_DEBUG_MSG( 3, ( "<= skip parse certificate request" ) );
         return( SSL_CERTIFICATE_REQUEST_SKIP );
@@ -3317,12 +3315,12 @@ static int ssl_server_hello_postprocess( mbedtls_ssl_context* ssl )
     if( ssl->handshake->extensions_present & MBEDTLS_SSL_EXT_PRE_SHARED_KEY )
     {
         if( ssl->handshake->extensions_present & MBEDTLS_SSL_EXT_KEY_SHARE )
-            ssl->handshake->key_exchange = MBEDTLS_KEY_EXCHANGE_ECDHE_PSK;
+            ssl->handshake->key_exchange = MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_DHE_KE;
         else
-            ssl->handshake->key_exchange = MBEDTLS_KEY_EXCHANGE_PSK;
+            ssl->handshake->key_exchange = MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_KE;
     }
     else if( ssl->handshake->extensions_present & MBEDTLS_SSL_EXT_KEY_SHARE )
-        ssl->handshake->key_exchange = MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA;
+        ssl->handshake->key_exchange = MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_ECDHE_ECDSA;
     else
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "Unknown key exchange." ) );

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -636,7 +636,7 @@ static int ssl_write_certificate_verify_coordinate( mbedtls_ssl_context* ssl )
     int have_own_cert = 1;
     int ret;
 
-    if( mbedtls_ssl_tls13_key_exchange_with_psk( ssl ) )
+    if( mbedtls_ssl_tls13_kex_with_psk( ssl ) )
     {
         MBEDTLS_SSL_DEBUG_MSG( 2, ( "<= skip write certificate verify" ) );
         return( SSL_WRITE_CERTIFICATE_VERIFY_SKIP );
@@ -1024,10 +1024,8 @@ cleanup:
 
 static int ssl_read_certificate_verify_coordinate( mbedtls_ssl_context* ssl )
 {
-    if( ssl->handshake->key_exchange != MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA )
-    {
+    if( mbedtls_ssl_tls13_kex_with_psk( ssl ) )
         return( SSL_CERTIFICATE_VERIFY_SKIP );
-    }
 
 #if !defined(MBEDTLS_KEY_EXCHANGE_WITH_CERT_ENABLED)
     MBEDTLS_SSL_DEBUG_MSG( 1, ( "should never happen" ) );
@@ -1369,8 +1367,7 @@ static int ssl_write_certificate_coordinate( mbedtls_ssl_context* ssl )
 #endif /* MBEDTLS_SSL_CLI_C */
 
     /* For PSK and ECDHE-PSK ciphersuites there is no certificate to exchange. */
-    if( ssl->handshake->key_exchange == MBEDTLS_KEY_EXCHANGE_PSK ||
-        ssl->handshake->key_exchange == MBEDTLS_KEY_EXCHANGE_ECDHE_PSK )
+    if( mbedtls_ssl_tls13_kex_with_psk( ssl ) )
     {
         MBEDTLS_SSL_DEBUG_MSG( 2, ( "<= skip write certificate" ) );
         return( SSL_WRITE_CERTIFICATE_SKIP );
@@ -1712,11 +1709,8 @@ static int ssl_read_certificate_coordinate( mbedtls_ssl_context* ssl )
     }
 #endif /* MBEDTLS_SSL_SRV_C */
 
-    if( ssl->handshake->key_exchange == MBEDTLS_KEY_EXCHANGE_PSK ||
-        ssl->handshake->key_exchange == MBEDTLS_KEY_EXCHANGE_ECDHE_PSK )
-    {
+    if( mbedtls_ssl_tls13_kex_with_psk( ssl ) )
         return( SSL_CERTIFICATE_SKIP );
-    }
 
 #if !defined(MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED)
     ( ( void )authmode );

--- a/library/ssl_tls13_keys.c
+++ b/library/ssl_tls13_keys.c
@@ -941,8 +941,7 @@ static int ssl_tls1_3_complete_ephemeral_secret( mbedtls_ssl_context *ssl,
      * Compute ECDHE secret for second stage of secret evolution.
      */
 #if defined(MBEDTLS_KEY_EXCHANGE_SOME_ECDHE_ENABLED)
-    if( ssl->handshake->key_exchange == MBEDTLS_KEY_EXCHANGE_ECDHE_PSK ||
-        ssl->handshake->key_exchange == MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA )
+    if( mbedtls_ssl_tls13_kex_with_ecdhe( ssl ) )
     {
         ret = mbedtls_ecdh_calc_secret(
                    &ssl->handshake->ecdh_ctx,

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -2297,38 +2297,39 @@ static void ssl_debug_print_client_hello_exts( mbedtls_ssl_context *ssl )
 #endif /* MBEDTLS_ZERO_RTT*/
 }
 
+static int ssl_client_hello_has_exts( mbedtls_ssl_context *ssl,
+                                      int ext_id_mask )
+{
+    int masked = ssl->handshake->extensions_present & ext_id_mask;
+    return( masked == ext_id_mask );
+}
+
 static int ssl_client_hello_has_psk_extensions( mbedtls_ssl_context *ssl )
 {
-    if( ( ssl->handshake->extensions_present & MBEDTLS_SSL_EXT_PRE_SHARED_KEY ) &&
-        ( ssl->handshake->extensions_present & MBEDTLS_SSL_EXT_PSK_KEY_EXCHANGE_MODES ) )
-    {
-        return( 1 );
-    }
+    return( ssl_client_hello_has_exts( ssl,
+                MBEDTLS_SSL_EXT_PRE_SHARED_KEY |
+                MBEDTLS_SSL_EXT_PSK_KEY_EXCHANGE_MODES ) );
+}
 
-    return( 0 );
+static int ssl_client_hello_has_key_share_extensions( mbedtls_ssl_context *ssl )
+{
+    return( ssl_client_hello_has_exts( ssl,
+                          MBEDTLS_SSL_EXT_SUPPORTED_GROUPS |
+                          MBEDTLS_SSL_EXT_KEY_SHARE ) );
 }
 
 static int ssl_client_hello_has_cert_extensions( mbedtls_ssl_context *ssl )
 {
-    if( ( ssl->handshake->extensions_present & MBEDTLS_SSL_EXT_SUPPORTED_GROUPS )    &&
-        ( ssl->handshake->extensions_present & MBEDTLS_SSL_EXT_SIGNATURE_ALGORITHM ) &&
-        ( ssl->handshake->extensions_present & MBEDTLS_SSL_EXT_KEY_SHARE ) )
-    {
-        return( 1 );
-    }
-
-    return( 0 );
+    return( ssl_client_hello_has_exts( ssl,
+                          MBEDTLS_SSL_EXT_SUPPORTED_GROUPS |
+                          MBEDTLS_SSL_EXT_KEY_SHARE        |
+                          MBEDTLS_SSL_EXT_SIGNATURE_ALGORITHM ) );
 }
 
 static int ssl_client_hello_allows_psk_mode( mbedtls_ssl_context *ssl,
                                              unsigned psk_mode )
 {
-    if( ( ssl->handshake->key_exchange_modes & psk_mode ) != 0 )
-    {
-        return( 1 );
-    }
-
-    return( 0 );
+    return( ( ssl->handshake->key_exchange_modes & psk_mode ) != 0 );
 }
 
 static int ssl_client_hello_allows_pure_psk( mbedtls_ssl_context *ssl )
@@ -2359,7 +2360,8 @@ static int ssl_check_psk_key_exchange( mbedtls_ssl_context *ssl )
 
     /* Test whether PSK-ECDHE is offered by client and supported by us. */
     if( mbedtls_ssl_conf_tls13_psk_ecdhe_enabled( ssl ) &&
-        ssl_client_hello_allows_psk_ecdhe( ssl ) )
+        ssl_client_hello_allows_psk_ecdhe( ssl )        &&
+        ssl_client_hello_has_key_share_extensions( ssl ) )
     {
         MBEDTLS_SSL_DEBUG_MSG( 3, ( "Using a ECDHE-PSK key exchange" ) );
         ssl->handshake->key_exchange = MBEDTLS_KEY_EXCHANGE_ECDHE_PSK;

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -2354,7 +2354,7 @@ static int ssl_check_psk_key_exchange( mbedtls_ssl_context *ssl )
         ssl_client_hello_allows_pure_psk( ssl ) )
     {
         MBEDTLS_SSL_DEBUG_MSG( 3, ( "Using a PSK key exchange" ) );
-        ssl->handshake->key_exchange = MBEDTLS_KEY_EXCHANGE_PSK;
+        ssl->handshake->key_exchange = MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_KE;
         return( 1 );
     }
 
@@ -2364,7 +2364,7 @@ static int ssl_check_psk_key_exchange( mbedtls_ssl_context *ssl )
         ssl_client_hello_has_key_share_extensions( ssl ) )
     {
         MBEDTLS_SSL_DEBUG_MSG( 3, ( "Using a ECDHE-PSK key exchange" ) );
-        ssl->handshake->key_exchange = MBEDTLS_KEY_EXCHANGE_ECDHE_PSK;
+        ssl->handshake->key_exchange = MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_PSK_DHE_KE;
         return( 1 );
     }
 
@@ -2380,7 +2380,7 @@ static int ssl_check_certificate_key_exchange( mbedtls_ssl_context *ssl )
     if( !ssl_client_hello_has_cert_extensions( ssl ) )
         return( 0 );
 
-    ssl->handshake->key_exchange = MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA;
+    ssl->handshake->key_exchange = MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_ECDHE_ECDSA;
     return( 1 );
 }
 
@@ -2429,7 +2429,7 @@ static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
     const mbedtls_ssl_ciphersuite_t* ciphersuite_info;
 
     ssl->handshake->extensions_present = MBEDTLS_SSL_EXT_NONE;
-    ssl->handshake->key_exchange = MBEDTLS_KEY_EXCHANGE_NONE;
+    ssl->handshake->key_exchange = MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_NONE;
 
     /* TBD: Refactor */
     orig_buf = buf;
@@ -2877,7 +2877,7 @@ static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
      *  3 ) Certificate Mode
      */
 
-    ssl->handshake->key_exchange = 0;
+    ssl->handshake->key_exchange = MBEDTLS_SSL_TLS13_KEY_EXCHANGE_MODE_NONE;
 
     if( !ssl_check_psk_key_exchange( ssl ) &&
         !ssl_check_certificate_key_exchange( ssl ) )
@@ -2895,7 +2895,7 @@ static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
 #endif /* MBEDTLS_ZERO_RTT */
 
     /* If we've settled on a PSK-based exchange, parse PSK identity ext */
-    if( mbedtls_ssl_tls13_key_exchange_with_psk( ssl ) )
+    if( mbedtls_ssl_tls13_kex_with_psk( ssl ) )
     {
         ret = mbedtls_ssl_parse_client_psk_identity_ext( ssl,
                                                          ext_psk_ptr,
@@ -3657,11 +3657,8 @@ static int ssl_write_hello_retry_request_write( mbedtls_ssl_context* ssl,
      *
      */
 
-    /* For a pure PSK-based ciphersuite there is no key share to declare.
-     * Hence, we focus on ECDHE-EDSA and ECDHE-PSK.
-     */
-    if( ssl->handshake->key_exchange == MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA ||
-        ssl->handshake->key_exchange == MBEDTLS_KEY_EXCHANGE_ECDHE_PSK )
+    /* For a pure PSK-based ciphersuite there is no key share to declare. */
+    if( mbedtls_ssl_tls13_kex_with_ecdhe( ssl ) )
     {
         /* Write extension header */
         *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_KEY_SHARES >> 8 ) & 0xFF );
@@ -3940,12 +3937,7 @@ static int ssl_server_hello_write( mbedtls_ssl_context* ssl,
     buf += 2;
 
 #if defined(MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED)
-    /* Only add the pre_shared_key extension if the client provided it in the ClientHello
-     * and if the key exchange supports PSK
-     */
-    if( ssl->handshake->extensions_present & MBEDTLS_SSL_EXT_PRE_SHARED_KEY && (
-            ssl->handshake->key_exchange == MBEDTLS_KEY_EXCHANGE_ECDHE_PSK ||
-            ssl->handshake->key_exchange == MBEDTLS_KEY_EXCHANGE_PSK ) )
+    if( mbedtls_ssl_tls13_kex_with_psk( ssl ) )
     {
         ret = ssl_write_server_pre_shared_key_ext( ssl, buf, end,
                                                    &cur_ext_len );
@@ -3962,12 +3954,7 @@ static int ssl_server_hello_write( mbedtls_ssl_context* ssl,
 #endif /* MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED */
 
 #if ( defined(MBEDTLS_ECDH_C) || defined(MBEDTLS_ECDSA_C) )
-    /* Only add the key_share extension if the client provided it in the ClientHello
-     * and if the appropriate key exchange mechanism was selected
-     */
-    if( ssl->handshake->extensions_present & MBEDTLS_SSL_EXT_KEY_SHARE && (
-            ssl->handshake->key_exchange == MBEDTLS_KEY_EXCHANGE_ECDHE_PSK ||
-            ssl->handshake->key_exchange == MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA ) )
+    if( mbedtls_ssl_tls13_kex_with_ecdhe( ssl ) )
     {
         if( ( ret = ssl_write_key_shares_ext( ssl, buf, end, &cur_ext_len ) ) != 0 )
         {
@@ -4136,8 +4123,7 @@ static int ssl_certificate_request_coordinate( mbedtls_ssl_context* ssl )
 {
     int authmode;
 
-    if( ( ssl->handshake->key_exchange == MBEDTLS_KEY_EXCHANGE_PSK ||
-          ssl->handshake->key_exchange == MBEDTLS_KEY_EXCHANGE_ECDHE_PSK ) )
+    if( mbedtls_ssl_tls13_kex_with_psk( ssl ) )
         return( SSL_CERTIFICATE_REQUEST_SKIP );
 
 #if !defined(MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED)


### PR DESCRIPTION
While the TLS 1.3 prototype introduces its own identifiers for key exchanges, it still partly uses the TLS 1.2 identifiers, which can be confusing and error prone. This PR modifies the prototype to only use 1.3 key exchange identifiers. Moreover, it introduces various inline helpers for checking whether the configured/negotiated key exchange uses PSK and/or ECDHE, improving readability.