### PR TITLE
Add support for attestation via PARSEC

### DIFF
--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -1673,6 +1673,17 @@
 #define MBEDTLS_SSL_ATTESTATION_NONCE_LEN_MAX   32
 
 /**
+ * \def MBEDTLS_PARSEC_ATTESTATION
+ *
+ * Enable support for attestation using the PARSEC service
+ *
+ * Requires: MBEDTLS_SSL_TLS_ATTESTATION
+ *
+ * Comment this macro to disable support for PARSEC attestation
+ */
+#define MBEDTLS_PARSEC_ATTESTATION
+
+/**
  * \def MBEDTLS_SSL_VARIABLE_BUFFER_LENGTH
  *
  * When this option is enabled, the SSL buffer will be resized automatically
@@ -2713,7 +2724,7 @@
  * Requires: MBEDTLS_PSA_CRYPTO_C, MBEDTLS_PSA_CRYPTO_STORAGE_C
  *
  */
-//#define MBEDTLS_PSA_CRYPTO_SE_C
+#define MBEDTLS_PSA_CRYPTO_SE_C
 
 /**
  * \def MBEDTLS_PSA_CRYPTO_STORAGE_C

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -434,8 +434,10 @@ static int ssl_tls13_write_eat_write( mbedtls_ssl_context *ssl,
                                 sizeof(cab_scratch),
                                 &n2);
 
-    if( status != PSA_SUCCESS )
+    if( status != PSA_SUCCESS ) {
+        MBEDTLS_SSL_DEBUG_MSG( 1, ( "Failed attesting key, %d", status) );
         return( psa_ssl_status_to_mbedtls( status ) );
+    }
 
     if( n2 > buf_len - 3 - i )
     {

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -25,6 +25,11 @@
 #include "test/psa_crypto_helpers.h"
 #endif /* MBEDTLS_USE_PSA_CRYPTO || MBEDTLS_SSL_PROTO_TLS1_3 */
 
+#if defined(MBEDTLS_PARSEC_ATTESTATION)
+#include "parsec/parsec_se_driver.h"
+#include "parsec/parsec_client.h"
+#endif /* MBEDTLS_PARSEC_ATTESTATION */
+
 #if defined(MBEDTLS_SSL_TEST_IMPOSSIBLE)
 int main( void )
 {
@@ -675,6 +680,15 @@ int main( int argc, char *argv[] )
     io_ctx_t io_ctx;
 
 #if defined(MBEDTLS_SSL_TLS_ATTESTATION) && defined(MBEDTLS_PSA_CRYPTO_C)
+
+#if defined(MBEDTLS_PARSEC_ATTESTATION)
+    psa_status_t reg_status = psa_register_se_driver((psa_key_location_t)0x000001,
+			&PARSEC_SE_DRIVER);
+	if (reg_status != PSA_SUCCESS) {
+		printf("Register failed (status = %d)\n", reg_status);
+		return 1;
+	}
+#endif /* MBEDTLS_PARSEC_ATTESTATION */
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
 
 //    psa_status_t status;


### PR DESCRIPTION
Hey!

I've added some stuff as part of the PoC, to enable the integration with Parsec. Let me know if we should move to a different fork/branch instead.

## Description

Adding a new configuration flag to allow selection of PARSEC as the attestation mechanism of choice. The built-in EAT token generation is excluded when the flag isn't set.

Also enabling ssl_clent2 to make use of this integration.

cc @thomas-fossati 