### PR TITLE
Fix unused variable in ssl_finished_in_postprocess

### DIFF
--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -2463,8 +2463,8 @@ static int ssl_finished_in_postprocess_cli( mbedtls_ssl_context *ssl )
 
 static int ssl_finished_in_postprocess( mbedtls_ssl_context* ssl )
 {
-    int ret;
 #if defined(MBEDTLS_SSL_SRV_C)
+    int ret;
     if( ssl->conf->endpoint == MBEDTLS_SSL_IS_SERVER )
     {
         /* Compute resumption_master_secret */


### PR DESCRIPTION
Summary:
Fix the following compiler warning.
```
/home/lhuang04/upstream/library/ssl_tls13_generic.c: In function ‘ssl_finished_in_postprocess’:
/home/lhuang04/upstream/library/ssl_tls13_generic.c:2466:9: error: unused variable ‘ret’ [-Werror=unused-variable]
     int ret;
```

Test Plan:
Apply the following patch to disable `MBEDTLS_SSL_SRV_C` and build.
```
diff --git a/include/mbedtls/mbedtls_config.h b/include/mbedtls/mbedtls_config.h
index ffaa4e3ea..b2cb9a1e4 100644
--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -2908,7 +2908,7 @@
  *
  * This module is required for SSL/TLS server support.
  */
-#define MBEDTLS_SSL_SRV_C
+//#define MBEDTLS_SSL_SRV_C

 /**
  * \def MBEDTLS_SSL_TLS_C
```

Reviewers:

Subscribers:

Tasks:

Tags:

Notes:
* Pull requests cannot be accepted until the PR follows the [contributing guidelines](../CONTRIBUTING.md). In particular, each commit must have at least one `Signed-off-by:` line from the committer to certify that the contribution is made under the terms of the [Developer Certificate of Origin](../dco.txt).
* This is just a template, so feel free to use/remove the unnecessary things
## Description
A few sentences describing the overall goals of the pull request's commits.


## Status
**READY/IN DEVELOPMENT/HOLD**

## Requires Backporting
When there is a bug fix, it should be backported to all maintained and supported branches.
Changes do not have to be backported if:
- This PR is a new feature\enhancement
- This PR contains changes in the API. If this is true, and there is a need for the fix to be backported, the fix should be handled differently in the legacy branch

Yes | NO  
Which branch?

## Migrations
If there is any API change, what's the incentive and logic for it.

YES | NO

## Additional comments
Any additional information that could be of interest

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported


## Steps to test or reproduce
Outline the steps to test or reproduce the PR here.
