### PR TITLE
Simplify TLS 1.3 handshake state machine and handshake handlers

### DIFF
--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -672,6 +672,10 @@ struct mbedtls_ssl_handshake_params
 
     mbedtls_ssl_tls_prf_cb *tls_prf;
 
+#if defined(MBEDTLS_SSL_USE_MPS)
+    mbedtls_mps_handshake_out hs_msg_out;
+#endif
+
     /*
      * State-local variables used during the processing
      * of a specific handshake state.
@@ -2014,6 +2018,14 @@ static inline int mbedtls_ssl_named_group_is_ecdhe( uint16_t named_group )
             named_group == MBEDTLS_SSL_TLS13_NAMED_GROUP_X25519   ||
             named_group == MBEDTLS_SSL_TLS13_NAMED_GROUP_X448 );
 }
+
+int mbedtls_ssl_start_handshake_msg( mbedtls_ssl_context *ssl,
+                                     unsigned hs_type,
+                                     unsigned char **buf,
+                                     size_t *buflen );
+int mbedtls_ssl_finish_handshake_msg( mbedtls_ssl_context *ssl,
+                                      size_t buf_len,
+                                      size_t msg_len );
 
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -140,9 +140,6 @@ int ssl_write_early_data_process( mbedtls_ssl_context* ssl )
         MBEDTLS_SSL_PROC_CHK( ssl_write_early_data_prepare( ssl ) );
 
 #if defined(MBEDTLS_SSL_USE_MPS)
-        /* Make sure we can write a new message. */
-        MBEDTLS_SSL_PROC_CHK( mbedtls_mps_flush( &ssl->mps.l4 ) );
-
         MBEDTLS_SSL_PROC_CHK( mbedtls_mps_write_application( &ssl->mps.l4,
                                                              &msg ) );
 
@@ -163,9 +160,6 @@ int ssl_write_early_data_process( mbedtls_ssl_context* ssl )
         MBEDTLS_SSL_PROC_CHK( ssl_write_early_data_postprocess( ssl ) );
 
 #else  /* MBEDTLS_SSL_USE_MPS */
-
-        /* Make sure we can write a new message. */
-        MBEDTLS_SSL_PROC_CHK( mbedtls_ssl_flush_output( ssl ) );
 
         /* Write early-data to message buffer. */
         MBEDTLS_SSL_PROC_CHK( ssl_write_early_data_write( ssl, ssl->out_msg,
@@ -398,9 +392,6 @@ int ssl_write_end_of_early_data_process( mbedtls_ssl_context* ssl )
     {
 #if defined(MBEDTLS_SSL_USE_MPS)
         mbedtls_mps_handshake_out msg;
-        /* Make sure we can write a new message. */
-        MBEDTLS_SSL_PROC_CHK( mbedtls_mps_flush( &ssl->mps.l4 ) );
-
         msg.type   = MBEDTLS_SSL_HS_END_OF_EARLY_DATA;
         msg.length = MBEDTLS_MPS_SIZE_UNKNOWN;
         MBEDTLS_SSL_PROC_CHK( mbedtls_mps_write_handshake( &ssl->mps.l4,
@@ -419,9 +410,6 @@ int ssl_write_end_of_early_data_process( mbedtls_ssl_context* ssl )
         MBEDTLS_SSL_PROC_CHK( mbedtls_mps_flush( &ssl->mps.l4 ) );
 
 #else  /* MBEDTLS_SSL_USE_MPS */
-
-        /* Make sure we can write a new message. */
-        MBEDTLS_SSL_PROC_CHK( mbedtls_ssl_flush_output( ssl ) );
 
         /* EndOfEarlyData message is empty */
 
@@ -1399,10 +1387,6 @@ static int ssl_client_hello_process( mbedtls_ssl_context* ssl )
     }
 
 #if defined(MBEDTLS_SSL_USE_MPS)
-
-    /* Make sure we can write a new message. */
-    MBEDTLS_SSL_PROC_CHK( mbedtls_mps_flush( &ssl->mps.l4 ) );
-
     msg.type   = MBEDTLS_SSL_HS_CLIENT_HELLO;
     msg.length = MBEDTLS_MPS_SIZE_UNKNOWN;
     MBEDTLS_SSL_PROC_CHK( mbedtls_mps_write_handshake( &ssl->mps.l4,
@@ -1446,9 +1430,6 @@ static int ssl_client_hello_process( mbedtls_ssl_context* ssl )
     MBEDTLS_SSL_PROC_CHK( ssl_client_hello_postprocess( ssl ) );
 
 #else /* MBEDTLS_SSL_USE_MPS */
-
-    /* Make sure we can write a new message. */
-    MBEDTLS_SSL_PROC_CHK( mbedtls_ssl_flush_output( ssl ) );
 
     /* Prepare ClientHello message in output buffer, up to
      * but excluding the PSK binder list (if present).

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -4223,6 +4223,7 @@ int mbedtls_ssl_handshake_client_step_tls1_3( mbedtls_ssl_context *ssl )
 #if defined(MBEDTLS_SSL_TLS13_COMPATIBILITY_MODE)
         case MBEDTLS_SSL_CLIENT_CCS_AFTER_CLIENT_HELLO:
         case MBEDTLS_SSL_CLIENT_CCS_BEFORE_2ND_CLIENT_HELLO:
+        case MBEDTLS_SSL_CLIENT_CCS_AFTER_SERVER_FINISHED:
             ret = mbedtls_ssl_write_change_cipher_spec_process( ssl );
             break;
 #endif /* MBEDTLS_SSL_TLS13_COMPATIBILITY_MODE */
@@ -4276,96 +4277,25 @@ int mbedtls_ssl_handshake_client_step_tls1_3( mbedtls_ssl_context *ssl )
 
         case MBEDTLS_SSL_CERTIFICATE_VERIFY:
             ret = mbedtls_ssl_read_certificate_verify_process( ssl );
-
-            if( ret != 0 )
-            {
-                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_read_certificate_verify_process", ret );
-                break;
-            }
-
             break;
-
-            /* ----- READ FINISHED ----*/
 
         case MBEDTLS_SSL_SERVER_FINISHED:
-
             ret = mbedtls_ssl_finished_in_process( ssl );
-
-            if( ret != 0 )
-            {
-                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_finished_in_process", ret );
-                break;
-            }
-
-            mbedtls_ssl_handshake_set_state( ssl, MBEDTLS_SSL_END_OF_EARLY_DATA );
             break;
-
-            /* ----- WRITE END-OF-EARLY-DATA ----*/
 
         case MBEDTLS_SSL_END_OF_EARLY_DATA:
-
             ret = ssl_write_end_of_early_data_process( ssl );
-
-            if( ret != 0 )
-            {
-                MBEDTLS_SSL_DEBUG_RET( 1, "ssl_write_end_of_early_data_process", ret );
-                break;
-            }
-
             break;
-
-            /* ----- WRITE CHANGE CIPHER SPEC ----*/
-
-#if defined(MBEDTLS_SSL_TLS13_COMPATIBILITY_MODE)
-        case MBEDTLS_SSL_CLIENT_CCS_AFTER_SERVER_FINISHED:
-
-            ret = mbedtls_ssl_write_change_cipher_spec_process( ssl );
-
-            if( ret != 0 )
-            {
-                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_write_change_cipher_spec_process", ret );
-                break;
-            }
-
-            break;
-#endif /* MBEDTLS_SSL_TLS13_COMPATIBILITY_MODE */
-
-
-            /* ----- WRITE CERTIFICATE ----*/
 
         case MBEDTLS_SSL_CLIENT_CERTIFICATE:
-
             ret = mbedtls_ssl_write_certificate_process( ssl );
-
-            if( ret != 0 )
-            {
-                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_write_certificate_process", ret );
-                break;
-            }
-            break;
-
-            /* ----- WRITE CLIENT CERTIFICATE VERIFY ----*/
 
         case MBEDTLS_SSL_CLIENT_CERTIFICATE_VERIFY:
             ret = mbedtls_ssl_write_certificate_verify_process( ssl );
-
-            if( ret != 0 )
-            {
-                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_write_certificate_verify_process", ret );
-                break;
-            }
             break;
-
-            /* ----- WRITE CLIENT FINISHED ----*/
 
         case MBEDTLS_SSL_CLIENT_FINISHED:
             ret = mbedtls_ssl_finished_out_process( ssl );
-
-            if( ret != 0 )
-            {
-                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_finished_out_process", ret );
-                break;
-            }
             break;
 
         case MBEDTLS_SSL_FLUSH_BUFFERS:

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -4146,10 +4146,9 @@ static int ssl_new_session_ticket_parse( mbedtls_ssl_context* ssl,
     return( 0 );
 }
 
-static int ssl_new_session_ticket_postprocess( mbedtls_ssl_context* ssl, int ret )
+static int ssl_new_session_ticket_postprocess( mbedtls_ssl_context* ssl )
 {
-    ((void ) ssl);
-    ((void ) ret);
+    mbedtls_ssl_handshake_set_state( ssl, MBEDTLS_SSL_HANDSHAKE_OVER );
     return( 0 );
 }
 
@@ -4161,7 +4160,7 @@ static int ssl_new_session_ticket_postprocess( mbedtls_ssl_context* ssl, int ret
 
 static int ssl_new_session_ticket_process( mbedtls_ssl_context* ssl )
 {
-    int ret;
+    int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     unsigned char* buf;
     size_t buflen;
 
@@ -4185,7 +4184,7 @@ static int ssl_new_session_ticket_process( mbedtls_ssl_context* ssl )
 
 #endif /* MBEDTLS_SSL_USE_MPS */
 
-    MBEDTLS_SSL_PROC_CHK( ssl_new_session_ticket_postprocess( ssl, ret ) );
+    MBEDTLS_SSL_PROC_CHK( ssl_new_session_ticket_postprocess( ssl ) );
 
 cleanup:
 
@@ -4407,7 +4406,6 @@ int mbedtls_ssl_handshake_client_step_tls1_3( mbedtls_ssl_context *ssl )
                 break;
             }
 
-            mbedtls_ssl_handshake_set_state( ssl, MBEDTLS_SSL_HANDSHAKE_OVER );
             ret = MBEDTLS_ERR_SSL_RECEIVED_NEW_SESSION_TICKET;
             break;
 

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -1342,16 +1342,9 @@ static int ssl_client_hello_postprocess( mbedtls_ssl_context* ssl );
 static int ssl_client_hello_process( mbedtls_ssl_context* ssl )
 {
     int ret = 0;
-#if defined(MBEDTLS_SSL_USE_MPS)
+    unsigned char *buf;
+    size_t buf_len, msg_len;
     size_t len_without_binders;
-    mbedtls_mps_handshake_out msg;
-    unsigned char *buf;
-    mbedtls_mps_size_t buf_len, msg_len;
-#else /* MBEDTLS_SSL_USE_MPS */
-    size_t msg_len, len_without_binders;
-    unsigned char *buf;
-    size_t len;
-#endif /* MBEDTLS_SSL_USE_MPS */
 
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> write client hello" ) );
 
@@ -1361,15 +1354,8 @@ static int ssl_client_hello_process( mbedtls_ssl_context* ssl )
         ssl->handshake->state_local.cli_hello_out.preparation_done = 1;
     }
 
-#if defined(MBEDTLS_SSL_USE_MPS)
-    msg.type   = MBEDTLS_SSL_HS_CLIENT_HELLO;
-    msg.length = MBEDTLS_MPS_SIZE_UNKNOWN;
-    MBEDTLS_SSL_PROC_CHK( mbedtls_mps_write_handshake( &ssl->mps.l4,
-                                                       &msg, NULL, NULL ) );
-
-    /* Request write-buffer */
-    MBEDTLS_SSL_PROC_CHK( mbedtls_writer_get( msg.handle, MBEDTLS_MPS_SIZE_MAX,
-                                              &buf, &buf_len ) );
+    MBEDTLS_SSL_PROC_CHK( mbedtls_ssl_start_handshake_msg( ssl,
+                 MBEDTLS_SSL_HS_CLIENT_HELLO, &buf, &buf_len ) );
 
     MBEDTLS_SSL_PROC_CHK( ssl_client_hello_write_partial( ssl, buf, buf_len,
                                                   &len_without_binders,
@@ -1396,78 +1382,8 @@ static int ssl_client_hello_process( mbedtls_ssl_context* ssl )
     }
 #endif /* MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED */
 
-    /* Commit message */
-    MBEDTLS_SSL_PROC_CHK( mbedtls_writer_commit_partial( msg.handle,
-                                                         buf_len - msg_len ) );
-
-    MBEDTLS_SSL_PROC_CHK( mbedtls_mps_dispatch( &ssl->mps.l4 ) );
-
     MBEDTLS_SSL_PROC_CHK( ssl_client_hello_postprocess( ssl ) );
-
-#else /* MBEDTLS_SSL_USE_MPS */
-
-    /* Prepare ClientHello message in output buffer, up to
-     * but excluding the PSK binder list (if present).
-     *
-     * In contrast to other handshake writing functions, this
-     * function returns two length values: Firstly, the length
-     * of the message up to the binder's list. And secondly,
-     * the total length of the message including the binders
-     * list. */
-    buf = ssl->out_msg;
-    len = MBEDTLS_SSL_OUT_CONTENT_LEN;
-    MBEDTLS_SSL_PROC_CHK( ssl_client_hello_write_partial( ssl, buf, len,
-                                                  &len_without_binders,
-                                                  &msg_len ) );
-    ssl->out_msglen = msg_len;
-
-    {
-        unsigned char hs_hdr[4];
-        size_t const hs_len = msg_len - 4;
-
-        /* Build HS header for checksum update. */
-        hs_hdr[0] = MBEDTLS_SSL_HS_CLIENT_HELLO;
-        hs_hdr[1] = (unsigned char)( hs_len >> 16 );
-        hs_hdr[2] = (unsigned char)( hs_len >>  8 );
-        hs_hdr[3] = (unsigned char)( hs_len >>  0 );
-
-        ssl->handshake->update_checksum( ssl, hs_hdr, sizeof( hs_hdr ) );
-
-        /* Manually update the checksum with ClientHello using dummy PSK binders. */
-        ssl->handshake->update_checksum( ssl, buf + 4, len_without_binders - 4 );
-    }
-
-#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && \
-    defined(MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED)
-    /* Patch the PSK binder after updating the HS checksum. */
-    {
-
-        size_t dummy0, dummy1;
-        mbedtls_ssl_write_pre_shared_key_ext( ssl,
-                                              buf + len_without_binders,
-                                              buf + len,
-                                              &dummy0, &dummy1,
-                                              SSL_WRITE_PSK_EXT_ADD_PSK_BINDERS );
-
-        /* Manually update the checksum with ClientHello using dummy PSK binders. */
-        ssl->handshake->update_checksum( ssl, buf + len_without_binders,
-                                         msg_len - len_without_binders );
-    }
-#endif /* MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED &&
-          MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
-
-    ssl->out_msgtype = MBEDTLS_SSL_MSG_HANDSHAKE;
-    ssl->out_msg[0] = MBEDTLS_SSL_HS_CLIENT_HELLO;
-
-    MBEDTLS_SSL_DEBUG_BUF( 3, "ClientHello", ssl->out_msg, ssl->out_msglen );
-
-    MBEDTLS_SSL_PROC_CHK( ssl_client_hello_postprocess( ssl ) );
-
-    /* Dispatch message */
-    MBEDTLS_SSL_PROC_CHK( mbedtls_ssl_write_handshake_msg_ext(
-                              ssl, 0 /* no checksum update */ ) );
-
-#endif /* MBEDTLS_SSL_USE_MPS */
+    MBEDTLS_SSL_PROC_CHK( mbedtls_ssl_finish_handshake_msg( ssl, buf_len, msg_len ) );
 
 cleanup:
 
@@ -1573,22 +1489,6 @@ static int ssl_client_hello_write_partial( mbedtls_ssl_context* ssl,
      * are elided. The random bytes are shorter.
      */
     version_len = 2;
-
-    /* With MPS we don't need to write the handshake header. */
-#if !defined(MBEDTLS_SSL_USE_MPS)
-    {
-        size_t const tls_hs_hdr_len = 4;
-
-        if( buflen < tls_hs_hdr_len + version_len + rand_bytes_len )
-        {
-            MBEDTLS_SSL_DEBUG_MSG( 1, ( "buffer too small to hold ClientHello" ) );
-            return( MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL );
-        }
-
-        buf += tls_hs_hdr_len;
-        buflen -= tls_hs_hdr_len;
-    }
-#endif /* MBEDTLS_SSL_USE_MPS */
 
     if( ssl->conf->max_major_ver == 0 )
     {

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -287,7 +287,7 @@ static int ssl_write_change_cipher_spec_postprocess( mbedtls_ssl_context* ssl )
                 mbedtls_ssl_handshake_set_state( ssl, MBEDTLS_SSL_EARLY_APP_DATA );
                 break;
             case MBEDTLS_SSL_CLIENT_CCS_BEFORE_2ND_CLIENT_HELLO:
-                mbedtls_ssl_handshake_set_state( ssl, MBEDTLS_SSL_SECOND_CLIENT_HELLO );
+                mbedtls_ssl_handshake_set_state( ssl, MBEDTLS_SSL_CLIENT_HELLO );
                 break;
             case MBEDTLS_SSL_CLIENT_CCS_AFTER_SERVER_FINISHED:
                 mbedtls_ssl_handshake_set_state( ssl, MBEDTLS_SSL_CLIENT_CERTIFICATE );

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -1409,9 +1409,6 @@ static int ssl_write_new_session_ticket_process( mbedtls_ssl_context *ssl )
         unsigned char *buf;
         mbedtls_mps_size_t buf_len, msg_len;
 
-        /* Make sure we can write a new message. */
-        MBEDTLS_SSL_PROC_CHK( mbedtls_mps_flush( &ssl->mps.l4 ) );
-
         msg.type   = MBEDTLS_SSL_HS_NEW_SESSION_TICKET;
         msg.length = MBEDTLS_MPS_SIZE_UNKNOWN;
         MBEDTLS_SSL_PROC_CHK( mbedtls_mps_write_handshake( &ssl->mps.l4,
@@ -3183,9 +3180,6 @@ static int ssl_encrypted_extensions_process( mbedtls_ssl_context* ssl )
     }
 
 #if defined(MBEDTLS_SSL_USE_MPS)
-    /* Make sure we can write a new message. */
-    MBEDTLS_SSL_PROC_CHK( mbedtls_mps_flush( &ssl->mps.l4 ) );
-
     msg.type   = MBEDTLS_SSL_HS_ENCRYPTED_EXTENSION;
     msg.length = MBEDTLS_MPS_SIZE_UNKNOWN;
     MBEDTLS_SSL_PROC_CHK( mbedtls_mps_write_handshake( &ssl->mps.l4,
@@ -3211,9 +3205,6 @@ static int ssl_encrypted_extensions_process( mbedtls_ssl_context* ssl )
     MBEDTLS_SSL_PROC_CHK( ssl_encrypted_extensions_postprocess( ssl ) );
 
 #else  /* MBEDTLS_SSL_USE_MPS */
-
-    /* Make sure we can write a new message. */
-    MBEDTLS_SSL_PROC_CHK( mbedtls_ssl_flush_output( ssl ) );
 
     MBEDTLS_SSL_PROC_CHK( ssl_encrypted_extensions_write( ssl, ssl->out_msg,
                                                           MBEDTLS_SSL_OUT_CONTENT_LEN,
@@ -3451,9 +3442,6 @@ static int ssl_write_hello_retry_request_process( mbedtls_ssl_context *ssl )
     MBEDTLS_SSL_PROC_CHK( ssl_write_hello_retry_request_coordinate( ssl ) );
 
 #if defined(MBEDTLS_SSL_USE_MPS)
-
-    /* Make sure we can write a new message. */
-    MBEDTLS_SSL_PROC_CHK( mbedtls_mps_flush( &ssl->mps.l4 ) );
 
     msg.type   = MBEDTLS_SSL_HS_SERVER_HELLO;
     msg.length = MBEDTLS_MPS_SIZE_UNKNOWN;
@@ -3802,8 +3790,6 @@ static int ssl_server_hello_process( mbedtls_ssl_context* ssl ) {
     MBEDTLS_SSL_PROC_CHK( ssl_server_hello_prepare( ssl ) );
 
 #if defined(MBEDTLS_SSL_USE_MPS)
-    /* Make sure we can write a new message. */
-    MBEDTLS_SSL_PROC_CHK( mbedtls_mps_flush( &ssl->mps.l4 ) );
 
     msg.type   = MBEDTLS_SSL_HS_SERVER_HELLO;
     msg.length = MBEDTLS_MPS_SIZE_UNKNOWN;
@@ -3830,11 +3816,6 @@ static int ssl_server_hello_process( mbedtls_ssl_context* ssl ) {
     MBEDTLS_SSL_PROC_CHK( ssl_server_hello_postprocess( ssl ) );
 
 #else  /* MBEDTLS_SSL_USE_MPS */
-
-    /* Writing */
-
-    /* Make sure we can write a new message. */
-    MBEDTLS_SSL_PROC_CHK( mbedtls_ssl_flush_output( ssl ) );
 
     MBEDTLS_SSL_PROC_CHK( ssl_server_hello_write( ssl, ssl->out_msg,
                             MBEDTLS_SSL_OUT_CONTENT_LEN, &ssl->out_msglen ) );
@@ -4103,9 +4084,6 @@ static int ssl_certificate_request_process( mbedtls_ssl_context* ssl )
         unsigned char *buf;
         mbedtls_mps_size_t buf_len, msg_len;
 
-        /* Make sure we can write a new message. */
-        MBEDTLS_SSL_PROC_CHK( mbedtls_mps_flush( &ssl->mps.l4 ) );
-
         msg.type   = MBEDTLS_SSL_HS_CERTIFICATE_REQUEST;
         msg.length = MBEDTLS_MPS_SIZE_UNKNOWN;
         MBEDTLS_SSL_PROC_CHK( mbedtls_mps_write_handshake( &ssl->mps.l4,
@@ -4131,9 +4109,6 @@ static int ssl_certificate_request_process( mbedtls_ssl_context* ssl )
         MBEDTLS_SSL_PROC_CHK( ssl_certificate_request_postprocess( ssl ) );
 
 #else  /* MBEDTLS_SSL_USE_MPS */
-
-        /* Make sure we can write a new message. */
-        MBEDTLS_SSL_PROC_CHK( mbedtls_ssl_flush_output( ssl ) );
 
         /* Prepare CertificateRequest message in output buffer. */
         MBEDTLS_SSL_PROC_CHK( ssl_certificate_request_write( ssl, ssl->out_msg,

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -4465,25 +4465,7 @@ int mbedtls_ssl_handshake_server_step_tls1_3( mbedtls_ssl_context *ssl )
             /* ----- READ FINISHED ----*/
 
         case MBEDTLS_SSL_CLIENT_FINISHED:
-
             ret = mbedtls_ssl_finished_in_process( ssl );
-
-            if( ret != 0 )
-            {
-                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_finished_in_process", ret );
-                return( ret );
-            }
-
-            /* Compute resumption_master_secret */
-            ret = mbedtls_ssl_tls1_3_generate_resumption_master_secret( ssl );
-            if( ret != 0 )
-            {
-                MBEDTLS_SSL_DEBUG_RET( 1,
-                          "mbedtls_ssl_tls1_3_generate_resumption_master_secret ", ret );
-                return( ret );
-            }
-
-            mbedtls_ssl_handshake_set_state( ssl, MBEDTLS_SSL_HANDSHAKE_WRAPUP );
             break;
 
         case MBEDTLS_SSL_HANDSHAKE_WRAPUP:

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -4088,10 +4088,8 @@ static int ssl_certificate_request_process( mbedtls_ssl_context* ssl )
         MBEDTLS_SSL_PROC_CHK( ssl_certificate_request_write(
                                   ssl, buf, buf_len, &msg_len ) );
 
-#if defined(MBEDTLS_SSL_USE_MPS)
         mbedtls_ssl_add_hs_msg_to_checksum( ssl, MBEDTLS_SSL_HS_CERTIFICATE_REQUEST,
                                             buf, msg_len );
-#endif
 
         /* TODO: Logically this should come at the end, but the non-MPS msg
          *       layer impl'n of mbedtls_ssl_finish_handshake_msg() can fail. */
@@ -4160,17 +4158,6 @@ static int ssl_certificate_request_write( mbedtls_ssl_context* ssl,
     unsigned char* end = buf + buflen;
 
     p = buf;
-
-#if !defined(MBEDTLS_SSL_USE_MPS)
-    /* Skip over handshake header.
-     *
-     * NOTE:
-     * Even for DTLS, we are skipping 4 bytes for the TLS handshake
-     * header. The actual DTLS handshake header is inserted in
-     * the record writing routine mbedtls_ssl_write_record( ).
-     */
-    p += 4;
-#endif /* MBEDTLS_SSL_USE_MPS */
 
     if( p + 1 + 2 > end )
     {


### PR DESCRIPTION
Work in progress. So far:
* Remove dedicated state for second client hello
* Remove dedicated state for second server hello
* Move state machine updates to state handlers
* Consolidate two CCS sending states
* Add HS-write wrapper moving the MPS/non-MPS distinction into a few functions, rather than duplicating it in every state handler.
