### PR TITLE
[0-RTT][RFC] Create dedicated API for sending early_data.

### DIFF
--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -1289,7 +1289,7 @@
  *
  * TODO: Document
  */
-#define MBEDTLS_SSL_USE_MPS
+// #define MBEDTLS_SSL_USE_MPS
 
 /**
  * \def MBEDTLS_SSL_DTLS_CONNECTION_ID

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -101,6 +101,8 @@
 #define MBEDTLS_ERR_SSL_HRR_REQUIRED                      -0x7A80
 /** Received NewSessionTicket Post Handshake Message */
 #define MBEDTLS_ERR_SSL_RECEIVED_NEW_SESSION_TICKET       -0x7B00
+/** Early return when the client is ready to send early data */
+#define MBEDTLS_ERR_SSL_HANDSHAKE_EARLY_RETURN            -0x7B80
 /* Error space gap */
 /* Error space gap */
 /* Error space gap */
@@ -307,8 +309,9 @@
 #define MBEDTLS_SSL_EARLY_DATA_DISABLED        0
 #define MBEDTLS_SSL_EARLY_DATA_ENABLED         1
 
-#define MBEDTLS_SSL_EARLY_DATA_OFF        0
-#define MBEDTLS_SSL_EARLY_DATA_ON         1
+#define MBEDTLS_SSL_EARLY_DATA_STATE_DISABLED        0
+#define MBEDTLS_SSL_EARLY_DATA_STATE_OFF             1   /* early_data extension sent, cannot send early_data */
+#define MBEDTLS_SSL_EARLY_DATA_STATE_ON              2   /* early_data extension sent, can send early_data */
 
 #define MBEDTLS_SSL_FORCE_RR_CHECK_OFF      0
 #define MBEDTLS_SSL_FORCE_RR_CHECK_ON       1
@@ -1813,12 +1816,6 @@ struct mbedtls_ssl_context
     size_t MBEDTLS_PRIVATE(early_data_server_buf_len);
 #endif /* MBEDTLS_SSL_SRV_C */
 
-#if defined(MBEDTLS_SSL_CLI_C)
-    /* Pointer to early data buffer to send. */
-    const unsigned char* MBEDTLS_PRIVATE(early_data_buf);
-    /* Length of early data to send. */
-    size_t MBEDTLS_PRIVATE(early_data_len);
-#endif /* MBEDTLS_SSL_CLI_C */
 #endif /* MBEDTLS_ZERO_RTT */
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && \
@@ -1993,10 +1990,6 @@ void mbedtls_ssl_conf_early_data( mbedtls_ssl_config* conf, int early_data,
                                                              const unsigned char*,
                                                              size_t ) );
 
-#if defined(MBEDTLS_SSL_CLI_C)
-int mbedtls_ssl_set_early_data( mbedtls_ssl_context* ssl, const unsigned char* buffer,
-                                size_t len );
-#endif /* MBEDTLS_SSL_CLI_C */
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL && MBEDTLS_ZERO_RTT */
 
 #if defined(MBEDTLS_X509_CRT_PARSE_C)
@@ -4550,6 +4543,11 @@ int mbedtls_ssl_read( mbedtls_ssl_context *ssl, unsigned char *buf, size_t len )
  *                 application record being sent.
  */
 int mbedtls_ssl_write( mbedtls_ssl_context *ssl, const unsigned char *buf, size_t len );
+
+#if defined(MBEDTLS_ZERO_RTT)
+/** TODO: Add documentation. */
+int mbedtls_ssl_write_early_data( mbedtls_ssl_context *ssl, const unsigned char *buf, size_t len );
+#endif /* MBEDTLS_ZERO_RTT*/
 
 /**
  * \brief           Send an alert message

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -826,10 +826,6 @@ struct mbedtls_ssl_handshake_params
 #if defined(MBEDTLS_ZERO_RTT)
     mbedtls_ssl_tls1_3_early_secrets early_secrets;
 
-    /*!< Early data indication:
-    0  -- MBEDTLS_SSL_EARLY_DATA_DISABLED (for no early data), and
-    1  -- MBEDTLS_SSL_EARLY_DATA_ENABLED (for use early data)
-    */
     int early_data;
 #endif /* MBEDTLS_ZERO_RTT */
 

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -6050,11 +6050,24 @@ int mbedtls_ssl_write_early_data( mbedtls_ssl_context *ssl, const unsigned char 
     if( ssl == NULL || ssl->conf == NULL )
         return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
 
+    // Perform early handshake if necessary
+    if( ssl->state == MBEDTLS_SSL_HELLO_REQUEST ||
+        ssl->state == MBEDTLS_SSL_CLIENT_HELLO ||
+        ssl->state == MBEDTLS_SSL_EARLY_APP_DATA )
+    {
+        ret = mbedtls_ssl_handshake( ssl );
+        if( ret != MBEDTLS_ERR_SSL_HANDSHAKE_EARLY_RETURN && ret != 0 )
+        {
+            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_handshake", ret );
+            return( ret );
+        }
+    }
+
     if( ( ssl->state == MBEDTLS_SSL_HANDSHAKE_OVER ) ||
         ( ssl->handshake->early_data != MBEDTLS_SSL_EARLY_DATA_STATE_ON ) )
     {
         MBEDTLS_SSL_DEBUG_MSG( 2, ( "cannot send early_data" ) );
-        return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA ); // TODO: use a different error code.
+        return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
     }
 
 #if defined(MBEDTLS_SSL_RENEGOTIATION)

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -6018,19 +6018,15 @@ int mbedtls_ssl_write( mbedtls_ssl_context *ssl, const unsigned char *buf, size_
     }
 #endif
 
-#if defined(MBEDTLS_ZERO_RTT)
-    /* TODO: What's the purpose of this check? */
-    if( ( ssl->handshake != NULL ) &&
-        ( ssl->handshake->early_data == MBEDTLS_SSL_EARLY_DATA_OFF ) )
-#endif /* MBEDTLS_ZERO_RTT */
+    if( ssl->state != MBEDTLS_SSL_HANDSHAKE_OVER )
     {
-        if( ssl->state != MBEDTLS_SSL_HANDSHAKE_OVER )
+        ret = mbedtls_ssl_handshake( ssl );
+        if( ret == MBEDTLS_ERR_SSL_HANDSHAKE_EARLY_RETURN )
+            ret = mbedtls_ssl_handshake( ssl );
+        if( ret != 0 )
         {
-            if( ( ret = mbedtls_ssl_handshake( ssl ) ) != 0 )
-            {
-                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_handshake", ret );
-                return( ret );
-            }
+            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_handshake", ret );
+            return( ret );
         }
     }
 
@@ -6040,6 +6036,49 @@ int mbedtls_ssl_write( mbedtls_ssl_context *ssl, const unsigned char *buf, size_
 
     return( ret );
 }
+
+#if defined(MBEDTLS_ZERO_RTT)
+/*
+ * Write application data as early data (public-facing wrapper)
+ */
+int mbedtls_ssl_write_early_data( mbedtls_ssl_context *ssl, const unsigned char *buf, size_t len )
+{
+    int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
+
+    MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> write early_data" ) );
+
+    if( ssl == NULL || ssl->conf == NULL )
+        return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
+
+    if( ( ssl->state == MBEDTLS_SSL_HANDSHAKE_OVER ) ||
+        ( ssl->handshake->early_data != MBEDTLS_SSL_EARLY_DATA_STATE_ON ) )
+    {
+        MBEDTLS_SSL_DEBUG_MSG( 2, ( "cannot send early_data" ) );
+        return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA ); // TODO: use a different error code.
+    }
+
+#if defined(MBEDTLS_SSL_RENEGOTIATION)
+    if( ( ret = ssl_check_ctr_renegotiate( ssl ) ) != 0 )
+    {
+        MBEDTLS_SSL_DEBUG_RET( 1, "ssl_check_ctr_renegotiate", ret );
+        return( ret );
+    }
+#endif
+
+    ret = mbedtls_ssl_flush_output( ssl );
+    if ( ret != 0 )
+    {
+        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_flush_output", ret );
+        return ret;
+    }
+
+    ret = ssl_write_real( ssl, buf, len );
+
+    MBEDTLS_SSL_DEBUG_MSG( 2, ( "<= write early_data" ) );
+
+    return( ret );
+}
+#endif /* MBEDTLS_ZERO_RTT*/
 
 /*
  * Notify the peer that the connection is being closed

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -3936,10 +3936,6 @@ void mbedtls_ssl_session_reset_msg_layer( mbedtls_ssl_context *ssl,
     ssl_mps_init( ssl );
 #endif /* MBEDTLS_SSL_USE_MPS */
 
-#if defined(MBEDTLS_ZERO_RTT) && defined(MBEDTLS_SSL_CLI_C)
-    ssl->early_data_buf = NULL;
-    ssl->early_data_len = 0;
-#endif /* MBEDTLS_ZERO_RTT && MBEDTLS_SSL_CLI_C */
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 }
 

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -109,11 +109,6 @@ static int ssl_write_early_data_coordinate( mbedtls_ssl_context* ssl );
 #if defined(MBEDTLS_ZERO_RTT)
 static int ssl_write_early_data_prepare( mbedtls_ssl_context* ssl );
 
-/* Write early-data message */
-static int ssl_write_early_data_write( mbedtls_ssl_context* ssl,
-    unsigned char* buf,
-    size_t buflen,
-    size_t* olen );
 #endif /* MBEDTLS_ZERO_RTT */
 
 /* Update the state after handling the outgoing early-data message. */
@@ -126,75 +121,34 @@ static int ssl_write_early_data_postprocess( mbedtls_ssl_context* ssl );
 int ssl_write_early_data_process( mbedtls_ssl_context* ssl )
 {
     int ret;
-#if defined(MBEDTLS_SSL_USE_MPS)
-    mbedtls_writer *msg;
-    unsigned char *buf;
-    mbedtls_mps_size_t buf_len, msg_len;
-#endif /* MBEDTLS_SSL_USE_MPS */
-    MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> write early data" ) );
+    int early_data_status;
 
-    MBEDTLS_SSL_PROC_CHK_NEG( ssl_write_early_data_coordinate( ssl ) );
-    if( ret == SSL_EARLY_DATA_WRITE )
+    MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> prepare early data" ) );
+
+    early_data_status = ssl_write_early_data_coordinate( ssl );
+    if( early_data_status == SSL_EARLY_DATA_WRITE )
     {
 #if defined(MBEDTLS_ZERO_RTT)
-
         MBEDTLS_SSL_PROC_CHK( ssl_write_early_data_prepare( ssl ) );
 
-#if defined(MBEDTLS_SSL_USE_MPS)
-        MBEDTLS_SSL_PROC_CHK( mbedtls_mps_write_application( &ssl->mps->l4,
-                                                             &msg ) );
-
-        /* Request write-buffer */
-        MBEDTLS_SSL_PROC_CHK( mbedtls_writer_get( msg, MBEDTLS_MPS_SIZE_MAX,
-                                                  &buf, &buf_len ) );
-
-        MBEDTLS_SSL_PROC_CHK( ssl_write_early_data_write(
-                                  ssl, buf, buf_len, &msg_len ) );
-
-        /* Commit message */
-        MBEDTLS_SSL_PROC_CHK( mbedtls_writer_commit_partial( msg,
-                                                             buf_len - msg_len ) );
-
-        MBEDTLS_SSL_PROC_CHK( mbedtls_mps_dispatch( &ssl->mps->l4 ) );
-
-        /* Update state */
-        MBEDTLS_SSL_PROC_CHK( ssl_write_early_data_postprocess( ssl ) );
-
-#else  /* MBEDTLS_SSL_USE_MPS */
-
-        /* Write early-data to message buffer. */
-        MBEDTLS_SSL_PROC_CHK( ssl_write_early_data_write( ssl, ssl->out_msg,
-                                                          MBEDTLS_SSL_OUT_CONTENT_LEN,
-                                                          &ssl->out_msglen ) );
-
-        ssl->out_msgtype = MBEDTLS_SSL_MSG_APPLICATION_DATA;
-
-        /* Update state */
-        MBEDTLS_SSL_PROC_CHK( ssl_write_early_data_postprocess( ssl ) );
-
-        /* Dispatch message */
-        MBEDTLS_SSL_PROC_CHK( mbedtls_ssl_write_record( ssl, SSL_FORCE_FLUSH ) );
-
-#endif /* MBEDTLS_SSL_USE_MPS */
-
 #else /* MBEDTLS_ZERO_RTT */
-        ((void) buf);
-        ((void) buf_len);
-        ((void) msg);
-        ((void) msg_len);
+
         /* Should never happen */
         return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
 
 #endif /* MBEDTLS_ZERO_RTT */
     }
-    else
-    {
-        /* Update state */
-        MBEDTLS_SSL_PROC_CHK( ssl_write_early_data_postprocess( ssl ) );
+    /* Update state */
+    MBEDTLS_SSL_PROC_CHK( ssl_write_early_data_postprocess( ssl ) );
+
+#if defined(MBEDTLS_ZERO_RTT)
+    if( early_data_status == SSL_EARLY_DATA_WRITE ) {
+        MBEDTLS_SSL_DEBUG_MSG( 3, ( "return early for 0-RTT" ) );
+        ret = MBEDTLS_ERR_SSL_HANDSHAKE_EARLY_RETURN;
     }
+#endif
 
 cleanup:
-
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "<= write early data" ) );
     return( ret );
 }
@@ -203,7 +157,7 @@ cleanup:
 
 static int ssl_write_early_data_coordinate( mbedtls_ssl_context* ssl )
 {
-    if( ssl->handshake->early_data != MBEDTLS_SSL_EARLY_DATA_ON )
+    if( ssl->handshake->early_data != MBEDTLS_SSL_EARLY_DATA_STATE_ON )
         return( SSL_EARLY_DATA_SKIP );
 
     return( SSL_EARLY_DATA_WRITE );
@@ -299,34 +253,6 @@ static int ssl_write_early_data_prepare( mbedtls_ssl_context* ssl )
     return( 0 );
 }
 
-static int ssl_write_early_data_write( mbedtls_ssl_context* ssl,
-    unsigned char* buf,
-    size_t buflen,
-    size_t* olen )
-{
-    if( ssl->early_data_len > buflen )
-    {
-        MBEDTLS_SSL_DEBUG_MSG( 1, ( "buffer too small" ) );
-        return ( MBEDTLS_ERR_SSL_ALLOC_FAILED );
-    }
-    else
-    {
-        memcpy( buf, ssl->early_data_buf, ssl->early_data_len );
-
-#if defined(MBEDTLS_SSL_USE_MPS)
-        *olen = ssl->early_data_len;
-        MBEDTLS_SSL_DEBUG_BUF( 3, "Early Data", buf, ssl->early_data_len );
-#else
-        buf[ssl->early_data_len] = MBEDTLS_SSL_MSG_APPLICATION_DATA;
-        *olen = ssl->early_data_len + 1;
-
-        MBEDTLS_SSL_DEBUG_BUF( 3, "Early Data", ssl->out_msg, *olen );
-#endif /* MBEDTLS_SSL_USE_MPS */
-    }
-
-    return( 0 );
-}
-
 #else /* MBEDTLS_ZERO_RTT */
 
 static int ssl_write_early_data_coordinate( mbedtls_ssl_context* ssl )
@@ -407,7 +333,7 @@ static int ssl_write_end_of_early_data_coordinate( mbedtls_ssl_context* ssl )
     ((void) ssl);
 
 #if defined(MBEDTLS_ZERO_RTT)
-    if( ssl->handshake->early_data == MBEDTLS_SSL_EARLY_DATA_ON )
+    if( ssl->handshake->early_data != MBEDTLS_SSL_EARLY_DATA_STATE_DISABLED )
     {
         if( ssl->early_data_status == MBEDTLS_SSL_EARLY_DATA_ACCEPTED )
             return( SSL_END_OF_EARLY_DATA_WRITE );
@@ -1944,7 +1870,7 @@ int ssl_parse_encrypted_extensions_early_data_ext( mbedtls_ssl_context *ssl,
                                                    const unsigned char *buf,
                                                    size_t len )
 {
-    if( ssl->handshake->early_data != MBEDTLS_SSL_EARLY_DATA_ON )
+    if( ssl->handshake->early_data == MBEDTLS_SSL_EARLY_DATA_STATE_DISABLED )
     {
         /* The server must not send the EarlyDataIndication if the
          * client hasn't indicated the use of 0-RTT. */
@@ -1975,16 +1901,6 @@ int mbedtls_ssl_get_early_data_status( mbedtls_ssl_context *ssl )
     return( ssl->early_data_status );
 }
 
-int mbedtls_ssl_set_early_data( mbedtls_ssl_context *ssl,
-                                const unsigned char *buffer, size_t len )
-{
-    if( buffer == NULL || len == 0 )
-        return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
-
-    ssl->early_data_buf = buffer;
-    ssl->early_data_len = len;
-    return( 0 );
-}
 #endif /* MBEDTLS_ZERO_RTT */
 
 #if ( defined(MBEDTLS_ECDH_C) || defined(MBEDTLS_ECDSA_C) )
@@ -2579,7 +2495,7 @@ static int ssl_encrypted_extensions_parse( mbedtls_ssl_context* ssl,
                     ssl, ext + 4, ext_size );
                 if( ret != 0 )
                 {
-                    MBEDTLS_SSL_DEBUG_RET( 1, "ssl_parse_early_data_ext", ret );
+                    MBEDTLS_SSL_DEBUG_RET( 1, "ssl_parse_encrypted_extensions_early_data_ext", ret );
                     return( ret );
                 }
                 break;
@@ -2600,6 +2516,15 @@ static int ssl_encrypted_extensions_parse( mbedtls_ssl_context* ssl,
         }
     }
 
+#if defined(MBEDTLS_ZERO_RTT)
+    if( mbedtls_ssl_get_early_data_status( ssl ) == MBEDTLS_SSL_EARLY_DATA_REJECTED )
+    {
+        MBEDTLS_SSL_DEBUG_MSG( 2, ( "early data rejected by server" ) );
+        ssl->handshake->early_data = MBEDTLS_SSL_EARLY_DATA_STATE_OFF;
+    }
+#endif /* MBEDTLS_ZERO_RTT */
+
+    MBEDTLS_SSL_DEBUG_MSG( 2, ( "<= parse encrypted extension" ) );
     return( ret );
 }
 
@@ -2713,6 +2638,9 @@ static int ssl_server_hello_process( mbedtls_ssl_context* ssl )
 
         mbedtls_ssl_add_hs_msg_to_checksum( ssl, MBEDTLS_SSL_HS_SERVER_HELLO,
                                             buf, buflen );
+
+        MBEDTLS_SSL_DEBUG_MSG( 2, ( "received hello_retry, turn off early_data" ) );
+        ssl->handshake->early_data = MBEDTLS_SSL_EARLY_DATA_STATE_OFF;
 
 #if defined(MBEDTLS_SSL_USE_MPS)
         MBEDTLS_SSL_PROC_CHK( mbedtls_mps_reader_commit( msg.handle ) );
@@ -3947,6 +3875,10 @@ int mbedtls_ssl_handshake_client_step_tls1_3( mbedtls_ssl_context *ssl )
 
         case MBEDTLS_SSL_EARLY_APP_DATA:
             ret = ssl_write_early_data_process( ssl );
+            if( ret != 0 && ret != MBEDTLS_ERR_SSL_HANDSHAKE_EARLY_RETURN )
+	        {
+	            MBEDTLS_SSL_DEBUG_RET( 1, "ssl_write_early_data_process", ret );
+	        }
             break;
 
         /*
@@ -3989,6 +3921,8 @@ int mbedtls_ssl_handshake_client_step_tls1_3( mbedtls_ssl_context *ssl )
          */
         case MBEDTLS_SSL_END_OF_EARLY_DATA:
             ret = ssl_write_end_of_early_data_process( ssl );
+            if( ret == 0 )
+	            ssl->handshake->early_data = MBEDTLS_SSL_EARLY_DATA_STATE_OFF;
             break;
 
         case MBEDTLS_SSL_CLIENT_CERTIFICATE:

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -2564,7 +2564,7 @@ int mbedtls_ssl_write_early_data_ext( mbedtls_ssl_context *ssl,
             ssl->conf->early_data_enabled == MBEDTLS_SSL_EARLY_DATA_DISABLED )
         {
             MBEDTLS_SSL_DEBUG_MSG( 2, ( "<= skip write early_data extension" ) );
-            ssl->handshake->early_data = MBEDTLS_SSL_EARLY_DATA_OFF;
+            ssl->handshake->early_data = MBEDTLS_SSL_EARLY_DATA_STATE_DISABLED;
             return( 0 );
         }
     }
@@ -2581,7 +2581,7 @@ int mbedtls_ssl_write_early_data_ext( mbedtls_ssl_context *ssl,
             ssl->conf->early_data_enabled == MBEDTLS_SSL_EARLY_DATA_DISABLED )
         {
             MBEDTLS_SSL_DEBUG_MSG( 2, ( "<= skip write early_data extension" ) );
-            ssl->handshake->early_data = MBEDTLS_SSL_EARLY_DATA_OFF;
+            ssl->handshake->early_data = MBEDTLS_SSL_EARLY_DATA_STATE_DISABLED;
             return( 0 );
         }
     }
@@ -2610,7 +2610,7 @@ int mbedtls_ssl_write_early_data_ext( mbedtls_ssl_context *ssl,
     }
 #endif /* MBEDTLS_SSL_SRV_C */
 
-    ssl->handshake->early_data = MBEDTLS_SSL_EARLY_DATA_ON;
+    ssl->handshake->early_data = MBEDTLS_SSL_EARLY_DATA_STATE_ON;
 
     /* Write extension header */
     *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_EARLY_DATA >> 8 ) & 0xFF );

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -1764,7 +1764,7 @@ static int ssl_read_end_of_early_data_coordinate( mbedtls_ssl_context* ssl )
 #else /* MBEDTLS_ZERO_RTT */
 static int ssl_read_end_of_early_data_coordinate( mbedtls_ssl_context* ssl )
 {
-    if( ssl->handshake->early_data != MBEDTLS_SSL_EARLY_DATA_ON )
+    if( ssl->handshake->early_data != MBEDTLS_SSL_EARLY_DATA_STATE_ON )
         return( SSL_END_OF_EARLY_DATA_SKIP );
 
     return( SSL_END_OF_EARLY_DATA_EXPECT );
@@ -1933,7 +1933,7 @@ static int ssl_read_early_data_coordinate( mbedtls_ssl_context* ssl )
 {
     int ret;
 
-    if( ssl->handshake->early_data != MBEDTLS_SSL_EARLY_DATA_ON )
+    if( ssl->handshake->early_data != MBEDTLS_SSL_EARLY_DATA_STATE_ON )
         return( SSL_EARLY_DATA_SKIP );
 
     /* Activate early data transform */
@@ -2245,7 +2245,7 @@ static int ssl_check_use_0rtt_handshake( mbedtls_ssl_context *ssl )
     }
 
     /* Accept 0-RTT */
-    ssl->handshake->early_data = MBEDTLS_SSL_EARLY_DATA_ON;
+    ssl->handshake->early_data = MBEDTLS_SSL_EARLY_DATA_STATE_ON;
     return( 0 );
 }
 #endif /* MBEDTLS_ZERO_RTT*/
@@ -2804,7 +2804,7 @@ static int ssl_client_hello_postprocess( mbedtls_ssl_context* ssl,
     }
 
 #if defined(MBEDTLS_ZERO_RTT)
-    if( ssl->handshake->early_data == MBEDTLS_SSL_EARLY_DATA_ON )
+    if( ssl->handshake->early_data == MBEDTLS_SSL_EARLY_DATA_STATE_ON )
     {
         mbedtls_ssl_transform *transform_earlydata;
 

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -2276,13 +2276,7 @@ int main( int argc, char *argv[] )
 
     while( ( ret = mbedtls_ssl_handshake( &ssl ) ) != 0 )
     {
-        if ( ret == MBEDTLS_ERR_SSL_HANDSHAKE_EARLY_RETURN &&
-             opt.early_data == MBEDTLS_SSL_EARLY_DATA_ENABLED )
-        {
-            ret = mbedtls_ssl_write_early_data( &ssl, (const unsigned char*) early_data, strlen(early_data) );
-        }
-        if( ret < 0 &&
-            ret != MBEDTLS_ERR_SSL_WANT_READ &&
+        if( ret != MBEDTLS_ERR_SSL_WANT_READ &&
             ret != MBEDTLS_ERR_SSL_WANT_WRITE &&
             ret != MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS )
         {
@@ -3220,16 +3214,25 @@ reconnect:
             goto exit;
         }
 
-        while( ( ret = mbedtls_ssl_handshake( &ssl ) ) != 0 )
-        {
-            if ( ret == MBEDTLS_ERR_SSL_HANDSHAKE_EARLY_RETURN &&
-                 opt.early_data == MBEDTLS_SSL_EARLY_DATA_ENABLED )
-            {
-                ret = mbedtls_ssl_write_early_data( &ssl, (const unsigned char*) early_data, strlen(early_data) );
-            }
-
+        if( opt.early_data == MBEDTLS_SSL_EARLY_DATA_ENABLED ) {
+            mbedtls_printf( "\n  . Writing early_data..." );
+            fflush( stdout );
+            ret = mbedtls_ssl_write_early_data( &ssl, (const unsigned char*) early_data, strlen(early_data) );
             if( ret < 0 &&
                 ret != MBEDTLS_ERR_SSL_WANT_READ &&
+                ret != MBEDTLS_ERR_SSL_WANT_WRITE &&
+                ret != MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS )
+            {
+                mbedtls_printf( " failed\n  ! mbedtls_ssl_write_early_data returned -0x%x\n",
+                                (unsigned int) -ret );
+                mbedtls_printf( "\n" );
+                goto exit;
+            }
+        }
+
+        while( ( ret = mbedtls_ssl_handshake( &ssl ) ) != 0 )
+        {
+            if( ret != MBEDTLS_ERR_SSL_WANT_READ &&
                 ret != MBEDTLS_ERR_SSL_WANT_WRITE &&
                 ret != MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS )
             {

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -2154,8 +2154,6 @@ int main( int argc, char *argv[] )
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && defined(MBEDTLS_ZERO_RTT)
     mbedtls_ssl_conf_early_data( &conf, opt.early_data, 0, NULL );
-    mbedtls_ssl_set_early_data( &ssl, (const unsigned char*) early_data,
-                                strlen( early_data ) );
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL && MBEDTLS_ZERO_RTT */
 
     if( ( ret = mbedtls_ssl_setup( &ssl, &conf ) ) != 0 )
@@ -2278,7 +2276,13 @@ int main( int argc, char *argv[] )
 
     while( ( ret = mbedtls_ssl_handshake( &ssl ) ) != 0 )
     {
-        if( ret != MBEDTLS_ERR_SSL_WANT_READ &&
+        if ( ret == MBEDTLS_ERR_SSL_HANDSHAKE_EARLY_RETURN &&
+             opt.early_data == MBEDTLS_SSL_EARLY_DATA_ENABLED )
+        {
+            ret = mbedtls_ssl_write_early_data( &ssl, (const unsigned char*) early_data, strlen(early_data) );
+        }
+        if( ret < 0 &&
+            ret != MBEDTLS_ERR_SSL_WANT_READ &&
             ret != MBEDTLS_ERR_SSL_WANT_WRITE &&
             ret != MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS )
         {
@@ -3195,12 +3199,6 @@ reconnect:
         }
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 
-#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL) && defined(MBEDTLS_ZERO_RTT)
-        mbedtls_ssl_set_early_data( &ssl, (const unsigned char*) early_data,
-                                    strlen( early_data ) );
-#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL && MBEDTLS_ZERO_RTT */
-
-
         if( ( ret = mbedtls_net_connect( &server_fd,
                         opt.server_addr, opt.server_port,
                         opt.transport == MBEDTLS_SSL_TRANSPORT_STREAM ?
@@ -3224,7 +3222,14 @@ reconnect:
 
         while( ( ret = mbedtls_ssl_handshake( &ssl ) ) != 0 )
         {
-            if( ret != MBEDTLS_ERR_SSL_WANT_READ &&
+            if ( ret == MBEDTLS_ERR_SSL_HANDSHAKE_EARLY_RETURN &&
+                 opt.early_data == MBEDTLS_SSL_EARLY_DATA_ENABLED )
+            {
+                ret = mbedtls_ssl_write_early_data( &ssl, (const unsigned char*) early_data, strlen(early_data) );
+            }
+
+            if( ret < 0 &&
+                ret != MBEDTLS_ERR_SSL_WANT_READ &&
                 ret != MBEDTLS_ERR_SSL_WANT_WRITE &&
                 ret != MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS )
             {


### PR DESCRIPTION
This PR add a new API for sending early data on the client side. It deprecates the `mbedtls_ssl_set_early_data()` method.
It is a design alternative to #368.

## Changes proposed

1. Add an error code `MBEDTLS_ERR_SSL_HANDSHAKE_EARLY_RETURN` for early return. Handshake returns with this error indicating the user can start sending early data. Calling `mbedtls_ssl_handshake()` again will continue the handshake. This pattern is similar to the handling of `NewSessionTicket`.  
1. Rename `MBEDTLS_SSL_EARLY_DATA_ON|OFF` to `MBEDTLS_SSL_EARLY_DATA_STATE_DISABLED |ON|OFF` as these values represent the *state* of the client, rather than a configuration. When early data is enabled, the early_data state is initially ON, it will be turned to OFF if early data is rejected, a HRR is received, or max_early_data is reached (to add).

## Status
**DRAFT, solicit early feedback on design.**

## Requires Backporting
NO  

## Migrations


## Additional comments
Any additional information that could be of interest

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported


## Steps to test or reproduce
Outline the steps to test or reproduce the PR here.

Start openssl server using
```
/usr/local/opt/openssl/bin/openssl s_server -key server5.key -cert server5.crt -accept 1234 -early_data -state
```

Then try
```
./ssl_client2 server_name=localhost server_port=1234 auth_mode=none reconnect=1 early_data=1 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384  key_share_named_groups=secp384r1
```