### PR TITLE
[0-RTT] [RFC] Reuse mbedtls_ssl_write() for sending early data

### DIFF
--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -101,6 +101,8 @@
 #define MBEDTLS_ERR_SSL_HRR_REQUIRED                      -0x7A80
 /** Received NewSessionTicket Post Handshake Message */
 #define MBEDTLS_ERR_SSL_RECEIVED_NEW_SESSION_TICKET       -0x7B00
+/** Early return when the client is ready to send early data */
+#define MBEDTLS_ERR_SSL_HANDSHAKE_EARLY_RETURN            -0x7B80
 /* Error space gap */
 /* Error space gap */
 /* Error space gap */
@@ -307,8 +309,9 @@
 #define MBEDTLS_SSL_EARLY_DATA_DISABLED        0
 #define MBEDTLS_SSL_EARLY_DATA_ENABLED         1
 
-#define MBEDTLS_SSL_EARLY_DATA_OFF        0
-#define MBEDTLS_SSL_EARLY_DATA_ON         1
+#define MBEDTLS_SSL_EARLY_DATA_STATE_DISABLED        0
+#define MBEDTLS_SSL_EARLY_DATA_STATE_OFF             1   /* early_data extension sent, cannot send early_data */
+#define MBEDTLS_SSL_EARLY_DATA_STATE_ON              2   /* early_data extension sent, can send early_data */
 
 #define MBEDTLS_SSL_FORCE_RR_CHECK_OFF      0
 #define MBEDTLS_SSL_FORCE_RR_CHECK_ON       1
@@ -1813,12 +1816,6 @@ struct mbedtls_ssl_context
     size_t MBEDTLS_PRIVATE(early_data_server_buf_len);
 #endif /* MBEDTLS_SSL_SRV_C */
 
-#if defined(MBEDTLS_SSL_CLI_C)
-    /* Pointer to early data buffer to send. */
-    const unsigned char* MBEDTLS_PRIVATE(early_data_buf);
-    /* Length of early data to send. */
-    size_t MBEDTLS_PRIVATE(early_data_len);
-#endif /* MBEDTLS_SSL_CLI_C */
 #endif /* MBEDTLS_ZERO_RTT */
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && \

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -819,6 +819,16 @@ typedef struct mbedtls_ssl_flight_item mbedtls_ssl_flight_item;
  *                 of 0-RTT and the server has accepted it.
  */
 int mbedtls_ssl_get_early_data_status( mbedtls_ssl_context *ssl );
+
+/**
+ * \brief Get whether the init of the SSL has finised.
+ *
+ * \param ssl  The SSL context to query.
+ *
+ * \returns    1 if SSL init has finished, i.e., handshake has completed.
+ */
+int mbedtls_ssl_is_init_finished( mbedtls_ssl_context *ssl );
+
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL && MBEDTLS_ZERO_RTT && MBEDTLS_SSL_CLI_C */
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && defined(MBEDTLS_SSL_NEW_SESSION_TICKET)

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -826,9 +826,10 @@ struct mbedtls_ssl_handshake_params
 #if defined(MBEDTLS_ZERO_RTT)
     mbedtls_ssl_tls1_3_early_secrets early_secrets;
 
-    /*!< Early data indication:
-    0  -- MBEDTLS_SSL_EARLY_DATA_DISABLED (for no early data), and
-    1  -- MBEDTLS_SSL_EARLY_DATA_ENABLED (for use early data)
+    /*!< Early data state
+       MBEDTLS_SSL_EARLY_DATA_STATE_DISABLED
+       MBEDTLS_SSL_EARLY_DATA_STATE_ON
+       MBEDTLS_SSL_EARLY_DATA_STATE_OFF
     */
     int early_data;
 #endif /* MBEDTLS_ZERO_RTT */

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -6019,20 +6019,36 @@ int mbedtls_ssl_write( mbedtls_ssl_context *ssl, const unsigned char *buf, size_
 #endif
 
 #if defined(MBEDTLS_ZERO_RTT)
-    /* TODO: What's the purpose of this check? */
-    if( ( ssl->handshake != NULL ) &&
-        ( ssl->handshake->early_data == MBEDTLS_SSL_EARLY_DATA_OFF ) )
+    /* Finish handshake if cannot send early data. */
+    if( ssl->handshake != NULL &&
+        ( ssl->conf->endpoint == MBEDTLS_SSL_IS_SERVER ||
+          ssl->handshake->early_data != MBEDTLS_SSL_EARLY_DATA_STATE_ON ) )
 #endif /* MBEDTLS_ZERO_RTT */
     {
         if( ssl->state != MBEDTLS_SSL_HANDSHAKE_OVER )
         {
-            if( ( ret = mbedtls_ssl_handshake( ssl ) ) != 0 )
+            ret = mbedtls_ssl_handshake( ssl );
+            if( ret != 0 && ret != MBEDTLS_ERR_SSL_HANDSHAKE_EARLY_RETURN )
             {
                 MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_handshake", ret );
                 return( ret );
             }
         }
     }
+
+#if defined(MBEDTLS_ZERO_RTT)
+    if ( ssl->handshake != NULL &&
+         ssl->conf->endpoint == MBEDTLS_SSL_IS_CLIENT &&
+         ssl->handshake->early_data == MBEDTLS_SSL_EARLY_DATA_STATE_ON )
+    {
+        ret = mbedtls_ssl_flush_output( ssl );
+        if (ret != 0 ) {
+            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_flush_output", ret );
+            return ret;
+        }
+        MBEDTLS_SSL_DEBUG_MSG( 2, ( "write early_data" ) );
+    }
+#endif /* MBEDTLS_ZERO_RTT */
 
     ret = ssl_write_real( ssl, buf, len );
 

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -3936,10 +3936,6 @@ void mbedtls_ssl_session_reset_msg_layer( mbedtls_ssl_context *ssl,
     ssl_mps_init( ssl );
 #endif /* MBEDTLS_SSL_USE_MPS */
 
-#if defined(MBEDTLS_ZERO_RTT) && defined(MBEDTLS_SSL_CLI_C)
-    ssl->early_data_buf = NULL;
-    ssl->early_data_len = 0;
-#endif /* MBEDTLS_ZERO_RTT && MBEDTLS_SSL_CLI_C */
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 }
 

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -1899,6 +1899,13 @@ int mbedtls_ssl_get_early_data_status( mbedtls_ssl_context *ssl )
     return( ssl->early_data_status );
 }
 
+int mbedtls_ssl_is_init_finished( mbedtls_ssl_context *ssl )
+{
+    if( ssl->state != MBEDTLS_SSL_HANDSHAKE_OVER )
+        return 0;
+    return 1;
+}
+
 #endif /* MBEDTLS_ZERO_RTT */
 
 #if ( defined(MBEDTLS_ECDH_C) || defined(MBEDTLS_ECDSA_C) )

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -133,11 +133,9 @@ int ssl_write_early_data_process( mbedtls_ssl_context* ssl )
         return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
 #endif /* MBEDTLS_ZERO_RTT */
     }
-    else
-    {
-        /* Update state */
-        MBEDTLS_SSL_PROC_CHK( ssl_write_early_data_postprocess( ssl ) );
-    }
+
+    /* Update state */
+    MBEDTLS_SSL_PROC_CHK( ssl_write_early_data_postprocess( ssl ) );
 
 #if defined(MBEDTLS_ZERO_RTT)
     if( early_data_status == SSL_EARLY_DATA_WRITE ) {

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -108,12 +108,6 @@ static int ssl_write_early_data_coordinate( mbedtls_ssl_context* ssl );
 
 #if defined(MBEDTLS_ZERO_RTT)
 static int ssl_write_early_data_prepare( mbedtls_ssl_context* ssl );
-
-/* Write early-data message */
-static int ssl_write_early_data_write( mbedtls_ssl_context* ssl,
-    unsigned char* buf,
-    size_t buflen,
-    size_t* olen );
 #endif /* MBEDTLS_ZERO_RTT */
 
 /* Update the state after handling the outgoing early-data message. */
@@ -126,65 +120,17 @@ static int ssl_write_early_data_postprocess( mbedtls_ssl_context* ssl );
 int ssl_write_early_data_process( mbedtls_ssl_context* ssl )
 {
     int ret;
-#if defined(MBEDTLS_SSL_USE_MPS)
-    mbedtls_writer *msg;
-    unsigned char *buf;
-    mbedtls_mps_size_t buf_len, msg_len;
-#endif /* MBEDTLS_SSL_USE_MPS */
-    MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> write early data" ) );
+    int early_data_status;
+    MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> prepare early data" ) );
 
-    MBEDTLS_SSL_PROC_CHK_NEG( ssl_write_early_data_coordinate( ssl ) );
-    if( ret == SSL_EARLY_DATA_WRITE )
+    early_data_status = ssl_write_early_data_coordinate( ssl );
+    if( early_data_status == SSL_EARLY_DATA_WRITE )
     {
 #if defined(MBEDTLS_ZERO_RTT)
-
         MBEDTLS_SSL_PROC_CHK( ssl_write_early_data_prepare( ssl ) );
-
-#if defined(MBEDTLS_SSL_USE_MPS)
-        MBEDTLS_SSL_PROC_CHK( mbedtls_mps_write_application( &ssl->mps->l4,
-                                                             &msg ) );
-
-        /* Request write-buffer */
-        MBEDTLS_SSL_PROC_CHK( mbedtls_writer_get( msg, MBEDTLS_MPS_SIZE_MAX,
-                                                  &buf, &buf_len ) );
-
-        MBEDTLS_SSL_PROC_CHK( ssl_write_early_data_write(
-                                  ssl, buf, buf_len, &msg_len ) );
-
-        /* Commit message */
-        MBEDTLS_SSL_PROC_CHK( mbedtls_writer_commit_partial( msg,
-                                                             buf_len - msg_len ) );
-
-        MBEDTLS_SSL_PROC_CHK( mbedtls_mps_dispatch( &ssl->mps->l4 ) );
-
-        /* Update state */
-        MBEDTLS_SSL_PROC_CHK( ssl_write_early_data_postprocess( ssl ) );
-
-#else  /* MBEDTLS_SSL_USE_MPS */
-
-        /* Write early-data to message buffer. */
-        MBEDTLS_SSL_PROC_CHK( ssl_write_early_data_write( ssl, ssl->out_msg,
-                                                          MBEDTLS_SSL_OUT_CONTENT_LEN,
-                                                          &ssl->out_msglen ) );
-
-        ssl->out_msgtype = MBEDTLS_SSL_MSG_APPLICATION_DATA;
-
-        /* Update state */
-        MBEDTLS_SSL_PROC_CHK( ssl_write_early_data_postprocess( ssl ) );
-
-        /* Dispatch message */
-        MBEDTLS_SSL_PROC_CHK( mbedtls_ssl_write_record( ssl, SSL_FORCE_FLUSH ) );
-
-#endif /* MBEDTLS_SSL_USE_MPS */
-
 #else /* MBEDTLS_ZERO_RTT */
-        ((void) buf);
-        ((void) buf_len);
-        ((void) msg);
-        ((void) msg_len);
         /* Should never happen */
         return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
-
 #endif /* MBEDTLS_ZERO_RTT */
     }
     else
@@ -193,9 +139,15 @@ int ssl_write_early_data_process( mbedtls_ssl_context* ssl )
         MBEDTLS_SSL_PROC_CHK( ssl_write_early_data_postprocess( ssl ) );
     }
 
+#if defined(MBEDTLS_ZERO_RTT)
+    if( early_data_status == SSL_EARLY_DATA_WRITE ) {
+        MBEDTLS_SSL_DEBUG_MSG( 3, ( "return early for 0-RTT" ) );
+        ret = MBEDTLS_ERR_SSL_HANDSHAKE_EARLY_RETURN;
+    }
+#endif
 cleanup:
 
-    MBEDTLS_SSL_DEBUG_MSG( 2, ( "<= write early data" ) );
+    MBEDTLS_SSL_DEBUG_MSG( 2, ( "<= prepare early data" ) );
     return( ret );
 }
 
@@ -203,7 +155,7 @@ cleanup:
 
 static int ssl_write_early_data_coordinate( mbedtls_ssl_context* ssl )
 {
-    if( ssl->handshake->early_data != MBEDTLS_SSL_EARLY_DATA_ON )
+    if( ssl->handshake->early_data != MBEDTLS_SSL_EARLY_DATA_STATE_ON )
         return( SSL_EARLY_DATA_SKIP );
 
     return( SSL_EARLY_DATA_WRITE );
@@ -299,34 +251,6 @@ static int ssl_write_early_data_prepare( mbedtls_ssl_context* ssl )
     return( 0 );
 }
 
-static int ssl_write_early_data_write( mbedtls_ssl_context* ssl,
-    unsigned char* buf,
-    size_t buflen,
-    size_t* olen )
-{
-    if( ssl->early_data_len > buflen )
-    {
-        MBEDTLS_SSL_DEBUG_MSG( 1, ( "buffer too small" ) );
-        return ( MBEDTLS_ERR_SSL_ALLOC_FAILED );
-    }
-    else
-    {
-        memcpy( buf, ssl->early_data_buf, ssl->early_data_len );
-
-#if defined(MBEDTLS_SSL_USE_MPS)
-        *olen = ssl->early_data_len;
-        MBEDTLS_SSL_DEBUG_BUF( 3, "Early Data", buf, ssl->early_data_len );
-#else
-        buf[ssl->early_data_len] = MBEDTLS_SSL_MSG_APPLICATION_DATA;
-        *olen = ssl->early_data_len + 1;
-
-        MBEDTLS_SSL_DEBUG_BUF( 3, "Early Data", ssl->out_msg, *olen );
-#endif /* MBEDTLS_SSL_USE_MPS */
-    }
-
-    return( 0 );
-}
-
 #else /* MBEDTLS_ZERO_RTT */
 
 static int ssl_write_early_data_coordinate( mbedtls_ssl_context* ssl )
@@ -407,7 +331,7 @@ static int ssl_write_end_of_early_data_coordinate( mbedtls_ssl_context* ssl )
     ((void) ssl);
 
 #if defined(MBEDTLS_ZERO_RTT)
-    if( ssl->handshake->early_data == MBEDTLS_SSL_EARLY_DATA_ON )
+    if( ssl->handshake->early_data != MBEDTLS_SSL_EARLY_DATA_STATE_DISABLED)
     {
         if( ssl->early_data_status == MBEDTLS_SSL_EARLY_DATA_ACCEPTED )
             return( SSL_END_OF_EARLY_DATA_WRITE );
@@ -1944,7 +1868,7 @@ int ssl_parse_encrypted_extensions_early_data_ext( mbedtls_ssl_context *ssl,
                                                    const unsigned char *buf,
                                                    size_t len )
 {
-    if( ssl->handshake->early_data != MBEDTLS_SSL_EARLY_DATA_ON )
+    if( ssl->handshake->early_data == MBEDTLS_SSL_EARLY_DATA_STATE_DISABLED )
     {
         /* The server must not send the EarlyDataIndication if the
          * client hasn't indicated the use of 0-RTT. */
@@ -1975,16 +1899,6 @@ int mbedtls_ssl_get_early_data_status( mbedtls_ssl_context *ssl )
     return( ssl->early_data_status );
 }
 
-int mbedtls_ssl_set_early_data( mbedtls_ssl_context *ssl,
-                                const unsigned char *buffer, size_t len )
-{
-    if( buffer == NULL || len == 0 )
-        return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
-
-    ssl->early_data_buf = buffer;
-    ssl->early_data_len = len;
-    return( 0 );
-}
 #endif /* MBEDTLS_ZERO_RTT */
 
 #if ( defined(MBEDTLS_ECDH_C) || defined(MBEDTLS_ECDSA_C) )
@@ -2579,7 +2493,7 @@ static int ssl_encrypted_extensions_parse( mbedtls_ssl_context* ssl,
                     ssl, ext + 4, ext_size );
                 if( ret != 0 )
                 {
-                    MBEDTLS_SSL_DEBUG_RET( 1, "ssl_parse_early_data_ext", ret );
+                    MBEDTLS_SSL_DEBUG_RET( 1, "ssl_parse_encrypted_extensions_early_data_ext", ret );
                     return( ret );
                 }
                 break;
@@ -2599,6 +2513,15 @@ static int ssl_encrypted_extensions_parse( mbedtls_ssl_context* ssl,
             return( MBEDTLS_ERR_SSL_DECODE_ERROR );
         }
     }
+
+#if defined(MBEDTLS_ZERO_RTT)
+    if( mbedtls_ssl_get_early_data_status(ssl) == MBEDTLS_SSL_EARLY_DATA_REJECTED ) {
+         MBEDTLS_SSL_DEBUG_MSG( 2, ( "early data rejected by server" ) );
+        ssl->handshake->early_data = MBEDTLS_SSL_EARLY_DATA_STATE_OFF;
+    }
+#endif /* MBEDTLS_ZERO_RTT */
+
+    MBEDTLS_SSL_DEBUG_MSG( 2, ( "<= parse encrypted extension" ) );
 
     return( ret );
 }
@@ -2713,6 +2636,9 @@ static int ssl_server_hello_process( mbedtls_ssl_context* ssl )
 
         mbedtls_ssl_add_hs_msg_to_checksum( ssl, MBEDTLS_SSL_HS_SERVER_HELLO,
                                             buf, buflen );
+
+        MBEDTLS_SSL_DEBUG_MSG( 2, ( "received hello_retry, turn off early_data" ) );
+        ssl->handshake->early_data = MBEDTLS_SSL_EARLY_DATA_STATE_OFF;
 
 #if defined(MBEDTLS_SSL_USE_MPS)
         MBEDTLS_SSL_PROC_CHK( mbedtls_mps_reader_commit( msg.handle ) );
@@ -3947,6 +3873,10 @@ int mbedtls_ssl_handshake_client_step_tls1_3( mbedtls_ssl_context *ssl )
 
         case MBEDTLS_SSL_EARLY_APP_DATA:
             ret = ssl_write_early_data_process( ssl );
+	    if( ret != 0 && ret != MBEDTLS_ERR_SSL_HANDSHAKE_EARLY_RETURN )
+	    {
+	      MBEDTLS_SSL_DEBUG_RET( 1, "ssl_write_early_data_process", ret );
+	    }
             break;
 
         /*
@@ -3989,6 +3919,8 @@ int mbedtls_ssl_handshake_client_step_tls1_3( mbedtls_ssl_context *ssl )
          */
         case MBEDTLS_SSL_END_OF_EARLY_DATA:
             ret = ssl_write_end_of_early_data_process( ssl );
+	    if( ret == 0 )
+	      ssl->handshake->early_data = MBEDTLS_SSL_EARLY_DATA_STATE_OFF;
             break;
 
         case MBEDTLS_SSL_CLIENT_CERTIFICATE:

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -2564,7 +2564,7 @@ int mbedtls_ssl_write_early_data_ext( mbedtls_ssl_context *ssl,
             ssl->conf->early_data_enabled == MBEDTLS_SSL_EARLY_DATA_DISABLED )
         {
             MBEDTLS_SSL_DEBUG_MSG( 2, ( "<= skip write early_data extension" ) );
-            ssl->handshake->early_data = MBEDTLS_SSL_EARLY_DATA_OFF;
+            ssl->handshake->early_data = MBEDTLS_SSL_EARLY_DATA_STATE_DISABLED;
             return( 0 );
         }
     }
@@ -2581,7 +2581,7 @@ int mbedtls_ssl_write_early_data_ext( mbedtls_ssl_context *ssl,
             ssl->conf->early_data_enabled == MBEDTLS_SSL_EARLY_DATA_DISABLED )
         {
             MBEDTLS_SSL_DEBUG_MSG( 2, ( "<= skip write early_data extension" ) );
-            ssl->handshake->early_data = MBEDTLS_SSL_EARLY_DATA_OFF;
+            ssl->handshake->early_data = MBEDTLS_SSL_EARLY_DATA_STATE_DISABLED;
             return( 0 );
         }
     }
@@ -2610,7 +2610,7 @@ int mbedtls_ssl_write_early_data_ext( mbedtls_ssl_context *ssl,
     }
 #endif /* MBEDTLS_SSL_SRV_C */
 
-    ssl->handshake->early_data = MBEDTLS_SSL_EARLY_DATA_ON;
+    ssl->handshake->early_data = MBEDTLS_SSL_EARLY_DATA_STATE_ON;
 
     /* Write extension header */
     *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_EARLY_DATA >> 8 ) & 0xFF );

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -1764,7 +1764,7 @@ static int ssl_read_end_of_early_data_coordinate( mbedtls_ssl_context* ssl )
 #else /* MBEDTLS_ZERO_RTT */
 static int ssl_read_end_of_early_data_coordinate( mbedtls_ssl_context* ssl )
 {
-    if( ssl->handshake->early_data != MBEDTLS_SSL_EARLY_DATA_ON )
+    if( ssl->handshake->early_data != MBEDTLS_SSL_EARLY_DATA_STATE_ON )
         return( SSL_END_OF_EARLY_DATA_SKIP );
 
     return( SSL_END_OF_EARLY_DATA_EXPECT );
@@ -1933,7 +1933,7 @@ static int ssl_read_early_data_coordinate( mbedtls_ssl_context* ssl )
 {
     int ret;
 
-    if( ssl->handshake->early_data != MBEDTLS_SSL_EARLY_DATA_ON )
+    if( ssl->handshake->early_data != MBEDTLS_SSL_EARLY_DATA_STATE_ON )
         return( SSL_EARLY_DATA_SKIP );
 
     /* Activate early data transform */
@@ -1994,7 +1994,7 @@ static int ssl_read_early_data_parse( mbedtls_ssl_context* ssl,
     else
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "Buffer too small (recv %" MBEDTLS_PRINTF_SIZET " bytes, buffer %" MBEDTLS_PRINTF_SIZET " bytes)",
-                                    buflen, ssl->conf->max_early_data ) );
+                                    buflen, ssl->early_data_server_buf ) );
         return ( MBEDTLS_ERR_SSL_ALLOC_FAILED );
     }
 
@@ -2245,7 +2245,7 @@ static int ssl_check_use_0rtt_handshake( mbedtls_ssl_context *ssl )
     }
 
     /* Accept 0-RTT */
-    ssl->handshake->early_data = MBEDTLS_SSL_EARLY_DATA_ON;
+    ssl->handshake->early_data = MBEDTLS_SSL_EARLY_DATA_STATE_ON;
     return( 0 );
 }
 #endif /* MBEDTLS_ZERO_RTT*/
@@ -2804,7 +2804,7 @@ static int ssl_client_hello_postprocess( mbedtls_ssl_context* ssl,
     }
 
 #if defined(MBEDTLS_ZERO_RTT)
-    if( ssl->handshake->early_data == MBEDTLS_SSL_EARLY_DATA_ON )
+    if( ssl->handshake->early_data == MBEDTLS_SSL_EARLY_DATA_STATE_ON )
     {
         mbedtls_ssl_transform *transform_earlydata;
 

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -1994,7 +1994,7 @@ static int ssl_read_early_data_parse( mbedtls_ssl_context* ssl,
     else
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "Buffer too small (recv %" MBEDTLS_PRINTF_SIZET " bytes, buffer %" MBEDTLS_PRINTF_SIZET " bytes)",
-                                    buflen, ssl->early_data_server_buf ) );
+                                    buflen, ssl->conf->max_early_data ) );
         return ( MBEDTLS_ERR_SSL_ALLOC_FAILED );
     }
 

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -2154,8 +2154,6 @@ int main( int argc, char *argv[] )
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && defined(MBEDTLS_ZERO_RTT)
     mbedtls_ssl_conf_early_data( &conf, opt.early_data, 0, NULL );
-    mbedtls_ssl_set_early_data( &ssl, (const unsigned char*) early_data,
-                                strlen( early_data ) );
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL && MBEDTLS_ZERO_RTT */
 
     if( ( ret = mbedtls_ssl_setup( &ssl, &conf ) ) != 0 )
@@ -2278,7 +2276,13 @@ int main( int argc, char *argv[] )
 
     while( ( ret = mbedtls_ssl_handshake( &ssl ) ) != 0 )
     {
-        if( ret != MBEDTLS_ERR_SSL_WANT_READ &&
+        if ( ret == MBEDTLS_ERR_SSL_HANDSHAKE_EARLY_RETURN &&
+             opt.early_data == MBEDTLS_SSL_EARLY_DATA_ENABLED )
+        {
+            ret = mbedtls_ssl_write( &ssl, (const unsigned char*) early_data, strlen(early_data) );
+        }
+        if( ret < 0 &&
+            ret != MBEDTLS_ERR_SSL_WANT_READ &&
             ret != MBEDTLS_ERR_SSL_WANT_WRITE &&
             ret != MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS )
         {
@@ -3195,12 +3199,6 @@ reconnect:
         }
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 
-#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && defined(MBEDTLS_ZERO_RTT)
-        mbedtls_ssl_set_early_data( &ssl, (const unsigned char*) early_data,
-                                    strlen( early_data ) );
-#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL && MBEDTLS_ZERO_RTT */
-
-
         if( ( ret = mbedtls_net_connect( &server_fd,
                         opt.server_addr, opt.server_port,
                         opt.transport == MBEDTLS_SSL_TRANSPORT_STREAM ?
@@ -3224,7 +3222,14 @@ reconnect:
 
         while( ( ret = mbedtls_ssl_handshake( &ssl ) ) != 0 )
         {
-            if( ret != MBEDTLS_ERR_SSL_WANT_READ &&
+            if ( ret == MBEDTLS_ERR_SSL_HANDSHAKE_EARLY_RETURN &&
+                 opt.early_data == MBEDTLS_SSL_EARLY_DATA_ENABLED )
+            {
+                ret = mbedtls_ssl_write( &ssl, (const unsigned char*) early_data, strlen(early_data) );
+            }
+
+            if( ret < 0 &&
+                ret != MBEDTLS_ERR_SSL_WANT_READ &&
                 ret != MBEDTLS_ERR_SSL_WANT_WRITE &&
                 ret != MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS )
             {


### PR DESCRIPTION
This PR changes the API for sending early data on the client side. It deprecates the `mbedtls_ssl_set_early_data()` method and reuses `mbedtls_ssl_write()` method for sending early data. An alternative design is in #369.

## Changes proposed

1. Add an error code `MBEDTLS_ERR_SSL_HANDSHAKE_EARLY_RETURN` for early return. Handshake returns with this error indicating the user can start sending early data. Calling `mbedtls_ssl_handshake()` again will continue the handshake. This pattern is similar to the handling of `NewSessionTicket`.  
1. Rename `MBEDTLS_SSL_EARLY_DATA_ON|OFF` to `MBEDTLS_SSL_EARLY_DATA_STATE_DISABLED |ON|OFF` as these values represent the *state* of the client, rather than a configuration. When early data is enabled, the early_data state is initially ON, it will be turned to OFF if early data is rejected, a HRR is received, or max_early_data is reached (to add).

## Status
**DRAFT, solicit early feedback on design.**

## Requires Backporting
NO  

## Migrations


## Additional comments
Any additional information that could be of interest

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported


## Steps to test or reproduce
Outline the steps to test or reproduce the PR here.

Start openssl server using
```
/usr/local/opt/openssl/bin/openssl s_server -key server5.key -cert server5.crt -accept 1234 -early_data -state
```

Then try
```
./ssl_client2 server_name=localhost server_port=1234 auth_mode=none reconnect=1 early_data=1 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384  key_share_named_groups=secp384r1
```