### PR TITLE
Add wrapper to have MPS/non-MPS agnostic message parsers

### DIFF
--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -1332,7 +1332,7 @@ int mbedtls_ssl_tls13_populate_transform( mbedtls_ssl_transform *transform,
                                           mbedtls_ssl_key_set const *traffic_keys,
                                           mbedtls_ssl_context *ssl /* DEBUG ONLY */ );
 
-int mbedtls_ssl_mps_fetch_full_hs_msg( mbedtls_ssl_context *ssl,
+int mbedtls_ssl_fetch_handshake_msg( mbedtls_ssl_context *ssl,
                                        unsigned hs_type,
                                        unsigned char **buf,
                                        size_t *buflen );

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -5439,6 +5439,8 @@ static int ssl_check_new_session_ticket( mbedtls_ssl_context *ssl )
     {
         return( 0 );
     }
+
+    ssl->keep_current_message = 1;
 #endif /* MBEDTLS_SSL_USE_MPS */
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "NewSessionTicket received" ) );

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -3093,34 +3093,6 @@ int mbedtls_ssl_prepare_handshake_record( mbedtls_ssl_context *ssl )
         return( MBEDTLS_ERR_SSL_FEATURE_UNAVAILABLE );
     }
 
-#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
-    if( ssl->state != MBEDTLS_SSL_HANDSHAKE_OVER &&
-        ssl->handshake != NULL )
-    {
-        const char magic_hrr_string[32] = { 0xCF, 0x21, 0xAD, 0x74, 0xE5, 0x9A,
-                                            0x61, 0x11, 0xBE, 0x1D, 0x8C, 0x02,
-                                            0x1E, 0x65, 0xB8, 0x91, 0xC2, 0xA2,
-                                            0x11, 0x16, 0x7A, 0xBB, 0x8C, 0x5E,
-                                            0x07, 0x9E, 0x09, 0xE2, 0xC8, 0xA8,
-                                            0x33 ,0x9C };
-        /*
-         * If the server responds with the HRR message then a special handling
-         * with the modified transcript hash is necessary. We compute this hash later.
-         */
-        if( ssl->in_msg[0] == MBEDTLS_SSL_HS_SERVER_HELLO &&
-            memcmp( ssl->in_msg + mbedtls_ssl_hs_hdr_len( ssl ) + 2,
-                    &magic_hrr_string[0], 32 ) == 0 )
-        {
-            MBEDTLS_SSL_DEBUG_MSG( 4, ( "--- Special HRR Checksum Processing" ) );
-        }
-        else
-        {
-            MBEDTLS_SSL_DEBUG_MSG( 4, ( "--- Update Checksum ( ssl_prepare_handshake_record )" ) );
-            ssl->handshake->update_checksum( ssl, ssl->in_msg, ssl->in_hslen );
-        }
-    }
-#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
-
     return( 0 );
 }
 

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -2161,7 +2161,7 @@ static int ssl_certificate_request_process( mbedtls_ssl_context* ssl )
 
 #if defined(MBEDTLS_SSL_USE_MPS)
 
-        MBEDTLS_SSL_PROC_CHK( mbedtls_ssl_mps_fetch_full_hs_msg( ssl,
+        MBEDTLS_SSL_PROC_CHK( mbedtls_ssl_fetch_handshake_msg( ssl,
                                               MBEDTLS_SSL_HS_CERTIFICATE_REQUEST,
                                               &buf, &buflen ) );
 
@@ -2486,7 +2486,7 @@ static int ssl_encrypted_extensions_process( mbedtls_ssl_context* ssl )
 
 #if defined(MBEDTLS_SSL_USE_MPS)
 
-    MBEDTLS_SSL_PROC_CHK( mbedtls_ssl_mps_fetch_full_hs_msg( ssl,
+    MBEDTLS_SSL_PROC_CHK( mbedtls_ssl_fetch_handshake_msg( ssl,
                                              MBEDTLS_SSL_HS_ENCRYPTED_EXTENSION,
                                              &buf, &buflen ) );
 
@@ -4024,7 +4024,7 @@ static int ssl_new_session_ticket_process( mbedtls_ssl_context* ssl )
 
 #if defined(MBEDTLS_SSL_USE_MPS)
 
-    MBEDTLS_SSL_PROC_CHK( mbedtls_ssl_mps_fetch_full_hs_msg( ssl,
+    MBEDTLS_SSL_PROC_CHK( mbedtls_ssl_fetch_handshake_msg( ssl,
                                           MBEDTLS_SSL_HS_NEW_SESSION_TICKET,
                                           &buf, &buflen ) );
 

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -3623,18 +3623,6 @@ static int ssl_hrr_postprocess( mbedtls_ssl_context* ssl,
 
 #if defined(MBEDTLS_SSL_NEW_SESSION_TICKET)
 
-#if !defined(MBEDTLS_SSL_USE_MPS)
-static int ssl_new_session_ticket_fetch( mbedtls_ssl_context* ssl,
-                                         unsigned char** dst,
-                                         size_t* dstlen )
-{
-    *dst = ssl->in_msg + mbedtls_ssl_hs_hdr_len( ssl );
-    *dstlen = ssl->in_hslen - mbedtls_ssl_hs_hdr_len( ssl );
-
-    return( 0 );
-}
-#endif /* MBEDTLS_SSL_USE_MPS */
-
 static int ssl_new_session_ticket_early_data_ext_parse( mbedtls_ssl_context* ssl,
                                                         const unsigned char* buf,
                                                         size_t ext_size )
@@ -3928,22 +3916,14 @@ static int ssl_new_session_ticket_process( mbedtls_ssl_context* ssl )
 
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> parse new session ticket" ) );
 
-#if defined(MBEDTLS_SSL_USE_MPS)
-
     MBEDTLS_SSL_PROC_CHK( mbedtls_ssl_fetch_handshake_msg( ssl,
                                           MBEDTLS_SSL_HS_NEW_SESSION_TICKET,
                                           &buf, &buflen ) );
 
-    /* Process the message contents */
     MBEDTLS_SSL_PROC_CHK( ssl_new_session_ticket_parse( ssl, buf, buflen ) );
 
+#if defined(MBEDTLS_SSL_USE_MPS)
     MBEDTLS_SSL_PROC_CHK( mbedtls_ssl_mps_hs_consume_full_hs_msg( ssl ) );
-
-#else /* MBEDTLS_SSL_USE_MPS */
-
-    MBEDTLS_SSL_PROC_CHK( ssl_new_session_ticket_fetch( ssl, &buf, &buflen ) );
-    MBEDTLS_SSL_PROC_CHK( ssl_new_session_ticket_parse( ssl, buf, buflen ) );
-
 #endif /* MBEDTLS_SSL_USE_MPS */
 
     MBEDTLS_SSL_PROC_CHK( ssl_new_session_ticket_postprocess( ssl ) );

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -989,9 +989,9 @@ int mbedtls_ssl_read_certificate_verify_process( mbedtls_ssl_context* ssl )
                                                                  verify_buffer,
                                                                  verify_buffer_len ) );
 
-#if defined(MBEDTLS_SSL_USE_MPS)
         mbedtls_ssl_add_hs_msg_to_checksum(
             ssl, MBEDTLS_SSL_HS_CERTIFICATE_VERIFY, buf, buflen );
+#if defined(MBEDTLS_SSL_USE_MPS)
         MBEDTLS_SSL_PROC_CHK( mbedtls_ssl_mps_hs_consume_full_hs_msg( ssl ) );
 #endif
     }
@@ -1552,9 +1552,9 @@ int mbedtls_ssl_read_certificate_process( mbedtls_ssl_context* ssl )
         /* Validate the certificate chain and set the verification results. */
         MBEDTLS_SSL_PROC_CHK( ssl_read_certificate_validate( ssl ) );
 
-#if defined(MBEDTLS_SSL_USE_MPS)
         mbedtls_ssl_add_hs_msg_to_checksum(
             ssl, MBEDTLS_SSL_HS_CERTIFICATE, buf, buflen );
+#if defined(MBEDTLS_SSL_USE_MPS)
         MBEDTLS_SSL_PROC_CHK( mbedtls_ssl_mps_hs_consume_full_hs_msg( ssl ) );
 #endif /* MBEDTLS_SSL_USE_MPS */
 
@@ -2350,9 +2350,9 @@ int mbedtls_ssl_finished_in_process( mbedtls_ssl_context* ssl )
                                               MBEDTLS_SSL_HS_FINISHED,
                                               &buf, &buflen ) );
     MBEDTLS_SSL_PROC_CHK( ssl_finished_in_parse( ssl, buf, buflen ) );
-#if defined(MBEDTLS_SSL_USE_MPS)
     mbedtls_ssl_add_hs_msg_to_checksum(
         ssl, MBEDTLS_SSL_HS_FINISHED, buf, buflen );
+#if defined(MBEDTLS_SSL_USE_MPS)
     MBEDTLS_SSL_PROC_CHK( mbedtls_ssl_mps_hs_consume_full_hs_msg( ssl ) );
 #endif /* MBEDTLS_SSL_USE_MPS */
     MBEDTLS_SSL_PROC_CHK( ssl_finished_in_postprocess( ssl ) );

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -52,7 +52,7 @@
 #endif /* MBEDTLS_PLATFORM_C */
 
 #if defined(MBEDTLS_SSL_USE_MPS)
-int mbedtls_ssl_mps_fetch_full_hs_msg( mbedtls_ssl_context *ssl,
+int mbedtls_ssl_fetch_handshake_msg( mbedtls_ssl_context *ssl,
                                        unsigned hs_type,
                                        unsigned char **buf,
                                        size_t *buflen )
@@ -956,7 +956,7 @@ int mbedtls_ssl_read_certificate_verify_process( mbedtls_ssl_context* ssl )
 
 #if defined(MBEDTLS_SSL_USE_MPS)
 
-        MBEDTLS_SSL_PROC_CHK( mbedtls_ssl_mps_fetch_full_hs_msg( ssl,
+        MBEDTLS_SSL_PROC_CHK( mbedtls_ssl_fetch_handshake_msg( ssl,
                                               MBEDTLS_SSL_HS_CERTIFICATE_VERIFY,
                                               &buf, &buflen ) );
 
@@ -1571,7 +1571,7 @@ int mbedtls_ssl_read_certificate_process( mbedtls_ssl_context* ssl )
 
 #if defined(MBEDTLS_SSL_USE_MPS)
 
-        MBEDTLS_SSL_PROC_CHK( mbedtls_ssl_mps_fetch_full_hs_msg( ssl,
+        MBEDTLS_SSL_PROC_CHK( mbedtls_ssl_fetch_handshake_msg( ssl,
                                           MBEDTLS_SSL_HS_CERTIFICATE,
                                           &buf, &buflen ) );
 
@@ -2427,7 +2427,7 @@ int mbedtls_ssl_finished_in_process( mbedtls_ssl_context* ssl )
 
 #if defined(MBEDTLS_SSL_USE_MPS)
 
-    MBEDTLS_SSL_PROC_CHK( mbedtls_ssl_mps_fetch_full_hs_msg( ssl,
+    MBEDTLS_SSL_PROC_CHK( mbedtls_ssl_fetch_handshake_msg( ssl,
                                               MBEDTLS_SSL_HS_FINISHED,
                                               &buf, &buflen ) );
 

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -53,9 +53,9 @@
 
 #if defined(MBEDTLS_SSL_USE_MPS)
 int mbedtls_ssl_fetch_handshake_msg( mbedtls_ssl_context *ssl,
-                                       unsigned hs_type,
-                                       unsigned char **buf,
-                                       size_t *buflen )
+                                     unsigned hs_type,
+                                     unsigned char **buf,
+                                     size_t *buflen )
 {
     int ret;
     mbedtls_mps_handshake_in msg;
@@ -147,6 +147,38 @@ cleanup:
 }
 
 #else /* MBEDTLS_SSL_USE_MPS */
+
+int mbedtls_ssl_fetch_handshake_msg( mbedtls_ssl_context *ssl,
+                                     unsigned hs_type,
+                                     unsigned char **buf,
+                                     size_t *buflen )
+{
+    int ret;
+
+    if( ( ret = mbedtls_ssl_read_record( ssl, 0 ) ) != 0 )
+    {
+        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_read_record", ret );
+        goto cleanup;
+    }
+
+    if( ssl->in_msgtype != MBEDTLS_SSL_MSG_HANDSHAKE         ||
+        ssl->in_msg[0]  != hs_type )
+    {
+        MBEDTLS_SSL_DEBUG_MSG( 1, ( "bad certificate verify message" ) );
+        SSL_PEND_FATAL_ALERT( MBEDTLS_SSL_ALERT_MSG_UNEXPECTED_MESSAGE,
+                              MBEDTLS_ERR_SSL_UNEXPECTED_MESSAGE );
+        ret = MBEDTLS_ERR_SSL_UNEXPECTED_MESSAGE;
+        goto cleanup;
+    }
+
+    *buf    = ssl->in_msg   + 4;
+    *buflen = ssl->in_hslen - 4;
+
+
+cleanup:
+
+    return( ret );
+}
 
 int mbedtls_ssl_start_handshake_msg( mbedtls_ssl_context *ssl,
                                      unsigned hs_type,

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -2071,7 +2071,7 @@ static int ssl_client_hello_process( mbedtls_ssl_context* ssl )
 
 #if defined(MBEDTLS_SSL_USE_MPS)
 
-    MBEDTLS_SSL_PROC_CHK( mbedtls_ssl_mps_fetch_full_hs_msg( ssl,
+    MBEDTLS_SSL_PROC_CHK( mbedtls_ssl_fetch_handshake_msg( ssl,
                                             MBEDTLS_SSL_HS_CLIENT_HELLO,
                                             &buf, &buflen ) );
 

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -1667,13 +1667,12 @@ int ssl_read_end_of_early_data_process( mbedtls_ssl_context* ssl )
 #if defined(MBEDTLS_SSL_USE_MPS)
         MBEDTLS_SSL_PROC_CHK( ssl_end_of_early_data_fetch( ssl ) );
         MBEDTLS_SSL_PROC_CHK( mbedtls_mps_read_consume( &ssl->mps.l4 ) );
-
-        mbedtls_ssl_add_hs_hdr_to_checksum(
-            ssl, MBEDTLS_SSL_HS_END_OF_EARLY_DATA, 0 );
-
 #else /* MBEDTLS_SSL_USE_MPS */
         MBEDTLS_SSL_PROC_CHK( ssl_end_of_early_data_fetch( ssl ) );
 #endif /* MBEDTLS_SSL_USE_MPS */
+
+        mbedtls_ssl_add_hs_hdr_to_checksum(
+            ssl, MBEDTLS_SSL_HS_END_OF_EARLY_DATA, 0 );
 
 #else /* MBEDTLS_ZERO_RTT */
 
@@ -2063,14 +2062,13 @@ static int ssl_client_hello_process( mbedtls_ssl_context* ssl )
     size_t buflen = 0;
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> parse client hello" ) );
 
+    ssl->major_ver = MBEDTLS_SSL_MAJOR_VERSION_3;
     MBEDTLS_SSL_PROC_CHK( mbedtls_ssl_fetch_handshake_msg( ssl,
                                             MBEDTLS_SSL_HS_CLIENT_HELLO,
                                             &buf, &buflen ) );
 
-#if defined(MBEDTLS_SSL_USE_MPS)
     mbedtls_ssl_add_hs_hdr_to_checksum( ssl,
                   MBEDTLS_SSL_HS_CLIENT_HELLO, buflen );
-#endif /* MBEDTLS_SSL_USE_MPS */
 
     MBEDTLS_SSL_PROC_CHK_NEG( ssl_client_hello_parse( ssl, buf, buflen ) );
     hrr_required = ret;
@@ -2970,12 +2968,8 @@ static int ssl_encrypted_extensions_postprocess( mbedtls_ssl_context* ssl );
 static int ssl_encrypted_extensions_process( mbedtls_ssl_context* ssl )
 {
     int ret;
-
-#if defined(MBEDTLS_SSL_USE_MPS)
-    mbedtls_mps_handshake_out msg;
     unsigned char *buf;
-    mbedtls_mps_size_t buf_len, msg_len;
-#endif /* MBEDTLS_SSL_USE_MPS */
+    size_t buf_len, msg_len;
 
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> write encrypted extension" ) );
 
@@ -2985,15 +2979,8 @@ static int ssl_encrypted_extensions_process( mbedtls_ssl_context* ssl )
         ssl->handshake->state_local.encrypted_extensions_out.preparation_done = 1;
     }
 
-#if defined(MBEDTLS_SSL_USE_MPS)
-    msg.type   = MBEDTLS_SSL_HS_ENCRYPTED_EXTENSION;
-    msg.length = MBEDTLS_MPS_SIZE_UNKNOWN;
-    MBEDTLS_SSL_PROC_CHK( mbedtls_mps_write_handshake( &ssl->mps.l4,
-                                                       &msg, NULL, NULL ) );
-
-    /* Request write-buffer */
-    MBEDTLS_SSL_PROC_CHK( mbedtls_writer_get( msg.handle, MBEDTLS_MPS_SIZE_MAX,
-                                              &buf, &buf_len ) );
+    MBEDTLS_SSL_PROC_CHK( mbedtls_ssl_start_handshake_msg( ssl,
+                       MBEDTLS_SSL_HS_ENCRYPTED_EXTENSION, &buf, &buf_len ) );
 
     MBEDTLS_SSL_PROC_CHK( ssl_encrypted_extensions_write(
                               ssl, buf, buf_len, &msg_len ) );
@@ -3001,42 +2988,11 @@ static int ssl_encrypted_extensions_process( mbedtls_ssl_context* ssl )
     mbedtls_ssl_add_hs_msg_to_checksum( ssl, MBEDTLS_SSL_HS_ENCRYPTED_EXTENSION,
                                         buf, msg_len );
 
-    /* Commit message */
-    MBEDTLS_SSL_PROC_CHK( mbedtls_writer_commit_partial( msg.handle,
-                                                         buf_len - msg_len ) );
-
-    MBEDTLS_SSL_PROC_CHK( mbedtls_mps_dispatch( &ssl->mps.l4 ) );
-
     /* Update state */
     MBEDTLS_SSL_PROC_CHK( ssl_encrypted_extensions_postprocess( ssl ) );
 
-#else  /* MBEDTLS_SSL_USE_MPS */
-
-    MBEDTLS_SSL_PROC_CHK( ssl_encrypted_extensions_write( ssl, ssl->out_msg,
-                                                          MBEDTLS_SSL_OUT_CONTENT_LEN,
-                                                          &ssl->out_msglen ) );
-
-    ssl->out_msgtype = MBEDTLS_SSL_MSG_HANDSHAKE;
-    ssl->out_msg[0] = MBEDTLS_SSL_HS_ENCRYPTED_EXTENSION;
-
-    MBEDTLS_SSL_DEBUG_BUF( 3, "EncryptedExtensions", ssl->out_msg, ssl->out_msglen );
-
-    /* Update state */
-    MBEDTLS_SSL_PROC_CHK( ssl_encrypted_extensions_postprocess( ssl ) );
-
-    /* Dispatch message */
-    MBEDTLS_SSL_PROC_CHK( mbedtls_ssl_write_handshake_msg( ssl ) );
-
-    /* NOTE: For the new messaging layer, the postprocessing step
-     *       might come after the dispatching step if the latter
-     *       doesn't send the message immediately.
-     *       At the moment, we must do the postprocessing
-     *       prior to the dispatching because if the latter
-     *       returns WANT_WRITE, we want the handshake state
-     *       to be updated in order to not enter
-     *       this function again on retry. */
-
-#endif /* MBEDTLS_SSL_USE_MPS */
+    MBEDTLS_SSL_PROC_CHK( mbedtls_ssl_finish_handshake_msg( ssl,
+                                                  buf_len, msg_len ) );
 
 cleanup:
 
@@ -3143,17 +3099,6 @@ static int ssl_encrypted_extensions_write( mbedtls_ssl_context* ssl,
 
     end = buf + buflen;
     p = buf;
-
-#if !defined(MBEDTLS_SSL_USE_MPS)
-    if( buflen < 4 )
-    {
-        MBEDTLS_SSL_DEBUG_MSG( 1, ( "buffer too small" ) );
-        return( MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL );
-    }
-
-    /* Skip HS header */
-    p += 4;
-#endif /* MBEDTLS_SSL_USE_MPS */
 
     /*
      * struct {


### PR DESCRIPTION
This PR introduces a helper function for fetching handshake messages of a given expected type,
```c
int mbedtls_ssl_fetch_handshake_msg( mbedtls_ssl_context *ssl,
                                     unsigned hs_type,
                                     unsigned char **buf,
                                     size_t *buflen )
```
which is implemented based on either MPS or the legacy messaging layer, depending on `MBEDTLS_SSL_USE_MPS`. The handshake state handlers now use primarily this function instead of the previous MPS/non-MPS `#ifdef`-salad, which makes the code both shorter and easier to read.