### PR TITLE
tls13-prototype non PSA  for client

### DIFF
--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -746,8 +746,7 @@
  */
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3) && \
     ( ( !defined(MBEDTLS_HKDF_C) ) || \
-      ( !defined(MBEDTLS_SHA256_C) && !defined(MBEDTLS_SHA384_C) ) || \
-      ( !defined(MBEDTLS_PSA_CRYPTO_C) ) )
+      ( !defined(MBEDTLS_SHA256_C) && !defined(MBEDTLS_SHA384_C) ) )
 #error "MBEDTLS_SSL_PROTO_TLS1_3 defined, but not all prerequisites"
 #endif
 

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -679,14 +679,14 @@ struct mbedtls_ssl_handshake_params
     mbedtls_ecdh_context ecdh_ctx;              /*!<  ECDH key exchange       */
 #endif /* !MBEDTLS_USE_PSA_CRYPTO */
 
-#if defined(MBEDTLS_USE_PSA_CRYPTO) || defined(MBEDTLS_SSL_PROTO_TLS1_3)
+#if defined(MBEDTLS_USE_PSA_CRYPTO) || (defined(MBEDTLS_SSL_SRV_C) && defined(MBEDTLS_SSL_PROTO_TLS1_3))
     psa_key_type_t ecdh_psa_type;
     size_t ecdh_bits;
     mbedtls_svc_key_id_t ecdh_psa_privkey;
     uint8_t ecdh_psa_privkey_is_external;
     unsigned char ecdh_psa_peerkey[MBEDTLS_PSA_MAX_EC_PUBKEY_LENGTH];
     size_t ecdh_psa_peerkey_len;
-#endif /* MBEDTLS_USE_PSA_CRYPTO || MBEDTLS_SSL_PROTO_TLS1_3 */
+#endif /* MBEDTLS_USE_PSA_CRYPTO || (defined(MBEDTLS_SSL_SRV_C) && defined(MBEDTLS_SSL_PROTO_TLS1_3)) */
 #endif /* MBEDTLS_ECDH_C || MBEDTLS_ECDSA_C */
 
 #if defined(MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED)
@@ -2014,6 +2014,34 @@ static inline int mbedtls_ssl_conf_is_hybrid_tls12_tls13( const mbedtls_ssl_conf
 #endif /* MBEDTLS_SSL_PROTO_TLS1_2 && MBEDTLS_SSL_PROTO_TLS1_3 */
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3)
+#if defined(MBEDTLS_ECDH_C)
+/**
+ * \brief           This function generates an EC key pair and exports its
+ *                  in the format used in a TLS 1.3 KeyShare extension.
+ *
+ * \see             ecp.h
+ *
+ * \param ctx       The ECDH context to use. This must be initialized
+ *                  and bound to a group, for example via mbedtls_ecdh_setup().
+ * \param olen      The address at which to store the number of Bytes written.
+ * \param buf       The destination buffer. This must be a writable buffer of
+ *                  length \p blen Bytes.
+ * \param blen      The length of the destination buffer \p buf in Bytes.
+ * \param f_rng     The RNG function to use. This must not be \c NULL.
+ * \param p_rng     The RNG context to be passed to \p f_rng. This may be
+ *                  \c NULL in case \p f_rng doesn't need a context argument.
+ *
+ * \return          \c 0 on success.
+ * \return          #MBEDTLS_ERR_ECP_IN_PROGRESS if maximum number of
+ *                  operations was reached: see \c mbedtls_ecp_set_max_ops().
+ * \return          Another \c MBEDTLS_ERR_ECP_XXX error code on failure.
+ */
+int mbedtls_ecdh_make_tls13_params( mbedtls_ecdh_context *ctx, size_t *olen,
+                      unsigned char *buf, size_t blen,
+                      int (*f_rng)(void *, unsigned char *, size_t),
+                      void *p_rng );
+
+#endif /* MBEDTLS_ECDH_C */
 extern const uint8_t mbedtls_ssl_tls13_hello_retry_request_magic[
                         MBEDTLS_SERVER_HELLO_RANDOM_LEN ];
 MBEDTLS_CHECK_RETURN_CRITICAL
@@ -2637,7 +2665,7 @@ int mbedtls_ssl_tls13_check_sig_alg_cert_key_match( uint16_t sig_alg,
 
 #endif /* MBEDTLS_KEY_EXCHANGE_WITH_CERT_ENABLED */
 
-#if defined(MBEDTLS_USE_PSA_CRYPTO) || defined(MBEDTLS_SSL_PROTO_TLS1_3)
+#if defined(MBEDTLS_USE_PSA_CRYPTO) || (defined(MBEDTLS_SSL_SRV_C) && defined(MBEDTLS_SSL_PROTO_TLS1_3))
 /* Corresponding PSA algorithm for MBEDTLS_CIPHER_NULL.
  * Same value is used for PSA_ALG_CATEGORY_CIPHER, hence it is
  * guaranteed to not be a valid PSA algorithm identifier.
@@ -2697,7 +2725,7 @@ static inline int psa_ssl_status_to_mbedtls( psa_status_t status )
             return( MBEDTLS_ERR_PLATFORM_HW_ACCEL_FAILED );
     }
 }
-#endif /* MBEDTLS_USE_PSA_CRYPTO || MBEDTLS_SSL_PROTO_TLS1_3 */
+#endif /* MBEDTLS_USE_PSA_CRYPTO || (defined(MBEDTLS_SSL_SRV_C) && defined(MBEDTLS_SSL_PROTO_TLS1_3))*/
 
 /**
  * \brief       TLS record protection modes

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -3975,11 +3975,12 @@ void mbedtls_ssl_handshake_free( mbedtls_ssl_context *ssl )
     mbedtls_ssl_buffering_free( ssl );
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
 
-#if defined(MBEDTLS_ECDH_C) && \
-    ( defined(MBEDTLS_USE_PSA_CRYPTO) || defined(MBEDTLS_SSL_PROTO_TLS1_3) )
+#if defined(MBEDTLS_ECDH_C) && ( defined(MBEDTLS_USE_PSA_CRYPTO) \
+    || ( defined(MBEDTLS_SSL_SRV_C) && defined(MBEDTLS_SSL_PROTO_TLS1_3) ) )
     if( handshake->ecdh_psa_privkey_is_external == 0 )
         psa_destroy_key( handshake->ecdh_psa_privkey );
-#endif /* MBEDTLS_ECDH_C && MBEDTLS_USE_PSA_CRYPTO */
+#endif /* MBEDTLS_ECDH_C && ( defined(MBEDTLS_USE_PSA_CRYPTO) \
+    || ( defined(MBEDTLS_SSL_SRV_C) && defined(MBEDTLS_SSL_PROTO_TLS1_3) ) ) */
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3)
     mbedtls_ssl_transform_free( handshake->transform_handshake );

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -45,6 +45,8 @@
 #define mbedtls_free       free
 #endif
 
+#include "ecp_internal.h"
+
 /* Write extensions */
 
 /*
@@ -203,6 +205,7 @@ static int ssl_tls13_reset_key_share( mbedtls_ssl_context *ssl )
 #if defined(MBEDTLS_ECDH_C)
     if( mbedtls_ssl_tls13_named_group_is_ecdhe( group_id ) )
     {
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
         int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
         psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
 
@@ -216,6 +219,7 @@ static int ssl_tls13_reset_key_share( mbedtls_ssl_context *ssl )
         }
 
         ssl->handshake->ecdh_psa_privkey = MBEDTLS_SVC_KEY_ID_INIT;
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
         return( 0 );
     }
     else
@@ -337,8 +341,34 @@ static int ssl_tls13_write_key_share_ext( mbedtls_ssl_context *ssl,
          */
         MBEDTLS_SSL_CHK_BUF_PTR( p, end, 4 );
         p += 4;
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
         ret = mbedtls_ssl_tls13_generate_and_write_ecdh_key_exchange(
                                     ssl, group_id, p, end, &key_exchange_len );
+#else
+        mbedtls_ecp_group_id ecp_group_id = mbedtls_ecp_named_group_to_id( group_id );
+        if( ecp_group_id == MBEDTLS_ECP_DP_NONE )
+        {
+            MBEDTLS_SSL_DEBUG_MSG( 4, ( "Unrecognized NamedGroup %u",
+                                        (unsigned) group_id ) );
+            return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
+        }
+
+        ret = mbedtls_ecdh_setup( &ssl->handshake->ecdh_ctx, ecp_group_id);
+        if( ret != 0 )
+        {
+            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ecdh_setup", ret );
+            return( ret );
+        }
+
+        ret = mbedtls_ecdh_make_tls13_params( &ssl->handshake->ecdh_ctx, &key_exchange_len,
+                                               p, end - p,
+                                               ssl->conf->f_rng, ssl->conf->p_rng );
+        if( ret != 0 )
+        {
+            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ecdh_make_tls_13_params", ret );
+            return( ret );
+        }
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
         p += key_exchange_len;
         if( ret != 0 )
             return( ret );
@@ -385,6 +415,33 @@ cleanup:
 
     return( ret );
 }
+
+#if defined(MBEDTLS_ECDH_C)
+
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+static int ssl_tls13_read_public_ecdhe_share( mbedtls_ssl_context *ssl,
+                                              const unsigned char *buf,
+                                              size_t buf_len )
+{
+    uint8_t *p = (uint8_t*)buf;
+    mbedtls_ssl_handshake_params *handshake = ssl->handshake;
+
+    /* Get size of the TLS opaque key_exchange field of the KeyShareEntry struct. */
+    uint16_t peerkey_len = MBEDTLS_GET_UINT16_BE( p, 0 );
+    p += 2;
+
+    /* Check if key size is consistent with given buffer length. */
+    if ( peerkey_len > ( buf_len - 2 ) )
+        return( MBEDTLS_ERR_SSL_DECODE_ERROR );
+
+    /* Store peer's ECDH public key. */
+    memcpy( handshake->ecdh_psa_peerkey, p, peerkey_len );
+    handshake->ecdh_psa_peerkey_len = peerkey_len;
+
+    return( 0 );
+}
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
+#endif /* MBEDTLS_ECDH_C */
 
 /*
  * ssl_tls13_parse_hrr_key_share_ext()
@@ -511,9 +568,18 @@ static int ssl_tls13_parse_key_share_ext( mbedtls_ssl_context *ssl,
 
         MBEDTLS_SSL_DEBUG_MSG( 2, ( "ECDH curve: %s", curve_info->name ) );
 
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
         ret = mbedtls_ssl_tls13_read_public_ecdhe_share( ssl, p, end - p );
         if( ret != 0 )
             return( ret );
+#else
+        if( ( ret = mbedtls_ecdh_import_public_raw( &ssl->handshake->ecdh_ctx, p,
+                end ) ) != 0 )
+        {
+            MBEDTLS_SSL_DEBUG_RET( 1, ( "mbedtls_ecdh_import_public_raw" ), ret );
+            return( ret );
+        }
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
     }
     else
 #endif /* MBEDTLS_ECDH_C */
@@ -926,7 +992,10 @@ int mbedtls_ssl_tls13_write_pre_shared_key_ext_binders(
         return( ret );
 
     ret = mbedtls_ssl_tls13_create_psk_binder( ssl,
-              mbedtls_psa_translate_md( suite_info->mac ),
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+        mbedtls_psa_translate_md
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
+        ( suite_info->mac ),
               psk, psk_len, psk_type,
               transcript, p );
     if( ret != 0 )
@@ -3244,7 +3313,10 @@ static int ssl_tls13_new_session_ticket_parse( mbedtls_ssl_context *ssl,
      *                    "resumption", ticket_nonce, Hash.length )
      */
     ret = mbedtls_ssl_tls13_hkdf_expand_label(
-                    mbedtls_psa_translate_md( suite_info->mac ),
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+        mbedtls_psa_translate_md
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
+        ( suite_info->mac ),
                     ssl->session->app_secrets.resumption_master_secret,
                     hash_length,
                     MBEDTLS_SSL_TLS1_3_LBL_WITH_LEN( resumption ),

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -43,6 +43,8 @@
 #include "mps_all.h"
 #endif /* MBEDTLS_SSL_USE_MPS */
 
+#include "ecp_internal.h"
+
 #include "psa/crypto.h"
 #include "mbedtls/psa_util.h"
 
@@ -1575,6 +1577,7 @@ static int ssl_tls13_write_certificate_verify_body( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_DEBUG_BUF( 3, "verify hash", verify_hash, verify_hash_len );
 
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
     if( ( ret = mbedtls_pk_sign_ext( pk_type, own_key,
                         md_alg, verify_hash, verify_hash_len,
                         p + 2, (size_t)( end - ( p + 2 ) ), &signature_len,
@@ -1583,6 +1586,16 @@ static int ssl_tls13_write_certificate_verify_body( mbedtls_ssl_context *ssl,
         MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_pk_sign", ret );
         return( ret );
     }
+#else
+    if( ( ret = mbedtls_pk_sign( own_key, md_alg,
+                                 verify_hash, verify_hash_len,
+                                 p + 2, (size_t)( end - ( p + 2 ) ), &signature_len,
+                                 ssl->conf->f_rng, ssl->conf->p_rng ) ) != 0 )
+    {
+        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_pk_sign", ret );
+        return( ret );
+    }
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
     MBEDTLS_PUT_UINT16_BE( signature_len, p, 0 );
     p += 2 + signature_len;
@@ -1743,6 +1756,151 @@ int mbedtls_ssl_tls13_write_early_data_ext( mbedtls_ssl_context *ssl,
 }
 #endif /* MBEDTLS_ZERO_RTT */
 
+#if defined(MBEDTLS_ECP_C)
+#define ECP_VALIDATE_RET( cond )    \
+    MBEDTLS_INTERNAL_VALIDATE_RET( cond, MBEDTLS_ERR_ECP_BAD_INPUT_DATA )
+
+static int mbedtls_ecp_tls13_read_point( const mbedtls_ecp_group *grp,
+                                  mbedtls_ecp_point *pt,
+                                  const unsigned char **buf, size_t buf_len )
+{
+    unsigned char data_len;
+    const unsigned char *buf_start;
+    ECP_VALIDATE_RET( grp != NULL );
+    ECP_VALIDATE_RET( pt  != NULL );
+    ECP_VALIDATE_RET( buf != NULL );
+    ECP_VALIDATE_RET( *buf != NULL );
+
+    if( buf_len < 3 )
+        return( MBEDTLS_ERR_ECP_BAD_INPUT_DATA );
+
+    data_len = MBEDTLS_GET_UINT16_BE( *buf, 0 );
+    *buf += 2;
+
+    if( data_len < 1 || data_len > buf_len - 2 )
+        return( MBEDTLS_ERR_ECP_BAD_INPUT_DATA );
+
+    /*
+     * Save buffer start for read_binary and update buf
+     */
+    buf_start = *buf;
+    *buf += data_len;
+
+    return( mbedtls_ecp_point_read_binary( grp, pt, buf_start, data_len ) );
+}
+
+#endif /* MBEDTLS_ECP_C */
+
+#if defined(MBEDTLS_ECDH_C)
+#if defined(MBEDTLS_ECDH_LEGACY_CONTEXT)
+typedef mbedtls_ecdh_context mbedtls_ecdh_context_mbed;
+#endif
+
+#define ECDH_VALIDATE_RET( cond )    \
+    MBEDTLS_INTERNAL_VALIDATE_RET( cond, MBEDTLS_ERR_ECP_BAD_INPUT_DATA )
+
+static int ecdh_make_tls13_params_internal( mbedtls_ecdh_context_mbed *ctx,
+                                      size_t *out_len, int point_format,
+                                      unsigned char *buf, size_t blen,
+                                      int (*f_rng)(void *,
+                                                   unsigned char *,
+                                                   size_t),
+                                      void *p_rng,
+                                      int restart_enabled )
+{
+    int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
+#if defined(MBEDTLS_ECP_RESTARTABLE)
+    mbedtls_ecp_restart_ctx *rs_ctx = NULL;
+#endif
+
+    if( ctx->grp.pbits == 0 )
+        return( MBEDTLS_ERR_ECP_BAD_INPUT_DATA );
+
+#if defined(MBEDTLS_ECP_RESTARTABLE)
+    if( restart_enabled )
+        rs_ctx = &ctx->rs;
+#else
+    (void) restart_enabled;
+#endif
+
+
+#if defined(MBEDTLS_ECP_RESTARTABLE)
+    if( ( ret = ecdh_gen_public_restartable( &ctx->grp, &ctx->d, &ctx->Q,
+                                             f_rng, p_rng, rs_ctx ) ) != 0 )
+        return( ret );
+#else
+    if( ( ret = mbedtls_ecdh_gen_public( &ctx->grp, &ctx->d, &ctx->Q,
+                                         f_rng, p_rng ) ) != 0 )
+        return( ret );
+#endif /* MBEDTLS_ECP_RESTARTABLE */
+
+    ret = mbedtls_ecp_point_write_binary( &ctx->grp, &ctx->Q, point_format,
+                                          out_len, buf, blen );
+    if( ret != 0 )
+        return( ret );
+
+    return( 0 );
+}
+
+int mbedtls_ecdh_make_tls13_params( mbedtls_ecdh_context *ctx, size_t *out_len,
+                              unsigned char *buf, size_t blen,
+                              int (*f_rng)(void *, unsigned char *, size_t),
+                              void *p_rng )
+{
+    int restart_enabled = 0;
+    ECDH_VALIDATE_RET( ctx != NULL );
+    ECDH_VALIDATE_RET( out_len != NULL );
+    ECDH_VALIDATE_RET( buf != NULL );
+    ECDH_VALIDATE_RET( f_rng != NULL );
+
+#if defined(MBEDTLS_ECP_RESTARTABLE)
+    restart_enabled = ctx->restart_enabled;
+#else
+    (void) restart_enabled;
+#endif
+
+#if defined(MBEDTLS_ECDH_LEGACY_CONTEXT)
+    return( ecdh_make_tls13_params_internal( ctx, out_len, ctx->point_format, buf, blen,
+                                       f_rng, p_rng, restart_enabled ) );
+#else
+    switch( ctx->var )
+    {
+        case MBEDTLS_ECDH_VARIANT_MBEDTLS_2_0:
+            return( ecdh_make_tls13_params_internal( &ctx->ctx.mbed_ecdh, out_len,
+                                               ctx->point_format, buf, blen,
+                                               f_rng, p_rng,
+                                               restart_enabled ) );
+        default:
+            return MBEDTLS_ERR_ECP_BAD_INPUT_DATA;
+    }
+#endif
+}
+
+int mbedtls_ecdh_import_public_raw( mbedtls_ecdh_context *ctx,
+                                    const unsigned char *buf,
+                                    const unsigned char *end )
+{
+    ECDH_VALIDATE_RET( ctx != NULL );
+    ECDH_VALIDATE_RET( buf != NULL );
+    ECDH_VALIDATE_RET( end != NULL );
+
+#if defined(MBEDTLS_ECDH_LEGACY_CONTEXT)
+    return( mbedtls_ecp_tls13_read_point( &ctx->grp, &ctx->Qp, &buf,
+                                        end - buf ) );
+#else
+    switch( ctx->var )
+    {
+        case MBEDTLS_ECDH_VARIANT_MBEDTLS_2_0:
+            return( mbedtls_ecp_tls13_read_point( &ctx->ctx.mbed_ecdh.grp,
+                  &ctx->ctx.mbed_ecdh.Qp, &buf, end - buf ) );
+        default:
+            return MBEDTLS_ERR_ECP_BAD_INPUT_DATA;
+    }
+#endif
+}
+
+#endif /* MBEDTLS_ECDH_C */
+
 /* Reset SSL context and update hash for handling HRR.
  *
  * Replace Transcript-Hash(X) by
@@ -1820,6 +1978,7 @@ int mbedtls_ssl_reset_transcript_for_hrr( mbedtls_ssl_context *ssl )
 
 #if defined(MBEDTLS_ECDH_C)
 
+#if defined(MBEDTLS_USE_PSA_CRYPTO) || (defined(MBEDTLS_SSL_SRV_C) && defined(MBEDTLS_SSL_PROTO_TLS1_3))
 int mbedtls_ssl_tls13_read_public_ecdhe_share( mbedtls_ssl_context *ssl,
                                                const unsigned char *buf,
                                                size_t buf_len )
@@ -1899,6 +2058,7 @@ int mbedtls_ssl_tls13_generate_and_write_ecdh_key_exchange(
 
     return( 0 );
 }
+#endif /* MBEDTLS_USE_PSA_CRYPTO || (defined(MBEDTLS_SSL_SRV_C) && defined(MBEDTLS_SSL_PROTO_TLS1_3)) */
 #endif /* MBEDTLS_ECDH_C */
 
 #endif /* MBEDTLS_SSL_TLS_C && MBEDTLS_SSL_PROTO_TLS1_3 */

--- a/library/ssl_tls13_keys.c
+++ b/library/ssl_tls13_keys.c
@@ -33,7 +33,9 @@
 #include "ssl_tls13_keys.h"
 #include "ssl_tls13_invasive.h"
 
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
 #include "psa/crypto.h"
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
 #if defined(MBEDTLS_SSL_USE_MPS)
 #include "mps_all.h"
@@ -150,18 +152,27 @@ static void ssl_tls13_hkdf_encode_label(
 }
 
 int mbedtls_ssl_tls13_hkdf_expand_label(
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
                      psa_algorithm_t hash_alg,
+#else
+                     mbedtls_md_type_t hash_alg,
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
                      const unsigned char *secret, size_t secret_len,
                      const unsigned char *label, size_t label_len,
                      const unsigned char *ctx, size_t ctx_len,
                      unsigned char *buf, size_t buf_len )
 {
+#if !defined(MBEDTLS_USE_PSA_CRYPTO)
+    const mbedtls_md_info_t *md_info;
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
     unsigned char hkdf_label[ SSL_TLS1_3_KEY_SCHEDULE_MAX_HKDF_LABEL_LEN ];
     size_t hkdf_label_len = 0;
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
     psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
     psa_status_t abort_status = PSA_ERROR_CORRUPTION_DETECTED;
     psa_key_derivation_operation_t operation =
         PSA_KEY_DERIVATION_OPERATION_INIT;
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
     if( label_len > MBEDTLS_SSL_TLS1_3_KEY_SCHEDULE_MAX_LABEL_LEN )
     {
@@ -183,8 +194,14 @@ int mbedtls_ssl_tls13_hkdf_expand_label(
         return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
     }
 
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
     if( ! PSA_ALG_IS_HASH( hash_alg ) )
         return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
+#else
+    md_info = mbedtls_md_info_from_type( hash_alg );
+    if( md_info == NULL )
+        return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
     ssl_tls13_hkdf_encode_label( buf_len,
                                  label, label_len,
@@ -192,6 +209,7 @@ int mbedtls_ssl_tls13_hkdf_expand_label(
                                  hkdf_label,
                                  &hkdf_label_len );
 
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
     status = psa_key_derivation_setup( &operation, PSA_ALG_HKDF_EXPAND( hash_alg ) );
 
     if( status != PSA_SUCCESS )
@@ -225,6 +243,12 @@ cleanup:
     status = ( status == PSA_SUCCESS ? abort_status : status );
     mbedtls_platform_zeroize( hkdf_label, hkdf_label_len );
     return( psa_ssl_status_to_mbedtls ( status ) );
+#else
+    return( mbedtls_hkdf_expand( md_info,
+                                 secret, secret_len,
+                                 hkdf_label, hkdf_label_len,
+                                 buf, buf_len ) );
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 }
 
 static int ssl_tls13_get_psk( mbedtls_ssl_context *ssl,
@@ -282,7 +306,11 @@ static int ssl_tls13_get_psk( mbedtls_ssl_context *ssl,
  * keys in a single function call.
  */
 int mbedtls_ssl_tls13_make_traffic_keys(
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
                      psa_algorithm_t hash_alg,
+#else
+                     mbedtls_md_type_t hash_alg,
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
                      const unsigned char *client_secret,
                      const unsigned char *server_secret, size_t secret_len,
                      size_t key_len, size_t iv_len,
@@ -329,7 +357,11 @@ int mbedtls_ssl_tls13_make_traffic_keys(
 }
 
 int mbedtls_ssl_tls13_derive_secret(
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
                    psa_algorithm_t hash_alg,
+#else
+                   mbedtls_md_type_t hash_alg,
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
                    const unsigned char *secret, size_t secret_len,
                    const unsigned char *label, size_t label_len,
                    const unsigned char *ctx, size_t ctx_len,
@@ -337,6 +369,7 @@ int mbedtls_ssl_tls13_derive_secret(
                    unsigned char *dstbuf, size_t dstbuf_len )
 {
     int ret;
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
     unsigned char hashed_context[ PSA_HASH_MAX_SIZE ];
     if( ctx_hashed == MBEDTLS_SSL_TLS1_3_CONTEXT_UNHASHED )
     {
@@ -350,6 +383,22 @@ int mbedtls_ssl_tls13_derive_secret(
             return ret;
         }
     }
+#else
+    unsigned char hashed_context[ MBEDTLS_MD_MAX_SIZE ];
+
+    const mbedtls_md_info_t *md_info;
+    md_info = mbedtls_md_info_from_type( hash_alg );
+    if( md_info == NULL )
+        return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
+
+    if( ctx_hashed == MBEDTLS_SSL_TLS1_3_CONTEXT_UNHASHED )
+    {
+        ret = mbedtls_md( md_info, ctx, ctx_len, hashed_context );
+        if( ret != 0 )
+            return( ret );
+        ctx_len = mbedtls_md_get_size( md_info );
+    }
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
     else
     {
         if( ctx_len > sizeof(hashed_context) )
@@ -373,15 +422,22 @@ int mbedtls_ssl_tls13_derive_secret(
 }
 
 int mbedtls_ssl_tls13_evolve_secret(
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
                    psa_algorithm_t hash_alg,
+#else
+                   mbedtls_md_type_t hash_alg,
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
                    const unsigned char *secret_old,
                    const unsigned char *input, size_t input_len,
                    unsigned char *secret_new )
 {
     int ret = MBEDTLS_ERR_SSL_INTERNAL_ERROR;
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
     psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
     psa_status_t abort_status = PSA_ERROR_CORRUPTION_DETECTED;
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
     size_t hlen, ilen;
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
     unsigned char tmp_secret[ PSA_MAC_MAX_SIZE ] = { 0 };
     unsigned char tmp_input [ MBEDTLS_SSL_TLS1_3_MAX_IKM_SIZE ] = { 0 };
     psa_key_derivation_operation_t operation =
@@ -391,6 +447,17 @@ int mbedtls_ssl_tls13_evolve_secret(
         return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
 
     hlen = PSA_HASH_LENGTH( hash_alg );
+#else
+    unsigned char tmp_secret[ MBEDTLS_MD_MAX_SIZE ] = { 0 };
+    unsigned char tmp_input [ MBEDTLS_SSL_TLS1_3_MAX_IKM_SIZE ] = { 0 };
+
+    const mbedtls_md_info_t *md_info;
+    md_info = mbedtls_md_info_from_type( hash_alg );
+    if( md_info == NULL )
+        return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
+
+    hlen = mbedtls_md_get_size( md_info );
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
     /* For non-initial runs, call Derive-Secret( ., "derived", "")
      * on the old secret. */
@@ -419,6 +486,7 @@ int mbedtls_ssl_tls13_evolve_secret(
         ilen = hlen;
     }
 
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
     status = psa_key_derivation_setup( &operation,
                                        PSA_ALG_HKDF_EXTRACT( hash_alg ) );
 
@@ -447,29 +515,51 @@ int mbedtls_ssl_tls13_evolve_secret(
 
     if( status != PSA_SUCCESS )
          goto cleanup;
+#else
+    ret = mbedtls_hkdf_extract( md_info,
+                    tmp_secret, hlen,
+                    tmp_input, ilen,
+                    secret_new );
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
  cleanup:
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
     abort_status = psa_key_derivation_abort( &operation );
     status = ( status == PSA_SUCCESS ? abort_status : status );
     ret = ( ret == 0 ? psa_ssl_status_to_mbedtls ( status ) : ret );
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
     mbedtls_platform_zeroize( tmp_secret, sizeof(tmp_secret) );
     mbedtls_platform_zeroize( tmp_input,  sizeof(tmp_input)  );
     return( ret );
 }
 
 int mbedtls_ssl_tls13_derive_early_secrets(
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
           psa_algorithm_t hash_alg,
+#else
+          mbedtls_md_type_t hash_alg,
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
           unsigned char const *early_secret,
           unsigned char const *transcript, size_t transcript_len,
           mbedtls_ssl_tls13_early_secrets *derived )
 {
     int ret;
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
     size_t const hash_len = PSA_HASH_LENGTH( hash_alg );
 
     /* We should never call this function with an unknown hash,
      * but add an assertion anyway. */
     if( ! PSA_ALG_IS_HASH( hash_alg ) )
         return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
+#else
+    mbedtls_md_info_t const * const md_info = mbedtls_md_info_from_type( hash_alg );
+    size_t const hash_len = mbedtls_md_get_size( md_info );
+
+    /* We should never call this function with an unknown hash,
+     * but add an assertion anyway. */
+    if( md_info == 0 )
+        return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
     /*
      *            0
@@ -511,18 +601,33 @@ int mbedtls_ssl_tls13_derive_early_secrets(
 }
 
 int mbedtls_ssl_tls13_derive_handshake_secrets(
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
           psa_algorithm_t hash_alg,
+#else
+          mbedtls_md_type_t hash_alg,
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
           unsigned char const *handshake_secret,
           unsigned char const *transcript, size_t transcript_len,
           mbedtls_ssl_tls13_handshake_secrets *derived )
 {
     int ret;
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
     size_t const hash_len = PSA_HASH_LENGTH( hash_alg );
+#else
+    mbedtls_md_info_t const * const md_info = mbedtls_md_info_from_type( hash_alg );
+    size_t const hash_len = mbedtls_md_get_size( md_info );
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
     /* We should never call this function with an unknown hash,
      * but add an assertion anyway. */
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
     if( ! PSA_ALG_IS_HASH( hash_alg ) )
         return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
+#else
+    if( md_info == 0 )
+        return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
+
 
     /*
      *
@@ -572,18 +677,32 @@ int mbedtls_ssl_tls13_derive_handshake_secrets(
 }
 
 int mbedtls_ssl_tls13_derive_application_secrets(
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
           psa_algorithm_t hash_alg,
+#else
+          mbedtls_md_type_t hash_alg,
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
           unsigned char const *application_secret,
           unsigned char const *transcript, size_t transcript_len,
           mbedtls_ssl_tls13_application_secrets *derived )
 {
     int ret;
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
     size_t const hash_len = PSA_HASH_LENGTH( hash_alg );
 
     /* We should never call this function with an unknown hash,
      * but add an assertion anyway. */
     if( ! PSA_ALG_IS_HASH( hash_alg ) )
         return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
+#else
+    mbedtls_md_info_t const * const md_info = mbedtls_md_info_from_type( hash_alg );
+    size_t const hash_len = mbedtls_md_get_size( md_info );
+
+    /* We should never call this function with an unknown hash,
+     * but add an assertion anyway. */
+    if( md_info == 0 )
+        return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
     /* Generate {client,server}_application_traffic_secret_0
      *
@@ -641,18 +760,32 @@ int mbedtls_ssl_tls13_derive_application_secrets(
  * This is not integrated with mbedtls_ssl_tls13_derive_application_secrets()
  * because it uses the transcript hash up to and including ClientFinished. */
 int mbedtls_ssl_tls13_derive_resumption_master_secret(
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
           psa_algorithm_t hash_alg,
+#else
+          mbedtls_md_type_t hash_alg,
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
           unsigned char const *application_secret,
           unsigned char const *transcript, size_t transcript_len,
           mbedtls_ssl_tls13_application_secrets *derived )
 {
     int ret;
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
     size_t const hash_len = PSA_HASH_LENGTH( hash_alg );
 
     /* We should never call this function with an unknown hash,
      * but add an assertion anyway. */
     if( ! PSA_ALG_IS_HASH( hash_alg ) )
         return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
+#else
+    mbedtls_md_info_t const * const md_info = mbedtls_md_info_from_type( hash_alg );
+    size_t const hash_len = mbedtls_md_get_size( md_info );
+
+    /* We should never call this function with an unknown hash,
+     * but add an assertion anyway. */
+    if( md_info == 0 )
+        return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
     ret = mbedtls_ssl_tls13_derive_secret( hash_alg,
               application_secret, hash_len,
@@ -694,7 +827,10 @@ int mbedtls_ssl_tls13_generate_resumption_master_secret(
         return( ret );
 
     ret = mbedtls_ssl_tls13_derive_resumption_master_secret(
-                              mbedtls_psa_translate_md( md_type ),
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+                              mbedtls_psa_translate_md
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
+                              ( md_type ),
                               ssl->handshake->tls13_master_secrets.app,
                               transcript, transcript_len,
                               &ssl->session_negotiate->app_secrets );
@@ -719,8 +855,19 @@ int mbedtls_ssl_tls13_key_schedule_stage_application(
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     mbedtls_ssl_handshake_params *handshake = ssl->handshake;
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
     psa_algorithm_t const hash_alg = mbedtls_psa_translate_md(
                                         handshake->ciphersuite_info->mac );
+#if defined(MBEDTLS_DEBUG_C)
+    size_t const hash_len = PSA_HASH_LENGTH( hash_alg );
+#endif /* MBEDTLS_DEBUG_C */
+#else
+    mbedtls_md_type_t const hash_alg = handshake->ciphersuite_info->mac;
+#if defined(MBEDTLS_DEBUG_C)
+    mbedtls_md_info_t const * const md_info = mbedtls_md_info_from_type( hash_alg );
+    size_t const hash_len = mbedtls_md_get_size( md_info );
+#endif /* MBEDTLS_DEBUG_C */
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
     /*
      * Compute MasterSecret
@@ -736,30 +883,46 @@ int mbedtls_ssl_tls13_key_schedule_stage_application(
     }
 
     MBEDTLS_SSL_DEBUG_BUF( 4, "Master secret",
-             handshake->tls13_master_secrets.app, PSA_HASH_LENGTH( hash_alg ) );
+             handshake->tls13_master_secrets.app, hash_len );
 
     return( 0 );
 }
 
 MBEDTLS_CHECK_RETURN_CRITICAL
-static int ssl_tls13_calc_finished_core( psa_algorithm_t hash_alg,
+static int ssl_tls13_calc_finished_core(
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+                                         psa_algorithm_t hash_alg,
+#else
+                                         mbedtls_md_type_t hash_alg,
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
                                          unsigned char const *base_key,
                                          unsigned char const *transcript,
                                          unsigned char *dst,
                                          size_t *dst_len )
 {
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
     mbedtls_svc_key_id_t key = MBEDTLS_SVC_KEY_ID_INIT;
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
     size_t hash_len = PSA_HASH_LENGTH( hash_alg );
     unsigned char finished_key[PSA_MAC_MAX_SIZE];
+#else
+    const mbedtls_md_info_t * const md_info = mbedtls_md_info_from_type( hash_alg );
+    size_t const hash_len = mbedtls_md_get_size( md_info );
+    unsigned char finished_key[MBEDTLS_MD_MAX_SIZE];
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
     int ret;
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
     psa_algorithm_t alg;
 
     /* We should never call this function with an unknown hash,
      * but add an assertion anyway. */
     if( ! PSA_ALG_IS_HASH( hash_alg ) )
         return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
+#else
+    if( md_info == 0 )
+        return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
     /* TLS 1.3 Finished message
      *
@@ -778,6 +941,7 @@ static int ssl_tls13_calc_finished_core( psa_algorithm_t hash_alg,
      *    HKDF-Expand-Label( BaseKey, "finished", "", Hash.length )
      */
 
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
     ret = mbedtls_ssl_tls13_hkdf_expand_label(
                                  hash_alg, base_key, hash_len,
                                  MBEDTLS_SSL_TLS1_3_LBL_WITH_LEN( finished ),
@@ -801,12 +965,28 @@ static int ssl_tls13_calc_finished_core( psa_algorithm_t hash_alg,
     status = psa_mac_compute( key, alg, transcript, hash_len,
                               dst, hash_len, dst_len );
     ret = psa_ssl_status_to_mbedtls( status );
+#else
+    ret = mbedtls_ssl_tls13_hkdf_expand_label(
+                                 hash_alg, base_key, hash_len,
+                                 MBEDTLS_SSL_TLS1_3_LBL_WITH_LEN( finished ),
+                                 NULL, 0,
+                                 finished_key, hash_len );
+    if( ret != 0 )
+        goto exit;
+
+    ret = mbedtls_md_hmac( md_info, finished_key, hash_len, transcript, hash_len, dst );
+    if( ret != 0 )
+        goto exit;
+    *dst_len = hash_len;
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
 exit:
 
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
     status = psa_destroy_key( key );
     if( ret == 0 )
         ret = psa_ssl_status_to_mbedtls( status );
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
     mbedtls_platform_zeroize( finished_key, sizeof( finished_key ) );
 
@@ -829,11 +1009,19 @@ int mbedtls_ssl_tls13_calculate_verify_data( mbedtls_ssl_context *ssl,
     mbedtls_ssl_tls13_handshake_secrets *tls13_hs_secrets =
                                             &ssl->handshake->tls13_hs_secrets;
 
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
     mbedtls_md_type_t const md_type = ssl->handshake->ciphersuite_info->mac;
 
     psa_algorithm_t hash_alg = mbedtls_psa_translate_md(
                                     ssl->handshake->ciphersuite_info->mac );
     size_t const hash_len = PSA_HASH_LENGTH( hash_alg );
+#else
+    mbedtls_md_type_t const md_type = ssl->handshake->ciphersuite_info->mac;
+    mbedtls_md_type_t hash_alg = md_type;
+    const mbedtls_md_info_t* const md_info =
+                                   mbedtls_md_info_from_type( md_type );
+    size_t const hash_len = mbedtls_md_get_size( md_info );
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> mbedtls_ssl_tls13_calculate_verify_data" ) );
 
@@ -894,16 +1082,27 @@ exit:
  *                ...
  */
 int mbedtls_ssl_tls13_create_psk_binder( mbedtls_ssl_context *ssl,
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
                                const psa_algorithm_t hash_alg,
+#else
+                               const mbedtls_md_type_t hash_alg,
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
                                unsigned char const *psk, size_t psk_len,
                                int psk_type,
                                unsigned char const *transcript,
                                unsigned char *result )
 {
     int ret = 0;
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
     unsigned char binder_key[PSA_MAC_MAX_SIZE];
     unsigned char early_secret[PSA_MAC_MAX_SIZE];
     size_t const hash_len = PSA_HASH_LENGTH( hash_alg );
+#else
+    unsigned char binder_key[MBEDTLS_MD_MAX_SIZE];
+    unsigned char early_secret[MBEDTLS_MD_MAX_SIZE];
+    mbedtls_md_info_t const *md_info = mbedtls_md_info_from_type( hash_alg );
+    size_t const hash_len = mbedtls_md_get_size( md_info );
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
     size_t actual_len;
 
 #if !defined(MBEDTLS_DEBUG_C)
@@ -913,8 +1112,13 @@ int mbedtls_ssl_tls13_create_psk_binder( mbedtls_ssl_context *ssl,
 
     /* We should never call this function with an unknown hash,
      * but add an assertion anyway. */
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
     if( ! PSA_ALG_IS_HASH( hash_alg ) )
         return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
+#else
+    if( md_info == 0 )
+        return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
     /*
      *            0
@@ -1163,7 +1367,11 @@ int mbedtls_ssl_tls13_populate_transform( mbedtls_ssl_transform *transform,
 int mbedtls_ssl_tls13_key_schedule_stage_early( mbedtls_ssl_context *ssl )
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
     psa_algorithm_t hash_alg;
+#else
+    mbedtls_md_type_t hash_alg;
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
     mbedtls_ssl_handshake_params *handshake = ssl->handshake;
     unsigned char *psk;
     size_t psk_len;
@@ -1174,7 +1382,11 @@ int mbedtls_ssl_tls13_key_schedule_stage_early( mbedtls_ssl_context *ssl )
         return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
     }
 
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
     hash_alg = mbedtls_psa_translate_md( handshake->ciphersuite_info->mac );
+#else
+    hash_alg = handshake->ciphersuite_info->mac;
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
     ret = ssl_tls13_get_psk( ssl, &psk, &psk_len );
     if( ret != 0 )
@@ -1238,8 +1450,13 @@ int mbedtls_ssl_tls13_generate_handshake_keys( mbedtls_ssl_context *ssl,
 
     mbedtls_md_type_t md_type;
 
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
     psa_algorithm_t hash_alg;
     size_t hash_len;
+#else
+    mbedtls_md_info_t const *md_info;
+    size_t hash_len;
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
     unsigned char transcript[MBEDTLS_TLS1_3_MD_MAX_SIZE];
     size_t transcript_len;
@@ -1262,8 +1479,14 @@ int mbedtls_ssl_tls13_generate_handshake_keys( mbedtls_ssl_context *ssl,
 
     md_type = ciphersuite_info->mac;
 
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
     hash_alg = mbedtls_psa_translate_md( ciphersuite_info->mac );
     hash_len = PSA_HASH_LENGTH( hash_alg );
+#else
+    mbedtls_md_type_t hash_alg = md_type;
+    md_info = mbedtls_md_info_from_type( md_type );
+    hash_len = mbedtls_md_get_size( md_info );
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
     ret = mbedtls_ssl_get_handshake_transcript( ssl, md_type,
                                                 transcript,
@@ -1288,11 +1511,11 @@ int mbedtls_ssl_tls13_generate_handshake_keys( mbedtls_ssl_context *ssl,
     }
 
     MBEDTLS_SSL_DEBUG_BUF( 4, "Client handshake traffic secret",
-                    tls13_hs_secrets->client_handshake_traffic_secret,
-                    hash_len );
+                     tls13_hs_secrets->client_handshake_traffic_secret,
+                     hash_len );
     MBEDTLS_SSL_DEBUG_BUF( 4, "Server handshake traffic secret",
-                    tls13_hs_secrets->server_handshake_traffic_secret,
-                    hash_len );
+                     tls13_hs_secrets->server_handshake_traffic_secret,
+                     hash_len );
 
     /*
      * Export client handshake traffic secret
@@ -1352,12 +1575,23 @@ exit:
 int mbedtls_ssl_tls13_key_schedule_stage_handshake( mbedtls_ssl_context *ssl )
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
+    mbedtls_ssl_handshake_params *handshake = ssl->handshake;
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
 #if defined(MBEDTLS_KEY_EXCHANGE_SOME_ECDHE_ENABLED) && defined(MBEDTLS_ECDH_C)
     psa_status_t status = PSA_ERROR_GENERIC_ERROR;
-#endif /* MBEDTLS_KEY_EXCHANGE_SOME_ECDHE_ENABLED && MBEDTLS_ECDH_C */
-    mbedtls_ssl_handshake_params *handshake = ssl->handshake;
     psa_algorithm_t const hash_alg = mbedtls_psa_translate_md(
                                         handshake->ciphersuite_info->mac );
+#endif /* MBEDTLS_KEY_EXCHANGE_SOME_ECDHE_ENABLED && MBEDTLS_ECDH_C */
+#if defined(MBEDTLS_DEBUG_C)
+    size_t hash_len = PSA_HASH_LENGTH( hash_alg );
+#endif /* MBEDTLS_DEBUG_C */
+#else
+    mbedtls_md_type_t const hash_alg = handshake->ciphersuite_info->mac;
+#if defined(MBEDTLS_DEBUG_C)
+    mbedtls_md_info_t const * const md_info = mbedtls_md_info_from_type( hash_alg );
+    size_t const hash_len = mbedtls_md_get_size( md_info );
+#endif /* MBEDTLS_DEBUG_C */
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
 #if defined(MBEDTLS_KEY_EXCHANGE_SOME_ECDHE_ENABLED)
     /*
@@ -1370,6 +1604,7 @@ int mbedtls_ssl_tls13_key_schedule_stage_handshake( mbedtls_ssl_context *ssl )
         if( mbedtls_ssl_tls13_named_group_is_ecdhe( handshake->offered_group_id ) )
         {
 #if defined(MBEDTLS_ECDH_C)
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
         /* Compute ECDH shared secret. */
         status = psa_raw_key_agreement(
                     PSA_ALG_ECDH, handshake->ecdh_psa_privkey,
@@ -1392,6 +1627,17 @@ int mbedtls_ssl_tls13_key_schedule_stage_handshake( mbedtls_ssl_context *ssl )
         }
 
         handshake->ecdh_psa_privkey = MBEDTLS_SVC_KEY_ID_INIT;
+#else
+        ret = mbedtls_ecdh_calc_secret( &handshake->ecdh_ctx,
+                                        &handshake->pmslen, handshake->premaster, sizeof( handshake->premaster ),
+                                        ssl->conf->f_rng,
+                                        ssl->conf->p_rng );
+        if( ret != 0 )
+        {
+            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ecdh_calc_secret", ret );
+            return( ret );
+        }
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 #endif /* MBEDTLS_ECDH_C */
         }
         else if( mbedtls_ssl_tls13_named_group_is_dhe( handshake->offered_group_id ) )
@@ -1418,8 +1664,7 @@ int mbedtls_ssl_tls13_key_schedule_stage_handshake( mbedtls_ssl_context *ssl )
     }
 
     MBEDTLS_SSL_DEBUG_BUF( 4, "Handshake secret",
-                           handshake->tls13_master_secrets.handshake,
-                           PSA_HASH_LENGTH( hash_alg ) );
+                           handshake->tls13_master_secrets.handshake, hash_len );
 
 #if defined(MBEDTLS_KEY_EXCHANGE_SOME_ECDHE_ENABLED)
     mbedtls_platform_zeroize( handshake->premaster, sizeof( handshake->premaster ) );
@@ -1448,8 +1693,13 @@ int mbedtls_ssl_tls13_generate_application_keys(
     /* Variables relating to the hash for the chosen ciphersuite. */
     mbedtls_md_type_t md_type;
 
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
     psa_algorithm_t hash_alg;
     size_t hash_len;
+#else
+    mbedtls_md_info_t const *md_info;
+    size_t hash_len;
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
     /* Variables relating to the cipher for the chosen ciphersuite. */
     size_t key_len, iv_len;
@@ -1468,8 +1718,14 @@ int mbedtls_ssl_tls13_generate_application_keys(
 
     md_type = handshake->ciphersuite_info->mac;
 
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
     hash_alg = mbedtls_psa_translate_md( handshake->ciphersuite_info->mac );
     hash_len = PSA_HASH_LENGTH( hash_alg );
+#else
+    mbedtls_md_type_t hash_alg = md_type;
+    md_info = mbedtls_md_info_from_type( md_type );
+    hash_len = mbedtls_md_get_size( md_info );
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
     /* Compute current handshake transcript. It's the caller's responsibility
      * to call this at the right time, that is, after the ServerFinished. */
@@ -1595,7 +1851,10 @@ int mbedtls_ssl_tls13_generate_early_data_keys(
     }
 
     ret = mbedtls_ssl_tls13_derive_early_secrets(
-              mbedtls_psa_translate_md( md_type ),
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+              mbedtls_psa_translate_md
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
+              ( md_type ),
               ssl->handshake->tls13_master_secrets.early,
               transcript, transcript_len,
               &ssl->handshake->early_secrets );
@@ -1623,7 +1882,10 @@ int mbedtls_ssl_tls13_generate_early_data_keys(
 #endif /* MBEDTLS_SSL_EXPORT_KEYS */
 
     ret = mbedtls_ssl_tls13_make_traffic_keys(
-                      mbedtls_psa_translate_md( md_type ),
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+                      mbedtls_psa_translate_md
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
+                      ( md_type ),
                       ssl->handshake->early_secrets.client_early_traffic_secret,
                       ssl->handshake->early_secrets.client_early_traffic_secret,
                       md_size, key_len, iv_len, traffic_keys );

--- a/library/ssl_tls13_keys.h
+++ b/library/ssl_tls13_keys.h
@@ -161,7 +161,11 @@ extern const struct mbedtls_ssl_tls13_labels_struct mbedtls_ssl_tls13_labels;
 
 MBEDTLS_CHECK_RETURN_CRITICAL
 int mbedtls_ssl_tls13_hkdf_expand_label(
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
                      psa_algorithm_t hash_alg,
+#else
+                     mbedtls_md_type_t hash_alg,
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
                      const unsigned char *secret, size_t secret_len,
                      const unsigned char *label, size_t label_len,
                      const unsigned char *ctx, size_t ctx_len,
@@ -200,7 +204,11 @@ int mbedtls_ssl_tls13_hkdf_expand_label(
 
 MBEDTLS_CHECK_RETURN_CRITICAL
 int mbedtls_ssl_tls13_make_traffic_keys(
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
                      psa_algorithm_t hash_alg,
+#else
+                     mbedtls_md_type_t hash_alg,
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
                      const unsigned char *client_secret,
                      const unsigned char *server_secret, size_t secret_len,
                      size_t key_len, size_t iv_len,
@@ -247,7 +255,11 @@ int mbedtls_ssl_tls13_make_traffic_keys(
  */
 MBEDTLS_CHECK_RETURN_CRITICAL
 int mbedtls_ssl_tls13_derive_secret(
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
                    psa_algorithm_t hash_alg,
+#else
+                   mbedtls_md_type_t hash_alg,
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
                    const unsigned char *secret, size_t secret_len,
                    const unsigned char *label, size_t label_len,
                    const unsigned char *ctx, size_t ctx_len,
@@ -298,7 +310,11 @@ int mbedtls_ssl_tls13_derive_secret(
  */
 MBEDTLS_CHECK_RETURN_CRITICAL
 int mbedtls_ssl_tls13_derive_early_secrets(
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
           psa_algorithm_t hash_alg,
+#else
+          mbedtls_md_type_t hash_alg,
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
           unsigned char const *early_secret,
           unsigned char const *transcript, size_t transcript_len,
           mbedtls_ssl_tls13_early_secrets *derived );
@@ -344,7 +360,11 @@ int mbedtls_ssl_tls13_derive_early_secrets(
  */
 MBEDTLS_CHECK_RETURN_CRITICAL
 int mbedtls_ssl_tls13_derive_handshake_secrets(
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
           psa_algorithm_t hash_alg,
+#else
+          mbedtls_md_type_t hash_alg,
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
           unsigned char const *handshake_secret,
           unsigned char const *transcript, size_t transcript_len,
           mbedtls_ssl_tls13_handshake_secrets *derived );
@@ -395,7 +415,11 @@ int mbedtls_ssl_tls13_derive_handshake_secrets(
  */
 MBEDTLS_CHECK_RETURN_CRITICAL
 int mbedtls_ssl_tls13_derive_application_secrets(
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
           psa_algorithm_t hash_alg,
+#else
+          mbedtls_md_type_t hash_alg,
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
           unsigned char const *master_secret,
           unsigned char const *transcript, size_t transcript_len,
           mbedtls_ssl_tls13_application_secrets *derived );
@@ -426,7 +450,11 @@ int mbedtls_ssl_tls13_derive_application_secrets(
  */
 MBEDTLS_CHECK_RETURN_CRITICAL
 int mbedtls_ssl_tls13_derive_resumption_master_secret(
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
           psa_algorithm_t hash_alg,
+#else
+          mbedtls_md_type_t hash_alg,
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
           unsigned char const *application_secret,
           unsigned char const *transcript, size_t transcript_len,
           mbedtls_ssl_tls13_application_secrets *derived );
@@ -501,7 +529,11 @@ int mbedtls_ssl_tls13_derive_resumption_master_secret(
 
 MBEDTLS_CHECK_RETURN_CRITICAL
 int mbedtls_ssl_tls13_evolve_secret(
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
                    psa_algorithm_t hash_alg,
+#else
+                   mbedtls_md_type_t hash_alg,
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
                    const unsigned char *secret_old,
                    const unsigned char *input, size_t input_len,
                    unsigned char *secret_new );
@@ -531,7 +563,11 @@ int mbedtls_ssl_tls13_evolve_secret(
  */
 MBEDTLS_CHECK_RETURN_CRITICAL
 int mbedtls_ssl_tls13_create_psk_binder( mbedtls_ssl_context *ssl,
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
                                const psa_algorithm_t hash_alg,
+#else
+                               const mbedtls_md_type_t hash_alg,
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
                                unsigned char const *psk, size_t psk_len,
                                int psk_type,
                                unsigned char const *transcript,

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -12056,6 +12056,7 @@ requires_config_enabled MBEDTLS_DEBUG_C
 requires_config_enabled MBEDTLS_SSL_CLI_C
 requires_config_enabled MBEDTLS_RSA_C
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
+requires_config_enabled MBEDTLS_USE_PSA_CRYPTO
 run_test    "TLS 1.3: Client authentication, rsa_pss_rsae_sha256 - openssl" \
             "$O_NEXT_SRV -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache -Verify 10" \
             "$P_CLI debug_level=4 crt_file=data_files/cert_sha256.crt \
@@ -12073,6 +12074,7 @@ requires_config_enabled MBEDTLS_DEBUG_C
 requires_config_enabled MBEDTLS_SSL_CLI_C
 requires_config_enabled MBEDTLS_RSA_C
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
+requires_config_enabled MBEDTLS_USE_PSA_CRYPTO
 run_test    "TLS 1.3: Client authentication, rsa_pss_rsae_sha256 - gnutls" \
             "$G_NEXT_SRV --debug=4 --priority=NORMAL:-VERS-ALL:+VERS-TLS1.3:+CIPHER-ALL:%NO_TICKETS" \
             "$P_CLI debug_level=3 crt_file=data_files/server2-sha256.crt \
@@ -12089,6 +12091,7 @@ requires_config_enabled MBEDTLS_DEBUG_C
 requires_config_enabled MBEDTLS_SSL_CLI_C
 requires_config_enabled MBEDTLS_RSA_C
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
+requires_config_enabled MBEDTLS_USE_PSA_CRYPTO
 run_test    "TLS 1.3: Client authentication, rsa_pss_rsae_sha384 - openssl" \
             "$O_NEXT_SRV -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache -Verify 10" \
             "$P_CLI debug_level=4 force_version=tls13 crt_file=data_files/cert_sha256.crt \
@@ -12106,6 +12109,7 @@ requires_config_enabled MBEDTLS_DEBUG_C
 requires_config_enabled MBEDTLS_SSL_CLI_C
 requires_config_enabled MBEDTLS_RSA_C
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
+requires_config_enabled MBEDTLS_USE_PSA_CRYPTO
 run_test    "TLS 1.3: Client authentication, rsa_pss_rsae_sha384 - gnutls" \
             "$G_NEXT_SRV --debug=4 --priority=NORMAL:-VERS-ALL:+VERS-TLS1.3:+CIPHER-ALL:%NO_TICKETS" \
             "$P_CLI debug_level=3 force_version=tls13 crt_file=data_files/server2-sha256.crt \
@@ -12122,6 +12126,7 @@ requires_config_enabled MBEDTLS_DEBUG_C
 requires_config_enabled MBEDTLS_SSL_CLI_C
 requires_config_enabled MBEDTLS_RSA_C
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
+requires_config_enabled MBEDTLS_USE_PSA_CRYPTO
 run_test    "TLS 1.3: Client authentication, rsa_pss_rsae_sha512 - openssl" \
             "$O_NEXT_SRV -msg -tls1_3 -num_tickets 0 -no_resume_ephemeral -no_cache -Verify 10" \
             "$P_CLI debug_level=4 force_version=tls13 crt_file=data_files/cert_sha256.crt \
@@ -12139,6 +12144,7 @@ requires_config_enabled MBEDTLS_DEBUG_C
 requires_config_enabled MBEDTLS_SSL_CLI_C
 requires_config_enabled MBEDTLS_RSA_C
 requires_config_enabled MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
+requires_config_enabled MBEDTLS_USE_PSA_CRYPTO
 run_test    "TLS 1.3: Client authentication, rsa_pss_rsae_sha512 - gnutls" \
             "$G_NEXT_SRV --debug=4 --priority=NORMAL:-VERS-ALL:+VERS-TLS1.3:+CIPHER-ALL:%NO_TICKETS" \
             "$P_CLI debug_level=3 force_version=tls13 crt_file=data_files/server2-sha256.crt \


### PR DESCRIPTION
Notes:
Add non-PSA crypto support for the client when it uses TLS 1.3.
    * Update include/mbedtls/check_config.h to allow
    MBEDTLS_SSL_PROTO_TLS1_3 without MBEDTLS_PSA_CRYPTO_C
    * Add non-PSA crypto support in TLS 1.3 implementation.
    * Require MBEDTLS_USE_PSA_CRYPTO for the TLS 1.3: Client authentication, rsa_pss_rsae tests. It is because the padding is set to [PSA_ALG_RSA_PSS](https://github.com/hannestschofenig/mbedtls/blob/tls13-prototype/library/pk.c#L557) in `mbedtls_pk_sign_ext` which is only for MBEDTLS_USE_PSA_CRYPTO.


## Status
**READY/IN DEVELOPMENT/HOLD**

## Requires Backporting
When there is a bug fix, it should be backported to all maintained and supported branches.
Changes do not have to be backported if:
- This PR is a new feature\enhancement
- This PR contains changes in the API. If this is true, and there is a need for the fix to be backported, the fix should be handled differently in the legacy branch

Yes | NO  
Which branch?

## Migrations
If there is any API change, what's the incentive and logic for it.

YES | NO

## Additional comments
Any additional information that could be of interest

## Todos
- [ ] Tests
    ```
    tests/ssl-opt.sh -p -s -f "TLS 1.3: "
    ```
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported


## Steps to test or reproduce
Outline the steps to test or reproduce the PR here.
