### PR TITLE
Fix duplication between SSL and cipher error codes

### DIFF
--- a/include/mbedtls/error.h
+++ b/include/mbedtls/error.h
@@ -97,9 +97,9 @@
  * HKDF      5   1 (Started from top)
  * SSL       5   2 (Started from 0x5F00)
  * CIPHER    6   8 (Started from 0x6080)
- * SSL       6   24 (Started from top, plus 0x6000)
- * SSL       7   20 (Started from 0x7000, gaps at
- *                   0x7380, 0x7900-0x7980, 0x7A80-0x7E80)
+ * SSL       6   22 (Started from top, plus 0x6000)
+ * SSL       7   22 (Started from 0x7000, gaps at
+ *                   0x7380, 0x7900-0x7980, 0x7B80-0x7E80)
  *
  * Module dependent error code (5 bits 0x.00.-0x.F8.)
  */

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -88,8 +88,8 @@
 /* Error space gap */
 /* Error space gap */
 #define MBEDTLS_ERR_SSL_BAD_CERTIFICATE                   -0x7A00  /**< Processing of the Certificate handshake message failed. */
-/* Error space gap */
-/* Error space gap */
+#define MBEDTLS_ERR_SSL_HRR_REQUIRED                      -0x7A80  /**< Server needs to send a HelloRetryRequest */
+#define MBEDTLS_ERR_SSL_RECEIVED_NEW_SESSION_TICKET       -0x7B00  /**< Received NewSessionTicket Post Handshake Message */
 /* Error space gap */
 /* Error space gap */
 /* Error space gap */
@@ -121,8 +121,6 @@
 #define MBEDTLS_ERR_SSL_CONTINUE_PROCESSING               -0x6580  /**< Internal-only message signaling that further message-processing should be done */
 #define MBEDTLS_ERR_SSL_ASYNC_IN_PROGRESS                 -0x6500  /**< The asynchronous operation is not completed yet. */
 #define MBEDTLS_ERR_SSL_EARLY_MESSAGE                     -0x6480  /**< Internal-only message signaling that a message arrived early. */
-#define MBEDTLS_ERR_SSL_HRR_REQUIRED                      -0x6400  /**< Server needs to send a HelloRetryRequest */
-#define MBEDTLS_ERR_SSL_RECEIVED_NEW_SESSION_TICKET       -0x6380  /**< Received NewSessionTicket Post Handshake Message */
 /* Error space gap */
 /* Error space gap */
 /* Error space gap */


### PR DESCRIPTION
There was an overlap between an SSL and Cipher error code which made out of the box compilation fail.