### PR TITLE
Add size check in ssl_session_load to fix a bug found in fuzzing

### DIFF
--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -5911,7 +5911,7 @@ static size_t ssl_session_load_tls13( mbedtls_ssl_session *session,
     session->key_len = *p++;
 
     if( session->key_len > (size_t)( end - p ) ||
-        session->key_len > sizeof(session->key) )
+        session->key_len > sizeof( session->key ) )
         return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
 
     memcpy( session->key, p, session->key_len );

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -5910,9 +5910,11 @@ static size_t ssl_session_load_tls13( mbedtls_ssl_session *session,
 
     session->key_len = *p++;
 
-    if( session->key_len > (size_t)( end - p ) ||
-        session->key_len > sizeof( session->key ) )
+    if( session->key_len > (size_t)( end - p ) )
         return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
+
+    if( session->key_len > sizeof( session->key ) )
+        return( MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL );
 
     memcpy( session->key, p, session->key_len );
     p += session->key_len;

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -5910,7 +5910,8 @@ static size_t ssl_session_load_tls13( mbedtls_ssl_session *session,
 
     session->key_len = *p++;
 
-    if( session->key_len > (size_t)( end - p ) )
+    if( session->key_len > (size_t)( end - p ) ||
+        session->key_len > sizeof(session->key) )
         return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
 
     memcpy( session->key, p, session->key_len );


### PR DESCRIPTION
This is a bug we found while fuzzing the session load functionalities by modifying the ticket buffer. The failure looks like the following:

```
==18960==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x61500067fe70 at pc 0x00000048c734 bp 0x7ffdd9e68cb0 sp 0x7ffdd9e68460
WRITE of size 165 at 0x61500067fe70 thread T0
SCARINESS: 45 (multi-byte-write-heap-buffer-overflow)
    #0 0x48c733 in __asan_memcpy (/harnesses/a5806c367b90/MNSDecodeSessionDataMbedFuzzer+0x48c733)

    #1 0x2c78e9 in ssl_session_load xplat/mobilenetwork/third-party/mbedtls/library/ssl_tls.c:6547

    #2 0x2c78e9 in mbedtls_ssl_session_load xplat/mobilenetwork/third-party/mbedtls/library/ssl_tls.c:6804
```

Content of the input data buffer to `mbedtls_ssl_session_load`, `len`=194:

```
0x612000000684: 0x02    0x19    0x00    0x00    0x03    0x00    0xff    0xa8
0x61200000068c: 0x00    0x00    0x00    0xff    0xff    0x66    0xa5    0xa5
0x612000000694: 0xa5    0xa5    0xa5    0xa5    0xa5    0xa5    0xa5    0xa5
0x61200000069c: 0xa5    0xa5    0xa5    0xa5    0xa5    0xa5    0xa5    0xa5
0x6120000006a4: 0xa5    0xa5    0xa5    0xa5    0xa5    0xa5    0xa5    0xa5
0x6120000006ac: 0xa5    0xa5    0xa5    0xa5    0xa5    0xa5    0xa5    0x02
0x6120000006b4: 0x19    0x00    0x00    0x32    0x0e    0x03    0x00    0x00
0x6120000006bc: 0x00    0x00    0x00    0x06    0x00    0x06    0x19    0x00
0x6120000006c4: 0x00    0x03    0x00    0x00    0x00    0x00    0x00    0x00
0x6120000006cc: 0x00    0x00    0x00    0x00    0x00    0x00    0x00    0x03
0x6120000006d4: 0x00    0x00    0x00    0x0c    0x43    0x00    0x00    0x00
0x6120000006dc: 0x00    0x00    0x00    0x00    0xa5    0xa5    0xa5    0xa5
0x6120000006e4: 0xa5    0xa5    0xa5    0xa5    0xa5    0x02    0x19    0x00
0x6120000006ec: 0x00    0x32    0x0e    0x03    0x00    0x00    0x00    0x00
0x6120000006f4: 0x00    0x06    0x00    0x06    0x19    0x00    0x00    0x03
0x6120000006fc: 0x00    0x00    0x19    0x00    0x00    0x32    0x0e    0x03
0x612000000704: 0x00    0x00    0x00    0x00    0x00    0x06    0x00    0x06
0x61200000070c: 0x19    0x00    0x00    0x03    0x00    0x00    0x00    0x00
0x612000000714: 0x00    0x00    0x00    0x00    0x00    0x00    0x00    0x00
0x61200000071c: 0x00    0x03    0x00    0x00    0x00    0x0c    0x43    0x00
0x612000000724: 0x00    0x00    0x00    0x00    0x00    0x00    0x00    0x00
0x61200000072c: 0x00    0x00    0x00    0x03    0x00    0x00    0x00    0x00
0x612000000734: 0x00    0x00    0x00    0x00    0x00    0x00    0x00    0x00
0x61200000073c: 0x00    0x03    0x00    0x00    0x00    0x0c    0x43    0x00
0x612000000744: 0x00    0x00
```