### PR TITLE
Try to consolidate TLS 1.2 and TLS 1.3 ECDH parsing/writing functions

### DIFF
--- a/library/ecp_internal.h
+++ b/library/ecp_internal.h
@@ -1,0 +1,35 @@
+/**
+ * \file ecp_internal.h
+ *
+ * \brief ECC-related functions with external linkage but which are
+ *        not part of the public API.
+ */
+/*
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+#ifndef MBEDTLS_ECP_INTERNAL_H
+#define MBEDTLS_ECP_INTERNAL_H
+
+#include "common.h"
+#include "mbedtls/ecp.h"
+
+/* Convert NamedCurve (RFC 4492) to an Mbed TLS internal curve id.
+ * - Returns MBEDTLS_ERR_ECP_BAD_INPUT_DATA if buffer is too small.
+ * - Returns MBEDTLS_ERR_ECP_FEATURE_UNAVAILABLE is the group is unknown. */
+int mbedtls_ecp_tls_read_named_curve( mbedtls_ecp_group_id *grp,
+                                      const unsigned char **buf, size_t len );
+
+#endif /* MBEDTLS_ECP_INTERNAL_H */

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -1929,29 +1929,6 @@ int mbedtls_ecp_tls_13_write_point( const mbedtls_ecp_group *grp,
 
 
 /**
- * \brief           This function extracts an elliptic curve group ID from a
- *                  TLS ECParameters record as defined in TLS 1.3.
- *
- * \note            The read pointer \p buf is updated to point right after
- *                  the ECParameters record on exit.
- *
- * \param grp       The address at which to store the group id.
- *                  This must not be \c NULL.
- * \param buf       The address of the pointer to the start of the input buffer.
- * \param len       The length of the input buffer \c *buf in Bytes.
- *
- * \return          \c 0 on success.
- * \return          #MBEDTLS_ERR_ECP_BAD_INPUT_DATA if input is invalid.
- * \return          #MBEDTLS_ERR_ECP_FEATURE_UNAVAILABLE if the group is not
- *                  recognized.
- * \return          Another negative error code on other kinds of failure.
- */
-int mbedtls_ecp_tls_13_read_group_id( mbedtls_ecp_group_id *grp,
-                                   const unsigned char **buf,
-                                   size_t len );
-
-
-/**
  * \brief           This function exports an elliptic curve as a TLS
  *                  ECParameters record as defined in TLS 1.3.
  *

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -2074,6 +2074,9 @@ static int ssl_parse_key_shares_ext( mbedtls_ssl_context *ssl,
     int match_found = 0;
     mbedtls_ecp_group_id their_gid;
 
+    /* Note: When we introduce non-ECP key shares, e.g. from PQC,
+     *       we will want to call multiple parsers here and dispatch
+     *       to the corresponding handler. */
     ret = mbedtls_ecp_tls_read_named_curve( &their_gid, &buf, len );
     if( ret == MBEDTLS_ERR_ECP_FEATURE_UNAVAILABLE )
         return( MBEDTLS_ERR_SSL_FEATURE_UNAVAILABLE );

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -36,6 +36,8 @@
 #include "ssl_misc.h"
 #include "ssl_tls13_keys.h"
 
+#include "ecp_internal.h"
+
 #include <string.h>
 
 #if defined(MBEDTLS_PLATFORM_C)
@@ -2067,11 +2069,7 @@ static int ssl_parse_key_shares_ext( mbedtls_ssl_context *ssl,
                                      const unsigned char *buf,
                                      size_t len ) {
 
-    int ret = 0;
-    int named_group;
-    int i;
-    const mbedtls_ecp_curve_info *curve_info;
-    int match_found = 0;
+    int ret = 0, i, match_found;
     mbedtls_ecp_group_id their_gid;
 
     /* Note: When we introduce non-ECP key shares, e.g. from PQC,
@@ -2086,14 +2084,13 @@ static int ssl_parse_key_shares_ext( mbedtls_ssl_context *ssl,
     len -= 2;
 
     /* Check if chosen group matches one of the offered key shares. */
-    for( i=0;
-         ssl->handshake->key_shares_curve_list[i] != MBEDTLS_ECP_DP_NONE;
+    match_found = 0;
+    for( i=0; ssl->handshake->key_shares_curve_list[i] != MBEDTLS_ECP_DP_NONE;
          i++ )
     {
         mbedtls_ecp_group_id our_gid = ssl->handshake->key_shares_curve_list[i];
         if( our_gid != their_gid )
             continue;
-
         match_found = 1;
         break;
     }


### PR DESCRIPTION
As we discussed before, there are some annoying minor differences between the way TLS 1.2 and TLS 1.3 encode ECDHE key shares on the wire, which forbid the use of the existing ECDH-TLS API, which is specific to TLS 1.2. As agreed, @hannestschofenig therefore duplicated all ECDH-TLS functions and made adjustments for TLS 1.3. We did not, however, take a closer look to what extent those duplications are necessary, and what the greatest common denominator between the 1.2 and 1.3 parsing/writing functions would be.

This PR is a first step in this direction, removing _some_ duplication.