### PR TITLE
cherry pick d15018972c604dd2d49932ddb49e2adb5ad4a4f8 : Change script to solve G_NEXT_SRV_RSA not set issue

### DIFF
--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -83,6 +83,7 @@ if [ -n "${GNUTLS_NEXT_SERV:-}" ]; then
     G_NEXT_SRV_RSA="$GNUTLS_NEXT_SERV --x509certfile data_files/server2.crt --x509keyfile data_files/server2.key"
 else
     G_NEXT_SRV=false
+    G_NEXT_SRV_RSA=false
 fi
 
 if [ -n "${GNUTLS_NEXT_CLI:-}" ]; then


### PR DESCRIPTION
For the following issue found when I tested with `ssl-opt.sh`.
```
tests/ssl-opt.sh: line 1647: G_NEXT_SRV_RSA: unbound variable
```

```
git cherry-pick d15018972c604dd2d49932ddb49e2adb5ad4a4f8
```
Signed-off-by: XiaokangQian <xiaokang.qian@arm.com>

Notes:
* Pull requests cannot be accepted until the PR follows the [contributing guidelines](../CONTRIBUTING.md). In particular, each commit must have at least one `Signed-off-by:` line from the committer to certify that the contribution is made under the terms of the [Developer Certificate of Origin](../dco.txt).
* This is just a template, so feel free to use/remove the unnecessary things
## Description
A few sentences describing the overall goals of the pull request's commits.


## Status
**READY/IN DEVELOPMENT/HOLD**

## Requires Backporting
When there is a bug fix, it should be backported to all maintained and supported branches.
Changes do not have to be backported if:
- This PR is a new feature\enhancement
- This PR contains changes in the API. If this is true, and there is a need for the fix to be backported, the fix should be handled differently in the legacy branch

Yes | NO  
Which branch?

## Migrations
If there is any API change, what's the incentive and logic for it.

YES | NO

## Additional comments
Any additional information that could be of interest

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported


## Steps to test or reproduce
Outline the steps to test or reproduce the PR here.
