### PR TITLE
Fix compiler error when ALPN is enabled in server.

### DIFF
--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -1310,7 +1310,7 @@ static int ssl_parse_supported_versions_ext( mbedtls_ssl_context *ssl,
 static int ssl_parse_alpn_ext( mbedtls_ssl_context *ssl,
                               const unsigned char *buf, size_t len )
 {
-    const unsigned char *end const = buf + len;
+    const unsigned char *end = buf + len;
     size_t list_len;
 
     const char **cur_ours;
@@ -1357,7 +1357,7 @@ static int ssl_parse_alpn_ext( mbedtls_ssl_context *ssl,
             cur_cli_len = *cur_cli++;
 
             if( cur_cli_len == cur_ours_len &&
-                memcmp( cur_cli, *cur_ours, cur_len ) == 0 )
+                memcmp( cur_cli, *cur_ours, cur_ours_len ) == 0 )
             {
                 ssl->alpn_chosen = *cur_ours;
                 return( 0 );
@@ -2601,7 +2601,7 @@ static int ssl_client_hello_parse( mbedtls_ssl_context* ssl,
                     MBEDTLS_SSL_DEBUG_RET( 1, ( "ssl_parse_alpn_ext" ), ret );
                     return( ret );
                 }
-                ssl->handshake->extensions_present |= ALPN_EXTENSION;
+                ssl->handshake->extensions_present |= MBEDTLS_SSL_EXT_ALPN;
                 break;
 #endif /* MBEDTLS_SSL_ALPN */
 
@@ -2904,7 +2904,7 @@ static int ssl_write_alpn_ext( mbedtls_ssl_context *ssl,
 {
     *olen = 0;
 
-    if( ( ssl->handshake->extensions_present & ALPN_EXTENSION ) == 0 ||
+    if( ( ssl->handshake->extensions_present & MBEDTLS_SSL_EXT_ALPN ) == 0 ||
         ssl->alpn_chosen == NULL )
     {
         return( 0 );


### PR DESCRIPTION
Summary:
Fix the following error when I enable ALPN.
```
diff --git a/include/mbedtls/mbedtls_config.h b/include/mbedtls/mbedtls_config.h
index 9d0f5f070..31bc3270c 100644
--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -1585,7 +1585,7 @@
  *
  * Comment this macro to disable support for ALPN.
  */
-//#define MBEDTLS_SSL_ALPN
+#define MBEDTLS_SSL_ALPN
 
 /**
  * \def MBEDTLS_SSL_DTLS_ANTI_REPLAY

```

```
[ 33%] Linking C executable crl_app
/home/lhuang04/upstream/library/ssl_tls13_server.c: In function ‘ssl_parse_alpn_ext’:
/home/lhuang04/upstream/library/ssl_tls13_server.c:1313:29: error: expected ‘;’ before ‘const’
     const unsigned char *end const = buf + len;
                             ^~~~~~
                             ;
/home/lhuang04/upstream/library/ssl_tls13_server.c:1313:36: error: expected identifier or ‘(’ before ‘=’ token
     const unsigned char *end const = buf + len;
                                    ^
/home/lhuang04/upstream/library/ssl_tls13_server.c:1342:36: error: ‘end’ undeclared (first use in this function)
     for( cur_cli = buf; cur_cli != end; cur_cli += cur_cli_len )
                                    ^~~
/home/lhuang04/upstream/library/ssl_tls13_server.c:1342:36: note: each undeclared identifier is reported only once for each function it appears in
/home/lhuang04/upstream/library/ssl_tls13_server.c:1360:45: error: ‘cur_len’ undeclared (first use in this function); did you mean ‘cur_cli’?
                 memcmp( cur_cli, *cur_ours, cur_len ) == 0 )
                                             ^~~~~~~
                                             cur_cli
[ 33%] Linking C executable req_app
/home/lhuang04/upstream/library/ssl_tls13_server.c: In function ‘ssl_client_hello_parse’:
/home/lhuang04/upstream/library/ssl_tls13_server.c:2604:55: error: ‘ALPN_EXTENSION’ undeclared (first use in this function)
                 ssl->handshake->extensions_present |= ALPN_EXTENSION;
                                                       ^~~~~~~~~~~~~~
/home/lhuang04/upstream/library/ssl_tls13_server.c: In function ‘ssl_write_alpn_ext’:
/home/lhuang04/upstream/library/ssl_tls13_server.c:2907:48: error: ‘ALPN_EXTENSION’ undeclared (first use in this function)
     if( ( ssl->handshake->extensions_present & ALPN_EXTENSION ) == 0 ||
                                                ^~~~~~~~~~~~~~
[ 34%] Linking C executable cert_req
make[2]: *** [library/CMakeFiles/mbedtls.dir/build.make:258: library/CMakeFiles/mbedtls.dir/ssl_tls13_server.c.o] Error 1
make[2]: *** Waiting for unfinished jobs....

```
Test Plan:
```
tests/ssl-opt.sh -p -s -f "TLS 1.3, ALPN" 
```
Reviewers:

Subscribers:

Tasks:

Tags:

Notes:
* Pull requests cannot be accepted until the PR follows the [contributing guidelines](../CONTRIBUTING.md). In particular, each commit must have at least one `Signed-off-by:` line from the committer to certify that the contribution is made under the terms of the [Developer Certificate of Origin](../dco.txt).
* This is just a template, so feel free to use/remove the unnecessary things
## Description
A few sentences describing the overall goals of the pull request's commits.


## Status
**READY/IN DEVELOPMENT/HOLD**

## Requires Backporting
When there is a bug fix, it should be backported to all maintained and supported branches.
Changes do not have to be backported if:
- This PR is a new feature\enhancement
- This PR contains changes in the API. If this is true, and there is a need for the fix to be backported, the fix should be handled differently in the legacy branch

Yes | NO  
Which branch?

## Migrations
If there is any API change, what's the incentive and logic for it.

YES | NO

## Additional comments
Any additional information that could be of interest

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported


## Steps to test or reproduce
Outline the steps to test or reproduce the PR here.
