### PR TITLE
Fix early data send and receive on client and server

### DIFF
--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -313,15 +313,8 @@ static int ssl_write_early_data_write( mbedtls_ssl_context* ssl,
     {
         memcpy( buf, ssl->early_data_buf, ssl->early_data_len );
 
-#if defined(MBEDTLS_SSL_USE_MPS)
         *olen = ssl->early_data_len;
         MBEDTLS_SSL_DEBUG_BUF( 3, "Early Data", buf, ssl->early_data_len );
-#else
-        buf[ssl->early_data_len] = MBEDTLS_SSL_MSG_APPLICATION_DATA;
-        *olen = ssl->early_data_len + 1;
-
-        MBEDTLS_SSL_DEBUG_BUF( 3, "Early Data", ssl->out_msg, *olen );
-#endif /* MBEDTLS_SSL_USE_MPS */
     }
 
     return( 0 );

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -1913,7 +1913,7 @@ static int ssl_early_data_fetch( mbedtls_ssl_context *ssl,
     }
 
     *buf    = ssl->in_msg;
-    *buflen = ssl->in_hslen;
+    *buflen = ssl->in_msglen;
 
 cleanup:
 

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -1743,6 +1743,7 @@ run_test    "TLS 1.3, TLS1-3-AES-256-GCM-SHA384, ext PSK, early data status - ac
             "$P_CLI nbio=2 debug_level=5 force_version=tls1_3 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 key_exchange_modes=psk early_data=1 psk=010203 psk_identity=0a0b0c" \
             0 \
 	    -c "early data status = 2"  \
+	    -s "15 bytes early data received: early data test"
 
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL
 requires_config_enabled MBEDTLS_DEBUG_C


### PR DESCRIPTION
Summary:
Courtesy to Bill Warshaw. We found two issues related to early data in client and server, it happens on
existing early data API and when MPS is not used.

* Client sends [one extra byte](https://github.com/hannestschofenig/mbedtls/blob/tls13-prototype/library/ssl_tls13_client.c#L320-L321) as `MBEDTLS_SSL_MSG_APPLICATION_DATA`
* Server doesn't set early data length properly, and the server early
data call back doesn't work because [early data length](https://github.com/hannestschofenig/mbedtls/blob/tls13-prototype/programs/ssl/ssl_server2.c#L1011-L1017) is not set.

Also add a test case for it.

Test Plan:
tests/ssl-opt.sh -p -s -f "status - accepted"

Reviewers:

Subscribers:

Tasks:

Tags:

Notes:
* Pull requests cannot be accepted until the PR follows the [contributing guidelines](../CONTRIBUTING.md). In particular, each commit must have at least one `Signed-off-by:` line from the committer to certify that the contribution is made under the terms of the [Developer Certificate of Origin](../dco.txt).
* This is just a template, so feel free to use/remove the unnecessary things
## Description
A few sentences describing the overall goals of the pull request's commits.


## Status
**READY/IN DEVELOPMENT/HOLD**

## Requires Backporting
When there is a bug fix, it should be backported to all maintained and supported branches.
Changes do not have to be backported if:
- This PR is a new feature\enhancement
- This PR contains changes in the API. If this is true, and there is a need for the fix to be backported, the fix should be handled differently in the legacy branch

Yes | NO  
Which branch?

## Migrations
If there is any API change, what's the incentive and logic for it.

YES | NO

## Additional comments
Any additional information that could be of interest

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported


## Steps to test or reproduce
Outline the steps to test or reproduce the PR here.
