### PR TITLE
Modularize key share handling

### DIFF
--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -150,6 +150,15 @@
 
 
 /*
+ * TLS 1.3 NamedGroup values
+ */
+#define MBEDTLS_SSL_TLS13_NAMED_GROUP_SEC256R1  0x0017
+#define MBEDTLS_SSL_TLS13_NAMED_GROUP_SEC384R1  0x0018
+#define MBEDTLS_SSL_TLS13_NAMED_GROUP_SEC521R1  0x0019
+#define MBEDTLS_SSL_TLS13_NAMED_GROUP_X25519    0x001D
+#define MBEDTLS_SSL_TLS13_NAMED_GROUP_X448      0x001E
+
+/*
  * TLS 1.3 Key Exchange Modes
  *
  * Mbed TLS internal identifiers for use with the SSL configuration API

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -782,9 +782,13 @@ struct mbedtls_ssl_handshake_params
     unsigned char* certificate_request_context;
 #endif
 
-#if defined(MBEDTLS_ECDH_C)
-    mbedtls_ecp_group_id offered_group_id;
-#endif /* MBEDTLS_ECDH_C */
+    uint16_t named_group_id; /* The NamedGroup value for the group
+                              * that is being used for ephemeral
+                              * key exchange.
+                              *
+                              * On the client: Defaults to the first
+                              * entry in the client's group list,
+                              * but can be overwritten by the HRR. */
 
 #if defined(MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED)
     // pointer to the pre_shared_key extension

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -1992,4 +1992,30 @@ static inline int ssl_conf_is_tls12_and_tls13(const mbedtls_ssl_config *conf)
 }
 #endif /* MBEDTLS_SSL_PROTO_TLS1_2 && MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL*/
 
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+/* From RF 8446
+ *    enum {
+ *         // Elliptic Curve Groups (ECDHE)
+ *         secp256r1(0x0017), secp384r1(0x0018), secp521r1(0x0019),
+ *         x25519(0x001D), x448(0x001E),
+ *         // Finite Field Groups (DHE)
+ *         ffdhe2048(0x0100), ffdhe3072(0x0101), ffdhe4096(0x0102),
+ *         ffdhe6144(0x0103), ffdhe8192(0x0104),
+ *         // Reserved Code Points
+ *         ffdhe_private_use(0x01FC..0x01FF),
+ *         ecdhe_private_use(0xFE00..0xFEFF),
+ *         (0xFFFF)
+ *     } NamedGroup; */
+static inline int mbedtls_ssl_named_group_is_ecdhe( uint16_t named_group )
+{
+    return( named_group == MBEDTLS_SSL_TLS13_NAMED_GROUP_SEC256R1 ||
+            named_group == MBEDTLS_SSL_TLS13_NAMED_GROUP_SEC384R1 ||
+            named_group == MBEDTLS_SSL_TLS13_NAMED_GROUP_SEC521R1 ||
+            named_group == MBEDTLS_SSL_TLS13_NAMED_GROUP_X25519   ||
+            named_group == MBEDTLS_SSL_TLS13_NAMED_GROUP_X448 );
+}
+
+#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
+
+
 #endif /* ssl_misc.h */

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -1275,16 +1275,6 @@ static uint16_t ssl_get_default_group_id( mbedtls_ssl_context *ssl )
     return( curve_info->tls_id );
 }
 
-static int ssl_named_group_is_ecdhe( mbedtls_ssl_context *ssl,
-                                     uint16_t named_group )
-{
-    ((void) ssl);
-    ((void) named_group);
-    /* TODO: This will need to include some range checks
-     *       as we start to support non-ECDHE exchanges. */
-    return( 1 );
-}
-
 static int ssl_write_key_shares_ext( mbedtls_ssl_context *ssl,
                                      unsigned char* buf,
                                      unsigned char* end,
@@ -1325,7 +1315,7 @@ static int ssl_write_key_shares_ext( mbedtls_ssl_context *ssl,
      * type of KEM, and dispatch to the corresponding crypto.
      */
 
-    if( ssl_named_group_is_ecdhe( ssl, group_id ) )
+    if( mbedtls_ssl_named_group_is_ecdhe( group_id ) )
     {
         /* Skip over NamedGroup value and share length bytes */
         unsigned char * const key_share = key_share_entry + 4;
@@ -2176,7 +2166,7 @@ static int ssl_parse_key_shares_ext( mbedtls_ssl_context *ssl,
         return( MBEDTLS_ERR_SSL_ILLEGAL_PARAMETER );
     }
 
-    if( ssl_named_group_is_ecdhe( ssl, their_group ) )
+    if( mbedtls_ssl_named_group_is_ecdhe( their_group ) )
     {
         /* Complete ECDHE key agreement */
         ret = ssl_read_public_ecdhe_share( ssl, buf, len );

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -32,6 +32,7 @@
 
 #include "mbedtls/debug.h"
 #include "mbedtls/ssl.h"
+#include "mbedtls/error.h"
 
 #include "ssl_misc.h"
 #include "ssl_tls13_keys.h"
@@ -1200,18 +1201,7 @@ static int ssl_write_supported_groups_ext( mbedtls_ssl_context *ssl,
  *  Key Shares Extension
  *
  *  enum {
- *    obsolete_RESERVED(1..22),
- *    secp256r1(23), secp384r1(24), secp521r1(25),
- *    obsolete_RESERVED(26..28),
- *    x25519(29), x448(30),
- *
- *    ffdhe2048(256), ffdhe3072(257), ffdhe4096(258),
- *    ffdhe6144(259), ffdhe8192(260),
- *
- *    ffdhe_private_use(0x01FC..0x01FF),
- *    ecdhe_private_use(0xFE00..0xFEFF),
- *    obsolete_RESERVED(0xFF01..0xFF02),
- *    (0xFFFF)
+ *    ... (0xFFFF)
  *  } NamedGroup;
  *
  *  struct {
@@ -1223,62 +1213,36 @@ static int ssl_write_supported_groups_ext( mbedtls_ssl_context *ssl,
  *    select(role) {
  *      case client:
  *        KeyShareEntry client_shares<0..2^16-1>;
- *      case server:
- *        KeyShareEntry server_share;
  *    }
  *  } KeyShare;
  */
 
 #if defined(MBEDTLS_ECDH_C) || defined(MBEDTLS_ECDSA_C)
-static int ssl_write_key_shares_ext( mbedtls_ssl_context *ssl,
-                                     unsigned char* buf,
-                                     unsigned char* end,
-                                     size_t* olen )
+static int ssl_gen_and_write_ecdhe_share( mbedtls_ssl_context *ssl,
+                                          uint16_t named_group,
+                                          unsigned char* buf,
+                                          unsigned char* end,
+                                          size_t* olen )
 {
-    mbedtls_ecp_group_id grp_id;
-    const mbedtls_ecp_curve_info *curve_info;
+    int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
 
-    size_t len;
-    int ret;
+    const mbedtls_ecp_curve_info *curve_info =
+        mbedtls_ecp_curve_info_from_tls_id( named_group );
 
-    unsigned char *header = buf; /* Pointer where the header has to go. */
-    unsigned char* p = buf + 4   /* Skip header for now */;
-
-    /* TODO: Add bounds checks! Only then remove the next line. */
-    ((void) end );
-
-    *olen = 0;
-
-    if( !mbedtls_ssl_conf_tls13_some_ecdhe_enabled( ssl ) )
-        return( 0 );
-
-    MBEDTLS_SSL_DEBUG_MSG( 3, ( "client hello, adding key share extension" ) );
-
-    /* By default, offer topmost entry in the curve list, but an HRR
-     * will be able to overwrite this. */
-    grp_id = ssl->handshake->offered_group_id;
-    if( grp_id == MBEDTLS_ECP_DP_NONE )
-        grp_id = ssl->conf->curve_list[0];
-    if( grp_id == MBEDTLS_ECP_DP_NONE )
-    {
-        MBEDTLS_SSL_DEBUG_MSG( 1, ( "Should never happen" ) );
-        return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
-    }
-
-    curve_info = mbedtls_ecp_curve_info_from_grp_id( grp_id );
     if( curve_info == NULL )
         return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
+
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "offer curve %s", curve_info->name ) );
 
     if( ( ret = mbedtls_ecdh_setup( &ssl->handshake->ecdh_ctx,
-                                    grp_id ) ) != 0 )
+                                    curve_info->grp_id ) ) != 0 )
     {
         MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ecp_group_load", ret );
         return( ret );
     }
 
-    ret = mbedtls_ecdh_make_tls_13_params( &ssl->handshake->ecdh_ctx, &len,
-                                           p+2, end - (p+2),
+    ret = mbedtls_ecdh_make_tls_13_params( &ssl->handshake->ecdh_ctx, olen,
+                                           buf, end - buf,
                                            ssl->conf->f_rng, ssl->conf->p_rng );
     if( ret != 0 )
     {
@@ -1288,27 +1252,118 @@ static int ssl_write_key_shares_ext( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_DEBUG_ECDH( 3, &ssl->handshake->ecdh_ctx,
                             MBEDTLS_DEBUG_ECDH_Q );
+    return( 0 );
+}
 
-    /* Write length of the key_exchange entry */
-    *p++ = (unsigned char)( ( len >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( len      ) & 0xFF );
+static uint16_t ssl_get_default_group_id( mbedtls_ssl_context *ssl )
+{
+    const mbedtls_ecp_curve_info *curve_info;
+    /* Pick first entry of curve list.
+     *
+     * TODO: When we introduce PQC KEMs, we'll have a NamedGroup
+     *       list instead, and can just return its first element. */
 
-    p += len;
-    *olen += len + 2;
+    mbedtls_ecp_group_id curve_id = ssl->conf->curve_list[0];
+    if( curve_id == MBEDTLS_ECP_DP_NONE )
+        return( 0 );
+
+
+    curve_info = mbedtls_ecp_curve_info_from_grp_id( curve_id );
+    if( curve_info == 0 )
+        return( 0 );
+
+    return( curve_info->tls_id );
+}
+
+static int ssl_named_group_is_ecdhe( mbedtls_ssl_context *ssl,
+                                     uint16_t named_group )
+{
+    ((void) ssl);
+    ((void) named_group);
+    /* TODO: This will need to include some range checks
+     *       as we start to support non-ECDHE exchanges. */
+    return( 1 );
+}
+
+static int ssl_write_key_shares_ext( mbedtls_ssl_context *ssl,
+                                     unsigned char* buf,
+                                     unsigned char* end,
+                                     size_t* olen )
+{
+    uint16_t group_id;
+    unsigned char* key_share_entry = buf + 6; /* Skip header and length field */
+    size_t share_len, total_ext_len, key_share_list_len;
+    int ret;
+
+    /* Check if we have space for headers and length fields:
+     * - Extension type (2 bytes)
+     * - Extension length (2 bytes)
+     * - key share list length (2 bytes)
+     * - NamedGroup (2 bytes)
+     * - key share length (2 bytes) */
+    if( (size_t)( buf - end ) < 10 )
+        return( MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL );
+
+    *olen = 0;
+
+    MBEDTLS_SSL_DEBUG_MSG( 3, ( "client hello, adding key share extension" ) );
+
+    if( !mbedtls_ssl_conf_tls13_some_ecdhe_enabled( ssl ) )
+        return( 0 );
+
+    /* By default, offer topmost entry in the curve list, but an HRR
+     * could already have requested something else. */
+    group_id = ssl->handshake->named_group_id;
+    if( group_id == 0 )
+        group_id = ssl_get_default_group_id( ssl );
+
+    /*
+     * Dispatch to type-specific key generation function.
+     *
+     * So far, we're only supporting ECDHE. With the introduction
+     * of PQC KEMs, we'll want to have multiple branches, one per
+     * type of KEM, and dispatch to the corresponding crypto.
+     */
+
+    if( ssl_named_group_is_ecdhe( ssl, group_id ) )
+    {
+        /* Skip over NamedGroup value and share length bytes */
+        unsigned char * const key_share = key_share_entry + 4;
+        ret = ssl_gen_and_write_ecdhe_share( ssl, group_id,
+                                             key_share, end, &share_len );
+        if( ret != 0 )
+            return( ret );
+    }
+    else if( 0 /* other KEMs? */ )
+    {
+        /* Do something */
+    }
+    else
+        return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
+
+    /* Write group ID */
+    *key_share_entry++ = ( group_id >> 8 ) & 0xFF;
+    *key_share_entry++ = ( group_id >> 0 ) & 0xFF;
+    /* Write key share length */
+    *key_share_entry++ = ( share_len >> 8 ) & 0xFF;
+    *key_share_entry++ = ( share_len >> 0 ) & 0xFF;
 
     /* Write extension header */
-    *header++ = (unsigned char)( ( MBEDTLS_TLS_EXT_KEY_SHARES >> 8 ) & 0xFF );
-    *header++ = (unsigned char)( ( MBEDTLS_TLS_EXT_KEY_SHARES ) & 0xFF );
-
+    *buf++ = (unsigned char)( ( MBEDTLS_TLS_EXT_KEY_SHARES >> 8 ) & 0xFF );
+    *buf++ = (unsigned char)( ( MBEDTLS_TLS_EXT_KEY_SHARES      ) & 0xFF );
     /* Write total extension length */
-    *header++ = (unsigned char)( ( *olen >> 8 ) & 0xFF );
-    *header++ = (unsigned char)( *olen & 0xFF );
+    total_ext_len = share_len + 6;
+    *buf++ = (unsigned char)( ( total_ext_len >> 8 ) & 0xFF );
+    *buf++ = (unsigned char)( ( total_ext_len      ) & 0xFF );
+    /* Write key share list length */
+    key_share_list_len = share_len + 4;
+    *buf++ = (unsigned char)( ( key_share_list_len >> 8 ) & 0xFF );
+    *buf++ = (unsigned char)( ( key_share_list_len      ) & 0xFF );
 
-    *olen += 4; /* 4 bytes for fixed header */
+    *olen = total_ext_len + 4;
 
     ssl->handshake->extensions_present |= MBEDTLS_SSL_EXT_KEY_SHARE;
-    ssl->handshake->offered_group_id = grp_id;
-
+    ssl->handshake->named_group_id = group_id;
     return( 0 );
 }
 
@@ -2075,34 +2130,15 @@ int mbedtls_ssl_set_early_data( mbedtls_ssl_context *ssl,
  *
  *  The server only provides a single KeyShareEntry.
  */
-static int ssl_parse_key_shares_ext( mbedtls_ssl_context *ssl,
-                                     const unsigned char *buf,
-                                     size_t len )
+static int ssl_read_public_ecdhe_share( mbedtls_ssl_context *ssl,
+                                        const unsigned char *buf,
+                                        size_t len )
 {
-    int ret = 0;
-    mbedtls_ecp_group_id their_gid;
+    int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
 
-    /* Note: When we introduce non-ECP key shares, e.g. from PQC,
-     *       we will want to call multiple parsers here and dispatch
-     *       to the corresponding handler. */
-    ret = mbedtls_ecp_tls_read_named_curve( &their_gid, buf, len );
-    if( ret == MBEDTLS_ERR_ECP_FEATURE_UNAVAILABLE )
-        return( MBEDTLS_ERR_SSL_FEATURE_UNAVAILABLE );
-    else if( ret != 0 )
-        return( MBEDTLS_ERR_SSL_DECODE_ERROR );
-
-    buf += 2;
-    len -= 2;
-
-    /* Check that chosen group matches the one we offered. */
-    if( ssl->handshake->offered_group_id != their_gid )
-    {
-        MBEDTLS_SSL_DEBUG_MSG( 1, ( "Invalid server key share" ) );
-        return( MBEDTLS_ERR_SSL_ILLEGAL_PARAMETER );
-    }
-
-    if( ( ret = mbedtls_ecdh_read_tls_13_public( &ssl->handshake->ecdh_ctx,
-                                                 buf, len ) ) != 0 )
+    ret = mbedtls_ecdh_read_tls_13_public( &ssl->handshake->ecdh_ctx,
+                                           buf, len );
+    if( ret != 0 )
     {
         MBEDTLS_SSL_DEBUG_RET( 1, ( "mbedtls_ecdh_read_tls_13_public" ), ret );
         return( ret );
@@ -2113,6 +2149,46 @@ static int ssl_parse_key_shares_ext( mbedtls_ssl_context *ssl,
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "check_ecdh_params() failed!" ) );
         return( MBEDTLS_ERR_SSL_HANDSHAKE_FAILURE );
     }
+
+    return( 0 );
+}
+
+static int ssl_parse_key_shares_ext( mbedtls_ssl_context *ssl,
+                                     const unsigned char *buf,
+                                     size_t len )
+{
+    int ret = 0;
+    uint16_t their_group;
+
+    if( len < 2 )
+        return( MBEDTLS_ERR_SSL_DECODE_ERROR );
+
+    their_group = ((uint16_t) buf[0] << 8 ) | ((uint16_t) buf[1] );
+    buf += 2;
+    len -= 2;
+
+    /* Check that chosen group matches the one we offered. */
+    if( ssl->handshake->named_group_id != their_group )
+    {
+        MBEDTLS_SSL_DEBUG_MSG( 1, ( "Invalid server key share, our group %u, their group %u",
+                                    (unsigned) ssl->handshake->named_group_id,
+                                    (unsigned) their_group ) );
+        return( MBEDTLS_ERR_SSL_ILLEGAL_PARAMETER );
+    }
+
+    if( ssl_named_group_is_ecdhe( ssl, their_group ) )
+    {
+        /* Complete ECDHE key agreement */
+        ret = ssl_read_public_ecdhe_share( ssl, buf, len );
+        if( ret != 0 )
+            return( ret );
+    }
+    else if( 0 /* other KEMs? */ )
+    {
+        /* Do something */
+    }
+    else
+        return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
 
     ssl->handshake->extensions_present |= MBEDTLS_SSL_EXT_KEY_SHARE;
     return( ret );
@@ -3701,7 +3777,7 @@ static int ssl_hrr_parse( mbedtls_ssl_context* ssl,
                  * HRR message with a key share already provided in the
                  * ClientHello then the client MUST abort the handshake with
                  * an "illegal_parameter" alert. */
-                if( found == 0 || *grp_id == ssl->handshake->offered_group_id )
+                if( found == 0 || tls_id == ssl->handshake->named_group_id )
                 {
                     MBEDTLS_SSL_DEBUG_MSG( 1, ( "Invalid key share in HRR" ) );
                     SSL_PEND_FATAL_ALERT( MBEDTLS_SSL_ALERT_MSG_ILLEGAL_PARAMETER,
@@ -3710,7 +3786,7 @@ static int ssl_hrr_parse( mbedtls_ssl_context* ssl,
                 }
 
                 /* Remember server's preference for next ClientHello */
-                ssl->handshake->offered_group_id = *grp_id;
+                ssl->handshake->named_group_id = tls_id;
                 break;
             }
 

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -2860,7 +2860,6 @@ static int ecdh_make_tls_13_params_internal( mbedtls_ecdh_context_mbed *ctx,
                                       int restart_enabled )
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
-    size_t grp_len, pt_len;
 #if defined(MBEDTLS_ECP_RESTARTABLE)
     mbedtls_ecp_restart_ctx *rs_ctx = NULL;
 #endif
@@ -2886,18 +2885,11 @@ static int ecdh_make_tls_13_params_internal( mbedtls_ecdh_context_mbed *ctx,
         return( ret );
 #endif /* MBEDTLS_ECP_RESTARTABLE */
 
-    if( ( ret = mbedtls_ecp_tls_13_write_group( &ctx->grp, &grp_len, buf,
-                                             blen ) ) != 0 )
+    ret = mbedtls_ecp_point_write_binary( &ctx->grp, &ctx->Q, point_format,
+                                          olen, buf, blen );
+    if( ret != 0 )
         return( ret );
 
-    buf += grp_len;
-    blen -= grp_len;
-
-    if( ( ret = mbedtls_ecp_tls_13_write_point( &ctx->grp, &ctx->Q, point_format,
-                                             &pt_len, buf, blen ) ) != 0 )
-        return( ret );
-
-    *olen = grp_len + pt_len;
     return( 0 );
 }
 

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -124,54 +124,51 @@ static int ssl_write_key_shares_ext(
     unsigned char* end,
     size_t* olen )
 {
-    unsigned char *p = buf + 4;
-    unsigned char *header = buf; /* Pointer where the header has to go. */
-    size_t len;
+    unsigned char *key_share_entry = buf + 4;
+    unsigned char *key_share       = buf + 8;
+
+    size_t share_len, ext_len;
     int ret;
 
     *olen = 0;
 
     /* TBD: Can we say something about the smallest number of bytes needed for the ecdhe parameters */
-    if( end < p || ( end - p ) < 4 )
+    if( end < buf || ( end - buf ) < 8 )
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "buffer too small" ) );
         return( MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL );
     }
 
-    if( ssl->conf->curve_list == NULL )
-    {
-        /* This should never happen since we previously checked the
-         * server-supported curves against the client-provided curves.
-         * We should have returned a HelloRetryRequest instead.
-         */
-        MBEDTLS_SSL_DEBUG_MSG( 3, ( "server key share extension: empty curve list" ) );
-        return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
-    }
-
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "server hello, adding key share extension" ) );
 
-    if( ( ret = mbedtls_ecdh_make_tls_13_params( &ssl->handshake->ecdh_ctx, &len,
-                                        p, end-buf,
+    if( ( ret = mbedtls_ecdh_make_tls_13_params( &ssl->handshake->ecdh_ctx, &share_len,
+                                        key_share, end - key_share,
                                         ssl->conf->f_rng, ssl->conf->p_rng ) ) != 0 )
     {
         MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ecdh_make_tls_13_params", ret );
         return( ret );
     }
 
-    p += len;
+    /* Write group ID */
+    *key_share_entry++ = ( ssl->handshake->named_group_id >> 8 ) & 0xFF;
+    *key_share_entry++ = ( ssl->handshake->named_group_id >> 0 ) & 0xFF;
+    /* Write key share length */
+    *key_share_entry++ = ( share_len >> 8 ) & 0xFF;
+    *key_share_entry++ = ( share_len >> 0 ) & 0xFF;
 
     MBEDTLS_SSL_DEBUG_ECDH( 3, &ssl->handshake->ecdh_ctx, MBEDTLS_DEBUG_ECDH_Q );
 
+    ext_len = share_len + 4;
+
     /* Write extension header */
-    *header++ = (unsigned char)( ( MBEDTLS_TLS_EXT_KEY_SHARES >> 8 ) & 0xFF );
-    *header++ = (unsigned char)( ( MBEDTLS_TLS_EXT_KEY_SHARES ) & 0xFF );
+    *buf++ = (unsigned char)( ( MBEDTLS_TLS_EXT_KEY_SHARES >> 8 ) & 0xFF );
+    *buf++ = (unsigned char)( ( MBEDTLS_TLS_EXT_KEY_SHARES ) & 0xFF );
 
     /* Write total extension length */
-    *header++ = (unsigned char)( ( ( len ) >> 8 ) & 0xFF );
-    *header++ = (unsigned char)( ( ( len ) ) & 0xFF );
+    *buf++ = (unsigned char)( ( ext_len >> 8 ) & 0xFF );
+    *buf++ = (unsigned char)( ( ext_len ) & 0xFF );
 
-    *olen = len + 4; /* 4 bytes for fixed header + length of key share */
-
+    *olen = ext_len + 4; /* 4 bytes for fixed header + length of key share */
     return( 0 );
 }
 #endif /* MBEDTLS_ECDH_C && MBEDTLS_ECDSA_C */
@@ -323,7 +320,7 @@ static int ssl_parse_key_shares_ext( mbedtls_ssl_context *ssl,
         return( MBEDTLS_ERR_SSL_DECODE_ERROR );
     }
 
-    ssl->handshake->offered_group_id = MBEDTLS_ECP_DP_NONE;
+    ssl->handshake->named_group_id = 0;
 
     /* We try to find a suitable key share entry and copy it to the
      * handshake context. Later, we have to find out whether we can do
@@ -332,7 +329,7 @@ static int ssl_parse_key_shares_ext( mbedtls_ssl_context *ssl,
 
     for( ; len > 0; p += cur_share_len, len -= cur_share_len )
     {
-        uint16_t named_group;
+        uint16_t their_group;
         mbedtls_ecp_group_id their_curve;
         mbedtls_ecp_curve_info const *their_curve_info;
         unsigned char const *end_of_share;
@@ -350,7 +347,7 @@ static int ssl_parse_key_shares_ext( mbedtls_ssl_context *ssl,
             return( MBEDTLS_ERR_SSL_DECODE_ERROR );
         }
 
-        named_group = ((size_t) p[0] << 8) | (size_t) p[1];
+        their_group = ((size_t) p[0] << 8) | (size_t) p[1];
         p   += 2;
         len -= 2;
 
@@ -381,7 +378,7 @@ static int ssl_parse_key_shares_ext( mbedtls_ssl_context *ssl,
          * - Check if it's supported
          */
 
-        their_curve = mbedtls_ecp_named_group_to_id( named_group );
+        their_curve = mbedtls_ecp_named_group_to_id( their_group );
         if( mbedtls_ssl_check_curve( ssl, their_curve ) != 0 )
             continue;
 
@@ -392,7 +389,7 @@ static int ssl_parse_key_shares_ext( mbedtls_ssl_context *ssl,
         if( their_curve == MBEDTLS_ECP_DP_NONE )
         {
             MBEDTLS_SSL_DEBUG_MSG( 4, ( "Unrecognized NamedGroup %u",
-                                        (unsigned) named_group ) );
+                                        (unsigned) their_group ) );
             continue;
         }
 
@@ -428,7 +425,7 @@ static int ssl_parse_key_shares_ext( mbedtls_ssl_context *ssl,
             return( ret );
         }
 
-        ssl->handshake->offered_group_id = their_curve;
+        ssl->handshake->named_group_id = their_group;
     }
 
     if( match_found == 0 )
@@ -3528,7 +3525,7 @@ static int ssl_write_hrr_key_share_ext( mbedtls_ssl_context *ssl,
 
     /* We should only send the key_share extension if the client's initial
      * key share was not acceptable. */
-    if( ssl->handshake->offered_group_id != MBEDTLS_ECP_DP_NONE )
+    if( ssl->handshake->named_group_id != 0 )
     {
         MBEDTLS_SSL_DEBUG_MSG( 4, ( "Skip key_share extension in HRR" ) );
         return( 0 );


### PR DESCRIPTION
This PR restructures and modularizes all code around parsing and writing of key shares in preparation for the introduction of non-ECDHE KEMs, specifically PQC KEMs.
