### PR TITLE
Fix memory leak in mbedtls_ssl_handshake_free

### DIFF
--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -6423,9 +6423,6 @@ void mbedtls_ssl_handshake_free( mbedtls_ssl_context *ssl )
     psa_destroy_key( handshake->ecdh_psa_privkey );
 #endif /* MBEDTLS_ECDH_C && MBEDTLS_USE_PSA_CRYPTO */
 
-    mbedtls_platform_zeroize( handshake,
-                              sizeof( mbedtls_ssl_handshake_params ) );
-
 #if defined(MBEDTLS_SSL_VARIABLE_BUFFER_LENGTH)
     /* If the buffers are too big - reallocate. Because of the way Mbed TLS
      * processes datagrams and the fact that a datagram is allowed to have
@@ -6441,6 +6438,9 @@ void mbedtls_ssl_handshake_free( mbedtls_ssl_context *ssl )
     handshake->transform_earlydata = NULL;
     handshake->transform_handshake = NULL;
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
+
+    mbedtls_platform_zeroize( handshake,
+                              sizeof( mbedtls_ssl_handshake_params ) );
 }
 
 void mbedtls_ssl_session_free( mbedtls_ssl_session *session )


### PR DESCRIPTION
Summary:
We try to [mbedtls_free](https://github.com/hannestschofenig/mbedtls/blob/tls13-prototype/library/ssl_tls.c#L6439-L6440) object inside `handshake` after its address is zeroed out by [mbedtls_platform_zeroize](https://github.com/hannestschofenig/mbedtls/blob/tls13-prototype/library/ssl_tls.c#L6426)

Test Plan:
Here is from our report.
```
=================================================================
==3365627==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 256 byte(s) in 1 object(s) allocated from:
    #0 0x1ab37c7 in calloc (/data/users/lhuang04/fbsource/fbcode/buck-out/dbg/cells/fbsource/gen/aab7ed39/xplat/mobilenetwork/test/test+0x1ab37c7)
    #1 0x10f549d in ssl_server_hello_postprocess xplat/mobilenetwork/third-party/mbedtls/library/ssl_tls13_client.c:3369
    #2 0x10e7e2e in ssl_server_hello_process xplat/mobilenetwork/third-party/mbedtls/library/ssl_tls13_client.c:2864
    #3 0x10e6b6c in mbedtls_ssl_handshake_client_step_tls1_3 xplat/mobilenetwork/third-party/mbedtls/library/ssl_tls13_client.c:4175
    #4 0x10dfd77 in mbedtls_ssl_handshake_step xplat/mobilenetwork/third-party/mbedtls/library/ssl_tls.c:6090
```

Reviewers:

Subscribers:

Tasks:

Tags:

Notes:
* Pull requests cannot be accepted until the PR follows the [contributing guidelines](../CONTRIBUTING.md). In particular, each commit must have at least one `Signed-off-by:` line from the committer to certify that the contribution is made under the terms of the [Developer Certificate of Origin](../dco.txt).
* This is just a template, so feel free to use/remove the unnecessary things
## Description
A few sentences describing the overall goals of the pull request's commits.


## Status
**READY/IN DEVELOPMENT/HOLD**

## Requires Backporting
When there is a bug fix, it should be backported to all maintained and supported branches.
Changes do not have to be backported if:
- This PR is a new feature\enhancement
- This PR contains changes in the API. If this is true, and there is a need for the fix to be backported, the fix should be handled differently in the legacy branch

Yes | NO  
Which branch?

## Migrations
If there is any API change, what's the incentive and logic for it.

YES | NO

## Additional comments
Any additional information that could be of interest

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported


## Steps to test or reproduce
Outline the steps to test or reproduce the PR here.
