### PR TITLE
Move 0-RTT + Handshake transforms to handshake parameters

### DIFF
--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -1606,15 +1606,11 @@ struct mbedtls_ssl_context
 #endif /* defined(MBEDTLS_SSL_PROTO_TLS1_2) */
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
-    mbedtls_ssl_transform *MBEDTLS_PRIVATE(transform_handshake);
-    mbedtls_ssl_transform *MBEDTLS_PRIVATE(transform_earlydata);
     mbedtls_ssl_transform *MBEDTLS_PRIVATE(transform_application);
 
 #if defined(MBEDTLS_SSL_USE_MPS)
     /* With MPS, we only remember opaque epoch IDs from the handshake
      * layer. The transform themselves are managed by MPS. */
-    int MBEDTLS_PRIVATE(epoch_handshake);
-    int MBEDTLS_PRIVATE(epoch_earlydata);
     int MBEDTLS_PRIVATE(epoch_application);
 
     mbedtls_ssl_mps *mps;

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -653,6 +653,13 @@ struct mbedtls_ssl_handshake_params
     uint16_t mtu;                       /*!<  Handshake mtu, used to fragment outgoing messages */
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
 
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+    int epoch_handshake;
+    int epoch_earlydata;
+    mbedtls_ssl_transform *transform_handshake;
+    mbedtls_ssl_transform *transform_earlydata;
+#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
+
     /*
      * Checksum contexts
      */

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -3914,14 +3914,8 @@ void mbedtls_ssl_session_reset_msg_layer( mbedtls_ssl_context *ssl,
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
 #if !defined(MBEDTLS_SSL_USE_MPS)
-    mbedtls_ssl_transform_free( ssl->transform_handshake   );
-    mbedtls_ssl_transform_free( ssl->transform_earlydata   );
     mbedtls_ssl_transform_free( ssl->transform_application );
-    mbedtls_free( ssl->transform_handshake   );
-    mbedtls_free( ssl->transform_earlydata   );
     mbedtls_free( ssl->transform_application );
-    ssl->transform_handshake   = NULL;
-    ssl->transform_earlydata   = NULL;
     ssl->transform_application = NULL;
 #else
     ssl_mps_free( ssl );
@@ -6438,6 +6432,13 @@ void mbedtls_ssl_handshake_free( mbedtls_ssl_context *ssl )
     handle_buffer_resizing( ssl, 1, mbedtls_ssl_get_input_buflen( ssl ),
                                     mbedtls_ssl_get_output_buflen( ssl ) );
 #endif
+
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+    mbedtls_free( handshake->transform_earlydata );
+    mbedtls_free( handshake->transform_handshake );
+    handshake->transform_earlydata = NULL;
+    handshake->transform_handshake = NULL;
+#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 }
 
 void mbedtls_ssl_session_free( mbedtls_ssl_session *session )
@@ -7137,14 +7138,8 @@ void mbedtls_ssl_free( mbedtls_ssl_context *ssl )
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && \
     !defined(MBEDTLS_SSL_USE_MPS)
-    mbedtls_ssl_transform_free( ssl->transform_handshake   );
-    mbedtls_ssl_transform_free( ssl->transform_earlydata   );
     mbedtls_ssl_transform_free( ssl->transform_application );
-    mbedtls_free( ssl->transform_handshake   );
-    mbedtls_free( ssl->transform_earlydata   );
     mbedtls_free( ssl->transform_application );
-    ssl->transform_handshake   = NULL;
-    ssl->transform_earlydata   = NULL;
     ssl->transform_application = NULL;
 #endif
 

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -276,21 +276,21 @@ static int ssl_write_early_data_prepare( mbedtls_ssl_context* ssl )
     /* Register transform with MPS. */
     ret = mbedtls_mps_add_key_material( &ssl->mps->l4,
                                         transform_earlydata,
-                                        &ssl->epoch_earlydata );
+                                        &ssl->handshake->epoch_earlydata );
     if( ret != 0 )
         return( ret );
 
     /* Use new transform for outgoing data. */
     ret = mbedtls_mps_set_outgoing_keys( &ssl->mps->l4,
-                                         ssl->epoch_earlydata );
+                                         ssl->handshake->epoch_earlydata );
     if( ret != 0 )
         return( ret );
 #else /* MBEDTLS_SSL_USE_MPS */
 
     /* Activate transform */
     MBEDTLS_SSL_DEBUG_MSG( 1, ( "Switch to 0-RTT keys for outbound traffic" ) );
-    ssl->transform_earlydata = transform_earlydata;
-    mbedtls_ssl_set_outbound_transform( ssl, ssl->transform_earlydata );
+    ssl->handshake->transform_earlydata = transform_earlydata;
+    mbedtls_ssl_set_outbound_transform( ssl, ssl->handshake->transform_earlydata );
 
 #endif /* MBEDTLS_SSL_USE_MPS */
 
@@ -3224,17 +3224,17 @@ static int ssl_server_hello_postprocess( mbedtls_ssl_context* ssl )
     }
 
 #if !defined(MBEDTLS_SSL_USE_MPS)
-    ssl->transform_handshake = transform_handshake;
-    mbedtls_ssl_set_inbound_transform( ssl, ssl->transform_handshake );
+    ssl->handshake->transform_handshake = transform_handshake;
+    mbedtls_ssl_set_inbound_transform( ssl, ssl->handshake->transform_handshake );
 #else /* MBEDTLS_SSL_USE_MPS */
     ret = mbedtls_mps_add_key_material( &ssl->mps->l4,
                                         transform_handshake,
-                                        &ssl->epoch_handshake );
+                                        &ssl->handshake->epoch_handshake );
     if( ret != 0 )
         return( ret );
 
     ret = mbedtls_mps_set_incoming_keys( &ssl->mps->l4,
-                                         ssl->epoch_handshake );
+                                         ssl->handshake->epoch_handshake );
     if( ret != 0 )
         return( ret );
 #endif /* MBEDTLS_SSL_USE_MPS */

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -1318,12 +1318,12 @@ static int ssl_write_certificate_coordinate( mbedtls_ssl_context* ssl )
 
             /* Use new transform for outgoing data. */
             ret = mbedtls_mps_set_outgoing_keys( &ssl->mps->l4,
-                                                 ssl->epoch_handshake );
+                                                 ssl->handshake->epoch_handshake );
             if( ret != 0 )
                 return( ret );
         }
 #else
-        mbedtls_ssl_set_outbound_transform( ssl, ssl->transform_handshake );
+        mbedtls_ssl_set_outbound_transform( ssl, ssl->handshake->transform_handshake );
 #endif /* MBEDTLS_SSL_USE_MPS */
     }
 #endif /* MBEDTLS_SSL_CLI_C */
@@ -1593,12 +1593,12 @@ static int ssl_read_certificate_coordinate( mbedtls_ssl_context* ssl )
         {
             int ret;
             ret = mbedtls_mps_set_incoming_keys( &ssl->mps->l4,
-                                                 ssl->epoch_handshake );
+                                                 ssl->handshake->epoch_handshake );
             if( ret != 0 )
                 return( ret );
         }
 #else
-        mbedtls_ssl_set_inbound_transform( ssl, ssl->transform_handshake );
+        mbedtls_ssl_set_inbound_transform( ssl, ssl->handshake->transform_handshake );
 #endif /* MBEDTLS_SSL_USE_MPS */
     }
 #endif /* MBEDTLS_SSL_SRV_C */

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -1939,7 +1939,7 @@ static int ssl_read_early_data_coordinate( mbedtls_ssl_context* ssl )
 
 #if defined(MBEDTLS_SSL_USE_MPS)
     MBEDTLS_SSL_PROC_CHK( mbedtls_mps_set_incoming_keys( &ssl->mps->l4,
-                                                   ssl->epoch_earlydata ) );
+                                                   ssl->handshake->epoch_earlydata ) );
 
     MBEDTLS_SSL_PROC_CHK_NEG( mbedtls_mps_read( &ssl->mps->l4 ) );
     if( ret != MBEDTLS_MPS_MSG_APP )
@@ -1953,7 +1953,7 @@ cleanup:
 
 #else /* MBEDTLS_SSL_USE_MPS */
 
-    mbedtls_ssl_set_inbound_transform( ssl, ssl->transform_earlydata );
+    mbedtls_ssl_set_inbound_transform( ssl, ssl->handshake->transform_earlydata );
 
     /* Fetching step */
     if( ( ret = mbedtls_ssl_read_record( ssl, 0 ) ) != 0 )
@@ -2831,12 +2831,12 @@ static int ssl_client_hello_postprocess( mbedtls_ssl_context* ssl,
         }
 
 #if !defined(MBEDTLS_SSL_USE_MPS)
-        ssl->transform_earlydata = transform_earlydata;
+        ssl->handshake->transform_earlydata = transform_earlydata;
 #else /* MBEDTLS_SSL_USE_MPS */
         /* Register transform with MPS. */
         ret = mbedtls_mps_add_key_material( &ssl->mps->l4,
                                             transform_earlydata,
-                                            &ssl->epoch_earlydata );
+                                            &ssl->handshake->epoch_earlydata );
         if( ret != 0 )
             return( ret );
 #endif /* MBEDTLS_SSL_USE_MPS */
@@ -3043,19 +3043,19 @@ static int ssl_encrypted_extensions_prepare( mbedtls_ssl_context* ssl )
     }
 
 #if !defined(MBEDTLS_SSL_USE_MPS)
-    ssl->transform_handshake = transform_handshake;
-    mbedtls_ssl_set_outbound_transform( ssl, ssl->transform_handshake );
+    ssl->handshake->transform_handshake = transform_handshake;
+    mbedtls_ssl_set_outbound_transform( ssl, ssl->handshake->transform_handshake );
 #else /* MBEDTLS_SSL_USE_MPS */
     /* Register transform with MPS. */
     ret = mbedtls_mps_add_key_material( &ssl->mps->l4,
                                         transform_handshake,
-                                        &ssl->epoch_handshake );
+                                        &ssl->handshake->epoch_handshake );
     if( ret != 0 )
         return( ret );
 
     /* Use new transform for outgoing data. */
     ret = mbedtls_mps_set_outgoing_keys( &ssl->mps->l4,
-                                         ssl->epoch_handshake );
+                                         ssl->handshake->epoch_handshake );
     if( ret != 0 )
         return( ret );
 #endif /* MBEDTLS_SSL_USE_MPS */


### PR DESCRIPTION
The 0-RTT and handshake transforms are only needed during the handshake, and hence should be part of `mbedtls_ssl_handshake_params` and, as such, be freed after the handshake.