### PR TITLE
Cleanup TLS 1.3 SSL error codes

### DIFF
--- a/include/mbedtls/error.h
+++ b/include/mbedtls/error.h
@@ -97,7 +97,7 @@
  * HKDF      5   1 (Started from top)
  * SSL       5   2 (Started from 0x5F00)
  * CIPHER    6   8 (Started from 0x6080)
- * SSL       6   22 (Started from top, plus 0x6000)
+ * SSL       6   24 (Started from top, plus 0x6000)
  * SSL       7   20 (Started from 0x7000, gaps at
  *                   0x7380, 0x7900-0x7980, 0x7A80-0x7E80)
  *

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -121,8 +121,8 @@
 #define MBEDTLS_ERR_SSL_CONTINUE_PROCESSING               -0x6580  /**< Internal-only message signaling that further message-processing should be done */
 #define MBEDTLS_ERR_SSL_ASYNC_IN_PROGRESS                 -0x6500  /**< The asynchronous operation is not completed yet. */
 #define MBEDTLS_ERR_SSL_EARLY_MESSAGE                     -0x6480  /**< Internal-only message signaling that a message arrived early. */
-/* Error space gap */
-/* Error space gap */
+#define MBEDTLS_ERR_SSL_HRR_REQUIRED                      -0x6400  /**< Server needs to send a HelloRetryRequest */
+#define MBEDTLS_ERR_SSL_RECEIVED_NEW_SESSION_TICKET       -0x6380  /**< Received NewSessionTicket Post Handshake Message */
 /* Error space gap */
 /* Error space gap */
 /* Error space gap */
@@ -132,23 +132,6 @@
 #define MBEDTLS_ERR_SSL_UNEXPECTED_CID                    -0x6000  /**< An encrypted DTLS-frame with an unexpected CID was received. */
 #define MBEDTLS_ERR_SSL_VERSION_MISMATCH                  -0x5F00  /**< An operation failed due to an unexpected version or configuration. */
 #define MBEDTLS_ERR_SSL_BAD_CONFIG                        -0x5E80  /**< Invalid value in SSL config */
-#define MBEDTLS_ERR_SSL_BAD_HS_CLIENT_KEY_SHARE           -0x6781  /**< Problem encountered with the key share provided by the client. */
-#define MBEDTLS_ERR_SSL_BAD_HS_SUPPORTED_GROUPS           -0x6782  /**< Problem encountered with the supported group extension provided by the client. */
-#define MBEDTLS_ERR_SSL_BAD_HS_SERVER_KEY_SHARE           -0x6783  /**< Problem encountered with the key share provided by the server. */
-#define MBEDTLS_ERR_SSL_BAD_HS_WRONG_KEY_SHARE            -0x6784  /**< The key share provided by the client does not match a group supported by the server. A Hello Retry Request will be needed. */
-#define MBEDTLS_ERR_SSL_BAD_HS_MAX_FRAGMENT_LENGTH_EXT    -0x6785  /**< Problem encountered with the max fragment length extension provided by the client. */
-#define MBEDTLS_ERR_SSL_BAD_HS_ALPN_EXT                   -0x6786  /**< Problem encountered with the ALPN extension provided by the client. */
-#define MBEDTLS_ERR_SSL_BAD_HS_SERVERNAME_EXT             -0x6787  /**< Problem encountered with the ServerName extension provided by the client. */
-#define MBEDTLS_ERR_SSL_BAD_HS_PRE_SHARED_KEY_EXT         -0x6788  /**< Problem encountered with the Pre-Shared-Key extension provided by the client. */
-#define MBEDTLS_ERR_SSL_BAD_HS_COOKIE_EXT                 -0x6789  /**< Problem encountered with the cookie extension provided by the client. */
-#define MBEDTLS_ERR_SSL_HRR_REQUIRED                      -0x6790  /**< Server needs to send a HelloRetryRequest */
-#define MBEDTLS_ERR_SSL_BAD_HS_UNKNOWN_MSG                -0x6791  /**< Case where an unknown handshake message was received */
-#define MBEDTLS_ERR_SSL_BAD_HS_TOO_MANY_HRR               -0x6792  /**< Too many Hello Retry Request messages received */
-#define MBEDTLS_ERR_SSL_BAD_HS_SUPPORTED_VERSIONS_EXT     -0x6793  /**< Problem encountered with the supported versions extension */
-#define MBEDTLS_ERR_SSL_BAD_HS_PSK_KEY_EXCHANGE_MODES_EXT -0x6794  /**< Problem encountered with the psk key exchange modes extension */
-#define MBEDTLS_ERR_SSL_BAD_HS_MISSING_EXTENSION_EXT      -0x6795  /**< Missing extension. */
-#define MBEDTLS_ERR_SSL_RECEIVED_NEW_SESSION_TICKET       -0x6796  /**< Received NewSessionTicket Post Handshake Message */
-#define MBEDTLS_ERR_SSL_BAD_HS_CID_EXT                    -0x6797  /**< Received invalid CID extension */
 
 #define MBEDTLS_ERR_LAST 0x7F80 /**< This definition points to the last error code to have a correct parsing in error.c */
 

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -1279,16 +1279,6 @@ struct mbedtls_ssl_config
     mbedtls_ssl_cache_set_t *MBEDTLS_PRIVATE(f_set_cache);
     void *MBEDTLS_PRIVATE(p_cache);                  /*!< context for cache callbacks        */
 
-    /* Ephemeral ECC key pair(s) for use with the key share extension
-     * Provided by the client during the ClientHello, and when used for
-     * the session copied to the ssl->handshake->ecdh_ctx.
-     * This structure is only used by the client since he may offer
-     * multiple key shares to the server.
-    */
-#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && defined(MBEDTLS_ECDH_C) && defined(MBEDTLS_SSL_CLI_C)
-    mbedtls_ecdh_context keyshare_ctx;
-#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL && MBEDTLS_ECDH_C && MBEDTLS_SSL_CLI_C */
-
 #if defined(MBEDTLS_SSL_SERVER_NAME_INDICATION)
     /** Callback for setting cert according to SNI extension                */
     int (*MBEDTLS_PRIVATE(f_sni))(void *, mbedtls_ssl_context *, const unsigned char *, size_t);

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -4343,9 +4343,10 @@ int mbedtls_ssl_handshake_client_step_tls1_3( mbedtls_ssl_context *ssl )
             /* if we received a second HRR we abort */
             if( ssl->handshake->hello_retry_requests_received == 2 )
             {
-                MBEDTLS_SSL_DEBUG_MSG( 1, ( "Too many HelloRetryRequests received from server; I give up." ) );
-                mbedtls_ssl_send_alert_message( ssl, MBEDTLS_SSL_ALERT_LEVEL_FATAL, MBEDTLS_SSL_ALERT_MSG_UNEXPECTED_MESSAGE );
-                return ( MBEDTLS_ERR_SSL_BAD_HS_TOO_MANY_HRR );
+                MBEDTLS_SSL_DEBUG_MSG( 1, ( "Multiple HRRs received" ) );
+                SSL_PEND_FATAL_ALERT( MBEDTLS_SSL_ALERT_LEVEL_FATAL,
+                                      MBEDTLS_SSL_ALERT_MSG_HANDSHAKE_FAILURE );
+                return( MBEDTLS_ERR_SSL_HANDSHAKE_FAILURE );
             }
             mbedtls_ssl_handshake_set_state( ssl, MBEDTLS_SSL_ENCRYPTED_EXTENSIONS );
             break;

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -249,10 +249,15 @@ int mbedtls_ssl_parse_supported_groups_ext(
     if( list_size + 2 != len || list_size % 2 != 0 )
         return( MBEDTLS_ERR_SSL_DECODE_ERROR );
 
-    /* Should only if the client duplicates the extension.
-     * TODO: Remove once we check for duplicated extensions. */
+    /* TODO: At the moment, this can happen when receiving a second
+     *       ClientHello after an HRR. We should properly reset the
+     *       state upon receiving an HRR, in which case we should
+     *       not observe handshake->curves already being allocated. */
     if( ssl->handshake->curves != NULL )
-	return( MBEDTLS_ERR_SSL_ILLEGAL_PARAMETER );
+    {
+        mbedtls_free( ssl->handshake->curves );
+        ssl->handshake->curves = NULL;
+    }
 
     /* Don't allow our peer to make us allocate too much memory,
      * and leave room for a final 0 */

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -2639,7 +2639,7 @@ static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
                 if( ret != 0 )
                 {
                     MBEDTLS_SSL_DEBUG_RET( 1, "ssl_parse_early_data_ext", ret );
-                    return( MBEDTLS_ERR_SSL_BAD_HS_SUPPORTED_GROUPS );
+                    return( ret );
                 }
 
                 ssl->handshake->extensions_present |= MBEDTLS_SSL_EXT_EARLY_DATA;
@@ -2661,7 +2661,7 @@ static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
                 if( ret != 0 )
                 {
                     MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_parse_supported_groups_ext", ret );
-                    return( MBEDTLS_ERR_SSL_BAD_HS_SUPPORTED_GROUPS );
+                    return( ret );
                 }
 
                 ssl->handshake->extensions_present |= MBEDTLS_SSL_EXT_SUPPORTED_GROUPS;
@@ -2676,7 +2676,7 @@ static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
                 if( ret != 0 )
                 {
                     MBEDTLS_SSL_DEBUG_RET( 1, "ssl_parse_key_exchange_modes_ext", ret );
-                    return( MBEDTLS_ERR_SSL_BAD_HS_PSK_KEY_EXCHANGE_MODES_EXT );
+                    return( ret );
                 }
 
                 ssl->handshake->extensions_present |= MBEDTLS_SSL_EXT_PSK_KEY_EXCHANGE_MODES;
@@ -2716,7 +2716,7 @@ static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
                 if( ret != 0 )
                 {
                     MBEDTLS_SSL_DEBUG_RET( 1, ( "ssl_parse_max_fragment_length_ext" ), ret );
-                    return( MBEDTLS_ERR_SSL_BAD_HS_MAX_FRAGMENT_LENGTH_EXT );
+                    return( ret );
                 }
                 ssl->handshake->extensions_present |= MAX_FRAGMENT_LENGTH_EXTENSION;
                 break;
@@ -2729,7 +2729,7 @@ static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
                 if( ret != 0 )
                 {
                     MBEDTLS_SSL_DEBUG_RET( 1, ( "ssl_parse_supported_versions_ext" ), ret );
-                    return( MBEDTLS_ERR_SSL_BAD_HS_SUPPORTED_VERSIONS_EXT );
+                    return( ret );
                 }
                 ssl->handshake->extensions_present |= MBEDTLS_SSL_EXT_SUPPORTED_VERSION;
                 break;
@@ -2742,7 +2742,7 @@ static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
                 if( ret != 0 )
                 {
                     MBEDTLS_SSL_DEBUG_RET( 1, ( "ssl_parse_alpn_ext" ), ret );
-                    return( MBEDTLS_ERR_SSL_BAD_HS_ALPN_EXT );
+                    return( ret );
                 }
                 ssl->handshake->extensions_present |= ALPN_EXTENSION;
                 break;
@@ -3452,7 +3452,7 @@ static int ssl_write_hello_retry_request_coordinate( mbedtls_ssl_context *ssl )
     if( ssl->handshake->hello_retry_requests_sent > 1 )
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "Too many HRRs" ) );
-        return( MBEDTLS_ERR_SSL_BAD_HS_TOO_MANY_HRR );
+        return( MBEDTLS_ERR_SSL_HANDSHAKE_FAILURE );
     }
 
     return( 0 );

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -1037,14 +1037,13 @@ static int ssl_parse_servername_ext( mbedtls_ssl_context *ssl,
 
 #if defined(MBEDTLS_SSL_MAX_FRAGMENT_LENGTH)
 static int ssl_parse_max_fragment_length_ext( mbedtls_ssl_context *ssl,
-                                             const unsigned char *buf,
-                                             size_t len )
+                                              const unsigned char *buf,
+                                              size_t len )
 {
-    if( len != 1 || buf[0] >= MBEDTLS_SSL_MAX_FRAG_LEN_INVALID )
-    {
-        MBEDTLS_SSL_DEBUG_MSG( 1, ( "bad client hello message" ) );
-        return( MBEDTLS_ERR_SSL_BAD_HS_CLIENT_HELLO );
-    }
+    if( len != 1 )
+        return( MBEDTLS_ERR_SSL_DECODE_ERROR );
+    if( buf[0] >= MBEDTLS_SSL_MAX_FRAG_LEN_INVALID )
+        return( MBEDTLS_ERR_SSL_ILLEGAL_PARAMETER );
 
     ssl->session_negotiate->mfl_code = buf[0];
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "Maximum fragment length = %d", buf[0] ) );


### PR DESCRIPTION
With the introduction of Mbed TLS 3.0, the SSL error code scheme has changed, and we use much fewer error codes instead of the various `MBEDTLS_ERR_SSL_BAD_HS_XYZ` as before. This PR adjusts the TLS 1.3 prototype to follow this new error scheme. It also does some minor cleanup along the way.