### PR TITLE
Fix the TLS 1.3 obfuscated_ticket_age caclulation

### DIFF
--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -939,7 +939,7 @@ int mbedtls_ssl_write_pre_shared_key_ext( mbedtls_ssl_context *ssl,
             }
 
             obfuscated_ticket_age =
-                (uint32_t)( now - ssl->session_negotiate->ticket_received ) +
+                (uint32_t)( ( now - ssl->session_negotiate->ticket_received ) * 1000 ) +
                 ssl->session_negotiate->ticket_age_add;
 
             MBEDTLS_SSL_DEBUG_MSG( 4, ( "obfuscated_ticket_age: %u",


### PR DESCRIPTION
Summary:
Courtesy to Bill Warshaw.  Fix the calcuation of `obfuscated_ticket_age`, it is [milliseconds](https://datatracker.ietf.org/doc/html/rfc8446#section-4.2.11.1). 

Test Plan:
```
tests/ssl-opt.sh
```

Reviewers:

Subscribers:

Tasks:

Tags:

Notes:
* Pull requests cannot be accepted until the PR follows the [contributing guidelines](../CONTRIBUTING.md). In particular, each commit must have at least one `Signed-off-by:` line from the committer to certify that the contribution is made under the terms of the [Developer Certificate of Origin](../dco.txt).
* This is just a template, so feel free to use/remove the unnecessary things
## Description
A few sentences describing the overall goals of the pull request's commits.


## Status
**READY/IN DEVELOPMENT/HOLD**

## Requires Backporting
When there is a bug fix, it should be backported to all maintained and supported branches.
Changes do not have to be backported if:
- This PR is a new feature\enhancement
- This PR contains changes in the API. If this is true, and there is a need for the fix to be backported, the fix should be handled differently in the legacy branch

Yes | NO  
Which branch?

## Migrations
If there is any API change, what's the incentive and logic for it.

YES | NO

## Additional comments
Any additional information that could be of interest

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported


## Steps to test or reproduce
Outline the steps to test or reproduce the PR here.
