### PR TITLE
Don't send CCS after server finish in 0-RTT rejected case

### DIFF
--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -3301,12 +3301,12 @@ static int ssl_tls13_write_end_of_early_data_coordinate( mbedtls_ssl_context *ss
 
 static int ssl_tls13_write_end_of_early_data_postprocess( mbedtls_ssl_context *ssl )
 {
-#if defined(MBEDTLS_SSL_TLS13_COMPATIBILITY_MODE)
+#if defined(MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE)
     mbedtls_ssl_handshake_set_state( ssl,
                         MBEDTLS_SSL_CLIENT_CCS_AFTER_SERVER_FINISHED );
 #else
     mbedtls_ssl_handshake_set_state( ssl, MBEDTLS_SSL_CLIENT_CERTIFICATE );
-#endif /* MBEDTLS_SSL_TLS13_COMPATIBILITY_MODE */
+#endif /* MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE */
 
     return( 0 );
 }

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -3301,15 +3301,13 @@ static int ssl_tls13_write_end_of_early_data_coordinate( mbedtls_ssl_context *ss
 
 static int ssl_tls13_write_end_of_early_data_postprocess( mbedtls_ssl_context *ssl )
 {
-#if defined(MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE)
-    if( ssl_tls13_write_end_of_early_data_coordinate( ssl ) != SSL_END_OF_EARLY_DATA_WRITE )
-    {
-        mbedtls_ssl_handshake_set_state( ssl,
-                         MBEDTLS_SSL_CLIENT_CCS_AFTER_SERVER_FINISHED );
-        return( 0 );
-    }
-#endif /* MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE */
+#if defined(MBEDTLS_SSL_TLS13_COMPATIBILITY_MODE)
+    mbedtls_ssl_handshake_set_state( ssl,
+                        MBEDTLS_SSL_CLIENT_CCS_AFTER_SERVER_FINISHED );
+#else
     mbedtls_ssl_handshake_set_state( ssl, MBEDTLS_SSL_CLIENT_CERTIFICATE );
+#endif /* MBEDTLS_SSL_TLS13_COMPATIBILITY_MODE */
+
     return( 0 );
 }
 

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -1437,7 +1437,7 @@ static int ssl_tls13_finalize_finished_message( mbedtls_ssl_context *ssl )
                     "mbedtls_ssl_tls13_generate_resumption_master_secret ", ret );
             return ( ret );
         }
-        
+
         mbedtls_ssl_handshake_set_state( ssl, MBEDTLS_SSL_FLUSH_BUFFERS );
     }
     else
@@ -1605,6 +1605,19 @@ static int ssl_tls13_write_change_cipher_spec_coordinate( mbedtls_ssl_context *s
         }
     }
 #endif /* MBEDTLS_SSL_SRV_C */
+
+#if defined(MBEDTLS_SSL_CLI_C) && defined(MBEDTLS_ZERO_RTT)
+    if( ssl->conf->endpoint == MBEDTLS_SSL_IS_CLIENT )
+    {
+        if( ssl->state == MBEDTLS_SSL_CLIENT_CCS_AFTER_SERVER_FINISHED )
+        {
+            if( ssl->handshake->early_data == MBEDTLS_SSL_EARLY_DATA_ON )
+                ret = SSL_WRITE_CCS_SKIP;
+            else
+                ret = SSL_WRITE_CCS_NEEDED;
+        }
+    }
+#endif /* MBEDTLS_SSL_CLI_C && MBEDTLS_ZERO_RTT */
     return( ret );
 }
 

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -1585,9 +1585,6 @@ void mbedtls_ssl_tls13_handshake_wrapup( mbedtls_ssl_context *ssl )
 #define SSL_WRITE_CCS_SKIP       1
 static int ssl_tls13_write_change_cipher_spec_coordinate( mbedtls_ssl_context *ssl )
 {
-#if !defined(MBEDTLS_SSL_SRV_C)
-    ( ( void ) ssl );
-#endif /* !MBEDTLS_SSL_SRV_C */
     int ret = SSL_WRITE_CCS_NEEDED;
 
 #if defined(MBEDTLS_SSL_SRV_C)
@@ -1606,18 +1603,33 @@ static int ssl_tls13_write_change_cipher_spec_coordinate( mbedtls_ssl_context *s
     }
 #endif /* MBEDTLS_SSL_SRV_C */
 
-#if defined(MBEDTLS_SSL_CLI_C) && defined(MBEDTLS_ZERO_RTT)
+#if defined(MBEDTLS_SSL_CLI_C)
     if( ssl->conf->endpoint == MBEDTLS_SSL_IS_CLIENT )
     {
-        if( ssl->state == MBEDTLS_SSL_CLIENT_CCS_AFTER_SERVER_FINISHED )
+#if defined(MBEDTLS_ZERO_RTT)
+        switch( ssl->state )
         {
-            if( ssl->handshake->early_data == MBEDTLS_SSL_EARLY_DATA_ON )
-                ret = SSL_WRITE_CCS_SKIP;
-            else
-                ret = SSL_WRITE_CCS_NEEDED;
+            case MBEDTLS_SSL_CLIENT_CCS_AFTER_CLIENT_HELLO:
+                if( ssl->handshake->early_data != MBEDTLS_SSL_EARLY_DATA_ON )
+                    ret = SSL_WRITE_CCS_SKIP;
+                break;
+
+            case MBEDTLS_SSL_CLIENT_CCS_BEFORE_2ND_CLIENT_HELLO:
+            case MBEDTLS_SSL_CLIENT_CCS_AFTER_SERVER_FINISHED:
+                if( ssl->handshake->early_data == MBEDTLS_SSL_EARLY_DATA_ON )
+                    ret = SSL_WRITE_CCS_SKIP;
+                break;
+
+            default:
+                MBEDTLS_SSL_DEBUG_MSG( 1, ( "should never happen" ) );
+                return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
         }
+#else /* MBEDTLS_ZERO_RTT */
+        if( ssl->state == MBEDTLS_SSL_CLIENT_CCS_AFTER_CLIENT_HELLO )
+            ret = SSL_WRITE_CCS_SKIP;
+#endif /* MBEDTLS_ZERO_RTT */
     }
-#endif /* MBEDTLS_SSL_CLI_C && MBEDTLS_ZERO_RTT */
+#endif /* MBEDTLS_SSL_CLI_C */
     return( ret );
 }
 
@@ -1725,6 +1737,7 @@ int mbedtls_ssl_tls13_write_change_cipher_spec_process( mbedtls_ssl_context *ssl
     }
     else
     {
+        MBEDTLS_SSL_DEBUG_MSG( 2, ( "<= skip write change cipher spec" ) );
         /* Update state */
         MBEDTLS_SSL_PROC_CHK( ssl_tls13_write_change_cipher_spec_postprocess( ssl ) );
     }


### PR DESCRIPTION
## Description
RFC 8446: 

> If not offering early data, the client sends a dummy change_cipher_spec record immediately before its second flight.  This may either be before its second ClientHello or before its encrypted handshake flight. If offering early data, the record is placed immediately after the first ClientHello.

Currently in the 0-RTT rejected case, the client will send two CCS messages, one immediately following ClientHello and one after ServerFinished, but because 0-RTT was attempted, the second CCS message is encrypted using the 0-RTT keys.

## Status
**READY**

## Additional comments
[ccs_with_fix.log](https://github.com/hannestschofenig/mbedtls/files/7723004/ccs_with_fix.log)
[ccs_without_fix.log](https://github.com/hannestschofenig/mbedtls/files/7723008/ccs_without_fix.log)
