### PR TITLE
Enable simultaneous support in mbedtls_ssl_setup

### DIFF
--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -1973,4 +1973,45 @@ int mbedtls_ecp_tls_13_write_group( const mbedtls_ecp_group *grp,
 #endif /* MBEDTLS_ECP_C */
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 
+/**
+ * ssl utils functions for checking configuration.
+ */
+
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+static inline int ssl_conf_is_tls13_only(const mbedtls_ssl_config *conf)
+{
+    if( conf->min_major_ver == MBEDTLS_SSL_MAJOR_VERSION_3 &&
+        conf->max_major_ver == MBEDTLS_SSL_MAJOR_VERSION_3 &&
+        conf->min_minor_ver == MBEDTLS_SSL_MINOR_VERSION_4 &&
+        conf->max_minor_ver == MBEDTLS_SSL_MINOR_VERSION_4 )
+        return( 1 );
+    return( 0 );
+}
+#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
+
+#if defined(MBEDTLS_SSL_PROTO_TLS1_2)
+static inline int ssl_conf_is_tls12_only(const mbedtls_ssl_config *conf)
+{
+    if( conf->min_major_ver == MBEDTLS_SSL_MAJOR_VERSION_3 &&
+        conf->max_major_ver == MBEDTLS_SSL_MAJOR_VERSION_3 &&
+        conf->min_minor_ver == MBEDTLS_SSL_MINOR_VERSION_3 &&
+        conf->max_minor_ver == MBEDTLS_SSL_MINOR_VERSION_3 )
+        return( 1 );
+    return( 0 );
+}
+#endif /* MBEDTLS_SSL_PROTO_TLS1_2 */
+
+#if defined(MBEDTLS_SSL_PROTO_TLS1_2) && defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+static inline int ssl_conf_is_tls12_and_tls13(const mbedtls_ssl_config *conf)
+{
+
+    if( conf->min_major_ver == MBEDTLS_SSL_MAJOR_VERSION_3 &&
+        conf->max_major_ver == MBEDTLS_SSL_MAJOR_VERSION_3 &&
+        conf->min_minor_ver == MBEDTLS_SSL_MINOR_VERSION_3 &&
+        conf->max_minor_ver == MBEDTLS_SSL_MINOR_VERSION_4 )
+        return( 1 );
+    return( 0 );
+}
+#endif /* MBEDTLS_SSL_PROTO_TLS1_2 && MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL*/
+
 #endif /* ssl_misc.h */


### PR DESCRIPTION
That's part of simultaneous support for TLS 1.2 and 1.3.
The job is breakdown into two steps for runtime behavior
1. Configured as TLS1.2 or TLS1.3.
2. Configured as TLS1.2 and TLS1.3.
This patch implemented the first target for `mbedtls_ssl_setup`

This patch introduces `ssl_conf_* ` functions to support different
configuration and branches.

Change-Id: Ia762bd3d817440ae130b45f19b80a2868afae924
Signed-off-by: Jerry Yu <jerry.h.yu@arm.com>


