### PR TITLE
fix Wunused-but-set-variable warning/error

### DIFF
--- a/library/ssl_tls13_keys.c
+++ b/library/ssl_tls13_keys.c
@@ -886,8 +886,10 @@ int mbedtls_ssl_tls1_3_generate_resumption_master_secret(
     int ret = 0;
 
     mbedtls_md_type_t md_type;
+#if defined(MBEDTLS_DEBUG_C)
     mbedtls_md_info_t const *md_info;
     size_t md_size;
+#endif /* MBEDTLS_DEBUG_C */
 
     unsigned char transcript[MBEDTLS_MD_MAX_SIZE];
     size_t transcript_len;
@@ -896,8 +898,10 @@ int mbedtls_ssl_tls1_3_generate_resumption_master_secret(
           ( "=> mbedtls_ssl_tls1_3_generate_resumption_master_secret" ) );
 
     md_type = ssl->handshake->ciphersuite_info->mac;
+#if defined(MBEDTLS_DEBUG_C)
     md_info = mbedtls_md_info_from_type( md_type );
     md_size = mbedtls_md_get_size( md_info );
+#endif /* MBEDTLS_DEBUG_C */
 
     ret = mbedtls_ssl_get_handshake_transcript( ssl, md_type,
                                                 transcript, sizeof( transcript ),

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -363,7 +363,9 @@ static int ssl_parse_key_shares_ext( mbedtls_ssl_context *ssl,
     {
         uint16_t their_group;
         mbedtls_ecp_group_id their_curve;
+#if defined(MBEDTLS_DEBUG_C)
         mbedtls_ecp_curve_info const *their_curve_info;
+#endif /* MBEDTLS_DEBUG_C */
         unsigned char const *end_of_share;
 
         /*
@@ -439,7 +441,9 @@ static int ssl_parse_key_shares_ext( mbedtls_ssl_context *ssl,
          * - Apply further curve checks
          */
 
+#if defined(MBEDTLS_DEBUG_C)
         their_curve_info = mbedtls_ecp_curve_info_from_grp_id( their_curve );
+#endif /* MBEDTLS_DEBUG_C */
         MBEDTLS_SSL_DEBUG_MSG( 2, ( "ECDH curve: %s", their_curve_info->name ) );
 
         ret = mbedtls_ecdh_setup( &ssl->handshake->ecdh_ctx, their_curve );


### PR DESCRIPTION
Summary:
When the `MBEDTLS_DEBUG_C` is undefined, we saw the following compiler
warnining/error.

```
/upstream/library/ssl_tls13_keys.c: In function
‘mbedtls_ssl_tls1_3_generate_resumption_master_secret’:
/upstream/library/ssl_tls13_keys.c:890:12: error: variable
‘md_size’ set but not used [-Werror=unused-but-set-variable]
     size_t md_size;
```

```
/upstream/library/ssl_tls13_server.c: In function
‘ssl_parse_key_shares_ext’:
/upstream/library/ssl_tls13_server.c:366:39: error:
variable ‘their_curve_info’ set but not used
[-Werror=unused-but-set-variable]
         mbedtls_ecp_curve_info const *their_curve_info;
```

Test Plan:
```
rm -rf build/; mkdir build; cd build; CFLAGS="-std=c99 -g
-Wunused-but-set-variable -Wno-unused-parameter" cmake ..; make -j
```

Reviewers:

Subscribers:

Tasks:

Tags:

Notes:
* Pull requests cannot be accepted until the PR follows the [contributing guidelines](../CONTRIBUTING.md). In particular, each commit must have at least one `Signed-off-by:` line from the committer to certify that the contribution is made under the terms of the [Developer Certificate of Origin](../dco.txt).
* This is just a template, so feel free to use/remove the unnecessary things
## Description
A few sentences describing the overall goals of the pull request's commits.


## Status
**READY/IN DEVELOPMENT/HOLD**

## Requires Backporting
When there is a bug fix, it should be backported to all maintained and supported branches.
Changes do not have to be backported if:
- This PR is a new feature\enhancement
- This PR contains changes in the API. If this is true, and there is a need for the fix to be backported, the fix should be handled differently in the legacy branch

Yes | NO  
Which branch?

## Migrations
If there is any API change, what's the incentive and logic for it.

YES | NO

## Additional comments
Any additional information that could be of interest

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported


## Steps to test or reproduce
Outline the steps to test or reproduce the PR here.
