### PR TITLE
[0-RTT] Use trial decryption if server rejects client 0-RTT attempt

### DIFF
--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -939,6 +939,9 @@ struct mbedtls_ssl_handshake_params
     1  -- MBEDTLS_SSL_EARLY_DATA_ENABLED (for use early data)
     */
     int early_data;
+#if defined(MBEDTLS_SSL_SRV_C)
+    int skip_failed_decryption;
+#endif /* MBEDTLS_SSL_SRV_C */
 #endif /* MBEDTLS_ZERO_RTT */
 
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3 */

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -2130,6 +2130,7 @@ int mbedtls_ssl_tls13_write_early_data_ext( mbedtls_ssl_context *ssl,
         {
             MBEDTLS_SSL_DEBUG_MSG( 2, ( "<= skip write early_data extension" ) );
             ssl->handshake->early_data = MBEDTLS_SSL_EARLY_DATA_OFF;
+            ssl->handshake->skip_failed_decryption = 1;
             return( 0 );
         }
     }

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -2754,6 +2754,9 @@ static int ssl_tls13_client_hello_postprocess( mbedtls_ssl_context *ssl,
     int ret = 0;
 #if defined(MBEDTLS_ZERO_RTT)
     mbedtls_ssl_key_set traffic_keys;
+
+    if( ssl->handshake->hello_retry_requests_sent == 1 )
+        ssl->handshake->skip_failed_decryption = 0;
 #endif /* MBEDTLS_ZERO_RTT */
 
     if( ssl->handshake->hello_retry_requests_sent == 0 &&

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -2188,6 +2188,19 @@ run_test    "TLS 1.3, TLS1-3-AES-256-GCM-SHA384, ext PSK, early data status - no
             0 \
 	    -c "early data status = 0"  \
 
+# test early data status - rejected
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
+requires_config_enabled MBEDTLS_DEBUG_C
+requires_config_enabled MBEDTLS_SSL_SRV_C
+requires_config_enabled MBEDTLS_SSL_CLI_C
+requires_config_enabled MBEDTLS_ZERO_RTT
+requires_config_disabled MBEDTLS_SSL_USE_MPS
+run_test    "TLS 1.3, TLS1-3-AES-256-GCM-SHA384, ext PSK, early data status - rejected" \
+            "$P_SRV nbio=2 debug_level=5 force_version=tls13 early_data=0 tls13_kex_modes=psk psk=010203 psk_identity=0a0b0c" \
+            "$P_CLI nbio=2 debug_level=5 force_version=tls13 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 tls13_kex_modes=psk early_data=1 psk=010203 psk_identity=0a0b0c" \
+            0 \
+            -c "early data status = 1"  \
+
 # test early data status - accepted
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_config_enabled MBEDTLS_DEBUG_C


### PR DESCRIPTION
## Description
This PR adds server support for handling trial decryption in order to make test output accessible for the early data rejected case by using `ssl_server2.c`. Without trial decryption logic, early data rejected tests that use `ssl_server2.c` will fail due to decryption errors caused by the client sending early data before receiving and parsing the server's extensions.

> RFC 8446: 
      Ignore the extension and return a regular 1-RTT response.  The
      server then skips past early data by attempting to deprotect
      received records using the handshake traffic key, discarding
      records which fail deprotection (up to the configured
      max_early_data_size).  Once a record is deprotected successfully,
      it is treated as the start of the client's second flight and the
      server proceeds as with an ordinary 1-RTT handshake.

## Status
**READY**

## Requires Backporting
NO

## Additional comments
The need for the `skip_failed_decryption` flag is to ensure we no longer drop records which fail deprotection once a record is deprotected successfully with the 1-RTT keys. The motivation was taken from [Fizz](https://github.com/facebookincubator/fizz/blob/main/fizz/record/EncryptedRecordLayer.cpp#L89-L98), but I'd like to know if (1) there's a more appropriate place than `mbedtls_ssl_read_record()` to disable the flag, and (2) if there's other existing state we can leverage to avoid using an additional flag.

## Todos
- [x] Tests
- [x] Documentation
- [ ] Changelog updated
- [ ] Backported


## Steps to test or reproduce
* Run `ssl-opt.sh -f 'early data status - rejected'` and verify it passes.
* Revert the trial decryption changes and run `ssl-opt.sh -f 'early data status - rejected'` - verify it fails due to `MBEDTLS_ERR_SSL_INVALID_MAC`.
