### PR TITLE
[0-RTT][RFC] Create new API for sending early data

### DIFF
--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -934,11 +934,9 @@ struct mbedtls_ssl_handshake_params
 #if defined(MBEDTLS_ZERO_RTT)
     mbedtls_ssl_tls13_early_secrets early_secrets;
 
-    /*!< Early data indication:
-    0  -- MBEDTLS_SSL_EARLY_DATA_DISABLED (for no early data), and
-    1  -- MBEDTLS_SSL_EARLY_DATA_ENABLED (for use early data)
-    */
     int early_data;
+    int early_data_write;
+    int early_data_ready;
 #if defined(MBEDTLS_SSL_SRV_C)
     int skip_failed_decryption;
 #endif /* MBEDTLS_SSL_SRV_C */

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -939,6 +939,9 @@ struct mbedtls_ssl_handshake_params
     1  -- MBEDTLS_SSL_EARLY_DATA_ENABLED (for use early data)
     */
     int early_data;
+#if defined(MBEDTLS_SSL_SRV_C)
+    int skip_failed_decryption;
+#endif /* MBEDTLS_SSL_SRV_C */
 #endif /* MBEDTLS_ZERO_RTT */
 
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3 */

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -775,6 +775,14 @@ static int ssl_handshake_init( mbedtls_ssl_context *ssl )
     }
 #endif
 
+#if defined(MBEDTLS_ZERO_RTT)
+    if( ( ssl->conf->early_data_api == MBEDTLS_SSL_EARLY_DATA_NEW_API ) &&
+        ( ssl->conf->early_data_enabled == MBEDTLS_SSL_EARLY_DATA_ENABLED ) )
+    {
+        ssl->handshake->early_data = MBEDTLS_SSL_EARLY_DATA_STATE_ENABLED;
+    }
+#endif
+
 /*
  * curve_list is translated to IANA TLS group identifiers here because
  * mbedtls_ssl_conf_curves returns void and so can't return

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -2128,8 +2128,7 @@ int mbedtls_ssl_tls13_write_early_data_ext( mbedtls_ssl_context *ssl,
         if( ( ssl->handshake->extensions_present & MBEDTLS_SSL_EXT_EARLY_DATA ) == 0 )
             return( 0 );
 
-        if( ssl->conf->tls13_kex_modes !=
-                   MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK ||
+        if( !mbedtls_ssl_conf_tls13_some_psk_enabled( ssl ) ||
             ssl->conf->early_data_enabled == MBEDTLS_SSL_EARLY_DATA_DISABLED )
         {
             MBEDTLS_SSL_DEBUG_MSG( 2, ( "<= skip write early_data extension" ) );

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -2130,6 +2130,7 @@ int mbedtls_ssl_tls13_write_early_data_ext( mbedtls_ssl_context *ssl,
         {
             MBEDTLS_SSL_DEBUG_MSG( 2, ( "<= skip write early_data extension" ) );
             ssl->handshake->early_data = MBEDTLS_SSL_EARLY_DATA_OFF;
+            ssl->handshake->skip_failed_decryption = 1;
             return( 0 );
         }
     }

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -1770,7 +1770,10 @@ static int ssl_tls13_read_end_of_early_data_coordinate( mbedtls_ssl_context *ssl
 #else /* MBEDTLS_ZERO_RTT */
 static int ssl_tls13_read_end_of_early_data_coordinate( mbedtls_ssl_context *ssl )
 {
-    if( ssl->handshake->early_data != MBEDTLS_SSL_EARLY_DATA_ON )
+    int early_data_state = ( ssl->conf->early_data_api == MBEDTLS_SSL_EARLY_DATA_NEW_API )
+                           ? MBEDTLS_SSL_EARLY_DATA_STATE_ON
+                           : MBEDTLS_SSL_EARLY_DATA_ON;
+    if( ssl->handshake->early_data != early_data_state )
         return( SSL_END_OF_EARLY_DATA_SKIP );
 
     return( SSL_END_OF_EARLY_DATA_EXPECT );
@@ -1939,7 +1942,10 @@ static int ssl_tls13_read_early_data_coordinate( mbedtls_ssl_context *ssl )
 {
     int ret;
 
-    if( ssl->handshake->early_data != MBEDTLS_SSL_EARLY_DATA_ON )
+    int early_data_state = ( ssl->conf->early_data_api == MBEDTLS_SSL_EARLY_DATA_NEW_API )
+                           ? MBEDTLS_SSL_EARLY_DATA_STATE_ON
+                           : MBEDTLS_SSL_EARLY_DATA_ON;
+    if( ssl->handshake->early_data != early_data_state )
         return( SSL_EARLY_DATA_SKIP );
 
     /* Activate early data transform */
@@ -2232,7 +2238,9 @@ static int ssl_tls13_check_use_0rtt_handshake( mbedtls_ssl_context *ssl )
     }
 
     /* Accept 0-RTT */
-    ssl->handshake->early_data = MBEDTLS_SSL_EARLY_DATA_ON;
+    ssl->handshake->early_data = ( ssl->conf->early_data_api == MBEDTLS_SSL_EARLY_DATA_NEW_API )
+                                 ? MBEDTLS_SSL_EARLY_DATA_STATE_ON
+                                 : MBEDTLS_SSL_EARLY_DATA_ON;
     return( 0 );
 }
 #endif /* MBEDTLS_ZERO_RTT*/
@@ -2793,7 +2801,10 @@ static int ssl_tls13_client_hello_postprocess( mbedtls_ssl_context *ssl,
     }
 
 #if defined(MBEDTLS_ZERO_RTT)
-    if( ssl->handshake->early_data == MBEDTLS_SSL_EARLY_DATA_ON )
+    int early_data_state = ( ssl->conf->early_data_api == MBEDTLS_SSL_EARLY_DATA_NEW_API )
+                           ? MBEDTLS_SSL_EARLY_DATA_STATE_ON
+                           : MBEDTLS_SSL_EARLY_DATA_ON;
+    if( ssl->handshake->early_data == early_data_state )
     {
         mbedtls_ssl_transform *transform_earlydata;
 

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -1922,7 +1922,7 @@ static int ssl_tls13_early_data_fetch( mbedtls_ssl_context *ssl,
     }
 
     *buf    = ssl->in_msg;
-    *buflen = ssl->in_hslen;
+    *buflen = ssl->in_msglen;
 
 cleanup:
 

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -2754,6 +2754,9 @@ static int ssl_tls13_client_hello_postprocess( mbedtls_ssl_context *ssl,
     int ret = 0;
 #if defined(MBEDTLS_ZERO_RTT)
     mbedtls_ssl_key_set traffic_keys;
+
+    if( ssl->handshake->hello_retry_requests_sent == 1 )
+        ssl->handshake->skip_failed_decryption = 0;
 #endif /* MBEDTLS_ZERO_RTT */
 
     if( ssl->handshake->hello_retry_requests_sent == 0 &&

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -2099,7 +2099,7 @@ int main( int argc, char *argv[] )
         mbedtls_ssl_conf_max_tls_version( &conf, opt.max_version );
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3) && defined(MBEDTLS_ZERO_RTT)
-    mbedtls_ssl_conf_early_data( &conf, opt.early_data, 0, NULL );
+    mbedtls_ssl_conf_early_data( &conf, opt.early_data, 0, MBEDTLS_SSL_EARLY_DATA_OLD_API, NULL );
     mbedtls_ssl_set_early_data( &ssl, (const unsigned char*) early_data,
                                 strlen( early_data ) );
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3 && MBEDTLS_ZERO_RTT */

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -2842,6 +2842,7 @@ int main( int argc, char *argv[] )
 #if defined(MBEDTLS_ZERO_RTT)
     mbedtls_ssl_conf_early_data( &conf, opt.early_data,
                                  opt.early_data_max,
+                                 MBEDTLS_SSL_EARLY_DATA_OLD_API,
                                  early_data_callback );
 #endif /* MBEDTLS_ZERO_RTT */
 

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -833,6 +833,17 @@ find_in_both() {
         fi
 }
 
+find_in_both_same_count() {
+        srv_count=$(sed -n -e "$1" "$2" | sort | uniq -c);
+        cli_count=$(sed -n -e "$1" "$3" | sort | uniq -c);
+
+        if [ "$srv_count" = "$cli_count" ]; then
+                return 0;
+        else
+                return 1;
+        fi
+}
+
 SKIP_HANDSHAKE_CHECK="NO"
 skip_handshake_stage_check() {
     SKIP_HANDSHAKE_CHECK="YES"
@@ -2103,6 +2114,104 @@ run_test    "TLS 1.3, TLS1-3-AES-256-GCM-SHA384, ECDHE-ECDSA, client tries early
       -c "Ciphersuite is TLS1-3-AES-256-GCM-SHA384"                   \
       -c "early data status = 0"
 
+# early data new api
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
+requires_config_enabled MBEDTLS_DEBUG_C
+requires_config_enabled MBEDTLS_SSL_SRV_C
+requires_config_enabled MBEDTLS_SSL_CLI_C
+requires_config_enabled MBEDTLS_ZERO_RTT
+requires_config_disabled MBEDTLS_SSL_USE_MPS
+run_test    "TLS 1.3, TLS1-3-AES-256-GCM-SHA384, ext PSK, early data new api" \
+            "$P_SRV nbio=2 debug_level=5 force_version=tls13 early_data=-1 tls13_kex_modes=psk psk=010203 psk_identity=0a0b0c" \
+            "$P_CLI nbio=2 debug_level=5 force_version=tls13 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 tls13_kex_modes=psk early_data=1 early_data_api=1 psk=010203 psk_identity=0a0b0c" \
+            0 \
+            -s "found early_data extension"                 \
+            -s "Derive Early Secret with 'ext binder'"      \
+            -c "client hello, adding early_data extension"  \
+            -c "Protocol is TLSv1.3"                        \
+            -c "Ciphersuite is TLS1-3-AES-256-GCM-SHA384"   \
+            -c "Derive Early Secret with 'ext binder'"      \
+            -c "<= write EndOfEarlyData"                    \
+            -s "<= parse early data"                        \
+            -s "<= parse end_of_early_data"
+
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
+requires_config_enabled MBEDTLS_DEBUG_C
+requires_config_enabled MBEDTLS_SSL_SRV_C
+requires_config_enabled MBEDTLS_SSL_CLI_C
+requires_config_enabled MBEDTLS_ZERO_RTT
+requires_config_disabled MBEDTLS_SSL_USE_MPS
+run_test    "TLS 1.3, TLS1-3-AES-128-CCM-SHA256, ext PSK, early data new api" \
+            "$P_SRV nbio=2 debug_level=5 force_version=tls13 early_data=-1 tls13_kex_modes=psk psk=010203 psk_identity=0a0b0c" \
+            "$P_CLI nbio=2 debug_level=5 force_version=tls13 force_ciphersuite=TLS1-3-AES-128-CCM-SHA256 tls13_kex_modes=psk early_data=1 early_data_api=1 psk=010203 psk_identity=0a0b0c" \
+            0 \
+            -s "found early_data extension"                 \
+            -s "Derive Early Secret with 'ext binder'"      \
+            -c "client hello, adding early_data extension"  \
+            -c "Protocol is TLSv1.3"                        \
+            -c "Ciphersuite is TLS1-3-AES-128-CCM-SHA256"   \
+            -c "Derive Early Secret with 'ext binder'"      \
+            -c "<= write EndOfEarlyData"                    \
+            -s "<= parse early data"                        \
+            -s "<= parse end_of_early_data"
+
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
+requires_config_enabled MBEDTLS_DEBUG_C
+requires_config_enabled MBEDTLS_SSL_SRV_C
+requires_config_enabled MBEDTLS_SSL_CLI_C
+requires_config_enabled MBEDTLS_ZERO_RTT
+requires_config_disabled MBEDTLS_SSL_USE_MPS
+run_test    "TLS 1.3, TLS1-3-AES-128-GCM-SHA256, ext PSK, early data new api" \
+            "$P_SRV nbio=2 debug_level=5 force_version=tls13 early_data=-1 tls13_kex_modes=psk psk=010203 psk_identity=0a0b0c" \
+            "$P_CLI nbio=2 debug_level=5 force_version=tls13 force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 tls13_kex_modes=psk early_data=1 early_data_api=1 psk=010203 psk_identity=0a0b0c" \
+            0 \
+            -s "found early_data extension"                 \
+            -s "Derive Early Secret with 'ext binder'"      \
+            -c "client hello, adding early_data extension"  \
+            -c "Protocol is TLSv1.3"                        \
+            -c "Ciphersuite is TLS1-3-AES-128-GCM-SHA256"   \
+            -c "Derive Early Secret with 'ext binder'"      \
+            -c "<= write EndOfEarlyData"                    \
+            -s "<= parse early data"                        \
+            -s "<= parse end_of_early_data"
+
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
+requires_config_enabled MBEDTLS_DEBUG_C
+requires_config_enabled MBEDTLS_SSL_SRV_C
+requires_config_enabled MBEDTLS_SSL_CLI_C
+requires_config_enabled MBEDTLS_ZERO_RTT
+requires_config_disabled MBEDTLS_SSL_USE_MPS
+run_test    "TLS 1.3, TLS1-3-AES-128-CCM-8-SHA256, ext PSK, early data new api" \
+            "$P_SRV nbio=2 debug_level=5 force_version=tls13 early_data=-1 tls13_kex_modes=psk psk=010203 psk_identity=0a0b0c" \
+            "$P_CLI nbio=2 debug_level=5 force_version=tls13 force_ciphersuite=TLS1-3-AES-128-CCM-8-SHA256 tls13_kex_modes=psk early_data=1 early_data_api=1 psk=010203 psk_identity=0a0b0c" \
+            0 \
+            -s "found early_data extension"                 \
+            -s "Derive Early Secret with 'ext binder'"      \
+            -c "client hello, adding early_data extension"  \
+            -c "Protocol is TLSv1.3"                        \
+            -c "Ciphersuite is TLS1-3-AES-128-CCM-8-SHA256" \
+            -c "Derive Early Secret with 'ext binder'"      \
+            -c "<= write EndOfEarlyData"                    \
+            -s "<= parse early data"                        \
+            -s "<= parse end_of_early_data"
+
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
+requires_config_enabled MBEDTLS_DEBUG_C
+requires_config_enabled MBEDTLS_SSL_SRV_C
+requires_config_enabled MBEDTLS_SSL_CLI_C
+requires_config_enabled MBEDTLS_ZERO_RTT
+requires_config_disabled MBEDTLS_SSL_USE_MPS
+run_test    "TLS 1.3, TLS1-3-AES-256-GCM-SHA384, ECDHE-ECDSA, client tries early data new api without PSK, and falls back to 1-RTT" \
+            "$P_SRV crt_file=data_files/server5.crt key_file=data_files/server5.key \
+                    nbio=2 debug_level=4 force_version=tls13" \
+            "$P_CLI nbio=2 debug_level=4 force_version=tls13 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 early_data=1 early_data_api=1" \
+            0 \
+            -s "Protocol is TLSv1.3"                                        \
+            -c "<= skip write early_data extension"                         \
+            -c "Protocol is TLSv1.3"                                        \
+            -c "Ciphersuite is TLS1-3-AES-256-GCM-SHA384"                   \
+            -c "early data status = 0"
+
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_config_enabled MBEDTLS_DEBUG_C
 requires_config_enabled MBEDTLS_SSL_SRV_C
@@ -2186,7 +2295,7 @@ run_test    "TLS 1.3, TLS1-3-AES-256-GCM-SHA384, ext PSK, early data status - no
             "$P_SRV nbio=2 debug_level=5 force_version=tls13 psk=010203 psk_identity=0a0b0c" \
             "$P_CLI_ nbio=2 debug_level=5 force_version=tls13 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 psk=010203 psk_identity=0a0b0c" \
             0 \
-	    -c "early data status = 0"  \
+            -c "early data status = 0"  \
 
 # test early data status - rejected
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
@@ -2211,7 +2320,81 @@ run_test    "TLS 1.3, TLS1-3-AES-256-GCM-SHA384, ext PSK, early data status - ac
             "$P_SRV_ nbio=2 debug_level=5 force_version=tls13 early_data=-1 tls13_kex_modes=psk psk=010203 psk_identity=0a0b0c" \
             "$P_CLI_ nbio=2 debug_level=5 force_version=tls13 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 tls13_kex_modes=psk early_data=1 psk=010203 psk_identity=0a0b0c" \
             0 \
-	    -c "early data status = 2"  \
+            -c "early data status = 2"  \
+
+# test new early data status - not sent
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
+requires_config_enabled MBEDTLS_DEBUG_C
+requires_config_enabled MBEDTLS_SSL_SRV_C
+requires_config_enabled MBEDTLS_SSL_CLI_C
+requires_config_enabled MBEDTLS_ZERO_RTT
+requires_config_disabled MBEDTLS_SSL_USE_MPS
+run_test    "TLS 1.3, TLS1-3-AES-256-GCM-SHA384, ext PSK, early data new api status - not sent" \
+            "$P_SRV nbio=2 debug_level=5 force_version=tls13 psk=010203 psk_identity=0a0b0c" \
+            "$P_CLI nbio=2 debug_level=5 force_version=tls13 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 psk=010203 psk_identity=0a0b0c early_data_api=1" \
+            0 \
+            -c "early data status = 0"  \
+
+# test new early data status - accepted
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
+requires_config_enabled MBEDTLS_DEBUG_C
+requires_config_enabled MBEDTLS_SSL_SRV_C
+requires_config_enabled MBEDTLS_SSL_CLI_C
+requires_config_enabled MBEDTLS_ZERO_RTT
+requires_config_disabled MBEDTLS_SSL_USE_MPS
+run_test    "TLS 1.3, TLS1-3-AES-256-GCM-SHA384, ext PSK, early data new api status - accepted" \
+            "$P_SRV nbio=2 debug_level=5 force_version=tls13 tls13_kex_modes=psk psk=010203 psk_identity=0a0b0c early_data=-1" \
+            "$P_CLI nbio=2 debug_level=5 force_version=tls13 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 tls13_kex_modes=psk psk=010203 psk_identity=0a0b0c early_data=1 early_data_api=1" \
+            0 \
+            -c "early data status = 2"  \
+
+# test new early data status with resumption - rejected
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
+requires_config_enabled MBEDTLS_DEBUG_C
+requires_config_enabled MBEDTLS_SSL_SRV_C
+requires_config_enabled MBEDTLS_SSL_CLI_C
+requires_config_enabled MBEDTLS_ZERO_RTT
+requires_config_disabled MBEDTLS_SSL_USE_MPS
+run_test    "TLS 1.3, TLS1-3-AES-256-GCM-SHA384, ext PSK, early data new api status with resumption - rejected" \
+            "$P_SRV crt_file=data_files/server5.crt key_file=data_files/server5.key nbio=2 debug_level=5 force_version=tls13 early_data=0 tickets=1" \
+            "$P_CLI crt_file=data_files/cli2.crt key_file=data_files/cli2.key server_name=localhost nbio=2 debug_level=5 force_version=tls13 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 reconnect=1 tickets=1 early_data=1 early_data_api=1 auth_mode=required" \
+            0 \
+            -c "early data status, reconnect = 1"     \
+            -s "<= parse new session ticket"          \
+            -s "<= skip write early_data extension"   \
+            -c "early data rejected by server"        \
+            -c "skip EndOfEarlyData, server rejected"
+
+# test new early data status with resumption - not sent
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
+requires_config_enabled MBEDTLS_DEBUG_C
+requires_config_enabled MBEDTLS_SSL_SRV_C
+requires_config_enabled MBEDTLS_SSL_CLI_C
+requires_config_enabled MBEDTLS_ZERO_RTT
+requires_config_disabled MBEDTLS_SSL_USE_MPS
+run_test    "TLS 1.3, TLS1-3-AES-256-GCM-SHA384, ext PSK, early data new api status with resumption - not sent" \
+            "$P_SRV crt_file=data_files/server5.crt key_file=data_files/server5.key nbio=2 debug_level=5 force_version=tls13 early_data=-1 tickets=1" \
+            "$P_CLI crt_file=data_files/cli2.crt key_file=data_files/cli2.key server_name=localhost nbio=2 debug_level=5 force_version=tls13 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 reconnect=1 tickets=1 early_data=0 early_data_api=1 auth_mode=required" \
+            0 \
+            -c "early data status, reconnect = 0"  \
+            -s "<= parse new session ticket"
+
+# test new early data with resumption and multiple sends:
+# find_in_both_same_count will verify the count, size, and content
+# matches for all early data sent and received
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
+requires_config_enabled MBEDTLS_DEBUG_C
+requires_config_enabled MBEDTLS_SSL_SRV_C
+requires_config_enabled MBEDTLS_SSL_CLI_C
+requires_config_enabled MBEDTLS_ZERO_RTT
+requires_config_disabled MBEDTLS_SSL_USE_MPS
+run_test    "TLS 1.3, TLS1-3-AES-256-GCM-SHA384, ext PSK, early data new api multiple sends" \
+            "$P_SRV crt_file=data_files/server5.crt key_file=data_files/server5.key nbio=2 debug_level=5 force_version=tls13 early_data=-1 tickets=1" \
+            "$P_CLI crt_file=data_files/cli2.crt key_file=data_files/cli2.key server_name=localhost nbio=2 debug_level=5 force_version=tls13 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 reconnect=1 tickets=1 early_data=1 early_data_api=1 auth_mode=required" \
+            0 \
+            -c "early data status, reconnect = 2"  \
+            -s "<= parse new session ticket"       \
+            -g "find_in_both_same_count 's/^\(.*bytes early data\).*\(:.*\)$/\1\2/p'"
 
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_config_enabled MBEDTLS_DEBUG_C
@@ -2270,6 +2453,24 @@ run_test    "TLS 1.3, TLS1-3-AES-128-GCM-SHA256, reject early data, OpenSSL serv
             -c "=> write early data" \
             -c "=> mbedtls_ssl_tls13_generate_early_data_keys" \
             -c "skip EndOfEarlyData, server rejected" \
+            -c "early data status, reconnect = 1"
+
+# Test OpenSSL server with resumption and reject early data new api
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
+requires_config_enabled MBEDTLS_DEBUG_C
+requires_config_enabled MBEDTLS_SSL_CLI_C
+requires_config_disabled MBEDTLS_SSL_USE_MPS
+requires_openssl_with_tls1_3
+run_test    "TLS 1.3, TLS1-3-AES-128-GCM-SHA256, reject early data new api, OpenSSL server" \
+            "$O_SRV"                                                                        \
+            "$P_CLI  debug_level=5 force_version=tls13 server_name=localhost               \
+                     force_ciphersuite=TLS1-3-AES-128-GCM-SHA256 reconnect=1 tickets=1      \
+                     early_data=1 early_data_api=1"                                         \
+            0                                                                               \
+            -c "=> prepare early data"                                                      \
+            -c "=> mbedtls_ssl_tls1_3_generate_early_data_keys"                             \
+            -c "=> write early_data"                                                        \
+            -c "skip EndOfEarlyData, server rejected"                                       \
             -c "early data status, reconnect = 1"
 
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -2188,6 +2188,19 @@ run_test    "TLS 1.3, TLS1-3-AES-256-GCM-SHA384, ext PSK, early data status - no
             0 \
 	    -c "early data status = 0"  \
 
+# test early data status - rejected
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
+requires_config_enabled MBEDTLS_DEBUG_C
+requires_config_enabled MBEDTLS_SSL_SRV_C
+requires_config_enabled MBEDTLS_SSL_CLI_C
+requires_config_enabled MBEDTLS_ZERO_RTT
+requires_config_disabled MBEDTLS_SSL_USE_MPS
+run_test    "TLS 1.3, TLS1-3-AES-256-GCM-SHA384, ext PSK, early data status - rejected" \
+            "$P_SRV nbio=2 debug_level=5 force_version=tls13 early_data=0 tls13_kex_modes=psk psk=010203 psk_identity=0a0b0c" \
+            "$P_CLI nbio=2 debug_level=5 force_version=tls13 force_ciphersuite=TLS1-3-AES-256-GCM-SHA384 tls13_kex_modes=psk early_data=1 psk=010203 psk_identity=0a0b0c" \
+            0 \
+            -c "early data status = 1"  \
+
 # test early data status - accepted
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3
 requires_config_enabled MBEDTLS_DEBUG_C


### PR DESCRIPTION
## Description
This PR adds a new API for sending early data, building off the work done in https://github.com/hannestschofenig/mbedtls/pull/369.

## Background
Currently, to send early data the client application calls `mbedtls_ssl_set_early_data()` before the handshake begins, with a pointer to the early data buffer. Once set, the early data buffer cannot be changed during the handshake, limiting the client application to a single early data payload and reducing the opportunity to take full advantage of early data.

Consider a streaming app for example, where real-time data is generated simultaneously with the handshake. The new API will support streaming early data throughout the duration of the handshake in accordance with the standard:
> Clients are permitted to "stream" 0-RTT data until they receive the server's Finished, only then sending the EndOfEarlyData message, followed by the rest of the handshake.

## Status
**DRAFT, solicit feedback on design.**

## Requires Backporting
NO

## Additional comments
* Credit to @zhihan for setting the foundation for this work, and @lhuang04 for offering feedback.
* I left the existing early data API untouched for now, anticipating it will eventually be removed. The new API can be enabled thru `mbedtls_ssl_conf_early_data()`.
* This branch is based off #386 in order to enable adding tests for the early data rejected case.

## Todos
- [x] Tests
- [x] Documentation
- [ ] Changelog updated
- [ ] Backported


## Steps to test or reproduce
`ssl-opt.sh -f 'early data'`
