### PR TITLE
Add size check in ssl_session_load to fix a bug found in fuzzing

### DIFF
--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -6526,7 +6526,8 @@ static int ssl_session_load( mbedtls_ssl_session *session,
 
         session->resumption_key_len = *p++;
 
-        if( session->resumption_key_len > (size_t)( end - p ) )
+        if( session->resumption_key_len > (size_t)( end - p ) ||
+            session->resumption_key_len > sizeof( session->key ) )
             return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
 
         memcpy( session->key, p, session->resumption_key_len );


### PR DESCRIPTION
This is a bug we found while fuzzing the session load functionalities by modifying the ticket buffer. The failure looks like the following:

```
==18960==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x61500067fe70 at pc 0x00000048c734 bp 0x7ffdd9e68cb0 sp 0x7ffdd9e68460
WRITE of size 165 at 0x61500067fe70 thread T0
SCARINESS: 45 (multi-byte-write-heap-buffer-overflow)
    #0 0x48c733 in __asan_memcpy (/harnesses/a5806c367b90/MNSDecodeSessionDataMbedFuzzer+0x48c733)

    #1 0x2c78e9 in ssl_session_load xplat/mobilenetwork/third-party/mbedtls/library/ssl_tls.c:6547

    #2 0x2c78e9 in mbedtls_ssl_session_load xplat/mobilenetwork/third-party/mbedtls/library/ssl_tls.c:6804

...
```
