### PR TITLE
Add PQC

### DIFF
--- a/include/mbedtls/oqs_ext.h
+++ b/include/mbedtls/oqs_ext.h
@@ -47,6 +47,14 @@
 #define GROUPID_sike_p751 0x0222
 
 /*
+ * Lightweight info struct for kem
+ */
+typedef struct mbedtls_kem_info {
+    const uint16_t tls_id;
+    const char *name;
+} mbedtls_kem_info;
+
+/*
  * Holds libOQS OQS_KEM struct, and additional fields to hold keys
  */
 typedef struct mbedtls_oqs_kem_ctx {
@@ -56,6 +64,26 @@ typedef struct mbedtls_oqs_kem_ctx {
     uint8_t* ciphertext;
     uint8_t* shared_secret;
 } mbedtls_oqs_kem_ctx;
+
+
+/* TODO NEED TO INTEGRATE LIBOQS ENABLE MACROS TO CONTROL WHAT IS INCLUDED */
+/**
+ * \brief           Returns supported libOQS KEMs
+ *
+ * \return          Array of supported mbedtls_kem_info structs
+ */
+const mbedtls_kem_info *mbedtls_get_kem_list( void );
+
+
+/* TODO NEED TO INTEGRATE LIBOQS ENABLE MACROS TO CONTROL WHAT IS INCLUDED */
+/**
+ * \brief           Returns mbedtls_kem_info corresponding to provided
+ *                  IANA TLS group id.
+ *
+ * \return          mbedtls_kem_info if provided id is supported, otherwise
+ *                  NULL.
+ */
+const mbedtls_kem_info *mbedtls_kem_info_from_tls_id( uint16_t tls_id )
 
 /**
  * \brief           This function initialises the provided medtls_oqs_kem_ctx struct.

--- a/include/mbedtls/oqs_ext.h
+++ b/include/mbedtls/oqs_ext.h
@@ -1,0 +1,93 @@
+#include <oqs/oqs.h>
+
+/*
+ * PQC error codes
+ */
+#define MBEDTLS_ERR_PQC_KEM_SETUP_FAILED                  -0x4E00
+/** Destination buffer too small */
+#define MBEDTLS_ERR_PQC_BUFFER_TOO_SMALL                  -0x4F00
+
+#define GROUPID_bikel1 0x0238
+#define GROUPID_bikel3 0x023b
+#define GROUPID_hqc128 0x022c
+#define GROUPID_hqc192 0x022d
+#define GROUPID_hqc256 0x022e
+#define GROUPID_kyber512 0x023a
+#define GROUPID_kyber768 0x023c
+#define GROUPID_kyber1024 0x023d
+#define GROUPID_kyber90s512 0x023e
+#define GROUPID_kyber90s768 0x023f
+#define GROUPID_kyber90s1024 0x0240
+#define GROUPID_ntru_hps2048509 0x0214
+#define GROUPID_ntru_hps2048677 0x0215
+#define GROUPID_ntru_hps4096821 0x0216
+#define GROUPID_ntruprime_ntru_hrss701 0x0217
+#define GROUPID_ntruprime_ntrulpr653 0x022f
+#define GROUPID_ntruprime_ntrulpr761 0x0230
+#define GROUPID_ntruprime_ntrulpr857 0x0231
+#define GROUPID_ntruprime_sntrup653 0x0232
+#define GROUPID_ntruprime_sntrup761 0x0233
+#define GROUPID_ntruprime_sntrup857 0x0234
+#define GROUPID_saber_lightsaber 0x0218
+#define GROUPID_saber_saber 0x0219
+#define GROUPID_saber_firesaber 0x021a
+#define GROUPID_frodokem_640_aes 0x0200
+#define GROUPID_frodokem_640_shake 0x0201
+#define GROUPID_frodokem_976_aes 0x0202
+#define GROUPID_frodokem_976_shake 0x0203
+#define GROUPID_frodokem_1344_aes 0x0204
+#define GROUPID_frodokem_1344_shake 0x0205
+#define GROUPID_sidh_p434 0x021b
+#define GROUPID_sidh_p503 0x021c
+#define GROUPID_sidh_p610 0x021d
+#define GROUPID_sidh_p751 0x021e
+#define GROUPID_sike_p434 0x021f
+#define GROUPID_sike_p503 0x0220
+#define GROUPID_sike_p610 0x0221
+#define GROUPID_sike_p751 0x0222
+
+/*
+ * Holds libOQS OQS_KEM struct, and additional fields to hold keys
+ */
+typedef struct mbedtls_oqs_kem_ctx {
+    OQS_KEM *kem;
+    uint8_t* public_key;
+    uint8_t* secret_key;
+    uint8_t* ciphertext;
+    uint8_t* shared_secret;
+} mbedtls_oqs_kem_ctx;
+
+/**
+ * \brief           This function initialises the provided medtls_oqs_kem_ctx struct.
+ *                  This is invoked in ssl_handshake_params_init().
+ *
+ * \param ctx       mbedtls_oqs_kem_ctx object to initialise.
+ */
+void mbedtls_oqs_kem_init( mbedtls_oqs_kem_ctx *ctx );
+
+/**
+ * \brief           Setups up provided mbedtls_oqs_kem_ctx object with
+ *                  provided tls_id.
+ *
+ * \param ctx       mbedtls_oqs_kem_ctx object to setup.
+ *
+ * \param tls_id    IANA TLS group id to set the context up with.
+ *
+ * \note            The key-holding fields of ctx are heap allocated
+ *                  according to their corresponding length_* field in
+ *                  ctx->kem (ctx->kem->length_public_key informs allocation size of
+ *                  ctx->public_key etc.).
+ *
+ * \return          \c 0 on success.
+ * \return          MBEDTLS_ERR_SSL_ALLOC_FAILED if heap allocation fails.
+ * \return          MBEDTLS_ERR_PQC_KEM_SETUP_FAILED if kem setup fails.
+ */
+int mbedtls_oqs_kem_setup( mbedtls_oqs_kem_ctx *ctx, uint16_t tls_id )
+
+/**
+ * \brief           This function frees the provided medtls_oqs_kem_ctx struct.
+ *                  This is invoked in ssl_handshake_params_free().
+ *
+ * \param ctx       mbedtls_oqs_kem_ctx object to free.
+ */
+void mbedtls_oqs_kem_free( mbedtls_oqs_kem_ctx *ctx );

--- a/library/oqs_ext.c
+++ b/library/oqs_ext.c
@@ -1,0 +1,60 @@
+#include "oqs_ext.h"
+
+static OQS_KEM *setup_kem( uint16_t group_id )
+{
+    const mbedtls_kem_info *kem_info;
+
+    if ( kem_info = mbedtls_kem_info_from_tls_id( group_id ) != 0 ) {
+        MBEDTLS_SSL_DEBUG_MSG( 3, ( "Given group_id not availiable" ) );
+        return( NULL );
+    }
+    return OQS_new( kem_info->name );
+}
+
+void mbedtls_oqs_kem_init( mbedtls_oqs_kem_ctx *ctx )
+{
+    ctx->kem = NULL;
+    ctx->public_key = NULL:
+    ctx->secret_key = NULL:
+    ctx->ciphertext = NULL:
+    ctx->shared_secret = NULL:
+}
+
+int mbedtls_oqs_kem_setup( mbedtls_oqs_kem_ctx *ctx, uint16_t tls_id )
+{
+    if( !( ctx->kem = setup_kem(tls_id) ) )
+        return( MBEDTLS_ERR_PQC_KEM_SETUP_FAILED );
+
+    if( ( ctx->public_key = mbedtls_alloc( 1, ctx->kem->length_public_key ) == NULL ) ||
+        ( ctx->serect_key = mbedtls_alloc( 1, ctx->kem->length_serect_key ) == NULL ) ||
+        ( ctx->ciphertext = mbedtls_alloc( 1, ctx->kem->length_ciphertext ) == NULL ) ||
+        ( ctx->shared_secret = mbedtls_alloc( 1, ctx->kem->length_shared_secret ) == NULL ) )
+        return( MBEDTLS_ERR_SSL_ALLOC_FAILED );
+
+    return( 0 );
+}
+
+int mbedtls_copy_byte_string( unsigned char *in,  unsigned char *inlen,
+                              unsigned char *out, size_t outlen )
+{
+    if ( inlen <= outlen )
+    {
+        memcpy( out, in, inlen );
+        return( 0 );
+    }
+    return ( MBEDTLS_ERR_PQC_BUFFER_TOO_SMALL );
+}
+
+void mbedtls_oqs_kem_free( mbedtls_oqs_kem_context *ctx )
+{
+    if( ctx->kem )
+        OQS_KEM_free(ctx->kem);
+    if( ctx->public_key )
+        mbedtls_free(ctx->public_key);
+    if( ctx->secret_key )
+        mbedtls_free(ctx->secret_key);
+    if( ctx->ciphertext )
+        mbedtls_free(ctx->ciphertext);
+    if( ctx->shared_secret )
+        mbedtls_free(ctx->shared_secret);
+}

--- a/library/oqs_ext.c
+++ b/library/oqs_ext.c
@@ -1,5 +1,68 @@
 #include "oqs_ext.h"
 
+static const mbedtls_kem_info kem_list[] =
+{
+    { GROUPID_bikel1, OQS_KEM_alg_bikel1 },
+    { GROUPID_bikel3, OQS_KEM_alg_bikel3 },
+    { GROUPID_hqc128, OQS_KEM_alg_hqc128 },
+    { GROUPID_hqc192, OQS_KEM_alg_hqc192 },
+    { GROUPID_hqc256, OQS_KEM_alg_hqc256 },
+    { GROUPID_kyber512, OQS_KEM_alg_kyber512 },
+    { GROUPID_kyber768, OQS_KEM_alg_kyber768 },
+    { GROUPID_kyber1024, OQS_KEM_alg_kyber1024 },
+    { GROUPID_kyber90s512, OQS_KEM_alg_kyber90s512 },
+    { GROUPID_kyber90s768, OQS_KEM_alg_kyber90s768 },
+    { GROUPID_kyber90s1024, OQS_KEM_alg_kyber90s1024 },
+    { GROUPID_ntru_hps2048509, OQS_KEM_alg_ntru_hps2048509 },
+    { GROUPID_ntru_hps2048677, OQS_KEM_alg_ntru_hps2048677 },
+    { GROUPID_ntru_hps4096821, OQS_KEM_alg_ntru_hps4096821 },
+    { GROUPID_ntruprime_ntru_hrss701, OQS_KEM_alg_ntruprime_ntru_hrss701 },
+    { GROUPID_ntruprime_ntrulpr653, OQS_KEM_alg_ntruprime_ntrulpr653 },
+    { GROUPID_ntruprime_ntrulpr761, OQS_KEM_alg_ntruprime_ntrulpr761 },
+    { GROUPID_ntruprime_ntrulpr857, OQS_KEM_alg_ntruprime_ntrulpr857 },
+    { GROUPID_ntruprime_sntrup653, OQS_KEM_alg_ntruprime_sntrup653 },
+    { GROUPID_ntruprime_sntrup761, OQS_KEM_alg_ntruprime_sntrup761 },
+    { GROUPID_ntruprime_sntrup857, OQS_KEM_alg_ntruprime_sntrup857 },
+    { GROUPID_saber_lightsaber, OQS_KEM_alg_saber_lightsaber },
+    { GROUPID_saber_saber, OQS_KEM_alg_saber_saber },
+    { GROUPID_saber_firesaber, OQS_KEM_alg_saber_firesaber },
+    { GROUPID_frodokem_640_aes, OQS_KEM_alg_frodokem_640_aes },
+    { GROUPID_frodokem_640_shake, OQS_KEM_alg_frodokem_640_shake },
+    { GROUPID_frodokem_976_aes, OQS_KEM_alg_frodokem_976_aes },
+    { GROUPID_frodokem_976_shake, OQS_KEM_alg_frodokem_976_shake },
+    { GROUPID_frodokem_1344_aes, OQS_KEM_alg_frodokem_1344_aes },
+    { GROUPID_frodokem_1344_shake, OQS_KEM_alg_frodokem_1344_shake },
+    { GROUPID_sidh_p434, OQS_KEM_alg_sidh_p434 },
+    { GROUPID_sidh_p503, OQS_KEM_alg_sidh_p503 },
+    { GROUPID_sidh_p610, OQS_KEM_alg_sidh_p610 },
+    { GROUPID_sidh_p751, OQS_KEM_alg_sidh_p751 },
+    { GROUPID_sike_p434, OQS_KEM_alg_sike_p434 },
+    { GROUPID_sike_p503, OQS_KEM_alg_sike_p503 },
+    { GROUPID_sike_p610, OQS_KEM_alg_sike_p610 },
+    { GROUPID_sike_p751, OQS_KEM_alg_sike_p751 },
+    { 0, 0 },
+};
+
+const mbedtls_kem_info *mbedtls_get_kem_list( void )
+{
+    return( kem_list );
+}
+
+const mbedtls_kem_info *mbedtls_kem_info_from_tls_id( uint16_t tls_id )
+{
+    const mbedtls_kem_info *kem_info;
+
+    for( kem_info = get_kem_list();
+         kem_info->tls_id != 0;
+         kem_info++ )
+    {
+        if( kem_info->tls_id == tls_id && OQS_KEM_alg_is_enabled( kem_info->name ))
+            return( kem_info );
+    }
+
+    return( NULL );
+}
+
 static OQS_KEM *setup_kem( uint16_t group_id )
 {
     const mbedtls_kem_info *kem_info;

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -538,6 +538,10 @@ struct mbedtls_ssl_handshake_params
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 #endif /* MBEDTLS_ECDH_C || MBEDTLS_ECDSA_C */
 
+#if defined(MBEDTLS_LIBOQS_ENABLE)
+    mbedtls_oqs_kem_ctx oqs_ctx;
+#endif
+
 #if defined(MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED)
     mbedtls_ecjpake_context ecjpake_ctx;        /*!< EC J-PAKE key exchange */
 #if defined(MBEDTLS_SSL_CLI_C)

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -515,6 +515,9 @@ struct mbedtls_ssl_handshake_params
 #endif /* MBEDTLS_SSL_TLS13_COMPATIBILITY_MODE */
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 
+    const uint16_t *group_list;
+    unsigned char group_list_heap_allocated;
+
 #if defined(MBEDTLS_SSL_PROTO_TLS1_2) && \
     defined(MBEDTLS_KEY_EXCHANGE_WITH_CERT_ENABLED)
     mbedtls_ssl_sig_hash_set_t hash_algs;             /*!<  Set of suitable sig-hash pairs */
@@ -2050,5 +2053,15 @@ int mbedtls_ssl_finish_handshake_msg( mbedtls_ssl_context *ssl,
 
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 
+static inline const void *mbedtls_get_supported_groups( const mbedtls_ssl_context *ssl )
+{
+    if ( ssl->handshake != NULL )
+    #if defined(MBEDTLS_DEPRECATED_REMOVED) || !defined(MBEDTLS_ECP_C)
+        return( ssl->conf->supported_groups );
+    #else
+        return( ssl->handshake->group_list );
+    #endif
+    return NULL;
+}
 
 #endif /* ssl_misc.h */

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -554,7 +554,7 @@ struct mbedtls_ssl_handshake_params
 #endif /* MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED */
 #if defined(MBEDTLS_ECDH_C) || defined(MBEDTLS_ECDSA_C) || \
     defined(MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED)
-    const mbedtls_ecp_curve_info **curves;      /*!<  Supported elliptic curves */
+    const uint16_t *groups;      /*!<  Supported elliptic curves */
 #endif
 #if defined(MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED)
 #if defined(MBEDTLS_USE_PSA_CRYPTO)

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -3347,6 +3347,9 @@ static void ssl_handshake_params_init( mbedtls_ssl_handshake_params *handshake )
 #if defined(MBEDTLS_ECDH_C)
     mbedtls_ecdh_init( &handshake->ecdh_ctx );
 #endif
+#if defined(MBEDTLS_LIBOQS_ENABLE)
+    mbedtls_oqs_kem_init( &handshake->oqs_ctx );
+#endif
 #if defined(MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED)
     mbedtls_ecjpake_init( &handshake->ecjpake_ctx );
 #if defined(MBEDTLS_SSL_CLI_C)
@@ -6363,6 +6366,9 @@ void mbedtls_ssl_handshake_free( mbedtls_ssl_context *ssl )
 #endif
 #if defined(MBEDTLS_ECDH_C)
     mbedtls_ecdh_free( &handshake->ecdh_ctx );
+#endif
+#if defined(MBEDTLS_LIBOQS_ENABLE)
+    mbedtls_oqs_kem_free( &handshake->oqs_ctx );
 #endif
 #if defined(MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED)
     mbedtls_ecjpake_free( &handshake->ecjpake_ctx );

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -1,4 +1,4 @@
-/*
+/*0;
  *  TLS 1.3 server-side functionality
  *
  *  Copyright The Mbed TLS Contributors
@@ -3259,8 +3259,8 @@ static int ssl_write_hrr_key_share_ext( mbedtls_ssl_context *ssl,
                                         unsigned char* end,
                                         size_t* olen )
 {
-    const mbedtls_ecp_group_id *gid;
-    const mbedtls_ecp_curve_info **curve = NULL;
+    const uint16_t *our_tls_id;
+    const uint16_t *thier_tls_id;
 
     size_t total_len = 0;
 
@@ -3303,25 +3303,25 @@ static int ssl_write_hrr_key_share_ext( mbedtls_ssl_context *ssl,
     *buf++ = 2;
 
     /* Find common curve */
-    for( gid = ssl->conf->curve_list; *gid != MBEDTLS_ECP_DP_NONE; gid++ )
+    for( our_tls_id = mbedtls_ssl_get_groups(); *our_tls_id != 0; our_tls_id++ )
     {
-        for( curve = ssl->handshake->curves; *curve != NULL; curve++ )
+        for( their_tls_id = ssl->handshake->groups; *their_tls_id != NULL; their_tls_id++ )
         {
-            if( (*curve)->grp_id == *gid )
+            if( ( our_tls_id == their_tls_id )
                 goto curve_matching_done;
         }
     }
 
 curve_matching_done:
-    if( curve == NULL || *curve == NULL )
+    if( their_tls_id == NULL )
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "no matching named group found" ) );
         return( MBEDTLS_ERR_SSL_HANDSHAKE_FAILURE );
     }
 
     /* Write selected group */
-    *buf++ = (*curve)->tls_id >> 8;
-    *buf++ = (*curve)->tls_id & 0xFF;
+    *buf++ = their_tls_id >> 8;
+    *buf++ = their_tls_id & 0xFF;
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "NamedGroup in HRR: %s", (*curve)->name ) );
     *olen = total_len;

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -545,7 +545,6 @@ struct options
     int reproducible;           /* make communication reproducible          */
     int skip_close_notify;      /* skip sending the close_notify alert      */
     const char *named_groups_string;           /* list of named groups      */
-    const char *key_share_named_groups_string; /* list of named groups      */
     int key_exchange_modes;     /* supported key exchange modes             */
     const char *sig_algs;       /* supported signature algorithms           */
     int early_data;             /* support for early data                   */
@@ -1199,8 +1198,6 @@ int main( int argc, char *argv[] )
 #if defined(MBEDTLS_ECP_C)
         else if( strcmp( p, "named_groups" ) == 0 )
             opt.named_groups_string = q;
-        else if( strcmp( p, "key_share_named_groups" ) == 0 )
-            opt.key_share_named_groups_string = q;
 #endif /* MBEDTLS_ECP_C */
 
         else if( strcmp( p, "key_exchange_modes" ) == 0 )

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -1273,6 +1273,9 @@ trap cleanup INT TERM HUP
 # TLS 1.3 specific tests
 #
 
+run_test    "PQC Bike test" \
+            "$P_SRV"
+
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL
 requires_config_disabled MBEDTLS_RSA_C
 run_test    "TLS 1.3, default suite, PSK" \


### PR DESCRIPTION
This is a WIP pull request to add post-quantum cryptography to the key sharing mechanism.

Checklist of things as far as my small mind can see:
    - Supported group ext (partially done) [ssl_tls13_client.c, ssl_tls13_server.c]
    - Key share ext (partially done) [ssl_tls13_client.c, ssl_tls13_server.c]
    - Early data ext (not started) [ssl_tls13_client.c, ssl_tls13_server.c]
    - Key schedule changes (not started) [ssl_tls13_keys.c]

Scope of work ends when ephemeral secret is calculated at ssl_tls13_keys.c:985.

Eventually hybrid post-quantum will also be added.

## Status
IN DEVELOPMENT

## Requires Backporting 
NO  

## Migrations
NO

## Todos
- [X] Tests
- [X] Documentation
- [X] Changelog updated
- [ ] Backported
